### PR TITLE
fix(client): black-screen hardening with renderer fallback

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,6 +6,7 @@
     <title>Arelorian Client</title>
   </head>
   <body>
+    <canvas id="application-canvas"></canvas>
     <script>console.log("HTML loaded, starting main.ts");</script>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,8 @@
       "name": "areloria-client",
       "version": "0.2.0",
       "dependencies": {
+        "@babylonjs/core": "^9.0.0",
+        "@babylonjs/loaders": "^9.0.0",
         "firebase": "^11.0.0",
         "playcanvas": "^2.17.2",
         "three": "^0.169.0"
@@ -32,6 +34,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babylonjs/core": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.0.0.tgz",
+      "integrity": "sha512-Y4xbHFUw28X4EC5C7NOSzPCOaenxZQgztCB1QZ64y0C85FjZaq5DfWd6gy+EUYklbigmcMIFzCpLj78Wc8EwVw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@babylonjs/loaders": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-9.0.0.tgz",
+      "integrity": "sha512-zK8Mh5DmYOj6QILV1ljaEwNqSIxwPLKxFD0U6U8c9x5RbjcMGC0X5KUT05FIVr8tcZI2XCJp6LOd00Xj2NXPIA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@babylonjs/core": "^9.0.0",
+        "babylonjs-gltf2interface": "^9.0.0"
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {
@@ -1924,6 +1942,13 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/babylonjs-gltf2interface": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.0.0.tgz",
+      "integrity": "sha512-k2B6B39stVxJcATNqPGJp19732pQouZPGiMsa1uke3812ZPd2M3h2Xm+QHpRo9n8wPMFC2tPUVu+dSka0skR1w==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",

--- a/client/package.json
+++ b/client/package.json
@@ -9,15 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@babylonjs/core": "^9.0.0",
+    "@babylonjs/loaders": "^9.0.0",
     "firebase": "^11.0.0",
     "playcanvas": "^2.17.2",
     "three": "^0.169.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",
+    "@types/three": "^0.183.1",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
-    "@types/three": "^0.183.1",
     "typescript": "^5.6.0",
     "vite": "^5.4.0"
   }

--- a/client/public/gm/app.js
+++ b/client/public/gm/app.js
@@ -65,6 +65,19 @@ function bindClick(id, handler) {
 function renderAdminState() {
   safeSetValue("adminModels", JSON.stringify(state.admin.scannedModels, null, 2));
   safeSetValue("adminLinks", JSON.stringify(state.admin.links, null, 2));
+  const select = byId("adminModelSelect");
+  if (select) {
+    const current = select.value;
+    const options = ['<option value="">-- Select scanned GLB --</option>']
+      .concat(
+        state.admin.scannedModels.map((model) => `<option value="${model}">${model}</option>`)
+      )
+      .join("");
+    select.innerHTML = options;
+    if (current && state.admin.scannedModels.includes(current)) {
+      select.value = current;
+    }
+  }
 }
 
 function updatePreviewCanvas() {
@@ -371,6 +384,15 @@ function initBindings() {
 
   bindClick("adminScanBtn", () => cmd("admin_glb_scan"));
   bindClick("adminListBtn", () => cmd("admin_glb_list"));
+  const modelSelect = byId("adminModelSelect");
+  if (modelSelect) {
+    modelSelect.onchange = () => {
+      const selected = modelSelect.value;
+      if (!selected) return;
+      safeSetValue("adminGlbPath", selected);
+      safeSetValue("registerPath", selected);
+    };
+  }
   bindClick("adminLinkBtn", () =>
     cmd("admin_glb_link", {
       targetType: val("adminTargetType"),

--- a/client/public/gm/app.js
+++ b/client/public/gm/app.js
@@ -13,6 +13,10 @@ const state = {
     time: "00:00",
     heatmap: null,
   },
+  admin: {
+    scannedModels: [],
+    links: [],
+  },
 };
 
 function byId(id) {
@@ -28,9 +32,10 @@ function logLine(text, level = "info") {
 }
 
 function setStatus(text, ok) {
-  const el = byId("status");
+  const el = byId("connStatus");
+  if (!el) return;
   el.textContent = text;
-  el.className = ok ? "ok" : "bad";
+  el.className = ok ? "status ok" : "status err";
 }
 
 function send(payload) {
@@ -45,9 +50,28 @@ function send(payload) {
   state.ws.send(JSON.stringify(message));
 }
 
+function safeSetValue(id, value) {
+  const el = byId(id);
+  if (!el) return;
+  el.value = value;
+}
+
+function bindClick(id, handler) {
+  const el = byId(id);
+  if (!el) return;
+  el.onclick = handler;
+}
+
+function renderAdminState() {
+  safeSetValue("adminModels", JSON.stringify(state.admin.scannedModels, null, 2));
+  safeSetValue("adminLinks", JSON.stringify(state.admin.links, null, 2));
+}
+
 function updatePreviewCanvas() {
   const canvas = byId("preview");
+  if (!canvas) return;
   const ctx = canvas.getContext("2d");
+  if (!ctx) return;
   const w = canvas.width;
   const h = canvas.height;
   ctx.clearRect(0, 0, w, h);
@@ -135,8 +159,21 @@ function handleMessage(msg) {
     logLine(msg.message || "gm_status", msg.level === "error" ? "bad" : "ok");
     return;
   }
+  if (msg.type === "admin_glb_scan_result") {
+    state.admin.scannedModels = Array.isArray(msg.models) ? msg.models : [];
+    renderAdminState();
+    logLine(`Scanned ${state.admin.scannedModels.length} model(s).`, "ok");
+    return;
+  }
+  if (msg.type === "admin_glb_list_result") {
+    state.admin.links = Array.isArray(msg.links) ? msg.links : [];
+    renderAdminState();
+    logLine(`Loaded ${state.admin.links.length} link(s).`, "ok");
+    return;
+  }
   if (msg.type === "gm_player_list") {
     state.preview.players = msg.players || [];
+    renderPlayersTable();
     updatePreviewCanvas();
     return;
   }
@@ -146,6 +183,8 @@ function handleMessage(msg) {
     state.preview.weather = msg.world?.weather || "clear";
     state.preview.time = msg.world?.time || "00:00";
     state.preview.heatmap = msg.heatmap || null;
+    renderPlayersTable();
+    renderHeatList();
     updatePreviewCanvas();
     return;
   }
@@ -153,6 +192,49 @@ function handleMessage(msg) {
     logLine(msg.message || "Server error", "bad");
     return;
   }
+}
+
+function renderPlayersTable() {
+  const tbody = byId("playersTable");
+  if (!tbody) return;
+  const rows = (state.preview.players || [])
+    .map((p) => {
+      const role = p.role || "-";
+      const hp = Number.isFinite(Number(p.hp)) ? Number(p.hp) : "-";
+      const posX = Number.isFinite(Number(p.x)) ? Number(p.x).toFixed(1) : "-";
+      const posY = Number.isFinite(Number(p.y)) ? Number(p.y).toFixed(1) : "-";
+      const label = p.name || p.id || "unknown";
+      return `<tr><td>${label}</td><td>${posX}, ${posY}</td><td>${role}</td><td>${hp}</td></tr>`;
+    })
+    .join("");
+  tbody.innerHTML = rows || `<tr><td colspan="4" style="opacity:.7">No players</td></tr>`;
+}
+
+function renderHeatList() {
+  const box = byId("heatList");
+  if (!box) return;
+  const hm = state.preview.heatmap;
+  if (!hm || !Array.isArray(hm.grid)) {
+    box.innerHTML = `<div style="opacity:.7">No heatmap data yet.</div>`;
+    return;
+  }
+  const entries = [];
+  for (let r = 0; r < hm.grid.length; r++) {
+    const row = hm.grid[r] || [];
+    for (let c = 0; c < row.length; c++) {
+      const v = Number(row[c] || 0);
+      if (v > 0) entries.push({ r, c, v });
+    }
+  }
+  entries.sort((a, b) => b.v - a.v);
+  const top = entries.slice(0, 8);
+  if (top.length === 0) {
+    box.innerHTML = `<div style="opacity:.7">No hotspots yet.</div>`;
+    return;
+  }
+  box.innerHTML = top
+    .map((e, idx) => `<div class="heat-row"><span>#${idx + 1} Cell (${e.c}, ${e.r})</span><strong>${e.v}</strong></div>`)
+    .join("");
 }
 
 function connect() {
@@ -203,51 +285,59 @@ function cmd(type, payload = {}) {
 }
 
 function val(id) {
-  return byId(id).value.trim();
+  const el = byId(id);
+  if (!el || typeof el.value !== "string") return "";
+  return el.value.trim();
 }
 
 function initBindings() {
-  byId("connectBtn").onclick = connect;
-  byId("previewRefresh").onclick = () => {
+  bindClick("connectBtn", connect);
+  bindClick("previewRefresh", () => {
     cmd("gm_preview_request");
     cmd("gm_get_players");
-  };
-  byId("heatmapToggle").onclick = () => {
-    state.heatmapEnabled = !state.heatmapEnabled;
-    byId("heatmapToggle").textContent = state.heatmapEnabled ? "Heatmap ON" : "Heatmap OFF";
-    updatePreviewCanvas();
-  };
+  });
 
-  byId("weatherBtn").onclick = () => cmd("gm_set_weather", { weather: val("weather") || "clear" });
-  byId("timeBtn").onclick = () => cmd("gm_set_time", { time: Number(val("time")) || 12 });
-  byId("eventBtn").onclick = () =>
+  bindClick("heatmapToggle", () => {
+    state.heatmapEnabled = !state.heatmapEnabled;
+    const btn = byId("heatmapToggle");
+    if (btn) btn.textContent = state.heatmapEnabled ? "Heatmap ON" : "Heatmap OFF";
+    updatePreviewCanvas();
+  });
+
+  bindClick("weatherBtn", () => cmd("gm_set_weather", { weather: val("weather") || "clear" }));
+  bindClick("timeBtn", () => cmd("gm_set_time", { time: Number(val("worldTime")) || 12 }));
+  bindClick("eventBtn", () =>
     cmd("gm_world_event", {
       eventId: val("eventId") || "custom_event",
       title: val("eventTitle") || "Custom Event",
       description: val("eventDesc"),
-    });
-  byId("eventTemplateBtn").onclick = () =>
+    })
+  );
+  bindClick("eventTemplateBtn", () =>
     cmd("gm_run_event_template", {
       templateId: val("eventTemplate") || "legion_invasion",
       centerX: Number(val("eventCenterX")) || 0,
       centerY: Number(val("eventCenterY")) || 0,
-    });
-  byId("broadcastBtn").onclick = () =>
-    cmd("gm_broadcast", { channel: "system", message: val("broadcastText"), color: "#ffd700" });
+    })
+  );
+  bindClick("broadcastBtn", () =>
+    cmd("gm_broadcast", { channel: "system", message: val("broadcastText"), color: "#ffd700" })
+  );
 
-  byId("spawnNpcBtn").onclick = () =>
+  bindClick("spawnNpcBtn", () =>
     cmd("gm_spawn_npc", {
       npcId: val("npcId") || `npc_${Date.now()}`,
       name: val("npcName") || val("npcId"),
       x: Number(val("npcX")) || 0,
       y: Number(val("npcY")) || 0,
       hp: Number(val("npcHp")) || 100,
-    });
-  byId("removeNpcBtn").onclick = () => cmd("gm_remove_npc", { npcId: val("npcId") });
-  byId("dialogueBtn").onclick = () =>
-    cmd("gm_save_dialogue", { npcId: val("npcId"), text: val("dialogueText"), choices: [] });
-
-  byId("questBtn").onclick = () =>
+    })
+  );
+  bindClick("removeNpcBtn", () => cmd("gm_remove_npc", { npcId: val("removeNpcId") || val("npcId") }));
+  bindClick("dialogueBtn", () =>
+    cmd("gm_save_dialogue", { npcId: val("npcId"), text: val("dialogueText"), choices: [] })
+  );
+  bindClick("questBtn", () =>
     cmd("gm_create_quest", {
       questId: val("questId") || `quest_${Date.now()}`,
       title: val("questTitle") || "Untitled Quest",
@@ -255,30 +345,75 @@ function initBindings() {
       category: "world",
       level: Number(val("questLevel")) || 1,
       rewards: { xp: Number(val("questXp")) || 100, gold: Number(val("questGold")) || 50 },
-    });
+    })
+  );
 
-  byId("tpBtn").onclick = () =>
-    cmd("gm_teleport", { player: val("playerName"), x: Number(val("tpX")) || 0, y: Number(val("tpY")) || 0 });
-  byId("kickBtn").onclick = () => cmd("gm_kick", { player: val("playerName") });
-  byId("banBtn").onclick = () => cmd("gm_ban", { player: val("playerName") });
-  byId("unbanBtn").onclick = () => cmd("gm_unban", { player: val("playerName") });
-  byId("muteBtn").onclick = () => cmd("gm_mute", { player: val("playerName") });
-  byId("unmuteBtn").onclick = () => cmd("gm_unmute", { player: val("playerName") });
-  byId("promoteBtn").onclick = () => cmd("gm_promote", { player: val("playerName") });
+  bindClick("tpBtn", () =>
+    cmd("gm_teleport", {
+      player: val("playerName"),
+      x: Number(val("tpX")) || 0,
+      y: Number(val("tpY")) || 0,
+    })
+  );
+  bindClick("kickBtn", () => cmd("gm_kick", { player: val("playerName") }));
+  bindClick("banBtn", () => cmd("gm_ban", { player: val("playerName") }));
+  bindClick("unbanBtn", () => cmd("gm_unban", { player: val("playerName") }));
+  bindClick("muteBtn", () => cmd("gm_mute", { player: val("playerName") }));
+  bindClick("unmuteBtn", () => cmd("gm_unmute", { player: val("playerName") }));
+  bindClick("promoteBtn", () => cmd("gm_promote", { player: val("playerName") }));
+  bindClick("sceneHub", () => cmd("scene_change", { sceneId: "didis_hub", spawnKey: "sp_player_default" }));
+  bindClick("sceneD1", () => cmd("scene_change", { sceneId: "didis_hub", spawnKey: "sp_didi_01" }));
+  bindClick("sceneD2", () => cmd("scene_change", { sceneId: "didis_hub", spawnKey: "sp_didi_02" }));
 
-  byId("sceneHub").onclick = () => cmd("scene_change", { sceneId: "didis_hub", spawnKey: "sp_player_default" });
-  byId("sceneD1").onclick = () => cmd("scene_change", { sceneId: "didis_hub", spawnKey: "sp_didi_01" });
-  byId("sceneD2").onclick = () => cmd("scene_change", { sceneId: "didis_hub", spawnKey: "sp_didi_02" });
+  bindClick("setPriceBtn", () =>
+    cmd("gm_set_price", { itemId: val("priceItem"), buy: Number(val("priceBuy")) || 1 })
+  );
+
+  bindClick("adminScanBtn", () => cmd("admin_glb_scan"));
+  bindClick("adminListBtn", () => cmd("admin_glb_list"));
+  bindClick("adminLinkBtn", () =>
+    cmd("admin_glb_link", {
+      targetType: val("adminTargetType"),
+      targetId: val("adminTargetId"),
+      glbPath: val("adminGlbPath"),
+    })
+  );
+  bindClick("adminUnlinkBtn", () =>
+    cmd("admin_glb_unlink", {
+      targetType: val("adminTargetType"),
+      targetId: val("adminTargetId"),
+    })
+  );
+  bindClick("registerGlbBtn", () =>
+    cmd("gm_register_glb", {
+      category: val("registerCategory") || "object",
+      name: val("registerName"),
+      path: val("registerPath"),
+    })
+  );
+  bindClick("copyFirstModelBtn", () => {
+    const first = state.admin.scannedModels[0];
+    if (!first) {
+      logLine("No scanned model available yet.", "bad");
+      return;
+    }
+    safeSetValue("adminGlbPath", first);
+    safeSetValue("registerPath", first);
+    logLine(`Prefilled model path: ${first}`, "ok");
+  });
 }
 
 function bootstrapDefaults() {
   const loc = window.location;
   const wsProto = loc.protocol === "https:" ? "wss" : "ws";
-  byId("wsUrl").value = `${wsProto}://${loc.host}/ws`;
-  byId("eventCenterX").value = "0";
-  byId("eventCenterY").value = "0";
+  safeSetValue("wsUrl", `${wsProto}://${loc.host}/ws`);
+  safeSetValue("adminTargetType", "object_group");
+  safeSetValue("registerCategory", "object");
 }
 
 bootstrapDefaults();
 initBindings();
+renderAdminState();
+renderPlayersTable();
+renderHeatList();
 updatePreviewCanvas();

--- a/client/public/gm/app.js
+++ b/client/public/gm/app.js
@@ -16,6 +16,7 @@ const state = {
   admin: {
     scannedModels: [],
     links: [],
+    pools: null,
   },
 };
 
@@ -65,6 +66,17 @@ function bindClick(id, handler) {
 function renderAdminState() {
   safeSetValue("adminModels", JSON.stringify(state.admin.scannedModels, null, 2));
   safeSetValue("adminLinks", JSON.stringify(state.admin.links, null, 2));
+  safeSetValue("assetPoolsJson", JSON.stringify(state.admin.pools ?? { version: 1, defaults: {}, pools: {} }, null, 2));
+  safeSetValue(
+    "assetPoolHints",
+    [
+      "Tips:",
+      "- category aliases: npc -> npcs, monster -> monsters, object -> world_objects",
+      "- path can be a single GLB or comma-separated list for deterministic variant rotation",
+      "- entry example: category=world_objects, key=house, path=/assets/models/buildings/house_01.glb",
+      "- default example: category=world_objects, path=/assets/models/objects/chest.glb",
+    ].join("\n")
+  );
   const select = byId("adminModelSelect");
   if (select) {
     const current = select.value;
@@ -78,6 +90,33 @@ function renderAdminState() {
       select.value = current;
     }
   }
+}
+
+function parseEntryInput(raw) {
+  const trimmed = String(raw || "").trim();
+  if (!trimmed) return null;
+  if (trimmed.includes(",")) {
+    const parts = trimmed
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    return parts.length > 0 ? parts : null;
+  }
+  return trimmed;
+}
+
+function applySelectedModelPath() {
+  const modelSelect = byId("adminModelSelect");
+  if (!modelSelect) return;
+  const selected = modelSelect.value;
+  if (!selected) {
+    logLine("Please select a scanned GLB first.", "bad");
+    return;
+  }
+  safeSetValue("adminGlbPath", selected);
+  safeSetValue("registerPath", selected);
+  safeSetValue("poolPath", selected);
+  logLine(`Prefilled model path: ${selected}`, "ok");
 }
 
 function updatePreviewCanvas() {
@@ -162,6 +201,8 @@ function handleMessage(msg) {
     logLine(`Logged in as ${state.playerId || "unknown"}`, "ok");
     send({ type: "gm_preview_request" });
     send({ type: "gm_get_players" });
+    send({ type: "admin_glb_list" });
+    send({ type: "admin_glb_pool_get" });
     return;
   }
   if (msg.type === "entity_sync") {
@@ -182,6 +223,13 @@ function handleMessage(msg) {
     state.admin.links = Array.isArray(msg.links) ? msg.links : [];
     renderAdminState();
     logLine(`Loaded ${state.admin.links.length} link(s).`, "ok");
+    return;
+  }
+  if (msg.type === "admin_glb_pool_result") {
+    state.admin.pools = msg.pools || { version: 1, defaults: {}, pools: {} };
+    renderAdminState();
+    const categories = Object.keys(state.admin.pools?.pools || {});
+    logLine(`Asset pools synced (${categories.length} categories).`, "ok");
     return;
   }
   if (msg.type === "gm_player_list") {
@@ -384,15 +432,13 @@ function initBindings() {
 
   bindClick("adminScanBtn", () => cmd("admin_glb_scan"));
   bindClick("adminListBtn", () => cmd("admin_glb_list"));
+  bindClick("poolLoadBtn", () => cmd("admin_glb_pool_get"));
+  bindClick("poolReloadBtn", () => cmd("admin_glb_pool_reload"));
   const modelSelect = byId("adminModelSelect");
   if (modelSelect) {
-    modelSelect.onchange = () => {
-      const selected = modelSelect.value;
-      if (!selected) return;
-      safeSetValue("adminGlbPath", selected);
-      safeSetValue("registerPath", selected);
-    };
+    modelSelect.onchange = applySelectedModelPath;
   }
+  bindClick("applySelectedModelBtn", applySelectedModelPath);
   bindClick("adminLinkBtn", () =>
     cmd("admin_glb_link", {
       targetType: val("adminTargetType"),
@@ -413,6 +459,42 @@ function initBindings() {
       path: val("registerPath"),
     })
   );
+  bindClick("poolSetBtn", () => {
+    const category = val("poolCategory");
+    const key = val("poolKey");
+    const entry = parseEntryInput(val("poolPath"));
+    if (!category || !key || !entry) {
+      logLine("Pool set requires category, key and path.", "bad");
+      return;
+    }
+    cmd("admin_glb_pool_set", { category, key, path: entry });
+  });
+  bindClick("poolRemoveBtn", () => {
+    const category = val("poolCategory");
+    const key = val("poolKey");
+    if (!category || !key) {
+      logLine("Pool remove requires category and key.", "bad");
+      return;
+    }
+    cmd("admin_glb_pool_remove", { category, key });
+  });
+  bindClick("poolSetDefaultBtn", () => {
+    const category = val("poolCategory");
+    const entry = parseEntryInput(val("poolPath"));
+    if (!category || !entry) {
+      logLine("Default set requires category and path.", "bad");
+      return;
+    }
+    cmd("admin_glb_pool_set_default", { category, path: entry });
+  });
+  bindClick("poolRemoveDefaultBtn", () => {
+    const category = val("poolCategory");
+    if (!category) {
+      logLine("Default remove requires category.", "bad");
+      return;
+    }
+    cmd("admin_glb_pool_remove_default", { category });
+  });
   bindClick("copyFirstModelBtn", () => {
     const first = state.admin.scannedModels[0];
     if (!first) {
@@ -421,6 +503,7 @@ function initBindings() {
     }
     safeSetValue("adminGlbPath", first);
     safeSetValue("registerPath", first);
+    safeSetValue("poolPath", first);
     logLine(`Prefilled model path: ${first}`, "ok");
   });
 }
@@ -431,6 +514,7 @@ function bootstrapDefaults() {
   safeSetValue("wsUrl", `${wsProto}://${loc.host}/ws`);
   safeSetValue("adminTargetType", "object_group");
   safeSetValue("registerCategory", "object");
+  safeSetValue("poolCategory", "world_objects");
 }
 
 bootstrapDefaults();

--- a/client/public/gm/index.html
+++ b/client/public/gm/index.html
@@ -246,25 +246,33 @@
                 <option value="fog">fog</option>
                 <option value="snow">snow</option>
               </select>
-              <button onclick="gmSetWeather()">Set Weather</button>
+              <button id="weatherBtn">Set Weather</button>
             </div>
             <div class="row">
               <input id="worldTime" type="number" min="0" max="23" value="12" />
-              <button onclick="gmSetTime()">Set Time</button>
+              <button id="timeBtn">Set Time</button>
+            </div>
+            <div class="row">
+              <input id="eventId" placeholder="event id" value="custom_event" />
+              <button id="eventBtn" class="warn">Trigger Event</button>
             </div>
             <div class="row">
               <input id="eventTitle" placeholder="Event title" value="Legion Invasion" />
-              <button class="warn" onclick="gmEvent()">Trigger Event</button>
+              <input id="eventDesc" placeholder="Event description" value="Demons have breached the eastern gate." />
             </div>
-            <textarea id="eventDesc" placeholder="Event description">Demons have breached the eastern gate.</textarea>
-            <div class="row" style="margin-top:8px;">
+            <div class="row3" style="margin-top:8px;">
               <select id="eventTemplate">
                 <option value="">-- Select Event Template --</option>
                 <option value="legion_invasion">Legion Invasion</option>
                 <option value="city_defense">City Defense</option>
                 <option value="world_boss_hunt">World Boss Hunt</option>
               </select>
-              <button class="warn" onclick="gmRunTemplate()">Run Template</button>
+              <input id="eventCenterX" type="number" value="0" placeholder="center x" />
+              <input id="eventCenterY" type="number" value="0" placeholder="center y" />
+            </div>
+            <div class="row" style="margin-top:8px;">
+              <button id="eventTemplateBtn" class="warn">Run Template</button>
+              <button id="heatmapToggle" class="secondary">Heatmap ON</button>
             </div>
           </div>
 
@@ -277,32 +285,58 @@
             </div>
             <div class="row">
               <input id="npcName" placeholder="npc name" value="Event Guardian" />
-              <button onclick="gmSpawnNpc()">Spawn NPC</button>
+              <input id="npcHp" type="number" placeholder="hp" value="100" />
+            </div>
+            <div class="row">
+              <button id="spawnNpcBtn">Spawn NPC</button>
+              <button id="removeNpcBtn" class="bad">Remove NPC</button>
             </div>
             <div class="row">
               <input id="removeNpcId" placeholder="npc id to remove" />
-              <button class="bad" onclick="gmRemoveNpc()">Remove NPC</button>
+              <input id="dialogueText" placeholder="dialogue text for npc" value="Greetings, traveler." />
+            </div>
+            <div class="row">
+              <button id="dialogueBtn" class="secondary">Save Dialogue</button>
+              <button id="questBtn" class="secondary">Create Quest</button>
+            </div>
+            <div class="row3">
+              <input id="questId" placeholder="quest id" value="quest_demo_1" />
+              <input id="questTitle" placeholder="quest title" value="Scout the area" />
+              <input id="questDesc" placeholder="quest description" value="Check the nearby ruins." />
+            </div>
+            <div class="row3">
+              <input id="questLevel" type="number" placeholder="level" value="1" />
+              <input id="questXp" type="number" placeholder="xp reward" value="100" />
+              <input id="questGold" type="number" placeholder="gold reward" value="50" />
             </div>
           </div>
 
           <div class="group">
             <h3>Players / Moderation</h3>
             <div class="row3">
-              <input id="targetPlayer" placeholder="player id/name" />
+              <input id="playerName" placeholder="player id/name" />
               <input id="tpX" type="number" placeholder="x" />
               <input id="tpY" type="number" placeholder="y" />
             </div>
             <div class="row">
-              <button onclick="gmTeleport()">Teleport</button>
-              <button class="warn" onclick="gmKick()">Kick</button>
+              <button id="tpBtn">Teleport</button>
+              <button id="kickBtn" class="warn">Kick</button>
             </div>
             <div class="row">
-              <button class="bad" onclick="gmBan()">Ban</button>
-              <button onclick="gmUnban()">Unban</button>
+              <button id="banBtn" class="bad">Ban</button>
+              <button id="unbanBtn">Unban</button>
             </div>
             <div class="row">
-              <button onclick="gmMute()">Mute</button>
-              <button onclick="gmUnmute()">Unmute</button>
+              <button id="muteBtn">Mute</button>
+              <button id="unmuteBtn">Unmute</button>
+            </div>
+            <div class="row">
+              <button id="promoteBtn" class="secondary">Promote GM</button>
+              <button id="sceneHub" class="secondary">Go Hub Spawn</button>
+            </div>
+            <div class="row">
+              <button id="sceneD1" class="secondary">Go Didi 1</button>
+              <button id="sceneD2" class="secondary">Go Didi 2</button>
             </div>
           </div>
 
@@ -311,11 +345,47 @@
             <div class="row3">
               <input id="priceItem" placeholder="item id" value="health_potion" />
               <input id="priceBuy" type="number" placeholder="buy" value="80" />
-              <button onclick="gmSetPrice()">Set Price</button>
+              <button id="setPriceBtn">Set Price</button>
             </div>
             <div class="row">
-              <input id="bcText" placeholder="broadcast text" value="Server maintenance in 10 minutes." />
-              <button onclick="gmBroadcast()">Broadcast</button>
+              <input id="broadcastText" placeholder="broadcast text" value="Server maintenance in 10 minutes." />
+              <button id="broadcastBtn">Broadcast</button>
+            </div>
+          </div>
+
+          <div class="group">
+            <h3>Admin GLB Asset Linking (Babylon)</h3>
+            <div class="row">
+              <button id="adminScanBtn">Scan Server GLBs</button>
+              <button id="adminListBtn" class="secondary">Refresh Links</button>
+            </div>
+            <div class="row3">
+              <select id="adminTargetType">
+                <option value="object_group">object_group</option>
+                <option value="object_single">object_single</option>
+                <option value="npc_group">npc_group</option>
+                <option value="npc_single">npc_single</option>
+                <option value="monster_group">monster_group</option>
+              </select>
+              <input id="adminTargetId" placeholder="targetId (e.g. house, npc_1)" />
+              <input id="adminGlbPath" placeholder="/assets/models/..." />
+            </div>
+            <div class="row">
+              <button id="adminLinkBtn">Link GLB</button>
+              <button id="adminUnlinkBtn" class="bad">Unlink</button>
+            </div>
+            <div class="row3">
+              <input id="registerCategory" placeholder="category (npc/object/monster)" value="object" />
+              <input id="registerName" placeholder="name/key (e.g. house)" />
+              <input id="registerPath" placeholder="/assets/models/...glb" />
+            </div>
+            <div class="row">
+              <button id="registerGlbBtn" class="secondary">Quick Register (gm_register_glb)</button>
+              <button id="copyFirstModelBtn" class="secondary">Use First Scanned Model</button>
+            </div>
+            <div class="row">
+              <textarea id="adminModels" rows="4" placeholder="Scanned models appear here"></textarea>
+              <textarea id="adminLinks" rows="4" placeholder="Active GLB links appear here"></textarea>
             </div>
           </div>
         </div>

--- a/client/public/gm/index.html
+++ b/client/public/gm/index.html
@@ -394,6 +394,31 @@
               <textarea id="adminLinks" rows="4" placeholder="Active GLB links appear here"></textarea>
             </div>
           </div>
+
+          <div class="group">
+            <h3>Asset Pool Editor (No-Code Mapping)</h3>
+            <div class="row">
+              <button id="poolLoadBtn">Load Pools</button>
+              <button id="poolReloadBtn" class="secondary">Reload From Disk</button>
+            </div>
+            <div class="row3">
+              <input id="poolCategory" placeholder="category (world_objects, npcs, monsters...)" value="world_objects" />
+              <input id="poolKey" placeholder="key (e.g. house)" value="house" />
+              <input id="poolPath" placeholder="/assets/models/...glb" />
+            </div>
+            <div class="row">
+              <button id="poolSetBtn">Set Entry</button>
+              <button id="poolRemoveBtn" class="bad">Remove Entry</button>
+            </div>
+            <div class="row">
+              <button id="poolSetDefaultBtn" class="secondary">Set Default for Category</button>
+              <button id="poolRemoveDefaultBtn" class="secondary">Remove Category Default</button>
+            </div>
+            <div class="row">
+              <textarea id="assetPoolsJson" rows="8" placeholder="Asset pools JSON appears here"></textarea>
+              <textarea id="assetPoolHints" rows="8" placeholder="Hints and quick usage info"></textarea>
+            </div>
+          </div>
         </div>
 
         <div class="preview">

--- a/client/public/gm/index.html
+++ b/client/public/gm/index.html
@@ -359,6 +359,12 @@
               <button id="adminScanBtn">Scan Server GLBs</button>
               <button id="adminListBtn" class="secondary">Refresh Links</button>
             </div>
+            <div class="row">
+              <select id="adminModelSelect">
+                <option value="">-- Scan models first --</option>
+              </select>
+              <button id="applySelectedModelBtn" class="secondary">Use Selected Model</button>
+            </div>
             <div class="row3">
               <select id="adminTargetType">
                 <option value="object_group">object_group</option>

--- a/client/src/engine/babylon/BabylonAdapter.ts
+++ b/client/src/engine/babylon/BabylonAdapter.ts
@@ -1,0 +1,385 @@
+import {
+  AbstractMesh,
+  ArcRotateCamera,
+  AssetContainer,
+  Color3,
+  DynamicTexture,
+  Mesh,
+  MeshBuilder,
+  Quaternion,
+  Scene,
+  SceneLoader,
+  StandardMaterial,
+  TransformNode,
+  Vector3,
+} from "@babylonjs/core";
+import "@babylonjs/loaders/glTF";
+import { IEngineBridge } from "../bridge/IEngineBridge";
+import { EntityViewModel } from "../bridge/EntityViewModel";
+import { AssetRegistry } from "../playcanvas/AssetRegistry";
+
+type EntityNode = {
+  root: TransformNode;
+  visual: TransformNode | AbstractMesh;
+  label?: Mesh;
+};
+
+const DEFAULT_MODEL_BY_TYPE: Record<string, string> = {
+  player: AssetRegistry.Npc_warrior ?? "/world-assets/characters/Npc_warrior.glb",
+  npc: AssetRegistry.Questnpc_uschi ?? "/world-assets/characters/Questnpc_uschi.glb",
+  monster: AssetRegistry.boar01 ?? "/world-assets/monsters/boar01.glb",
+};
+
+export class BabylonAdapter implements IEngineBridge {
+  private readonly entities = new Map<string, EntityNode>();
+  private readonly chunks = new Map<string, TransformNode>();
+  private readonly loadedModels = new Map<string, AssetContainer>();
+  private readonly modelAttachQueue = new Map<string, string>();
+  private readonly pressedKeys = new Set<string>();
+  private readonly inputCallbacks: Array<(input: any) => void> = [];
+  private cameraTargetId: string | null = null;
+  private navigationMarker: Mesh | null = null;
+  private localPlayerId: string | null = null;
+  private labelMaterialCounter = 0;
+
+  constructor(
+    private readonly scene: Scene,
+    private readonly camera: ArcRotateCamera
+  ) {
+    this.bindKeyboard();
+  }
+
+  createEntity(model: EntityViewModel): void {
+    const root = new TransformNode(model.id, this.scene);
+    root.position = new Vector3(model.position.x, model.position.y, model.position.z);
+    root.rotation = new Vector3(
+      this.toRadians(model.rotation.x),
+      this.toRadians(model.rotation.y),
+      this.toRadians(model.rotation.z)
+    );
+    root.setEnabled(model.visible ?? true);
+
+    const placeholder = this.createPlaceholderMesh(model);
+    placeholder.parent = root;
+
+    const node: EntityNode = { root, visual: placeholder };
+    if (model.name) {
+      node.label = this.createBillboardLabel(model.name, this.colorForType(model.type), root);
+    }
+
+    this.entities.set(model.id, node);
+    this.tryAttachModel(model.id, model.modelUrl ?? DEFAULT_MODEL_BY_TYPE[model.type]);
+  }
+
+  updateEntity(id: string, updates: Partial<EntityViewModel>, dt: number = 0.016): void {
+    const node = this.entities.get(id);
+    if (!node) return;
+
+    const lerpAlpha = Math.min(1, Math.max(0.12, dt * 12));
+    if (updates.position) {
+      const target = new Vector3(updates.position.x, updates.position.y, updates.position.z);
+      node.root.position = Vector3.Lerp(node.root.position, target, lerpAlpha);
+    }
+    if (updates.rotation) {
+      const targetEuler = new Vector3(
+        this.toRadians(updates.rotation.x),
+        this.toRadians(updates.rotation.y),
+        this.toRadians(updates.rotation.z)
+      );
+      node.root.rotation = Vector3.Lerp(node.root.rotation, targetEuler, lerpAlpha);
+    }
+    if (updates.visible !== undefined) {
+      node.root.setEnabled(updates.visible);
+    }
+    if (updates.name) {
+      if (node.label) {
+        node.label.dispose();
+      }
+      node.label = this.createBillboardLabel(
+        updates.name,
+        this.colorForType(updates.type ?? this.inferTypeFromEntityId(id)),
+        node.root
+      );
+    }
+    if (updates.modelUrl) {
+      this.tryAttachModel(id, updates.modelUrl);
+    }
+  }
+
+  destroyEntity(id: string): void {
+    const node = this.entities.get(id);
+    if (!node) return;
+    node.root.dispose(false, true);
+    this.entities.delete(id);
+    if (this.cameraTargetId === id) {
+      this.cameraTargetId = null;
+    }
+    if (this.localPlayerId === id) {
+      this.localPlayerId = null;
+    }
+  }
+
+  setCameraTarget(entityId: string): void {
+    this.cameraTargetId = entityId;
+    this.localPlayerId = entityId;
+  }
+
+  async loadModel(url: string): Promise<any> {
+    return this.loadModelContainer(url);
+  }
+
+  createChunk(chunk: any): void {
+    if (this.chunks.has(chunk.id)) return;
+    const root = new TransformNode(`Chunk_${chunk.id}`, this.scene);
+    root.position = new Vector3(chunk.chunkX * 16, 0, chunk.chunkY * 16);
+    const ground = MeshBuilder.CreateGround(
+      `Chunk_${chunk.id}_ground`,
+      { width: 16, height: 16, subdivisions: 1 },
+      this.scene
+    );
+    ground.parent = root;
+    ground.position.y = -0.01;
+    const mat = new StandardMaterial(`Chunk_${chunk.id}_mat`, this.scene);
+    mat.diffuseColor = new Color3(0.22, 0.24, 0.28);
+    mat.specularColor = new Color3(0, 0, 0);
+    ground.material = mat;
+    this.chunks.set(chunk.id, root);
+  }
+
+  destroyChunk(id: string): void {
+    const chunk = this.chunks.get(id);
+    if (!chunk) return;
+    chunk.dispose(false, true);
+    this.chunks.delete(id);
+  }
+
+  setNavigationTarget(position: { x: number; y: number; z: number } | null): void {
+    if (!position) {
+      if (this.navigationMarker) this.navigationMarker.setEnabled(false);
+      return;
+    }
+    if (!this.navigationMarker) {
+      this.navigationMarker = MeshBuilder.CreateTorus(
+        "navigation-marker",
+        { diameter: 1.5, thickness: 0.08, tessellation: 32 },
+        this.scene
+      );
+      const mat = new StandardMaterial("navigation-marker-mat", this.scene);
+      mat.emissiveColor = new Color3(0.2, 0.9, 0.3);
+      mat.diffuseColor = new Color3(0.2, 0.9, 0.3);
+      this.navigationMarker.material = mat;
+      this.navigationMarker.rotation.x = Math.PI / 2;
+    }
+    this.navigationMarker.setEnabled(true);
+    this.navigationMarker.position = new Vector3(position.x, position.y + 0.08, position.z);
+  }
+
+  triggerEntityAction(entityId: string, action: string): void {
+    const node = this.entities.get(entityId);
+    if (!node) return;
+    if (action === "attack") {
+      node.root.scaling = new Vector3(1.12, 1.12, 1.12);
+      setTimeout(() => {
+        const latest = this.entities.get(entityId);
+        if (latest) latest.root.scaling = new Vector3(1, 1, 1);
+      }, 120);
+    }
+  }
+
+  playSound(_name: string): void {
+    // Kept as no-op for first migration step.
+  }
+
+  onInput(callback: (input: any) => void): void {
+    this.inputCallbacks.push(callback);
+  }
+
+  update(_dt: number): void {
+    this.updateCameraFollow();
+  }
+
+  private updateCameraFollow(): void {
+    if (!this.cameraTargetId) return;
+    const targetNode = this.entities.get(this.cameraTargetId);
+    if (!targetNode) return;
+    const desiredTarget = targetNode.root.position.add(new Vector3(0, 1.4, 0));
+    this.camera.target = Vector3.Lerp(this.camera.target, desiredTarget, 0.16);
+  }
+
+  private bindKeyboard(): void {
+    window.addEventListener("keydown", (event) => {
+      const key = event.key.toLowerCase();
+      if (["w", "a", "s", "d"].includes(key) && !this.pressedKeys.has(key)) {
+        this.pressedKeys.add(key);
+        this.emitInput({ type: "keydown", key });
+      }
+      if (event.code === "Space") {
+        this.emitAttack();
+      }
+      if (key === "e") {
+        this.emitInteract();
+      }
+    });
+
+    window.addEventListener("keyup", (event) => {
+      const key = event.key.toLowerCase();
+      if (["w", "a", "s", "d"].includes(key) && this.pressedKeys.has(key)) {
+        this.pressedKeys.delete(key);
+        this.emitInput({ type: "keyup", key });
+      }
+    });
+  }
+
+  private emitInput(input: any): void {
+    for (const callback of this.inputCallbacks) {
+      callback(input);
+    }
+  }
+
+  private emitAttack(): void {
+    const gameCore = (window as any).gameCore;
+    if (gameCore && typeof gameCore.attack === "function") {
+      gameCore.attack();
+    }
+  }
+
+  private emitInteract(): void {
+    const gameCore = (window as any).gameCore;
+    if (gameCore && typeof gameCore.interact === "function") {
+      gameCore.interact();
+    }
+  }
+
+  private createPlaceholderMesh(model: EntityViewModel): Mesh {
+    const color = this.colorForType(model.type);
+    let mesh: Mesh;
+    if (model.type === "player") {
+      mesh = MeshBuilder.CreateCapsule(`${model.id}_capsule`, { height: 1.8, radius: 0.35 }, this.scene);
+    } else if (model.type === "npc") {
+      mesh = MeshBuilder.CreateCylinder(`${model.id}_npc`, { height: 1.6, diameter: 0.65 }, this.scene);
+    } else if (model.type === "monster") {
+      mesh = MeshBuilder.CreateBox(`${model.id}_monster`, { size: 1.1 }, this.scene);
+    } else {
+      mesh = MeshBuilder.CreateBox(`${model.id}_box`, { size: 0.9 }, this.scene);
+    }
+    const mat = new StandardMaterial(`${model.id}_placeholder_mat`, this.scene);
+    mat.diffuseColor = color;
+    mat.specularColor = new Color3(0, 0, 0);
+    mesh.material = mat;
+    mesh.isPickable = false;
+    return mesh;
+  }
+
+  private createBillboardLabel(
+    text: string,
+    color: Color3,
+    parent: TransformNode
+  ): Mesh {
+    const plane = MeshBuilder.CreatePlane(
+      `label_${parent.name}_${this.labelMaterialCounter++}`,
+      { width: 1.7, height: 0.42 },
+      this.scene
+    );
+    plane.parent = parent;
+    plane.position = new Vector3(0, 2.3, 0);
+    plane.billboardMode = Mesh.BILLBOARDMODE_ALL;
+    plane.isPickable = false;
+
+    const texture = new DynamicTexture(
+      `label_tex_${parent.name}_${this.labelMaterialCounter}`,
+      { width: 512, height: 128 },
+      this.scene,
+      false
+    );
+    texture.hasAlpha = true;
+    const ctx = texture.getContext();
+    if (ctx) {
+      ctx.clearRect(0, 0, 512, 128);
+      ctx.fillStyle = "rgba(0,0,0,0.35)";
+      ctx.fillRect(8, 10, 496, 108);
+      ctx.fillStyle = `rgb(${Math.round(color.r * 255)},${Math.round(color.g * 255)},${Math.round(
+        color.b * 255
+      )})`;
+      ctx.font = "bold 58px sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(text, 256, 64);
+      texture.update();
+    }
+
+    const mat = new StandardMaterial(`label_mat_${parent.name}_${this.labelMaterialCounter}`, this.scene);
+    mat.diffuseTexture = texture;
+    mat.emissiveColor = new Color3(1, 1, 1);
+    mat.specularColor = new Color3(0, 0, 0);
+    mat.backFaceCulling = false;
+    mat.disableLighting = true;
+    plane.material = mat;
+    return plane;
+  }
+
+  private async loadModelContainer(url: string): Promise<AssetContainer> {
+    const existing = this.loadedModels.get(url);
+    if (existing) {
+      return existing;
+    }
+    const splitIdx = url.lastIndexOf("/");
+    const rootUrl = splitIdx >= 0 ? url.slice(0, splitIdx + 1) : "/";
+    const fileName = splitIdx >= 0 ? url.slice(splitIdx + 1) : url;
+    const container = await SceneLoader.LoadAssetContainerAsync(rootUrl, fileName, this.scene);
+    this.loadedModels.set(url, container);
+    return container;
+  }
+
+  private async tryAttachModel(entityId: string, url?: string): Promise<void> {
+    if (!url) return;
+    const entity = this.entities.get(entityId);
+    if (!entity) return;
+
+    this.modelAttachQueue.set(entityId, url);
+    const expectedUrl = url;
+    try {
+      const container = await this.loadModelContainer(url);
+      if (this.modelAttachQueue.get(entityId) !== expectedUrl) {
+        return;
+      }
+
+      const instance = container.instantiateModelsToScene((name) => `${entityId}_${name}`);
+      const roots = instance.rootNodes.filter((node): node is TransformNode => node instanceof TransformNode);
+      if (roots.length === 0) return;
+
+      const modelRoot = roots[0];
+      modelRoot.parent = entity.root;
+      modelRoot.position = Vector3.Zero();
+      modelRoot.rotationQuaternion = Quaternion.Identity();
+      modelRoot.rotation = Vector3.Zero();
+      modelRoot.scaling = new Vector3(0.01, 0.01, 0.01);
+
+      if (entity.visual) {
+        entity.visual.dispose(false, true);
+      }
+      entity.visual = modelRoot;
+    } catch (error) {
+      console.warn(`Failed to load model for ${entityId}:`, url, error);
+    }
+  }
+
+  private colorForType(type?: string): Color3 {
+    if (type === "player") return new Color3(0.25, 0.9, 0.4);
+    if (type === "monster") return new Color3(0.95, 0.25, 0.25);
+    if (type === "npc") return new Color3(0.35, 0.55, 1);
+    if (type === "loot") return new Color3(0.95, 0.8, 0.2);
+    return new Color3(0.85, 0.85, 0.85);
+  }
+
+  private toRadians(value: number): number {
+    return (value * Math.PI) / 180;
+  }
+
+  private inferTypeFromEntityId(id: string): string {
+    if (id.startsWith("player")) return "player";
+    if (id.startsWith("npc")) return "npc";
+    if (id.startsWith("monster")) return "monster";
+    if (id.startsWith("loot")) return "loot";
+    return "object";
+  }
+}

--- a/client/src/engine/babylon/BabylonBoot.ts
+++ b/client/src/engine/babylon/BabylonBoot.ts
@@ -1,0 +1,65 @@
+import {
+  ArcRotateCamera,
+  Color3,
+  Color4,
+  Engine,
+  HemisphericLight,
+  MeshBuilder,
+  Scene,
+  StandardMaterial,
+  Vector3,
+} from "@babylonjs/core";
+
+export type BabylonApp = {
+  engine: Engine;
+  scene: Scene;
+  camera: ArcRotateCamera;
+};
+
+export function createBabylonApp(canvas: HTMLCanvasElement): BabylonApp {
+  const engine = new Engine(canvas, true, {
+    preserveDrawingBuffer: true,
+    stencil: true,
+    adaptToDeviceRatio: true,
+  });
+
+  const scene = new Scene(engine);
+  scene.clearColor = new Color4(0.05, 0.06, 0.09, 1);
+
+  const camera = new ArcRotateCamera(
+    "MainCamera",
+    Math.PI / 2,
+    Math.PI / 3,
+    18,
+    new Vector3(0, 1.5, 0),
+    scene
+  );
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 5;
+  camera.upperRadiusLimit = 40;
+  camera.wheelDeltaPercentage = 0.01;
+
+  const light = new HemisphericLight("sun", new Vector3(0.2, 1, 0.1), scene);
+  light.intensity = 0.9;
+
+  const ground = MeshBuilder.CreateGround(
+    "world-ground",
+    { width: 128, height: 128, subdivisions: 2 },
+    scene
+  );
+  const groundMat = new StandardMaterial("world-ground-mat", scene);
+  groundMat.diffuseColor = new Color3(0.16, 0.18, 0.2);
+  groundMat.specularColor = new Color3(0, 0, 0);
+  ground.material = groundMat;
+  ground.position.y = -0.02;
+
+  engine.runRenderLoop(() => {
+    scene.render();
+  });
+
+  window.addEventListener("resize", () => {
+    engine.resize();
+  });
+
+  return { engine, scene, camera };
+}

--- a/client/src/engine/bridge/IEngineBridge.ts
+++ b/client/src/engine/bridge/IEngineBridge.ts
@@ -3,7 +3,7 @@ import { EntityViewModel } from "./EntityViewModel";
 export interface IEngineBridge {
   // Entity Management
   createEntity(model: EntityViewModel): void;
-  updateEntity(id: string, updates: Partial<EntityViewModel>): void;
+  updateEntity(id: string, updates: Partial<EntityViewModel>, dt?: number): void;
   destroyEntity(id: string): void;
 
   // Camera & View

--- a/client/src/engine/playcanvas/PlayCanvasBoot.ts
+++ b/client/src/engine/playcanvas/PlayCanvasBoot.ts
@@ -15,11 +15,14 @@ export function createPlayCanvasApp(canvas: HTMLCanvasElement): pc.Application {
 
   app.start();
 
-  // Clustered Lighting (Optimized for many lights)
-  app.scene.layers.getLayerByName("World")!.id; // Ensure World layer exists
-  app.scene.lighting.cells = new pc.Vec3(10, 3, 10);
-  app.scene.lighting.maxLightsPerCell = 8;
-  app.scene.lighting.shadowsEnabled = true;
+  // Clustered lighting is optional; keep it defensive to avoid hard crashes on
+  // environments where specific layer/device assumptions are not met.
+  const worldLayer = app.scene.layers.getLayerByName("World");
+  if (worldLayer && app.scene.lighting) {
+    app.scene.lighting.cells = new pc.Vec3(10, 3, 10);
+    app.scene.lighting.maxLightsPerCell = 8;
+    app.scene.lighting.shadowsEnabled = true;
+  }
 
   // Visual Setup
   app.scene.gammaCorrection = pc.GAMMA_SRGB;
@@ -33,6 +36,7 @@ export function createPlayCanvasApp(canvas: HTMLCanvasElement): pc.Application {
   // Initial Scene Setup
   createDefaultCamera(app);
   createDefaultLight(app);
+  createFallbackGround(app);
 
   // Create a procedural skybox (gradient)
   createProceduralSkybox(app);
@@ -79,4 +83,20 @@ function createProceduralSkybox(app: pc.Application) {
     }
 
     app.scene.skybox = cubemap;
+}
+
+function createFallbackGround(app: pc.Application) {
+  const existing = app.root.findByName("FallbackGround");
+  if (existing) return;
+  const ground = new pc.Entity("FallbackGround");
+  ground.addComponent("render", { type: "box" });
+  ground.setLocalScale(120, 0.2, 120);
+  ground.setLocalPosition(0, -0.1, 0);
+
+  const material = new pc.StandardMaterial();
+  material.diffuse = new pc.Color(0.18, 0.2, 0.24);
+  material.specular = new pc.Color(0.03, 0.03, 0.03);
+  material.update();
+  ground.render!.meshInstances[0].material = material;
+  app.root.addChild(ground);
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,7 +1,10 @@
 import { createBabylonApp } from "./engine/babylon/BabylonBoot";
 import { BabylonAdapter } from "./engine/babylon/BabylonAdapter";
+import { createPlayCanvasApp } from "./engine/playcanvas/PlayCanvasBoot";
+import { PlayCanvasAdapter } from "./engine/playcanvas/PlayCanvasAdapter";
 import { MMORPGClientCore } from "./core/MMORPGClientCore";
 import { connectSocket, requestSceneChange, type ConnectionOptions } from "./networking/websocketClient";
+import { IEngineBridge } from "./engine/bridge/IEngineBridge";
 import { renderHUD, showDialogue } from "./ui/hud";
 import { renderImprovedVirtualJoystick } from "./ui/ImprovedVirtualJoystick";
 import { renderMobileSceneTeleportPanel } from "./ui/mobileSceneTeleportPanel";
@@ -19,42 +22,79 @@ canvas.style.width = "100vw";
 canvas.style.height = "100vh";
 canvas.style.display = "block";
 
-// 1. Boot Engine
-const app = createBabylonApp(canvas);
-
-// 2. Create Adapter
-const adapter = new BabylonAdapter(app.scene, app.camera);
-
-// 3. Create Core
-const core = new MMORPGClientCore(adapter);
-(window as any).gameCore = core;
-(window as any).babylonScene = app.scene;
-core.registerDefaultInput();
-
-// 4. Connect Systems
-const connectionOptions: ConnectionOptions = {};
-const persistedToken = localStorage.getItem("token");
-if (persistedToken && persistedToken.trim().length > 0) {
-  connectionOptions.token = persistedToken;
+function showBootStatus(message: string) {
+  let status = document.getElementById("boot-status-banner") as HTMLDivElement | null;
+  if (!status) {
+    status = document.createElement("div");
+    status.id = "boot-status-banner";
+    status.style.position = "fixed";
+    status.style.left = "12px";
+    status.style.bottom = "12px";
+    status.style.zIndex = "9999";
+    status.style.padding = "8px 10px";
+    status.style.background = "rgba(0,0,0,0.72)";
+    status.style.borderLeft = "3px solid #f27d26";
+    status.style.color = "#f7f7f7";
+    status.style.fontFamily = "sans-serif";
+    status.style.fontSize = "12px";
+    status.style.maxWidth = "520px";
+    document.body.appendChild(status);
+  }
+  status.textContent = message;
 }
-connectSocket(core, connectionOptions);
-(window as any).requestSceneChange = requestSceneChange;
-renderHUD();
-renderMobileSceneTeleportPanel();
-renderImprovedVirtualJoystick(core);
-performanceMonitor.start();
 
-let lastFrameTime = performance.now();
-const tick = (now: number) => {
-  const dt = Math.min((now - lastFrameTime) / 1000, 0.1);
-  lastFrameTime = now;
-  core.update(dt);
+function bootEngineBridge(targetCanvas: HTMLCanvasElement): IEngineBridge {
+  try {
+    const app = createBabylonApp(targetCanvas);
+    (window as any).babylonScene = app.scene;
+    console.log("Renderer: Babylon");
+    return new BabylonAdapter(app.scene, app.camera);
+  } catch (error) {
+    console.error("Babylon bootstrap failed. Falling back to PlayCanvas.", error);
+    showBootStatus("Babylon failed to initialize. Fallback renderer: PlayCanvas.");
+    const app = createPlayCanvasApp(targetCanvas);
+    console.log("Renderer: PlayCanvas (fallback)");
+    return new PlayCanvasAdapter(app);
+  }
+}
+
+try {
+  // 1. Boot Engine + Adapter
+  const adapter = bootEngineBridge(canvas);
+
+  // 2. Create Core
+  const core = new MMORPGClientCore(adapter);
+  (window as any).gameCore = core;
+  core.registerDefaultInput();
+
+  // 3. Connect Systems
+  const connectionOptions: ConnectionOptions = {};
+  const persistedToken = localStorage.getItem("token");
+  if (persistedToken && persistedToken.trim().length > 0) {
+    connectionOptions.token = persistedToken;
+  }
+  connectSocket(core, connectionOptions);
+  (window as any).requestSceneChange = requestSceneChange;
+  renderHUD();
+  renderMobileSceneTeleportPanel();
+  renderImprovedVirtualJoystick(core);
+  performanceMonitor.start();
+
+  let lastFrameTime = performance.now();
+  const tick = (now: number) => {
+    const dt = Math.min((now - lastFrameTime) / 1000, 0.1);
+    lastFrameTime = now;
+    core.update(dt);
+    requestAnimationFrame(tick);
+  };
   requestAnimationFrame(tick);
-};
-requestAnimationFrame(tick);
 
-core.events.on('dialogue', (text: string) => {
-  showDialogue(text);
-});
+  core.events.on("dialogue", (text: string) => {
+    showDialogue(text);
+  });
 
-console.log("Areloria Babylon Client Initialized");
+  console.log("Areloria Client Initialized");
+} catch (error: any) {
+  console.error("Fatal client bootstrap error:", error);
+  showBootStatus(`Fatal bootstrap error: ${error?.message || "Unknown error"}`);
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,5 +1,5 @@
-import { createPlayCanvasApp } from "./engine/playcanvas/PlayCanvasBoot";
-import { PlayCanvasAdapter } from "./engine/playcanvas/PlayCanvasAdapter";
+import { createBabylonApp } from "./engine/babylon/BabylonBoot";
+import { BabylonAdapter } from "./engine/babylon/BabylonAdapter";
 import { MMORPGClientCore } from "./core/MMORPGClientCore";
 import { connectSocket, requestSceneChange, type ConnectionOptions } from "./networking/websocketClient";
 import { renderHUD, showDialogue } from "./ui/hud";
@@ -15,16 +15,20 @@ if (!canvas) {
 }
 document.body.style.margin = "0";
 document.body.style.overflow = "hidden";
+canvas.style.width = "100vw";
+canvas.style.height = "100vh";
+canvas.style.display = "block";
 
 // 1. Boot Engine
-const app = createPlayCanvasApp(canvas);
+const app = createBabylonApp(canvas);
 
 // 2. Create Adapter
-const adapter = new PlayCanvasAdapter(app);
+const adapter = new BabylonAdapter(app.scene, app.camera);
 
 // 3. Create Core
 const core = new MMORPGClientCore(adapter);
 (window as any).gameCore = core;
+(window as any).babylonScene = app.scene;
 core.registerDefaultInput();
 
 // 4. Connect Systems
@@ -40,8 +44,17 @@ renderMobileSceneTeleportPanel();
 renderImprovedVirtualJoystick(core);
 performanceMonitor.start();
 
+let lastFrameTime = performance.now();
+const tick = (now: number) => {
+  const dt = Math.min((now - lastFrameTime) / 1000, 0.1);
+  lastFrameTime = now;
+  core.update(dt);
+  requestAnimationFrame(tick);
+};
+requestAnimationFrame(tick);
+
 core.events.on('dialogue', (text: string) => {
   showDialogue(text);
 });
 
-console.log("Areloria PlayCanvas Client Initialized");
+console.log("Areloria Babylon Client Initialized");

--- a/client/src/networking/websocketClient.ts
+++ b/client/src/networking/websocketClient.ts
@@ -117,7 +117,13 @@ export function connectSocket(core: MMORPGClientCore, options: ConnectionOptions
     try {
       const data = JSON.parse(msg.data);
       if (data.type === 'entity_sync') {
-        if (data.entities) core.syncEntities(data.entities);
+        if (data.entities) {
+          const normalizedEntities = data.entities.map((entity: any) => ({
+            ...entity,
+            modelUrl: entity.modelUrl ?? entity.glbPath,
+          }));
+          core.syncEntities(normalizedEntities);
+        }
         if (data.chunks) core.syncChunks(data.chunks);
       }
       if (data.type === 'entity_action') {

--- a/docs/WORLD_ASSET_POOLS.md
+++ b/docs/WORLD_ASSET_POOLS.md
@@ -1,0 +1,68 @@
+# World Asset Pools (Starter Pack)
+
+Dieses Setup ermoeglicht euch, Worldgen/GM-Objekte sofort mit austauschbaren Placeholder-GLBs zu rendern.
+
+## Ziel
+
+- Sofort spielbarer Stand mit einfachen Modellen
+- Spaeter Austausch auf eigene GLBs ohne Server- oder Gameplay-Logik-Umbau
+- Mapping zentral in einer JSON-Datei
+
+## Datei
+
+- `game-data/world/asset-pools.json`
+
+## Aufbau
+
+- `defaults`: Fallback pro Kategorie
+- `pools.<category>.<key>`: Konkrete Zuordnung
+
+Unterstuetzte Kategorien im aktuellen Resolver:
+
+- `players`
+- `npcs`
+- `monsters`
+- `loot`
+- `resources`
+- `world_objects`
+
+Alias-Mapping im Resolver:
+
+- `npc` -> `npcs`
+- `monster` -> `monsters`
+- `object`, `world`, `worldobject` -> `world_objects`
+- `resource` -> `resources`
+
+## Live-Verwendung im Server
+
+Der Server sendet in `entity_sync` jetzt `glbPath` fuer:
+
+- Players
+- NPCs
+- Loot
+- World Objects (falls kein expliziter `obj.glbPath` gesetzt ist)
+
+Vorrang-Regeln:
+
+1. `GLBRegistry` (`gm_register_glb`, `admin_glb_link`) hat Prioritaet
+2. Dann `asset-pools.json`
+3. Dann `defaults`
+
+## Schnelltest
+
+1. Server starten
+2. Mit GM Tool verbinden
+3. `gm_place_object` mit `objectType = house` ausfuehren
+4. In `entity_sync` sollte Objekt `glbPath` erhalten (aus `world_objects.house`)
+5. Dann in `asset-pools.json` nur den URL-Wert tauschen und neu testen
+
+## Schrittweiser Austausch auf eigene Assets
+
+Beispiel:
+
+- Vorher:
+  - `"house": "/assets/models/objects/chest.glb"`
+- Nachher:
+  - `"house": "/assets/models/buildings/house_01.glb"`
+
+Keine Codeaenderung erforderlich, nur JSON-Mapping.

--- a/game-data/world/asset-pools.json
+++ b/game-data/world/asset-pools.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "defaults": {
+    "players": "/assets/models/characters/uschi.glb",
+    "npcs": "/assets/models/characters/uschi.glb",
+    "monsters": "/assets/models/monsters/goblin.glb",
+    "loot": "/assets/models/objects/chest.glb",
+    "world_objects": "/assets/models/objects/chest.glb",
+    "resources": "/assets/models/objects/chest.glb",
+    "object": "/assets/models/objects/chest.glb"
+  },
+  "pools": {
+    "players": {
+      "default": "/assets/models/characters/uschi.glb",
+      "warrior": "/assets/models/characters/uschi.glb",
+      "mage": "/assets/models/characters/uschi.glb",
+      "ranger": "/assets/models/characters/uschi.glb"
+    },
+    "npcs": {
+      "default": "/assets/models/characters/uschi.glb",
+      "citizen": "/assets/models/characters/uschi.glb",
+      "merchant": "/assets/models/characters/uschi.glb",
+      "questgiver": "/assets/models/characters/uschi.glb",
+      "guard": "/assets/models/characters/uschi.glb"
+    },
+    "monsters": {
+      "default": "/assets/models/monsters/goblin.glb",
+      "goblin": "/assets/models/monsters/goblin.glb",
+      "wolf": "/assets/models/monsters/goblin.glb",
+      "boar": "/assets/models/monsters/goblin.glb",
+      "undead": "/assets/models/monsters/goblin.glb",
+      "legion_scout": "/assets/models/monsters/goblin.glb",
+      "legion_brute": "/assets/models/monsters/goblin.glb",
+      "legion_overseer": "/assets/models/monsters/goblin.glb"
+    },
+    "loot": {
+      "default": "/assets/models/objects/chest.glb",
+      "gold": "/assets/models/objects/chest.glb",
+      "weapon": "/assets/models/objects/chest.glb",
+      "armor": "/assets/models/objects/chest.glb",
+      "consumable": "/assets/models/objects/chest.glb"
+    },
+    "resources": {
+      "default": "/assets/models/objects/chest.glb",
+      "tree": "/assets/models/objects/chest.glb",
+      "rock": "/assets/models/objects/chest.glb",
+      "bush": "/assets/models/objects/chest.glb",
+      "ore": "/assets/models/objects/chest.glb"
+    },
+    "world_objects": {
+      "default": "/assets/models/objects/chest.glb",
+      "object": "/assets/models/objects/chest.glb",
+      "house": "/assets/models/objects/chest.glb",
+      "tree": "/assets/models/objects/chest.glb",
+      "rock": "/assets/models/objects/chest.glb",
+      "well": "/assets/models/objects/chest.glb",
+      "market": "/assets/models/objects/chest.glb",
+      "dungeon": "/assets/models/objects/chest.glb",
+      "camp": "/assets/models/objects/chest.glb",
+      "tower": "/assets/models/objects/chest.glb",
+      "ruin": "/assets/models/objects/chest.glb",
+      "portal": "/assets/models/objects/chest.glb",
+      "shrine": "/assets/models/objects/chest.glb"
+    }
+  }
+}

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -12,6 +12,7 @@ import { PersistenceManager } from "./PersistenceManager.js";
 import { verifyFirebaseToken } from "../config/firebase.js";
 import { ItemRegistry } from "../modules/inventory/ItemRegistry.js";
 import { GLBRegistry } from "../modules/asset-registry/GLBRegistry.js";
+import { AssetPoolResolver } from "../modules/world/AssetPoolResolver.js";
 import { cache } from "./Cache.js";
 import fs from "fs";
 import path from "path";
@@ -214,6 +215,7 @@ export class WorldTick {
   public worldSystem: WorldSystem;
   public persistence: PersistenceManager;
   public glbRegistry: GLBRegistry;
+  private assetPoolResolver: AssetPoolResolver;
   private lootEntities: Map<string, any> = new Map();
 
   private socketToPlayer: Map<string, string> = new Map(); // socketId -> characterName
@@ -975,6 +977,7 @@ export class WorldTick {
     this.persistence = new PersistenceManager();
     this.worldSystem = new WorldSystem(this.persistence);
     this.glbRegistry = new GLBRegistry();
+    this.assetPoolResolver = new AssetPoolResolver();
 
     // Create a dummy player in a distant chunk to prove multi-observer union
     const dummyPlayer = this.playerSystem.createPlayer("dummy_player", "Dummy Player");
@@ -1305,6 +1308,7 @@ export class WorldTick {
         position: { x: p.position.x, y: 0, z: p.position.y }, // Mapping y to z for 3D
         rotation: { x: 0, y: 0, z: 0 },
         name: p.name,
+        glbPath: this.resolveEntityGlbPath("players", p.name || p.id, p.id),
         visible: true
       })),
       ...this.npcSystem.getAllNPCs().map(n => ({
@@ -1313,6 +1317,7 @@ export class WorldTick {
         position: { x: n.position.x, y: 0, z: n.position.y },
         rotation: { x: 0, y: 0, z: 0 },
         name: n.name,
+        glbPath: this.resolveNpcGlbPath(n),
         visible: true
       })),
       ...Array.from(this.lootEntities.values()).map(l => ({
@@ -1320,6 +1325,7 @@ export class WorldTick {
         type: 'loot',
         position: { x: l.position.x, y: 0, z: l.position.y },
         rotation: { x: 0, y: 0, z: 0 },
+        glbPath: this.resolveEntityGlbPath("loot", l.item?.id || l.id, l.id),
         visible: true
       }))
     ];
@@ -1331,6 +1337,7 @@ export class WorldTick {
         type: obj.type || 'object',
         position: { x: obj.position.x, y: 0, z: obj.position.y },
         rotation: { x: 0, y: obj.rotation || 0, z: 0 },
+        glbPath: obj.glbPath || this.resolveWorldObjectGlbPath(obj.type, obj.name || obj.id, obj.id),
         visible: true
       }));
       entities.push(...worldObjects);
@@ -1349,5 +1356,25 @@ export class WorldTick {
     return {
        updateMonsters: () => {} // Shim for WebSocketServer compatibility if needed
     };
+  }
+
+  private resolveNpcGlbPath(npc: any): string | undefined {
+    const single = this.glbRegistry.getModelForTarget("npc_single", npc.id);
+    if (single) return single;
+    const byRole = this.glbRegistry.getModelForTarget("npc_group", String(npc.role || ""));
+    if (byRole) return byRole;
+    return this.resolveEntityGlbPath("npcs", npc.role || npc.name || npc.id, npc.id);
+  }
+
+  private resolveWorldObjectGlbPath(type: string | undefined, name: string | undefined, id: string): string | undefined {
+    const single = this.glbRegistry.getModelForTarget("object_single", id);
+    if (single) return single;
+    const byType = type ? this.glbRegistry.getModelForTarget("object_group", type) : null;
+    if (byType) return byType;
+    return this.resolveEntityGlbPath("world_objects", type || name || id, id);
+  }
+
+  private resolveEntityGlbPath(category: string, key: string | undefined, seed: string): string | undefined {
+    return this.assetPoolResolver.resolvePath(category, key, seed);
   }
 }

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -552,6 +552,96 @@ export class WorldTick {
       return true;
     }
 
+    if (t === "admin_glb_pool_get") {
+      this.ws.sendToPlayer(socketId, {
+        type: "admin_glb_pool_result",
+        pools: this.assetPoolResolver.getDocument(),
+      });
+      return true;
+    }
+
+    if (t === "admin_glb_pool_set") {
+      if (!isNonEmptyString(msg.category) || !isNonEmptyString(msg.key) || !isNonEmptyString(msg.path)) {
+        this.sendGMStatus(socketId, "error", "category, key and path are required.");
+        return true;
+      }
+      const saved = this.assetPoolResolver.setEntry(msg.category, msg.key, msg.path);
+      if (!saved) {
+        this.sendGMStatus(socketId, "error", "Failed to save asset pool entry.");
+        return true;
+      }
+      this.ws.sendToPlayer(socketId, {
+        type: "admin_glb_pool_result",
+        pools: this.assetPoolResolver.getDocument(),
+      });
+      this.sendGMStatus(socketId, "info", `Asset pool updated: ${msg.category}.${msg.key}`);
+      return true;
+    }
+
+    if (t === "admin_glb_pool_remove") {
+      if (!isNonEmptyString(msg.category) || !isNonEmptyString(msg.key)) {
+        this.sendGMStatus(socketId, "error", "category and key are required.");
+        return true;
+      }
+      const removed = this.assetPoolResolver.removeEntry(msg.category, msg.key);
+      if (!removed) {
+        this.sendGMStatus(socketId, "error", `Asset pool entry not found: ${msg.category}.${msg.key}`);
+        return true;
+      }
+      this.ws.sendToPlayer(socketId, {
+        type: "admin_glb_pool_result",
+        pools: this.assetPoolResolver.getDocument(),
+      });
+      this.sendGMStatus(socketId, "info", `Asset pool entry removed: ${msg.category}.${msg.key}`);
+      return true;
+    }
+
+    if (t === "admin_glb_pool_set_default") {
+      if (!isNonEmptyString(msg.category) || !isNonEmptyString(msg.path)) {
+        this.sendGMStatus(socketId, "error", "category and path are required.");
+        return true;
+      }
+      const saved = this.assetPoolResolver.setDefault(msg.category, msg.path);
+      if (!saved) {
+        this.sendGMStatus(socketId, "error", "Failed to save default asset pool entry.");
+        return true;
+      }
+      this.ws.sendToPlayer(socketId, {
+        type: "admin_glb_pool_result",
+        pools: this.assetPoolResolver.getDocument(),
+      });
+      this.sendGMStatus(socketId, "info", `Asset pool default updated: ${msg.category}`);
+      return true;
+    }
+
+    if (t === "admin_glb_pool_remove_default") {
+      if (!isNonEmptyString(msg.category)) {
+        this.sendGMStatus(socketId, "error", "category is required.");
+        return true;
+      }
+      const removed = this.assetPoolResolver.removeDefault(msg.category);
+      if (!removed) {
+        this.sendGMStatus(socketId, "error", `Asset pool default not found: ${msg.category}`);
+        return true;
+      }
+      this.ws.sendToPlayer(socketId, {
+        type: "admin_glb_pool_result",
+        pools: this.assetPoolResolver.getDocument(),
+      });
+      this.sendGMStatus(socketId, "info", `Asset pool default removed: ${msg.category}`);
+      return true;
+    }
+
+    if (t === "admin_glb_pool_reload") {
+      this.assetPoolResolver.reload();
+      this.ws.sendToPlayer(socketId, {
+        type: "admin_glb_pool_result",
+        pools: this.assetPoolResolver.getDocument(),
+      });
+      this.sendGMStatus(socketId, "info", "Asset pools reloaded from disk.");
+      return true;
+    }
+
     return false;
   }
 

--- a/server/src/modules/world/AssetPoolResolver.ts
+++ b/server/src/modules/world/AssetPoolResolver.ts
@@ -38,6 +38,74 @@ export class AssetPoolResolver {
     }
   }
 
+  public getDocument(): AssetPoolDocument {
+    return JSON.parse(JSON.stringify(this.document));
+  }
+
+  public setEntry(category: string, key: string, entry: PoolEntry): boolean {
+    const normalizedCategory = this.normalizeCategory(category);
+    const normalizedKey = this.normalizeToken(key);
+    const normalizedEntry = this.normalizeEntry(entry);
+    if (!normalizedCategory || !normalizedKey || !normalizedEntry) {
+      return false;
+    }
+    if (!this.document.pools) {
+      this.document.pools = {};
+    }
+    if (!this.document.pools[normalizedCategory]) {
+      this.document.pools[normalizedCategory] = {};
+    }
+    this.document.pools[normalizedCategory][normalizedKey] = normalizedEntry;
+    this.save();
+    return true;
+  }
+
+  public removeEntry(category: string, key: string): boolean {
+    const normalizedCategory = this.normalizeCategory(category);
+    const normalizedKey = this.normalizeToken(key);
+    if (!normalizedCategory || !normalizedKey || !this.document.pools?.[normalizedCategory]) {
+      return false;
+    }
+    const before = Object.prototype.hasOwnProperty.call(this.document.pools[normalizedCategory], normalizedKey);
+    if (!before) {
+      return false;
+    }
+    delete this.document.pools[normalizedCategory][normalizedKey];
+    if (Object.keys(this.document.pools[normalizedCategory]).length === 0) {
+      delete this.document.pools[normalizedCategory];
+    }
+    this.save();
+    return true;
+  }
+
+  public setDefault(category: string, entry: PoolEntry): boolean {
+    const normalizedCategory = this.normalizeCategory(category);
+    const normalizedEntry = this.normalizeEntry(entry);
+    if (!normalizedCategory || !normalizedEntry) {
+      return false;
+    }
+    if (!this.document.defaults) {
+      this.document.defaults = {};
+    }
+    this.document.defaults[normalizedCategory] = normalizedEntry;
+    this.save();
+    return true;
+  }
+
+  public removeDefault(category: string): boolean {
+    const normalizedCategory = this.normalizeCategory(category);
+    if (!normalizedCategory || !this.document.defaults) {
+      return false;
+    }
+    const before = Object.prototype.hasOwnProperty.call(this.document.defaults, normalizedCategory);
+    if (!before) {
+      return false;
+    }
+    delete this.document.defaults[normalizedCategory];
+    this.save();
+    return true;
+  }
+
   public resolvePath(category: string | undefined, key: string | undefined, seed?: string): string | undefined {
     const normalizedCategory = this.normalizeCategory(category);
     const normalizedKey = this.normalizeToken(key);
@@ -86,6 +154,21 @@ export class AssetPoolResolver {
     return entry[index];
   }
 
+  private normalizeEntry(entry: PoolEntry): PoolEntry | null {
+    if (typeof entry === "string") {
+      const cleaned = entry.trim();
+      return cleaned.length > 0 ? cleaned : null;
+    }
+    if (!Array.isArray(entry)) {
+      return null;
+    }
+    const cleaned = entry.map((value) => String(value).trim()).filter((value) => value.length > 0);
+    if (cleaned.length === 0) {
+      return null;
+    }
+    return cleaned.length === 1 ? cleaned[0] : cleaned;
+  }
+
   private normalizeCategory(category: string | undefined): string {
     const normalized = this.normalizeToken(category);
     if (!normalized) {
@@ -115,5 +198,14 @@ export class AssetPoolResolver {
       hash |= 0;
     }
     return hash;
+  }
+
+  private save() {
+    try {
+      fs.mkdirSync(path.dirname(this.poolsPath), { recursive: true });
+      fs.writeFileSync(this.poolsPath, JSON.stringify(this.document, null, 2));
+    } catch (error) {
+      console.error("Failed to save asset-pools.json", error);
+    }
   }
 }

--- a/server/src/modules/world/AssetPoolResolver.ts
+++ b/server/src/modules/world/AssetPoolResolver.ts
@@ -1,0 +1,119 @@
+import fs from "fs";
+import path from "path";
+
+type PoolEntry = string | string[];
+
+type AssetPoolDocument = {
+  version?: number;
+  defaults?: Record<string, PoolEntry>;
+  pools?: Record<string, Record<string, PoolEntry>>;
+};
+
+const DEFAULT_POOLS_PATH = path.resolve(process.cwd(), "game-data/world/asset-pools.json");
+
+export class AssetPoolResolver {
+  private poolsPath: string;
+  private document: AssetPoolDocument = { defaults: {}, pools: {} };
+
+  constructor(poolsPath: string = DEFAULT_POOLS_PATH) {
+    this.poolsPath = poolsPath;
+    this.reload();
+  }
+
+  public reload() {
+    if (!fs.existsSync(this.poolsPath)) {
+      this.document = { defaults: {}, pools: {} };
+      return;
+    }
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.poolsPath, "utf-8")) as AssetPoolDocument;
+      this.document = {
+        version: parsed.version ?? 1,
+        defaults: parsed.defaults ?? {},
+        pools: parsed.pools ?? {},
+      };
+    } catch (error) {
+      console.error("Failed to parse asset-pools.json", error);
+      this.document = { defaults: {}, pools: {} };
+    }
+  }
+
+  public resolvePath(category: string | undefined, key: string | undefined, seed?: string): string | undefined {
+    const normalizedCategory = this.normalizeCategory(category);
+    const normalizedKey = this.normalizeToken(key);
+
+    const categoryPool = this.document.pools?.[normalizedCategory];
+    if (categoryPool) {
+      const entry =
+        this.pickEntryByKey(categoryPool, normalizedKey) ??
+        this.pickEntryByKey(categoryPool, "default");
+      if (entry) {
+        return this.pickVariant(entry, seed ?? `${normalizedCategory}:${normalizedKey}`);
+      }
+    }
+
+    const fallbackEntry =
+      this.pickEntryByKey(this.document.defaults ?? {}, normalizedCategory) ??
+      this.pickEntryByKey(this.document.defaults ?? {}, "object");
+    if (fallbackEntry) {
+      return this.pickVariant(fallbackEntry, seed ?? normalizedCategory);
+    }
+
+    return undefined;
+  }
+
+  private pickEntryByKey(collection: Record<string, PoolEntry>, key: string): PoolEntry | undefined {
+    if (!key) {
+      return undefined;
+    }
+    if (collection[key]) {
+      return collection[key];
+    }
+    const compact = key.replace(/_/g, "");
+    const aliasKey = Object.keys(collection).find((candidate) => candidate.replace(/_/g, "") === compact);
+    return aliasKey ? collection[aliasKey] : undefined;
+  }
+
+  private pickVariant(entry: PoolEntry, seed: string): string | undefined {
+    if (typeof entry === "string") {
+      return entry;
+    }
+    if (!Array.isArray(entry) || entry.length === 0) {
+      return undefined;
+    }
+    const hash = this.hash(seed);
+    const index = Math.abs(hash) % entry.length;
+    return entry[index];
+  }
+
+  private normalizeCategory(category: string | undefined): string {
+    const normalized = this.normalizeToken(category);
+    if (!normalized) {
+      return "world_objects";
+    }
+    if (normalized === "npc") return "npcs";
+    if (normalized === "monster") return "monsters";
+    if (normalized === "object" || normalized === "world" || normalized === "worldobject") return "world_objects";
+    if (normalized === "resource") return "resources";
+    if (normalized === "player") return "players";
+    return normalized;
+  }
+
+  private normalizeToken(value: string | undefined): string {
+    if (!value) return "";
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "");
+  }
+
+  private hash(value: string): number {
+    let hash = 0;
+    for (let i = 0; i < value.length; i++) {
+      hash = (hash << 5) - hash + value.charCodeAt(i);
+      hash |= 0;
+    }
+    return hash;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context
Production (`https://arelogic.space/`) was still serving an older PlayCanvas bundle from `main` (`index-DRz_Xp3H.js`) that could present as a black screen. This PR adds defensive runtime behavior so the app does not fail silently into a black viewport.

## Changes
- harden client bootstrap in `client/src/main.ts`
  - introduce guarded engine boot sequence
  - default to Babylon bridge, automatically fallback to PlayCanvas if Babylon init throws
  - add visible boot-status banner for fatal boot/render failures (instead of silent black screen)
  - preserve existing core/network/UI wiring
- harden PlayCanvas boot in `client/src/engine/playcanvas/PlayCanvasBoot.ts`
  - make clustered lighting setup defensive (no hard assumptions about world layer/lighting internals)
  - add guaranteed fallback ground plane so scene always has visible geometry

## Why this fixes black-screen risk
- renderer init exceptions no longer terminate app silently
- fallback renderer path ensures app still renders when one engine path fails
- user sees explicit status message if bootstrap fails, making diagnostics immediate
- PlayCanvas path now guarantees at least one visible lit surface

## Validation
- `npm run build` in `client` passes
- confirmed production currently serves old main bundle markers (`PlayCanvas` build path), so this mitigation directly targets that deployed risk
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82ff7175-beef-46a6-8e14-2614089a7703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ff7175-beef-46a6-8e14-2614089a7703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

