### PR TITLE
fix(deploy): raise Node heap limit for Vite production build

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -11,7 +11,7 @@ git pull origin main
 # Rebuild client
 cd "$APP_DIR/client"
 npm install
-npx vite build
+NODE_OPTIONS=--max-old-space-size=8192 npx vite build
 
 # Rebuild server
 cd "$APP_DIR/server"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The VPS deploy was failing during `vite build` with **JavaScript heap out of memory** (~2GB) while rendering chunks after transforming 3400+ modules.

## Changes

- **`client/package.json`**: Run the client build with `NODE_OPTIONS=--max-old-space-size=8192` so `npm run build` in `deploy/deploy.sh` gets a larger heap without editing the deploy script.
- **`deploy/update.sh`**: Apply the same limit for the direct `npx vite build` path used by quick updates.

## Verification

- `npm run build` in `client/` completes successfully with the new script.

## Notes

If the VPS has less than ~8GB RAM, you may need a lower value (e.g. `4096`) or more swap; 8192 is the Node heap cap, not total RAM usage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d180d4-df03-4eb6-b096-ea5c611fe074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d180d4-df03-4eb6-b096-ea5c611fe074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

