### PR TITLE
fix: use server.deps.external in vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,12 +4,14 @@ export default defineConfig({
   test: {
     include: ["server/src/tests/**/*.test.ts"],
     environment: "node",
-    deps: {
-      external: [
-        "multer",
-        "firebase/auth",
-        "firebase/firestore",
-      ],
+    server: {
+      deps: {
+        external: [
+          "multer",
+          "firebase/auth",
+          "firebase/firestore",
+        ],
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Fixed vitest configuration to properly handle external modules.

## Problem

The glbUpload.test.ts was failing with:
```
Error: Failed to load url multer (resolved id: multer)
```

The issue was the vitest config structure - needed to use `server.deps.external` instead of just `deps.external`.

## Solution

Updated vitest.config.ts to use the correct structure:

```typescript
server: {
  deps: {
    external: [
      "multer",
      "firebase/auth",
      "firebase/firestore",
    ],
  },
},
```

## Testing

- All 544 tests pass ✅