### PR TITLE
Fix Vite OOM on deploy by increasing Node heap for client build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,8 @@ on:
     branches: [ main ]
   schedule:
     - cron: '0 * * * *' # Stündlich ausführen
-  workflow_dispatch: # Manuelles Triggern ermöglichen
+  # Re-run from Actions tab if deploy failed (e.g. Vite OOM on the VPS).
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/ContinuousDeploymenttoVPS.yml
+++ b/ContinuousDeploymenttoVPS.yml
@@ -5,7 +5,8 @@ on:
     branches: [ main ]
   schedule:
     - cron: '0 * * * *' # Stündlich ausführen
-  workflow_dispatch: # Manuelles Triggern ermöglichen
+  # Re-run from Actions tab if deploy failed (e.g. Vite OOM on the VPS).
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node --max-old-space-size=8192 node_modules/vite/bin/vite.js build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -8,10 +8,10 @@ echo "🔄 Updating Areloria MMORPG..."
 cd "$APP_DIR"
 git pull origin main
 
-# Rebuild client
+# Rebuild client (Vite needs extra heap on small VPS default ~2GB limit)
 cd "$APP_DIR/client"
 npm install
-npx vite build
+npm run build
 
 # Rebuild server
 cd "$APP_DIR/server"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Production Vite builds were failing on the VPS with `FATAL ERROR: Ineffective mark-compacts near heap limit` (~2GB default old space) during chunk rendering.

## Changes
- **`client/package.json`**: Run the production build as `node --max-old-space-size=8192 node_modules/vite/bin/vite.js build` so the Vite process gets a higher heap (works with `npm` on Linux and avoids Unix-only `VAR=value` prefixes in scripts).
- **`deploy/update.sh`**: Use `npm run build` for the client so it picks up the same script as `deploy/deploy.sh`.
- **`.github/workflows/deploy.yml`** and **`ContinuousDeploymenttoVPS.yml`**: Short comment that `workflow_dispatch` exists so failed deploys can be re-run manually from the Actions tab.

## Verification
- `npm run build` in `client/` completes successfully locally with the new script.

## Note
If the VPS has less than ~8GB RAM, the kernel may still OOM-kill the process; in that case upgrade RAM or lower `--max-old-space-size` to fit available memory.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedb1ddc-b237-4fca-88b9-66c914ab8c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedb1ddc-b237-4fca-88b9-66c914ab8c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

