### PR TITLE
fix(server): robust client dist path for VPS deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 PORT=3000
 NODE_ENV=development
+
+# Absolute path to the built client (index.html + assets). Optional: if unset, the server picks
+# client/dist next to the bundle or under process.cwd() (monorepo root when PM2 cwd is the repo).
+# CLIENT_DIST_PATH=/opt/areloria/client/dist
 MCP_ADMIN_TOKEN=
 MCP_PUBLIC_SSE_URL=https://your-domain.example/api/mcp/sse
 MCP_PUBLIC_MESSAGES_URL=https://your-domain.example/api/mcp/messages?sessionId=<id>

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { createServer } from "node:http";
+import fs from "node:fs";
 import { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import { WorldTick } from "./WorldTick.js";
 import path from "path";
@@ -9,6 +10,33 @@ import migrationRoute from "../api/migrationRoute.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+/** Resolves client/dist and client root for Vite; avoids /opt/client/dist when only server/ is deployed under /opt. */
+function resolveClientPaths(): { dist: string; root: string } {
+  const env = process.env.CLIENT_DIST_PATH?.trim();
+  if (env) {
+    const dist = path.isAbsolute(env) ? env : path.resolve(process.cwd(), env);
+    return { dist, root: path.dirname(dist) };
+  }
+  const fromBundle = path.resolve(__dirname, "../../../client/dist");
+  const fromCwd = path.resolve(process.cwd(), "client/dist");
+  const index = (d: string) => path.join(d, "index.html");
+  let dist: string;
+  if (fs.existsSync(index(fromBundle))) {
+    dist = fromBundle;
+  } else if (fs.existsSync(index(fromCwd))) {
+    dist = fromCwd;
+    console.warn(
+      `[ServerBootstrap] Serving client from ${fromCwd} (cwd); bundle path had no index.html: ${fromBundle}. Set CLIENT_DIST_PATH to pin the path.`
+    );
+  } else {
+    dist = fromBundle;
+    console.warn(
+      `[ServerBootstrap] No index.html under ${fromBundle} or ${fromCwd}. Static client may be missing; set CLIENT_DIST_PATH if the app lives elsewhere.`
+    );
+  }
+  return { dist, root: path.dirname(dist) };
+}
 
 export class ServerBootstrap {
   async start() {
@@ -33,22 +61,22 @@ export class ServerBootstrap {
       next();
     });
 
-    const clientPath = path.resolve(__dirname, "../../../client/dist");
+    const { dist: clientDistPath, root: clientRootPath } = resolveClientPaths();
     if (process.env.NODE_ENV !== "production") {
       try {
         const { createServer: createViteServer } = await import("vite");
         const vite = await createViteServer({
           server: { middlewareMode: true },
           appType: "spa",
-          root: path.resolve(__dirname, "../../../client"),
+          root: clientRootPath,
         });
         app.use(vite.middlewares);
       } catch (e) {
         console.error("Failed to start Vite middleware", e);
-        app.use(express.static(clientPath));
+        app.use(express.static(clientDistPath));
       }
     } else {
-      app.use(express.static(clientPath));
+      app.use(express.static(clientDistPath));
     }
 
     const ws = new GameWebSocketServer(httpServer);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ServerBootstrap` resolved static client files with `path.resolve(__dirname, "../../../client/dist")`. When only the compiled server lives under something like `/opt/server/dist`, that climbs to `/opt` and points at `/opt/client/dist` instead of the monorepo’s `client/dist` (e.g. `/opt/areloria/client/dist`).

## Changes

- **Resolve `client/dist` in order:** optional `CLIENT_DIST_PATH` env → bundle-relative path if `index.html` exists → else `process.cwd()/client/dist` when that has `index.html`, with a startup warning.
- **Vite dev root** follows the same base directory as the chosen dist folder.
- **Document** `CLIENT_DIST_PATH` in `.env.example`.

## Ops note

For unusual layouts, set `CLIENT_DIST_PATH` to an absolute path (e.g. `/opt/areloria/client/dist`). PM2 `cwd` should be the repo root so the fallback can find `client/dist` without symlinks.

## Verification

- `pnpm run lint`
- `pnpm exec tsc -p server/tsconfig.json --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e28a032d-9f74-4a72-9888-5ed0e116c1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e28a032d-9f74-4a72-9888-5ed0e116c1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

