### PR TITLE
I've optimized the GLBRegistry lookup to O(1) by replacing the array …

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - [GLBRegistry O(1) Optimization]
+**Learning:** The `GLBRegistry.getModelForTarget` method was performing an $O(n)$ array `find` for every NPC and loot item on every world tick (10Hz). In a world with many entities, this becomes a significant bottleneck.
+**Action:** Use an internal `Map` for $O(1)$ lookups in registries and managers that are queried frequently in the main game loop.
+
+## 2025-05-15 - [Monorepo Dependency Management]
+**Learning:** Running `pnpm install` in a monorepo that isn't fully set up for pnpm (missing `pnpm-workspace.yaml`) can generate a massive `pnpm-lock.yaml` file in the root, which is undesirable for small PRs.
+**Action:** Be extremely careful with installation commands in monorepos; prefer `npm install` within specific package directories if the root workspace configuration is unstable.

--- a/server/src/modules/asset-registry/GLBRegistry.ts
+++ b/server/src/modules/asset-registry/GLBRegistry.ts
@@ -9,6 +9,7 @@ export interface GLBLink {
 
 export class GLBRegistry {
   private links: GLBLink[] = [];
+  private linksMap: Map<string, string> = new Map(); // O(1) lookup
   private modelsDir = path.resolve(process.cwd(), '../client/public/assets/models');
 
   constructor() {
@@ -20,10 +21,19 @@ export class GLBRegistry {
     if (fs.existsSync(linksPath)) {
       try {
         this.links = JSON.parse(fs.readFileSync(linksPath, 'utf-8'));
+        this.rebuildMap();
       } catch (e) {
         console.error("Failed to parse glb-links.json", e);
         this.links = [];
+        this.linksMap.clear();
       }
+    }
+  }
+
+  private rebuildMap() {
+    this.linksMap.clear();
+    for (const link of this.links) {
+      this.linksMap.set(`${link.targetType}:${link.targetId}`, link.glbPath);
     }
   }
 
@@ -59,16 +69,18 @@ export class GLBRegistry {
     // remove existing link for the same target
     this.links = this.links.filter(l => !(l.targetType === link.targetType && l.targetId === link.targetId));
     this.links.push(link);
+    this.linksMap.set(`${link.targetType}:${link.targetId}`, link.glbPath);
     this.saveLinks();
   }
 
   public removeLink(targetType: string, targetId: string) {
     this.links = this.links.filter(l => !(l.targetType === targetType && l.targetId === targetId));
+    this.linksMap.delete(`${targetType}:${targetId}`);
     this.saveLinks();
   }
 
   public getModelForTarget(targetType: string, targetId: string): string | null {
-    const link = this.links.find(l => l.targetType === targetType && l.targetId === targetId);
-    return link ? link.glbPath : null;
+    // Using O(1) Map lookup instead of O(n) Array find for hot path performance
+    return this.linksMap.get(`${targetType}:${targetId}`) ?? null;
   }
 }


### PR DESCRIPTION
…search in `getModelForTarget` with a Map lookup. I also updated `GLBRegistry` to maintain a synchronized internal `linksMap`. These changes will significantly improve performance during world ticks, especially for model lookups involving active NPCs and loot items.