### PR TITLE
fix(deploy): raise Node heap limit for Vite production build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Continuous Deployment to VPS
 
+# If the VPS build fails (e.g. Vite OOM), fix is in-repo (client NODE_OPTIONS); re-run
+# from Actions → this workflow → Run workflow (workflow_dispatch).
+
 on:
   push:
     branches: [ main ]

--- a/ContinuousDeploymenttoVPS.yml
+++ b/ContinuousDeploymenttoVPS.yml
@@ -1,5 +1,8 @@
 name: Continuous Deployment to VPS
 
+# If the VPS build fails (e.g. Vite OOM), fix is in-repo (client NODE_OPTIONS); re-run
+# from Actions → this workflow → Run workflow (workflow_dispatch).
+
 on:
   push:
     branches: [ main ]

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -56,7 +56,7 @@ npm install
 # ── 6. Build client ───────────────────────────────────────
 echo "[6/10] Building client (Vite)..."
 cd "$APP_DIR/client"
-npm run build
+NODE_OPTIONS=--max-old-space-size=8192 npm run build
 
 # ── 7. Build server ───────────────────────────────────────
 echo "[7/10] Building server (TypeScript)..."

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -11,7 +11,7 @@ git pull origin main
 # Rebuild client
 cd "$APP_DIR/client"
 npm install
-npx vite build
+NODE_OPTIONS=--max-old-space-size=8192 npx vite build
 
 # Rebuild server
 cd "$APP_DIR/server"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The VPS deploy was failing during `vite build` with **JavaScript heap out of memory** (~2 GB) while rendering chunks after transforming 3400+ modules.

## Changes

- Set `NODE_OPTIONS=--max-old-space-size=8192` for the client production build in `client/package.json` so every `npm run build` in `client/` gets a higher heap.
- Applied the same in `deploy/deploy.sh` and `deploy/update.sh` for redundancy on the server.
- Added short comments to `.github/workflows/deploy.yml` and `ContinuousDeploymenttoVPS.yml` noting that **workflow_dispatch** can be used to manually re-run after the fix is on `main`.

## Verification

- Ran `pnpm --filter areloria-client run build` locally; build completed successfully.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a45522c-1992-454e-b081-25c140f1878a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a45522c-1992-454e-b081-25c140f1878a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

