### PR TITLE
feat: Babylon migration hardening + ARE Sovereign Phase 1-2 + deploy stabilization

### DIFF
--- a/client/public/gm/app.js
+++ b/client/public/gm/app.js
@@ -11,6 +11,7 @@ const state = {
     npcs: [],
     weather: "clear",
     time: "00:00",
+    areMode: "shader",
     heatmap: null,
   },
   admin: {
@@ -61,6 +62,16 @@ function bindClick(id, handler) {
   const el = byId(id);
   if (!el) return;
   el.onclick = handler;
+}
+
+function syncAREModeUI() {
+  const select = byId("areModeSelect");
+  if (!select) return;
+  const validModes = ["off", "cpu", "shader"];
+  if (!validModes.includes(state.preview.areMode)) {
+    state.preview.areMode = "shader";
+  }
+  select.value = state.preview.areMode;
 }
 
 function renderAdminState() {
@@ -192,7 +203,7 @@ function updatePreviewCanvas() {
   });
 
   byId("previewMeta").textContent =
-    `Weather: ${state.preview.weather} | Time: ${state.preview.time} | Players: ${state.preview.players.length} | NPCs: ${state.preview.npcs.length} | Heatmap: ${state.heatmapEnabled ? "on" : "off"}`;
+    `Weather: ${state.preview.weather} | Time: ${state.preview.time} | ARE: ${state.preview.areMode} | Players: ${state.preview.players.length} | NPCs: ${state.preview.npcs.length} | Heatmap: ${state.heatmapEnabled ? "on" : "off"}`;
 }
 
 function handleMessage(msg) {
@@ -203,6 +214,7 @@ function handleMessage(msg) {
     send({ type: "gm_get_players" });
     send({ type: "admin_glb_list" });
     send({ type: "admin_glb_pool_get" });
+    send({ type: "gm_are_mode_get" });
     return;
   }
   if (msg.type === "entity_sync") {
@@ -243,10 +255,21 @@ function handleMessage(msg) {
     state.preview.npcs = msg.npcs || [];
     state.preview.weather = msg.world?.weather || "clear";
     state.preview.time = msg.world?.time || "00:00";
+    state.preview.areMode = msg.world?.areMode || state.preview.areMode || "shader";
     state.preview.heatmap = msg.heatmap || null;
+    syncAREModeUI();
     renderPlayersTable();
     renderHeatList();
     updatePreviewCanvas();
+    return;
+  }
+  if (msg.type === "gm_are_mode_result") {
+    const mode = String(msg.mode || "").toLowerCase();
+    if (["off", "cpu", "shader"].includes(mode)) {
+      state.preview.areMode = mode;
+      syncAREModeUI();
+      logLine(`ARE mode synced: ${mode}`, "ok");
+    }
     return;
   }
   if (msg.type === "error") {
@@ -367,6 +390,11 @@ function initBindings() {
 
   bindClick("weatherBtn", () => cmd("gm_set_weather", { weather: val("weather") || "clear" }));
   bindClick("timeBtn", () => cmd("gm_set_time", { time: Number(val("worldTime")) || 12 }));
+  bindClick("areModeSetBtn", () => {
+    const mode = val("areModeSelect") || "shader";
+    cmd("gm_are_mode_set", { mode });
+  });
+  bindClick("areModeGetBtn", () => cmd("gm_are_mode_get"));
   bindClick("eventBtn", () =>
     cmd("gm_world_event", {
       eventId: val("eventId") || "custom_event",
@@ -515,6 +543,8 @@ function bootstrapDefaults() {
   safeSetValue("adminTargetType", "object_group");
   safeSetValue("registerCategory", "object");
   safeSetValue("poolCategory", "world_objects");
+  safeSetValue("areModeSelect", "shader");
+  syncAREModeUI();
 }
 
 bootstrapDefaults();

--- a/client/public/gm/index.html
+++ b/client/public/gm/index.html
@@ -252,6 +252,15 @@
               <input id="worldTime" type="number" min="0" max="23" value="12" />
               <button id="timeBtn">Set Time</button>
             </div>
+            <div class="row3">
+              <select id="areModeSelect">
+                <option value="shader">ARE Mode: shader</option>
+                <option value="cpu">ARE Mode: cpu</option>
+                <option value="off">ARE Mode: off</option>
+              </select>
+              <button id="areModeSetBtn" class="secondary">Set ARE Mode</button>
+              <button id="areModeGetBtn" class="secondary">Get ARE Mode</button>
+            </div>
             <div class="row">
               <input id="eventId" placeholder="event id" value="custom_event" />
               <button id="eventBtn" class="warn">Trigger Event</button>

--- a/client/src/core/MMORPGClientCore.ts
+++ b/client/src/core/MMORPGClientCore.ts
@@ -68,6 +68,12 @@ export class MMORPGClientCore {
     return this.localPlayerId;
   }
 
+  public setAREMode(mode: string) {
+    if (typeof this.engine.setAREMode === "function") {
+      this.engine.setAREMode(mode);
+    }
+  }
+
   public teleportLocalPlayerTo(position: { x: number; y: number; z: number }) {
     if (!this.localPlayerId) return;
     const player = this.entities.get(this.localPlayerId);

--- a/client/src/engine/babylon/BabylonAdapter.ts
+++ b/client/src/engine/babylon/BabylonAdapter.ts
@@ -22,6 +22,10 @@ type EntityNode = {
   root: TransformNode;
   visual: TransformNode | AbstractMesh;
   label?: Mesh;
+  baseScale: number;
+  arePhase: number;
+  areResonance: number;
+  arePlexity: number;
 };
 
 const DEFAULT_MODEL_BY_TYPE: Record<string, string> = {
@@ -37,6 +41,7 @@ export class BabylonAdapter implements IEngineBridge {
   private readonly modelAttachQueue = new Map<string, string>();
   private readonly pressedKeys = new Set<string>();
   private readonly inputCallbacks: Array<(input: any) => void> = [];
+  private readonly areWaveClock = { t: 0 };
   private cameraTargetId: string | null = null;
   private navigationMarker: Mesh | null = null;
   private localPlayerId: string | null = null;
@@ -62,11 +67,19 @@ export class BabylonAdapter implements IEngineBridge {
     const placeholder = this.createPlaceholderMesh(model);
     placeholder.parent = root;
 
-    const node: EntityNode = { root, visual: placeholder };
+    const node: EntityNode = {
+      root,
+      visual: placeholder,
+      baseScale: 1,
+      arePhase: model.are?.phaseShift ?? 0,
+      areResonance: model.are?.resonance ?? 0,
+      arePlexity: model.are?.plexity ?? 1,
+    };
     if (model.name) {
       node.label = this.createBillboardLabel(model.name, this.colorForType(model.type), root);
     }
 
+    this.applyAREState(node, model);
     this.entities.set(model.id, node);
     this.tryAttachModel(model.id, model.modelUrl ?? DEFAULT_MODEL_BY_TYPE[model.type]);
   }
@@ -104,6 +117,7 @@ export class BabylonAdapter implements IEngineBridge {
     if (updates.modelUrl) {
       this.tryAttachModel(id, updates.modelUrl);
     }
+    this.applyAREState(node, updates);
   }
 
   destroyEntity(id: string): void {
@@ -178,10 +192,13 @@ export class BabylonAdapter implements IEngineBridge {
     const node = this.entities.get(entityId);
     if (!node) return;
     if (action === "attack") {
-      node.root.scaling = new Vector3(1.12, 1.12, 1.12);
+      const boost = Math.max(1.12, node.baseScale * 1.08);
+      node.root.scaling = new Vector3(boost, boost, boost);
       setTimeout(() => {
         const latest = this.entities.get(entityId);
-        if (latest) latest.root.scaling = new Vector3(1, 1, 1);
+        if (latest) {
+          latest.root.scaling = new Vector3(latest.baseScale, latest.baseScale, latest.baseScale);
+        }
       }, 120);
     }
   }
@@ -194,7 +211,9 @@ export class BabylonAdapter implements IEngineBridge {
     this.inputCallbacks.push(callback);
   }
 
-  update(_dt: number): void {
+  update(dt: number): void {
+    this.areWaveClock.t += dt;
+    this.updateAREVisuals();
     this.updateCameraFollow();
   }
 
@@ -373,6 +392,34 @@ export class BabylonAdapter implements IEngineBridge {
 
   private toRadians(value: number): number {
     return (value * Math.PI) / 180;
+  }
+
+  private applyAREState(node: EntityNode, model: Partial<EntityViewModel>): void {
+    if (!model.are) {
+      return;
+    }
+    node.arePhase = Number.isFinite(model.are.phaseShift) ? model.are.phaseShift : node.arePhase;
+    node.areResonance = Number.isFinite(model.are.resonance) ? model.are.resonance : node.areResonance;
+    node.arePlexity = Number.isFinite(model.are.plexity)
+      ? Math.max(0.05, Math.min(1, model.are.plexity))
+      : node.arePlexity;
+    node.baseScale = 0.7 + node.arePlexity * 0.6;
+    const visibilityByPlexity = node.arePlexity > 0.08;
+    const explicitVisible =
+      model.visible !== undefined ? model.visible : (node.root.metadata as any)?.explicitVisible ?? true;
+    node.root.metadata = {
+      ...(node.root.metadata as Record<string, unknown> | null),
+      explicitVisible,
+    };
+    node.root.setEnabled(visibilityByPlexity && explicitVisible);
+  }
+
+  private updateAREVisuals(): void {
+    for (const node of this.entities.values()) {
+      const wave = Math.sin(this.areWaveClock.t * 2 + node.arePhase * 0.01) * 0.05 * (0.25 + node.areResonance);
+      const scale = Math.max(0.2, node.baseScale + wave);
+      node.root.scaling = new Vector3(scale, scale, scale);
+    }
   }
 
   private inferTypeFromEntityId(id: string): string {

--- a/client/src/engine/babylon/BabylonAdapter.ts
+++ b/client/src/engine/babylon/BabylonAdapter.ts
@@ -4,11 +4,14 @@ import {
   AssetContainer,
   Color3,
   DynamicTexture,
+  Effect,
+  Material,
   Mesh,
   MeshBuilder,
   Quaternion,
   Scene,
   SceneLoader,
+  ShaderMaterial,
   StandardMaterial,
   TransformNode,
   Vector3,
@@ -23,9 +26,17 @@ type EntityNode = {
   visual: TransformNode | AbstractMesh;
   label?: Mesh;
   baseScale: number;
+  areKappa: number;
+  areLogicalIndex: number;
+  areChain: string;
   arePhase: number;
   areResonance: number;
   arePlexity: number;
+  areColor: Color3;
+  areShader: ShaderMaterial | null;
+  areMeshes: AbstractMesh[];
+  areBaseMaterials: Map<number, Material | null>;
+  explicitVisible: boolean;
 };
 
 const DEFAULT_MODEL_BY_TYPE: Record<string, string> = {
@@ -42,6 +53,10 @@ export class BabylonAdapter implements IEngineBridge {
   private readonly pressedKeys = new Set<string>();
   private readonly inputCallbacks: Array<(input: any) => void> = [];
   private readonly areWaveClock = { t: 0 };
+  private readonly areDebugEnabled = new URLSearchParams(window.location.search).get("areDebug") === "1";
+  private readonly areDebugElement: HTMLDivElement | null = null;
+  private areMode: "off" | "cpu" | "shader" = "shader";
+  private areShaderRegistered = false;
   private cameraTargetId: string | null = null;
   private navigationMarker: Mesh | null = null;
   private localPlayerId: string | null = null;
@@ -51,6 +66,13 @@ export class BabylonAdapter implements IEngineBridge {
     private readonly scene: Scene,
     private readonly camera: ArcRotateCamera
   ) {
+    const modeFromQuery = this.normalizeAREMode(new URLSearchParams(window.location.search).get("areMode"));
+    if (modeFromQuery) {
+      this.areMode = modeFromQuery;
+    }
+    if (this.areDebugEnabled) {
+      this.areDebugElement = this.mountAREDebugOverlay();
+    }
     this.bindKeyboard();
   }
 
@@ -71,15 +93,24 @@ export class BabylonAdapter implements IEngineBridge {
       root,
       visual: placeholder,
       baseScale: 1,
+      areKappa: model.are?.kappa ?? 1000,
+      areLogicalIndex: model.are?.logicalIndex ?? 0,
+      areChain: model.are?.chain ?? "",
       arePhase: model.are?.phaseShift ?? 0,
       areResonance: model.are?.resonance ?? 0,
       arePlexity: model.are?.plexity ?? 1,
+      areColor: this.colorForType(model.type),
+      areShader: null,
+      areMeshes: [placeholder],
+      areBaseMaterials: new Map([[placeholder.uniqueId, placeholder.material as Material | null]]),
+      explicitVisible: model.visible ?? true,
     };
     if (model.name) {
       node.label = this.createBillboardLabel(model.name, this.colorForType(model.type), root);
     }
 
     this.applyAREState(node, model);
+    this.applyAREMaterialMode(node);
     this.entities.set(model.id, node);
     this.tryAttachModel(model.id, model.modelUrl ?? DEFAULT_MODEL_BY_TYPE[model.type]);
   }
@@ -102,7 +133,8 @@ export class BabylonAdapter implements IEngineBridge {
       node.root.rotation = Vector3.Lerp(node.root.rotation, targetEuler, lerpAlpha);
     }
     if (updates.visible !== undefined) {
-      node.root.setEnabled(updates.visible);
+      node.explicitVisible = updates.visible;
+      this.applyEntityVisibility(node);
     }
     if (updates.name) {
       if (node.label) {
@@ -116,6 +148,10 @@ export class BabylonAdapter implements IEngineBridge {
     }
     if (updates.modelUrl) {
       this.tryAttachModel(id, updates.modelUrl);
+    }
+    if (updates.type) {
+      node.areColor = this.colorForType(updates.type);
+      this.updateAREShaderUniforms(node);
     }
     this.applyAREState(node, updates);
   }
@@ -211,9 +247,22 @@ export class BabylonAdapter implements IEngineBridge {
     this.inputCallbacks.push(callback);
   }
 
+  setAREMode(mode: string): void {
+    const normalized = this.normalizeAREMode(mode);
+    if (!normalized || normalized === this.areMode) {
+      return;
+    }
+    this.areMode = normalized;
+    for (const node of this.entities.values()) {
+      this.applyAREMaterialMode(node);
+      this.applyEntityVisibility(node);
+    }
+  }
+
   update(dt: number): void {
     this.areWaveClock.t += dt;
     this.updateAREVisuals();
+    this.updateAREDebugOverlay();
     this.updateCameraFollow();
   }
 
@@ -377,6 +426,12 @@ export class BabylonAdapter implements IEngineBridge {
         entity.visual.dispose(false, true);
       }
       entity.visual = modelRoot;
+      entity.areMeshes = this.collectRenderableMeshes(modelRoot);
+      entity.areBaseMaterials = new Map(
+        entity.areMeshes.map((mesh) => [mesh.uniqueId, (mesh.material as Material | null) ?? null])
+      );
+      this.applyAREMaterialMode(entity);
+      this.updateAREShaderUniforms(entity);
     } catch (error) {
       console.warn(`Failed to load model for ${entityId}:`, url, error);
     }
@@ -395,31 +450,196 @@ export class BabylonAdapter implements IEngineBridge {
   }
 
   private applyAREState(node: EntityNode, model: Partial<EntityViewModel>): void {
-    if (!model.are) {
-      return;
+    if (model.are) {
+      node.areKappa = Number.isFinite(model.are.kappa) ? model.are.kappa : node.areKappa;
+      node.areLogicalIndex = Number.isFinite(model.are.logicalIndex)
+        ? model.are.logicalIndex
+        : node.areLogicalIndex;
+      node.areChain = typeof model.are.chain === "string" ? model.are.chain : node.areChain;
+      node.arePhase = Number.isFinite(model.are.phaseShift) ? model.are.phaseShift : node.arePhase;
+      node.areResonance = Number.isFinite(model.are.resonance) ? model.are.resonance : node.areResonance;
+      node.arePlexity = Number.isFinite(model.are.plexity)
+        ? Math.max(0.05, Math.min(1, model.are.plexity))
+        : node.arePlexity;
+      node.baseScale = 0.7 + node.arePlexity * 0.6;
     }
-    node.arePhase = Number.isFinite(model.are.phaseShift) ? model.are.phaseShift : node.arePhase;
-    node.areResonance = Number.isFinite(model.are.resonance) ? model.are.resonance : node.areResonance;
-    node.arePlexity = Number.isFinite(model.are.plexity)
-      ? Math.max(0.05, Math.min(1, model.are.plexity))
-      : node.arePlexity;
-    node.baseScale = 0.7 + node.arePlexity * 0.6;
-    const visibilityByPlexity = node.arePlexity > 0.08;
-    const explicitVisible =
-      model.visible !== undefined ? model.visible : (node.root.metadata as any)?.explicitVisible ?? true;
-    node.root.metadata = {
-      ...(node.root.metadata as Record<string, unknown> | null),
-      explicitVisible,
-    };
-    node.root.setEnabled(visibilityByPlexity && explicitVisible);
+    if (model.visible !== undefined) {
+      node.explicitVisible = model.visible;
+    }
+    this.applyEntityVisibility(node);
+    this.updateAREShaderUniforms(node);
   }
 
   private updateAREVisuals(): void {
     for (const node of this.entities.values()) {
       const wave = Math.sin(this.areWaveClock.t * 2 + node.arePhase * 0.01) * 0.05 * (0.25 + node.areResonance);
-      const scale = Math.max(0.2, node.baseScale + wave);
+      let scale = this.areMode === "off" ? 1 : node.baseScale;
+      if (this.areMode === "cpu") {
+        scale = Math.max(0.2, node.baseScale + wave);
+      }
       node.root.scaling = new Vector3(scale, scale, scale);
+      if (this.areMode === "shader") {
+        this.updateAREShaderUniforms(node);
+      }
     }
+  }
+
+  private collectRenderableMeshes(node: TransformNode | AbstractMesh): AbstractMesh[] {
+    if (node instanceof AbstractMesh) {
+      return [node];
+    }
+    return node.getChildMeshes(false);
+  }
+
+  private applyEntityVisibility(node: EntityNode): void {
+    const visibleByPlexity = this.areMode === "off" ? true : node.arePlexity > 0.08;
+    node.root.setEnabled(visibleByPlexity && node.explicitVisible);
+  }
+
+  private applyAREMaterialMode(node: EntityNode): void {
+    if (this.areMode === "shader") {
+      const shader = this.ensureAREShader(node);
+      for (const mesh of node.areMeshes) {
+        mesh.material = shader;
+      }
+      this.updateAREShaderUniforms(node);
+      return;
+    }
+    for (const mesh of node.areMeshes) {
+      if (node.areBaseMaterials.has(mesh.uniqueId)) {
+        mesh.material = node.areBaseMaterials.get(mesh.uniqueId) ?? null;
+      }
+    }
+  }
+
+  private ensureAREShader(node: EntityNode): ShaderMaterial {
+    if (node.areShader) {
+      return node.areShader;
+    }
+    this.ensureAREShaderRegistered();
+    const shader = new ShaderMaterial(
+      `are_shader_${node.root.name}`,
+      this.scene,
+      { vertex: "are", fragment: "are" },
+      {
+        attributes: ["position"],
+        uniforms: [
+          "worldViewProjection",
+          "uTime",
+          "uPhase",
+          "uResonance",
+          "uPlexity",
+          "uColor",
+        ],
+      }
+    );
+    shader.backFaceCulling = false;
+    node.areShader = shader;
+    return shader;
+  }
+
+  private ensureAREShaderRegistered(): void {
+    if (this.areShaderRegistered) {
+      return;
+    }
+    this.areShaderRegistered = true;
+    Effect.ShadersStore.areVertexShader = `
+      precision highp float;
+      attribute vec3 position;
+      uniform mat4 worldViewProjection;
+      uniform float uTime;
+      uniform float uPhase;
+      uniform float uResonance;
+      uniform float uPlexity;
+      varying float vWave;
+      void main(void) {
+        float amp = (0.03 + uResonance * 0.06) * max(0.1, uPlexity);
+        float wave = sin(uTime * 2.5 + uPhase * 0.01 + position.y * 2.0) * amp;
+        vec3 displaced = position + vec3(0.0, wave, 0.0);
+        vWave = wave;
+        gl_Position = worldViewProjection * vec4(displaced, 1.0);
+      }
+    `;
+    Effect.ShadersStore.areFragmentShader = `
+      precision highp float;
+      uniform vec3 uColor;
+      uniform float uPlexity;
+      uniform float uResonance;
+      varying float vWave;
+      void main(void) {
+        float glow = 0.55 + uResonance * 0.35 + abs(vWave) * 3.0;
+        vec3 color = uColor * glow;
+        color = mix(color * 0.35, color, clamp(uPlexity, 0.0, 1.0));
+        gl_FragColor = vec4(color, 1.0);
+      }
+    `;
+  }
+
+  private updateAREShaderUniforms(node: EntityNode): void {
+    if (!node.areShader) {
+      return;
+    }
+    node.areShader.setFloat("uTime", this.areWaveClock.t);
+    node.areShader.setFloat("uPhase", node.arePhase);
+    node.areShader.setFloat("uResonance", node.areResonance);
+    node.areShader.setFloat("uPlexity", node.arePlexity);
+    node.areShader.setColor3("uColor", node.areColor);
+  }
+
+  private normalizeAREMode(mode: unknown): "off" | "cpu" | "shader" | null {
+    if (typeof mode !== "string") return null;
+    const value = mode.trim().toLowerCase();
+    if (value === "off") return "off";
+    if (value === "cpu") return "cpu";
+    if (value === "shader" || value === "on" || value === "are" || value === "true") return "shader";
+    return null;
+  }
+
+  private mountAREDebugOverlay(): HTMLDivElement {
+    const node = document.createElement("div");
+    node.id = "are-debug-overlay";
+    node.style.position = "fixed";
+    node.style.top = "12px";
+    node.style.right = "12px";
+    node.style.zIndex = "10000";
+    node.style.padding = "10px";
+    node.style.minWidth = "220px";
+    node.style.background = "rgba(0,0,0,0.62)";
+    node.style.border = "1px solid rgba(95,160,255,0.5)";
+    node.style.borderRadius = "8px";
+    node.style.color = "#d7e6ff";
+    node.style.fontFamily = "ui-monospace, SFMono-Regular, Menlo, monospace";
+    node.style.fontSize = "11px";
+    node.style.whiteSpace = "pre";
+    document.body.appendChild(node);
+    return node;
+  }
+
+  private updateAREDebugOverlay(): void {
+    if (!this.areDebugEnabled || !this.areDebugElement) {
+      return;
+    }
+    let visible = 0;
+    let resonance = 0;
+    let plexity = 0;
+    for (const node of this.entities.values()) {
+      if (node.root.isEnabled()) visible += 1;
+      resonance += node.areResonance;
+      plexity += node.arePlexity;
+    }
+    const count = this.entities.size || 1;
+    const localNode = this.localPlayerId ? this.entities.get(this.localPlayerId) : null;
+    this.areDebugElement.textContent = [
+      "ARE DEBUG",
+      `mode: ${this.areMode}`,
+      `entities: ${this.entities.size} (visible ${visible})`,
+      `avg resonance: ${(resonance / count).toFixed(3)}`,
+      `avg plexity: ${(plexity / count).toFixed(3)}`,
+      `wave t: ${this.areWaveClock.t.toFixed(2)}`,
+      localNode
+        ? `local: k=${localNode.areKappa} idx=${localNode.areLogicalIndex}\nlocal: phase=${localNode.arePhase.toFixed(1)} res=${localNode.areResonance.toFixed(2)} plex=${localNode.arePlexity.toFixed(2)}\nchain: ${localNode.areChain.slice(0, 42)}`
+        : "local: -",
+    ].join("\n");
   }
 
   private inferTypeFromEntityId(id: string): string {

--- a/client/src/engine/bridge/EntityViewModel.ts
+++ b/client/src/engine/bridge/EntityViewModel.ts
@@ -8,4 +8,13 @@ export interface EntityViewModel {
   name?: string;
   health?: number;
   maxHealth?: number;
+  are?: {
+    kappa: number;
+    logicalIndex: number;
+    phaseShift: number;
+    resonance: number;
+    plexity: number;
+    chain: string;
+    kappaPos: { x: number; y: number; z: number };
+  };
 }

--- a/client/src/engine/bridge/IEngineBridge.ts
+++ b/client/src/engine/bridge/IEngineBridge.ts
@@ -30,4 +30,7 @@ export interface IEngineBridge {
 
   // Lifecycle
   update(dt: number): void;
+
+  // Optional renderer-specific controls
+  setAREMode?(mode: string): void;
 }

--- a/client/src/networking/websocketClient.ts
+++ b/client/src/networking/websocketClient.ts
@@ -155,6 +155,9 @@ export function connectSocket(core: MMORPGClientCore, options: ConnectionOptions
     try {
       const data = JSON.parse(msg.data);
       if (data.type === 'entity_sync') {
+        if (typeof data.areMode === "string") {
+          core.setAREMode(data.areMode);
+        }
         if (data.entities) {
           const normalizedEntities = data.entities.map((entity: any) => ({
             ...entity,

--- a/client/src/networking/websocketClient.ts
+++ b/client/src/networking/websocketClient.ts
@@ -25,6 +25,44 @@ function toEntityPosition(spawnPosition?: Partial<SpawnPosition>) {
   return { x, y, z };
 }
 
+function normalizeAREPayload(rawAre: any) {
+  if (!rawAre || typeof rawAre !== "object") {
+    return undefined;
+  }
+  const kappa = Number(rawAre.kappa);
+  const logicalIndex = Number(rawAre.logicalIndex);
+  const phaseShift = Number(rawAre.phaseShift);
+  const resonance = Number(rawAre.resonance);
+  const plexity = Number(rawAre.plexity);
+  const kappaPosRaw = rawAre.kappaPos || {};
+  const kappaPos = {
+    x: Number(kappaPosRaw.x),
+    y: Number(kappaPosRaw.y),
+    z: Number(kappaPosRaw.z),
+  };
+  if (
+    !Number.isFinite(kappa) ||
+    !Number.isFinite(logicalIndex) ||
+    !Number.isFinite(phaseShift) ||
+    !Number.isFinite(resonance) ||
+    !Number.isFinite(plexity) ||
+    !Number.isFinite(kappaPos.x) ||
+    !Number.isFinite(kappaPos.y) ||
+    !Number.isFinite(kappaPos.z)
+  ) {
+    return undefined;
+  }
+  return {
+    kappa,
+    logicalIndex,
+    phaseShift,
+    resonance,
+    plexity,
+    chain: typeof rawAre.chain === "string" ? rawAre.chain : "",
+    kappaPos,
+  };
+}
+
 function normalizeWebSocketUrl(rawUrl: string | undefined): string | null {
   if (!rawUrl || rawUrl.trim().length === 0) {
     return null;
@@ -121,6 +159,7 @@ export function connectSocket(core: MMORPGClientCore, options: ConnectionOptions
           const normalizedEntities = data.entities.map((entity: any) => ({
             ...entity,
             modelUrl: entity.modelUrl ?? entity.glbPath,
+            are: normalizeAREPayload(entity.are),
           }));
           core.syncEntities(normalizedEntities);
         }

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -13,6 +13,7 @@ import { verifyFirebaseToken } from "../config/firebase.js";
 import { ItemRegistry } from "../modules/inventory/ItemRegistry.js";
 import { GLBRegistry } from "../modules/asset-registry/GLBRegistry.js";
 import { AssetPoolResolver } from "../modules/world/AssetPoolResolver.js";
+import { AREStateCompiler } from "../modules/world/AREStateCompiler.js";
 import { cache } from "./Cache.js";
 import fs from "fs";
 import path from "path";
@@ -216,6 +217,7 @@ export class WorldTick {
   public persistence: PersistenceManager;
   public glbRegistry: GLBRegistry;
   private assetPoolResolver: AssetPoolResolver;
+  private areStateCompiler: AREStateCompiler;
   private lootEntities: Map<string, any> = new Map();
 
   private socketToPlayer: Map<string, string> = new Map(); // socketId -> characterName
@@ -1068,6 +1070,7 @@ export class WorldTick {
     this.worldSystem = new WorldSystem(this.persistence);
     this.glbRegistry = new GLBRegistry();
     this.assetPoolResolver = new AssetPoolResolver();
+    this.areStateCompiler = new AREStateCompiler();
 
     // Create a dummy player in a distant chunk to prove multi-observer union
     const dummyPlayer = this.playerSystem.createPlayer("dummy_player", "Dummy Player");
@@ -1391,6 +1394,7 @@ export class WorldTick {
   }
 
   broadcastState() {
+    const tickCount = this.tickCount;
     const entities = [
       ...this.playerSystem.getAllPlayers().map(p => ({
         id: p.id,
@@ -1399,6 +1403,17 @@ export class WorldTick {
         rotation: { x: 0, y: 0, z: 0 },
         name: p.name,
         glbPath: this.resolveEntityGlbPath("players", p.name || p.id, p.id),
+        are: this.areStateCompiler.compileEntity(
+          {
+            id: p.id,
+            type: "player",
+            position: { x: p.position.x, y: 0, z: p.position.y },
+            health: p.health,
+            maxHealth: p.maxHealth,
+            visible: true,
+          },
+          tickCount
+        ),
         visible: true
       })),
       ...this.npcSystem.getAllNPCs().map(n => ({
@@ -1408,6 +1423,17 @@ export class WorldTick {
         rotation: { x: 0, y: 0, z: 0 },
         name: n.name,
         glbPath: this.resolveNpcGlbPath(n),
+        are: this.areStateCompiler.compileEntity(
+          {
+            id: n.id,
+            type: "npc",
+            position: { x: n.position.x, y: 0, z: n.position.y },
+            health: n.health,
+            maxHealth: n.maxHealth,
+            visible: true,
+          },
+          tickCount
+        ),
         visible: true
       })),
       ...Array.from(this.lootEntities.values()).map(l => ({
@@ -1416,6 +1442,15 @@ export class WorldTick {
         position: { x: l.position.x, y: 0, z: l.position.y },
         rotation: { x: 0, y: 0, z: 0 },
         glbPath: this.resolveEntityGlbPath("loot", l.item?.id || l.id, l.id),
+        are: this.areStateCompiler.compileEntity(
+          {
+            id: l.id,
+            type: "loot",
+            position: { x: l.position.x, y: 0, z: l.position.y },
+            visible: true,
+          },
+          tickCount
+        ),
         visible: true
       }))
     ];
@@ -1428,6 +1463,15 @@ export class WorldTick {
         position: { x: obj.position.x, y: 0, z: obj.position.y },
         rotation: { x: 0, y: obj.rotation || 0, z: 0 },
         glbPath: obj.glbPath || this.resolveWorldObjectGlbPath(obj.type, obj.name || obj.id, obj.id),
+        are: this.areStateCompiler.compileEntity(
+          {
+            id: obj.id,
+            type: obj.type || "object",
+            position: { x: obj.position.x, y: 0, z: obj.position.y },
+            visible: true,
+          },
+          tickCount
+        ),
         visible: true
       }));
       entities.push(...worldObjects);

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -81,6 +81,7 @@ type ScheduledGMTemplateStep = {
   originY: number;
   step: GMTemplateStep;
 };
+type AREMode = "off" | "cpu" | "shader";
 
 const DEFAULT_SCENE_ID = "didis_hub";
 const DEFAULT_SCENE_PROFILES: Record<string, SceneProfile> = {
@@ -200,6 +201,19 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function normalizeAREMode(value: unknown): AREMode | null {
+  if (!isNonEmptyString(value)) {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "off") return "off";
+  if (normalized === "cpu") return "cpu";
+  if (normalized === "shader" || normalized === "on" || normalized === "true" || normalized === "are") {
+    return "shader";
+  }
+  return null;
+}
+
 export class WorldTick {
   private timer: NodeJS.Timeout | null = null;
   private tickCount = 0;
@@ -240,6 +254,7 @@ export class WorldTick {
     bannedPlayers: [],
     customDialogues: {},
   };
+  private areMode: AREMode = "shader";
   private eventTemplates: GMTemplateDefinition[] = Object.values(GM_EVENT_TEMPLATES);
   private pendingTemplateSteps: ScheduledGMTemplateStep[] = [];
 
@@ -496,6 +511,7 @@ export class WorldTick {
       world: {
         weather: this.worldState.weather,
         time: this.worldSystem.getFormattedTime(),
+        areMode: this.areMode,
       },
       players,
       npcs,
@@ -679,6 +695,22 @@ export class WorldTick {
           this.worldState = { ...this.worldState, ...msg.settings };
         }
         this.sendGMStatus(socketId, "info", "World settings updated.");
+        return true;
+      }
+      case "gm_are_mode_get": {
+        this.ws.sendToPlayer(socketId, { type: "gm_are_mode_result", mode: this.areMode });
+        return true;
+      }
+      case "gm_are_mode_set": {
+        const mode = normalizeAREMode(msg.mode);
+        if (!mode) {
+          this.sendGMStatus(socketId, "error", "Invalid ARE mode. Use off, cpu or shader.");
+          return true;
+        }
+        this.areMode = mode;
+        this.ws.sendToPlayer(socketId, { type: "gm_are_mode_result", mode: this.areMode });
+        this.ws.broadcast({ type: "world_event", event: "are_mode_changed", mode: this.areMode });
+        this.sendGMStatus(socketId, "info", `ARE mode set to ${this.areMode}`);
         return true;
       }
       case "gm_world_event": {
@@ -1481,6 +1513,7 @@ export class WorldTick {
 
     this.ws.broadcast({
       type: 'entity_sync',
+      areMode: this.areMode,
       entities,
       chunks: [{ id: 'main', chunkX: 0, chunkY: 0, objects: [] }]
     });

--- a/server/src/modules/world/AREStateCompiler.ts
+++ b/server/src/modules/world/AREStateCompiler.ts
@@ -1,0 +1,87 @@
+export type AREPayload = {
+  kappa: number;
+  logicalIndex: number;
+  phaseShift: number;
+  resonance: number;
+  plexity: number;
+  chain: string;
+  kappaPos: { x: number; y: number; z: number };
+};
+
+export class AREStateCompiler {
+  public static readonly KAPPA = 1000;
+  private readonly kappa = AREStateCompiler.KAPPA;
+
+  public compileEntity(
+    entity: {
+      id: string;
+      type: string;
+      position: { x: number; y: number; z: number };
+      health?: number;
+      maxHealth?: number;
+      visible?: boolean;
+    },
+    tickCount: number
+  ): AREPayload {
+    const kappaPos = this.toKappaPosition(entity.position);
+    const logicalIndex = this.computeLogicalIndex(entity.id, entity.type, kappaPos);
+    const healthRatio = this.computeHealthRatio(entity.health, entity.maxHealth);
+    const movementSignal =
+      (Math.abs(kappaPos.x) + Math.abs(kappaPos.y) + Math.abs(kappaPos.z) + tickCount) % this.kappa;
+    const resonance = Number((movementSignal / this.kappa).toFixed(4));
+    const phaseShift = (logicalIndex + tickCount) % this.kappa;
+    const plexity = this.computePlexity(entity.type, entity.visible ?? true, healthRatio, resonance);
+    const chain = this.buildChain(entity.type, logicalIndex, phaseShift, plexity);
+
+    return {
+      kappa: this.kappa,
+      logicalIndex,
+      phaseShift,
+      resonance,
+      plexity,
+      chain,
+      kappaPos,
+    };
+  }
+
+  private toKappaPosition(position: { x: number; y: number; z: number }) {
+    return {
+      x: Math.round(position.x * this.kappa),
+      y: Math.round(position.y * this.kappa),
+      z: Math.round(position.z * this.kappa),
+    };
+  }
+
+  private computeLogicalIndex(id: string, type: string, kappaPos: { x: number; y: number; z: number }): number {
+    const base = `${type}:${id}:${kappaPos.x}:${kappaPos.y}:${kappaPos.z}`;
+    return Math.abs(this.hash(base)) % this.kappa;
+  }
+
+  private computePlexity(type: string, visible: boolean, healthRatio: number, resonance: number): number {
+    if (!visible) return 0.05;
+    const typeWeight = type === "player" ? 1 : type === "npc" ? 0.78 : type === "monster" ? 0.88 : 0.64;
+    const score = 0.45 * typeWeight + 0.35 * healthRatio + 0.2 * (1 - resonance);
+    return Number(Math.max(0.05, Math.min(1, score)).toFixed(4));
+  }
+
+  private buildChain(type: string, logicalIndex: number, phaseShift: number, plexity: number): string {
+    const p = Math.round(plexity * this.kappa);
+    return `${type}|li:${logicalIndex}|ph:${phaseShift}|plx:${p}`;
+  }
+
+  private computeHealthRatio(health?: number, maxHealth?: number): number {
+    const hp = Number.isFinite(Number(health)) ? Number(health) : 1;
+    const maxHp = Number.isFinite(Number(maxHealth)) && Number(maxHealth)! > 0 ? Number(maxHealth) : 1;
+    const ratio = hp / maxHp;
+    return Math.max(0, Math.min(1, ratio));
+  }
+
+  private hash(input: string): number {
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+      hash = (hash << 5) - hash + input.charCodeAt(i);
+      hash |= 0;
+    }
+    return hash;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add server-side ARE mode audit trail with append-only JSONL persistence
- expose GM commands for audit retrieval and send append events on mode change
- add debug-only ARE mode HUD badge in Babylon renderer (`?areDebug=1`) showing mode + source + reason
- enrich ARE auto-policy decisions with explicit transition reasons (`low_fps` / `stable_fps`)
- extend external GM console with ARE audit controls and live audit log pane
- add focused server test for ARE mode audit trail persistence/readback
- extend ARE policy tests to assert reason propagation
- fix black-screen startup behavior by hardening client boot/network recovery and adding guaranteed visible boot anchor
- harden build memory settings across deploy/CI paths to prevent Node.js heap OOM
- enforce deploy-path Node heap export directly in the SSH workflow path used by production deploy
- add deploy-time heap preflight and reduce Vite peak memory usage in production builds
- add a dedicated Cursor handoff status logbook document in repo docs
- remove PlayCanvas runtime fallback and finalize Babylon-only client stack

## Babylon-only cleanup (new)
Per request, PlayCanvas has been removed from active client runtime.

### What changed
- **Updated** `client/src/main.ts`
  - removed PlayCanvas imports and fallback branch
  - boot path is now Babylon-only with explicit fatal status if Babylon init fails
- **Updated** `client/src/engine/babylon/BabylonAdapter.ts`
  - moved AssetRegistry import to a renderer-neutral path
- **New** `client/src/engine/assets/AssetRegistry.ts`
  - keeps shared asset mapping without PlayCanvas coupling
- **Removed** legacy PlayCanvas engine files:
  - `client/src/engine/playcanvas/PlayCanvasAdapter.ts`
  - `client/src/engine/playcanvas/PlayCanvasAssetLoader.ts`
  - `client/src/engine/playcanvas/PlayCanvasBoot.ts`
  - `client/src/engine/playcanvas/PlayCanvasCameraController.ts`
  - `client/src/engine/playcanvas/PlayCanvasEntityFactory.ts`
  - `client/src/engine/playcanvas/SceneInitializer.js`
  - `client/src/engine/playcanvas/AssetRegistry.ts` (replaced by neutral path above)
- **Updated** `client/package.json` + lockfile
  - removed `playcanvas` dependency

## New docs handoff artifact
- **New** `docs/CURSOR_STATUS_LOGBUCH.md`
  - structured handoff status for next Cursor instances
  - includes project identity, milestones, architecture refs, key files, risks, QA commands, and follow-up note

## Latest OOM incident response
Additional protections for deploy heap exhaustion:
- `deploy/deploy.sh`: default `BUILD_NODE_OPTIONS=--max-old-space-size=8192`, heap print, preflight guard
- `.github/workflows/deploy.yml`: passes `BUILD_NODE_OPTIONS=--max-old-space-size=8192`
- `client/vite.config.ts`: production sourcemaps disabled to lower build memory

## Validation run
- ✅ `npm install --prefix client`
- ✅ `npm run build --prefix client`
- ✅ `npm install --prefix server`
- ✅ `npm run build --prefix server`
- ✅ `bash -n deploy/deploy.sh`
- ⚠️ Focused vitest in this cloud environment still has the known root `vitest/config` resolution issue unrelated to these changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82ff7175-beef-46a6-8e14-2614089a7703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ff7175-beef-46a6-8e14-2614089a7703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

