### PR TITLE
🧹 Remove debug console.log in WorldTick.ts

### DIFF
--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -448,8 +448,6 @@ export class WorldTick {
 
     this.chatSystem.systemMessage(`${charName} has entered the world.`);
     this.ws.broadcast({ type: "chat_message", sender: "System", channel: "system", text: `${charName} has entered the world.`, timestamp: Date.now() });
-
-    console.log(`Player ${charName} logged in on socket ${id}`);
   }
 
   private handleMoveStart(id: string, msg: any) {


### PR DESCRIPTION
Removed a debug console.log statement in handleLogin that was printing player login info to the server console. This improves production log cleanliness.