### PR TITLE
Add secure Cursor MCP + PlayCanvas VPS integration

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "areloria-vps": {
+      "url": "https://your-domain.example/api/mcp/sse",
+      "headers": {
+        "Authorization": "Bearer REPLACE_WITH_MCP_ADMIN_TOKEN"
+      }
+    }
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 PORT=3000
 NODE_ENV=development
+MCP_ADMIN_TOKEN=
+MCP_PUBLIC_SSE_URL=https://your-domain.example/api/mcp/sse
+MCP_PUBLIC_MESSAGES_URL=https://your-domain.example/api/mcp/messages?sessionId=<id>
+PUBLIC_WEBSOCKET_URL=wss://your-domain.example/ws
 
 # Firebase Configuration (Primary)
 FIREBASE_PROJECT_ID=your-project-id

--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ For development: `pnpm run dev`
 - **Networking**: High-frequency entity synchronization via WebSockets.
 - **Server**: Authoritative modules (`server/src/modules/`) integrated into the `WorldTick` loop.
 
+## Cursor MCP + VPS setup
+- Detailed setup guide: `docs/PLAYCANVAS_MCP_CURSOR_VPS_SETUP.md`
+- Example Cursor config: `.cursor/mcp.json`
+
 ## Credits
 Migration and System Re-integration by Jules.

--- a/client/src/networking/websocketClient.ts
+++ b/client/src/networking/websocketClient.ts
@@ -2,8 +2,42 @@ import { MMORPGClientCore } from "../core/MMORPGClientCore";
 
 let globalWs: WebSocket | null = null;
 
+function normalizeWebSocketUrl(rawUrl: string | undefined): string | null {
+  if (!rawUrl || rawUrl.trim().length === 0) {
+    return null;
+  }
+
+  const value = rawUrl.trim();
+  if (value.startsWith("ws://") || value.startsWith("wss://")) {
+    return value;
+  }
+
+  if (value.startsWith("http://")) {
+    return `ws://${value.slice("http://".length)}`;
+  }
+
+  if (value.startsWith("https://")) {
+    return `wss://${value.slice("https://".length)}`;
+  }
+
+  return null;
+}
+
+function resolveWebSocketUrl() {
+  const configuredUrl = normalizeWebSocketUrl(
+    (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env?.VITE_WEBSOCKET_URL
+  );
+
+  if (configuredUrl) {
+    return configuredUrl;
+  }
+
+  const protocol = location.protocol === "https:" ? "wss" : "ws";
+  return `${protocol}://${location.host}/ws`;
+}
+
 export function connectSocket(core: MMORPGClientCore) {
-  const ws = new WebSocket(`wss://${location.hostname}/ws`);
+  const ws = new WebSocket(resolveWebSocketUrl());
   globalWs = ws;
 
   ws.onopen = () => {

--- a/deploy/vps_connect.py
+++ b/deploy/vps_connect.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Connect to and operate the Areloria VPS over SSH.
+
+This script avoids hardcoding secrets. You can either:
+- use interactive SSH password prompt (default), or
+- use --password / SSH_PASSWORD together with sshpass (optional).
+
+Examples:
+  python3 deploy/vps_connect.py shell
+  python3 deploy/vps_connect.py run "uname -a"
+  python3 deploy/vps_connect.py deploy --branch cursor/mmorpq-playcanvas-connection-3e3d
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+
+DEFAULT_HOST = "46.202.154.25"
+DEFAULT_USER = "root"
+DEFAULT_PORT = 22
+DEFAULT_APP_DIR = "/opt/areloria"
+DEFAULT_REPO = "https://github.com/OuroborosCollective/Wasd.git"
+DEFAULT_BRANCH = "cursor/mmorpq-playcanvas-connection-3e3d"
+
+
+def require_binary(binary_name: str) -> None:
+    if shutil.which(binary_name):
+        return
+    print(f"Error: required binary '{binary_name}' is not available in PATH.", file=sys.stderr)
+    sys.exit(1)
+
+
+def build_ssh_command(args: argparse.Namespace) -> list[str]:
+    host_target = f"{args.user}@{args.host}"
+    command: list[str] = [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+    ]
+    if args.port != DEFAULT_PORT:
+        command.extend(["-p", str(args.port)])
+    if args.identity_file:
+        command.extend(["-i", args.identity_file])
+    command.append(host_target)
+
+    password = args.password or os.getenv("SSH_PASSWORD")
+    if password:
+        require_binary("sshpass")
+        return ["sshpass", "-p", password, *command]
+    return command
+
+
+def run_ssh(args: argparse.Namespace, remote_command: str | None, force_tty: bool = False) -> int:
+    ssh_command = build_ssh_command(args)
+    if force_tty:
+        ssh_command.append("-t")
+    if remote_command:
+        ssh_command.append(remote_command)
+    return subprocess.call(ssh_command)
+
+
+def make_deploy_script(args: argparse.Namespace) -> str:
+    app_dir = shlex.quote(args.app_dir)
+    branch = shlex.quote(args.branch)
+    repo = shlex.quote(args.repo)
+    return (
+        "set -euo pipefail; "
+        f'if [ ! -d "{args.app_dir}/.git" ]; then '
+        f"git clone {repo} {app_dir}; "
+        "fi; "
+        f"cd {app_dir}; "
+        f"git fetch origin {branch}; "
+        f"git checkout {branch}; "
+        f"git pull origin {branch}"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="SSH helper for Areloria VPS workflows.")
+    parser.add_argument("--host", default=DEFAULT_HOST, help=f"VPS host (default: {DEFAULT_HOST})")
+    parser.add_argument("--user", default=DEFAULT_USER, help=f"SSH user (default: {DEFAULT_USER})")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"SSH port (default: {DEFAULT_PORT})")
+    parser.add_argument("--identity-file", help="Path to SSH private key file")
+    parser.add_argument(
+        "--password",
+        help="Optional password for sshpass. Prefer key-based auth or interactive password prompt.",
+    )
+    parser.add_argument("--app-dir", default=DEFAULT_APP_DIR, help=f"Remote app directory (default: {DEFAULT_APP_DIR})")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help=f"Git repository URL (default: {DEFAULT_REPO})")
+    parser.add_argument("--branch", default=DEFAULT_BRANCH, help=f"Git branch for deploy mode (default: {DEFAULT_BRANCH})")
+
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    subparsers.add_parser("shell", help="Open interactive shell on VPS (inside app directory).")
+
+    run_parser = subparsers.add_parser("run", help="Run one remote command.")
+    run_parser.add_argument("command", help="Shell command to execute remotely")
+
+    subparsers.add_parser("deploy", help="Fetch/checkout/pull the configured branch on VPS.")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.mode == "shell":
+        remote = f"cd {shlex.quote(args.app_dir)} && exec bash -l"
+        return run_ssh(args, remote, force_tty=True)
+
+    if args.mode == "run":
+        return run_ssh(args, args.command, force_tty=True)
+
+    if args.mode == "deploy":
+        return run_ssh(args, make_deploy_script(args), force_tty=True)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/PLAYCANVAS_MCP_CURSOR_VPS_SETUP.md
+++ b/docs/PLAYCANVAS_MCP_CURSOR_VPS_SETUP.md
@@ -74,6 +74,33 @@ Use `.cursor/mcp.json` in this repo (or your local Cursor config):
 
 Then restart Cursor.
 
+## 4b) Python SSH helper script
+
+You can use `deploy/vps_connect.py` for interactive SSH or automated deploy commands.
+
+Examples:
+
+```bash
+# 1) Interactive SSH login
+python3 deploy/vps_connect.py --host 46.202.154.25 --user root shell
+
+# 2) Run one command remotely
+python3 deploy/vps_connect.py --host 46.202.154.25 --user root run "uname -a"
+
+# 3) Run the Areloria update flow on VPS
+python3 deploy/vps_connect.py \
+  --host 46.202.154.25 \
+  --user root \
+  --app-dir /opt/areloria \
+  --branch cursor/mmorpq-playcanvas-connection-3e3d \
+  deploy
+```
+
+Notes:
+- The script prefers SSH key auth.
+- If you want non-interactive password auth, set `SSH_PASSWORD` or pass `--password` (requires `sshpass`).
+- Do not commit passwords or tokens in files.
+
 ## 5) Quick verification checklist
 
 1. Health endpoint works:

--- a/docs/PLAYCANVAS_MCP_CURSOR_VPS_SETUP.md
+++ b/docs/PLAYCANVAS_MCP_CURSOR_VPS_SETUP.md
@@ -1,0 +1,90 @@
+# PlayCanvas + Cursor MCP Integration (VPS)
+
+This document explains how to connect your deployed Areloria MMORPG server to Cursor using MCP, and how to keep PlayCanvas WebSocket networking aligned with that deployment.
+
+## 1) What was added in this repo
+
+- Hardened MCP auth: the MCP API now requires `MCP_ADMIN_TOKEN` and no longer falls back to a default insecure token.
+- New MCP helper tools:
+  - `list_files`
+  - `get_playcanvas_connection_profile`
+- PlayCanvas client WebSocket URL is now configurable through `VITE_WEBSOCKET_URL` and falls back safely based on the current page protocol/host.
+- Team-shareable Cursor config example at `.cursor/mcp.json`.
+
+## 2) VPS environment variables
+
+Set these on your VPS (for example in `/opt/areloria/.env`):
+
+```bash
+MCP_ADMIN_TOKEN=<very-strong-random-token>
+MCP_PUBLIC_SSE_URL=https://your-domain.example/api/mcp/sse
+MCP_PUBLIC_MESSAGES_URL=https://your-domain.example/api/mcp/messages?sessionId=<id>
+PUBLIC_WEBSOCKET_URL=wss://your-domain.example/ws
+```
+
+For client build/runtime (if needed for your deployment strategy):
+
+```bash
+VITE_WEBSOCKET_URL=wss://your-domain.example/ws
+```
+
+## 3) Reverse proxy requirements (Nginx)
+
+For `/api/mcp/sse`, disable buffering and keep long-lived connections:
+
+```nginx
+location /api/mcp/sse {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 3600;
+}
+```
+
+For game WebSocket:
+
+```nginx
+location /ws {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 600;
+}
+```
+
+## 4) Cursor MCP setup
+
+Use `.cursor/mcp.json` in this repo (or your local Cursor config):
+
+```json
+{
+  "mcpServers": {
+    "areloria-vps": {
+      "url": "https://your-domain.example/api/mcp/sse",
+      "headers": {
+        "Authorization": "Bearer REPLACE_WITH_MCP_ADMIN_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Then restart Cursor.
+
+## 5) Quick verification checklist
+
+1. Health endpoint works:
+   - `https://your-domain.example/health`
+2. MCP SSE endpoint requires auth:
+   - without bearer token -> unauthorized
+3. Cursor MCP server connects and lists tools.
+4. PlayCanvas client connects to `wss://your-domain.example/ws`.
+
+## 6) Security notes
+
+- Never commit real tokens/passwords.
+- Rotate `MCP_ADMIN_TOKEN` if it was ever shared.
+- Restrict firewall access to your VPS.

--- a/server/src/api/mcpRoute.ts
+++ b/server/src/api/mcpRoute.ts
@@ -1,22 +1,18 @@
 import express, { Router } from "express";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { randomUUID } from "node:crypto";
 import fs from "fs/promises";
 import path from "path";
 import { z } from "zod";
 
-// Create MCP server instance
-const mcpServer = new McpServer({
-  name: "Areloria Game Server MCP",
-  version: "1.0.0",
-});
-
 // Store SSE Transports for connecting clients
-const transports = new Map<string, SSEServerTransport>();
+const transports = new Map<string, { transport: SSEServerTransport }>();
 
 // --- Helper Functions ---
-function getAdminToken() {
-  return process.env.MCP_ADMIN_TOKEN || "areloria-admin-secret-dev-token";
+function getAdminToken(): string | undefined {
+  const raw = process.env.MCP_ADMIN_TOKEN?.trim();
+  return raw && raw.length > 0 ? raw : undefined;
 }
 
 /**
@@ -26,6 +22,9 @@ function getAdminToken() {
  * @throws Error if path traversal is detected.
  */
 export function validatePath(filepath: string): string {
+  if (!filepath || filepath.includes("\0")) {
+    throw new Error("Invalid path");
+  }
   const p = path.resolve(process.cwd(), filepath);
   // Ensure the resolved path is inside process.cwd()
   const relative = path.relative(process.cwd(), p);
@@ -35,42 +34,139 @@ export function validatePath(filepath: string): string {
   return p;
 }
 
-// --- Define MCP Tools ---
-
-// 1. Read files
-mcpServer.tool(
-  "read_file",
-  "Read code, configs or data files from the game server. Admins only.",
-  { filepath: z.string().describe("Path to the file relative to project root") },
-  async ({ filepath }) => {
-    try {
-      const p = validatePath(filepath);
-      const data = await fs.readFile(p, "utf-8");
-      return { content: [{ type: "text", text: data }] };
-    } catch (e: any) {
-      return { isError: true, content: [{ type: "text", text: `Error reading file: ${e.message}` }] };
-    }
+async function listPaths(
+  absoluteDirectoryPath: string,
+  maxDepth: number,
+  includeDirectories: boolean,
+  currentDepth = 0
+): Promise<string[]> {
+  if (currentDepth > maxDepth) {
+    return [];
   }
-);
 
-// 2. Write files
-mcpServer.tool(
-  "write_file",
-  "Write to code, config or data files on the game server. Admins only.",
-  {
-    filepath: z.string().describe("Path to the file relative to project root"),
-    content: z.string().describe("New content of the file")
-  },
-  async ({ filepath, content }) => {
-    try {
-      const p = validatePath(filepath);
-      await fs.writeFile(p, content, "utf-8");
-      return { content: [{ type: "text", text: `Successfully wrote to ${filepath}` }] };
-    } catch (e: any) {
-      return { isError: true, content: [{ type: "text", text: `Error writing file: ${e.message}` }] };
+  const entries = await fs.readdir(absoluteDirectoryPath, { withFileTypes: true });
+  const sortedEntries = entries.sort((a, b) => a.name.localeCompare(b.name));
+  const results: string[] = [];
+
+  for (const entry of sortedEntries) {
+    if (entry.name === ".git" || entry.name === "node_modules") {
+      continue;
     }
+
+    const fullPath = path.join(absoluteDirectoryPath, entry.name);
+    const relativePath = path.relative(process.cwd(), fullPath).replaceAll(path.sep, "/");
+
+    if (entry.isDirectory()) {
+      if (includeDirectories) {
+        results.push(`${relativePath}/`);
+      }
+      results.push(...(await listPaths(fullPath, maxDepth, includeDirectories, currentDepth + 1)));
+      continue;
+    }
+
+    results.push(relativePath);
   }
-);
+
+  return results;
+}
+
+function getConnectionProfile() {
+  return {
+    websocketUrl:
+      process.env.PUBLIC_WEBSOCKET_URL ||
+      process.env.NEXT_PUBLIC_WEBSOCKET_URL ||
+      "wss://<your-domain>/ws",
+    mcpSseUrl: process.env.MCP_PUBLIC_SSE_URL || "https://<your-domain>/api/mcp/sse",
+    mcpMessagesUrl:
+      process.env.MCP_PUBLIC_MESSAGES_URL || "https://<your-domain>/api/mcp/messages?sessionId=<id>",
+    notes: [
+      "Set MCP_ADMIN_TOKEN in your server environment.",
+      "Use Bearer auth in Cursor MCP server headers.",
+      "For Nginx, disable proxy buffering on /api/mcp/sse.",
+    ],
+  };
+}
+
+function createMcpServer() {
+  const mcpServer = new McpServer({
+    name: "Areloria Game Server MCP",
+    version: "1.1.0",
+  });
+
+  // 1. Read files
+  mcpServer.tool(
+    "read_file",
+    "Read code, configs or data files from the game server. Admins only.",
+    { filepath: z.string().describe("Path to the file relative to project root") },
+    async ({ filepath }) => {
+      try {
+        const p = validatePath(filepath);
+        const data = await fs.readFile(p, "utf-8");
+        return { content: [{ type: "text", text: data }] };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: `Error reading file: ${e.message}` }] };
+      }
+    }
+  );
+
+  // 2. Write files
+  mcpServer.tool(
+    "write_file",
+    "Write to code, config or data files on the game server. Admins only.",
+    {
+      filepath: z.string().describe("Path to the file relative to project root"),
+      content: z.string().describe("New content of the file"),
+    },
+    async ({ filepath, content }) => {
+      try {
+        const p = validatePath(filepath);
+        await fs.writeFile(p, content, "utf-8");
+        return { content: [{ type: "text", text: `Successfully wrote to ${filepath}` }] };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: `Error writing file: ${e.message}` }] };
+      }
+    }
+  );
+
+  // 3. List files
+  mcpServer.tool(
+    "list_files",
+    "List project files for MMORPG and PlayCanvas integration work.",
+    {
+      directory: z.string().default(".").describe("Directory path relative to project root"),
+      maxDepth: z.number().int().min(0).max(8).default(3),
+      includeDirectories: z.boolean().default(false),
+    },
+    async ({ directory, maxDepth, includeDirectories }) => {
+      try {
+        const absoluteDirectoryPath = validatePath(directory);
+        const paths = await listPaths(absoluteDirectoryPath, maxDepth, includeDirectories);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ directory, count: paths.length, paths }, null, 2),
+            },
+          ],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: `Error listing files: ${e.message}` }] };
+      }
+    }
+  );
+
+  // 4. PlayCanvas + MMORPG connection profile
+  mcpServer.tool(
+    "get_playcanvas_connection_profile",
+    "Return recommended WebSocket and MCP endpoint settings for PlayCanvas MMORPG deployment.",
+    {},
+    async () => {
+      return { content: [{ type: "text", text: JSON.stringify(getConnectionProfile(), null, 2) }] };
+    }
+  );
+
+  return mcpServer;
+}
 
 // --- Express Route Setup ---
 
@@ -80,6 +176,13 @@ export function mcpRoute() {
 
   // Auth Middleware
   router.use((req, res, next) => {
+    const adminToken = getAdminToken();
+    if (!adminToken) {
+      console.error("[MCP] Refusing request because MCP_ADMIN_TOKEN is not configured");
+      res.status(503).json({ error: "MCP is not configured on this server (missing MCP_ADMIN_TOKEN)" });
+      return;
+    }
+
     // Basic Bearer Token Auth
     const authHeader = req.headers.authorization;
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
@@ -89,7 +192,7 @@ export function mcpRoute() {
     }
 
     const token = authHeader.split(" ")[1];
-    if (token !== getAdminToken()) {
+    if (token !== adminToken) {
       console.warn("[MCP] Unauthorized attempt: Invalid Bearer Token");
       res.status(403).json({ error: "Forbidden: Invalid Admin Token" });
       return;
@@ -101,13 +204,18 @@ export function mcpRoute() {
   // SSE Endpoint to establish connection
   router.get("/sse", async (req, res) => {
     try {
-      const sessionId = (req.query.sessionId as string) || Math.random().toString(36).substring(7);
+      const requestedSessionId = typeof req.query.sessionId === "string" ? req.query.sessionId.trim() : "";
+      const sessionId = requestedSessionId || randomUUID();
       console.log(`[MCP Admin] Establishing SSE Connection. Session ID: ${sessionId}`);
 
-      const endpoint = `/api/mcp/messages?sessionId=${sessionId}`;
+      // Helpful when running behind Nginx or other reverse proxies.
+      res.setHeader("X-Accel-Buffering", "no");
+
+      const endpoint = `/api/mcp/messages?sessionId=${encodeURIComponent(sessionId)}`;
 
       const transport = new SSEServerTransport(endpoint, res as any);
-      transports.set(sessionId, transport);
+      const mcpServer = createMcpServer();
+      transports.set(sessionId, { transport });
 
       res.on("close", () => {
         console.log(`[MCP Admin] Connection closed for session: ${sessionId}`);
@@ -116,8 +224,8 @@ export function mcpRoute() {
 
       await mcpServer.connect(transport);
     } catch (err: any) {
-        console.error("[MCP] Setup error", err);
-        if (!res.headersSent) res.status(500).send(err.message);
+      console.error("[MCP] Setup error", err);
+      if (!res.headersSent) res.status(500).send(err.message);
     }
   });
 
@@ -130,14 +238,14 @@ export function mcpRoute() {
       return;
     }
 
-    const transport = transports.get(sessionId);
-    if (!transport) {
+    const sessionState = transports.get(sessionId);
+    if (!sessionState) {
       res.status(404).json({ error: "Transport not found for this session" });
       return;
     }
 
     try {
-      await transport.handlePostMessage(req as any, res as any);
+      await sessionState.transport.handlePostMessage(req as any, res as any);
     } catch (err: any) {
       console.error("[MCP] Message handling error:", err);
       res.status(500).json({ error: err.message });

--- a/server/src/tests/mcpPathTraversal.repro.test.ts
+++ b/server/src/tests/mcpPathTraversal.repro.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import path from "path";
 // Using relative path for testing purposes in this environment
-import { validatePath } from "../api/mcpRoute";
+import { validatePath } from "../api/mcpRoute.js";
 
 describe("MCP Path Traversal Validation", () => {
   it("should allow paths within the project root", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- harden MCP endpoint auth by requiring `MCP_ADMIN_TOKEN` (no insecure fallback token)
- expand MCP server tools for remote project work (`read_file`, `write_file`, `list_files`, `get_playcanvas_connection_profile`)
- make PlayCanvas WebSocket client URL configurable via `VITE_WEBSOCKET_URL` with protocol-safe fallback
- add team-shareable Cursor MCP config example at `.cursor/mcp.json`
- document full VPS + Cursor setup in `docs/PLAYCANVAS_MCP_CURSOR_VPS_SETUP.md`
- add Python SSH helper script `deploy/vps_connect.py` for shell, one-off command, and deploy branch flow on VPS

## Validation run
- `python3 -m py_compile deploy/vps_connect.py` ✅
- `npm run build --prefix server` ✅
- `npm run build --prefix client` ✅
- `npm run test -- mcpPathTraversal.repro.test.ts` ✅

## Notes
- `deploy/vps_connect.py` does not hardcode secrets
- password mode is optional and requires `sshpass`; key-based auth or interactive password prompt remains supported
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c9ef05-8932-4334-8ec2-96e9e5568fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c9ef05-8932-4334-8ec2-96e9e5568fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

