### PR TITLE
feat(client): migrate default renderer to Babylon

### DIFF
--- a/SESSION_CONTEXT.md
+++ b/SESSION_CONTEXT.md
@@ -1,0 +1,191 @@
+# SESSION_CONTEXT (2026-03-31)
+
+## Meta
+- Datum: 2026-03-31
+- Repo: `Wasd` (Arbeitsverzeichnis `/workspace`)
+- Branch in dieser Session: `cursor/instanz-chat-kontext-a431`
+- Historischer Arbeitsbranch aus vorheriger Instanz: `cursor/mcp-play-canvas-integration-e792`
+- Ziel: Wissensstand aus der vorherigen Cursor-Instanz nahtlos fortsetzen.
+
+---
+
+## Kurzfazit (heutiger Gesamtstand)
+
+1. Auto-Deploy wurde repariert und verifiziert.
+2. GM/PlayCanvas-Auslieferung und WebSocket-Scene-Flow wurden live verifiziert.
+3. PlayCanvas-Editor-Probleme wurden diagnostiziert (Routing, Ammo, Import-Map, Scene-Visibility).
+4. Architektur-Empfehlung wurde festgelegt: Babylon.js + React als sauberster Exit aus PlayCanvas, Server-Logik weitgehend unveraendert.
+5. Asset-Swap-Workflow wurde als codebasierter No-Code-freundlicher Pfad vorbereitet.
+6. Zweite Test-Repo wurde erstellt und auf denselben Stand synchronisiert.
+
+---
+
+## Chronologische Chronik (kompakt)
+
+### 1) Deploy-Fix gestartet
+- Anfrage: Deploy wieder stabil machen.
+- Arbeiten:
+  - Build-/Deploy-Pfad analysiert (`deploy/deploy.sh`, Client/Server package-Dateien).
+  - Fehlende Build-Abhaengigkeiten ergaenzt.
+  - Deploy-Script robuster gemacht (Node-Version-Upgrade-Logik, Build via package scripts).
+  - Zusaetzliche Build-Blocker im Server behoben.
+- Ergebnis: Lokale Builds gruen, Commit + Push + PR-Update.
+
+### 2) Nach Merge validiert
+- GitHub Actions auf `main` geprueft.
+- Ergebnis: Deploy-Workflow erfolgreich (`completed success`).
+
+### 3) GM-Link + Kurzanleitung + Script-Downloads
+- GM-Seite und knappe PlayCanvas-Schritte bereitgestellt.
+- Download-Links fuer:
+  - `didi-scene-bootstrap.js`
+  - `didi-scene-trigger.js`
+
+### 4) Live-Test auf Nutzerwunsch
+- Initialzustand: `/gm/*` teils falsch ausgeliefert (HTML statt JS), WS-Verhalten alt.
+- Nach Infra-/Routing-Korrekturen:
+  - GM-Konsole erreichbar
+  - PlayCanvas-Skripte korrekt erreichbar
+  - `welcome` + `scene_changed` inkl. `spawnPosition` vorhanden
+
+### 5) Schwarzer Bildschirm in PlayCanvas
+- Ursachen eingegrenzt:
+  - Host/WS-Aufloesung im Launch-Kontext
+  - Szene ohne sichtbare Geometrie
+- Gelieferte Fix-Anleitung:
+  - Kamera-/Root-/Trigger-Setup
+  - Ground-Testobjekt
+  - Root-Skalierung und Ziel-Entity fuer Bootstrap
+
+### 6) Editor-Fehler (rot) im Trigger/Collision-Bereich
+- Ursache: `Ammo module not found`.
+- Fix: Ammo importieren (`IMPORT AMMO`), Trigger/Rigidbody korrekt konfigurieren.
+
+### 7) Hierarchy-/Root-Feinabstimmung
+- `Root` Scale auf `1,1,1`.
+- Keine riesige Skalierung am Container.
+- Sichtbare Test-Geometrie als Child (`Ground_Test`).
+
+### 8) Publish-Fehler: `Import Map does not exist`
+- Fix:
+  - fehlerhaften Build entfernen
+  - Import Map auf none/leer oder Dummy-Datei setzen
+  - neu publishen
+
+### 9) Publish-Link geprueft
+- `https://playcanv.as/p/e2qxOtMp/` erreichbar.
+- Danach Sichtbarkeits-/Content-Checks empfohlen.
+
+### 10) GLB-Workflow und Strategiefragen
+- Klaerungen:
+  - Scene-ID vs. Dateiname
+  - Hybrid-Ansatz (statischer Hub + dynamische/prozedurale Welt)
+  - Mobile-Poly-/Performance-Richtwerte
+  - PlayCanvas rendert clientseitig (kein "unendliches Cloud-Polybudget")
+  - Ionic = App-Huelle, nicht 3D-Renderer
+
+### 11) "Mach alles fertig" (Asset-Swap ohne staendiges Editor-Gefummel)
+- Umgesetzt:
+  - `server/src/modules/world/AssetPoolResolver.ts` (neu)
+  - `game-data/world/asset-pools.json` (neu)
+  - `docs/WORLD_ASSET_POOLS.md` (neu)
+  - World-/Tick-/Client-Factory-Anpassungen
+  - `entity_sync` transportiert `modelUrl` aus `glbPath`
+  - Client laedt GLB modellgetrieben fuer World-Objekte
+- Ergebnis: `server` + `client` Build erfolgreich, Commit + Push + PR-Update.
+
+### 12) Wirksamkeit ohne Editor-Aufwand
+- Statuskommunikation:
+  - Code fertig
+  - Live-Wirksamkeit haengt von Merge/Deploy auf `main` ab
+  - Minimaler PlayCanvas-Aufwand bleibt fuer echte Asset-Platzierung
+
+### 13) Token-Frage
+- Antwort: Limits sind plan-/kontoabhaengig, Details in Dashboard/Billing.
+
+### 14) Zweite Repo/Testumgebung
+- Clone nach `/workspace/wasd-test-env`.
+- Test-Repo auf denselben Branch/Commit-Stand synchronisiert.
+
+### 15) Strategische Migration weg von PlayCanvas
+- Empfehlung: Rendering-Layer ersetzen, Backend/Protokoll beibehalten.
+- Best Path: Babylon.js (+ optional React).
+
+### 16) No-Code-Machbarkeit mit Babylon
+- Klare Aussage: deutlich stressfreier als PlayCanvas-Editor-Flow.
+- Hauptgrund: Alles codebasiert im Repo versioniert, kein externer Editor-Zwang.
+
+### 17) Kontextdokument angefragt
+- Datei `SESSION_CONTEXT.md` wurde in einer vorherigen Instanz bereits erstellt und verlinkt.
+- In dieser Instanz wird der Kontext erneut als Persistenzdatei gefuehrt.
+
+---
+
+## Relevante Artefakte (aus vorheriger Instanz, Auszug)
+
+### Deploy / Stabilitaet
+- `deploy/deploy.sh`
+- `client/package.json`
+- `server/package.json`
+
+### World / Asset-Swap
+- `server/src/modules/world/AssetPoolResolver.ts`
+- `server/src/modules/world/WorldObjectSystem.ts`
+- `server/src/modules/world/WorldSystem.ts`
+- `server/src/core/WorldTick.ts`
+- `client/src/engine/playcanvas/PlayCanvasEntityFactory.ts`
+- `client/src/engine/bridge/EntityViewModel.ts`
+- `game-data/world/asset-pools.json`
+- `docs/WORLD_ASSET_POOLS.md`
+
+### GM / PlayCanvas
+- `client/public/gm/index.html`
+- `client/public/gm/app.js`
+- `client/public/playcanvas/scripts/didi-scene-bootstrap.js`
+- `client/public/playcanvas/scripts/didi-scene-trigger.js`
+
+---
+
+## Follow-up aus dem letzten Austausch (Babylon)
+
+### Verbindliche Architektur-Empfehlung
+- Best Path: Babylon.js + React.
+- Serverseitige Logik so weit wie moeglich unveraendert lassen.
+- Ziel: geringes Risiko beim Exit aus PlayCanvas.
+
+### Warum Babylon hier besser passt
+- Kein externer Editor als Pflichtschritt.
+- Vollstaendig Git/versionierbar.
+- Agent kann autonom umsetzen:
+  - Szenenaufbau
+  - GLB-Import/Placement
+  - Trigger/Teleport
+  - Kamera/Input
+  - HUD/GM-UI
+  - WS-Anbindung an vorhandenes Protokoll
+
+### Dinge, die ggf. ausserhalb Code bleiben
+- DNS/Domain/SSL
+- Secrets/Infra-Freigaben
+- Deploy-Freigaben je nach Hosting
+
+---
+
+## Aktueller Status fuer Neustarts
+
+- Der Wissensstand fuer diese Session ist in dieser Datei persistiert.
+- Beim Neustart zuerst `SESSION_CONTEXT.md` lesen, danach mit Babylon-Migrationsschritten weitermachen.
+
+---
+
+## Naechste sinnvolle Schritte
+
+1. Exakte Babylon-Migrations-Checkliste pro Datei/Modul erstellen (erste 10 Dateien, Reihenfolge, unveraenderte Module markieren).
+2. Babylon-Client-Grundgeruest aufsetzen (React + Babylon + bestehendes WS-Protokoll).
+3. Feature-Paritaet fuer Kernfluss herstellen:
+   - Login/Welcome
+   - Scene change + Spawn
+   - GLB-World-Loader
+   - Trigger/Teleport
+4. GM-Hooks auf neuen Client adaptieren.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switch client runtime entrypoint from PlayCanvas boot to Babylon boot
- add Babylon engine bridge implementation (`BabylonAdapter`) compatible with existing `IEngineBridge` + `MMORPGClientCore`
- keep websocket/server protocol unchanged (`welcome`, `scene_changed`, `entity_sync` continue through current core flow)
- add Babylon dependencies and canvas bootstrap updates
- keep PlayCanvas code in repo for fallback/parallel migration safety
- add starter world asset pool system for incremental GLB replacement
  - new `server/src/modules/world/AssetPoolResolver.ts`
  - new `game-data/world/asset-pools.json`
  - world broadcast now includes `glbPath` for player/npc/loot/world objects
  - precedence: explicit GLBRegistry links first, then asset pools
  - client normalizes incoming `glbPath` to `modelUrl`
- upgrade external GM console with integrated Babylon asset admin panel
  - add Admin GLB controls in `/gm` UI (scan/list/link/unlink/quick register)
  - fix and harden GM UI bindings and IDs for reliable button behavior
  - improve preview updates (players + heat hotspots)
- add scanned-model dropdown UX in GM admin panel
  - selecting a scanned model now auto-fills link/register/pool path fields
- add no-code Asset Pool Editor in GM panel
  - new admin websocket commands in server:
    - `admin_glb_pool_get`
    - `admin_glb_pool_set`
    - `admin_glb_pool_remove`
    - `admin_glb_pool_set_default`
    - `admin_glb_pool_remove_default`
    - `admin_glb_pool_reload`
  - UI controls for load/reload/set/remove/default management
  - live JSON dump + hints in GM UI
  - persisted updates to `game-data/world/asset-pools.json` via resolver

## What works in this migration step
- Babylon scene boot + camera + ground + lighting
- entity create/update/destroy path from existing core
- chunk visualization path
- camera target following local player
- keyboard + existing UI/joystick input path
- model loading via GLB URLs and existing `modelUrl` mapping
- starter placeholder asset pools that can be replaced by your own GLBs without code changes
- in-browser GM admin workflow for asset link management
- in-browser no-code asset pool editing workflow

## Validation
- `npm run build` (client) passes
- `npm run build` (server) passes
- `node --check client/public/gm/app.js` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82ff7175-beef-46a6-8e14-2614089a7703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ff7175-beef-46a6-8e14-2614089a7703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

