### PR TITLE
fix(server): robust client static path for VPS / PM2 layouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 PORT=3000
 NODE_ENV=development
+
+# Optional: absolute or cwd-relative path to the built client (Vite output).
+# Use when the server process cwd is not the monorepo root (e.g. PM2 cwd is /opt/server).
+# CLIENT_DIST_PATH=/opt/areloria/client/dist
+# CLIENT_ROOT=/opt/areloria/client
 MCP_ADMIN_TOKEN=
 MCP_PUBLIC_SSE_URL=https://your-domain.example/api/mcp/sse
 MCP_PUBLIC_MESSAGES_URL=https://your-domain.example/api/mcp/messages?sessionId=<id>

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -1,11 +1,13 @@
 import express from "express";
 import { createServer } from "node:http";
+import fs from "node:fs";
 import { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import { WorldTick } from "./WorldTick.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import { mcpRoute } from "../api/mcpRoute.js";
 import migrationRoute from "../api/migrationRoute.js";
+import { resolveClientDistDir, resolveClientViteRoot } from "../utils/clientPaths.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,14 +35,22 @@ export class ServerBootstrap {
       next();
     });
 
-    const clientPath = path.resolve(__dirname, "../../../client/dist");
+    const clientPath = resolveClientDistDir(__dirname);
+    const clientIndex = path.join(clientPath, "index.html");
+    if (!fs.existsSync(clientIndex)) {
+      console.warn(
+        `[ServerBootstrap] No index.html at ${clientPath}. Set CLIENT_DIST_PATH or run the server with cwd at the monorepo root (or use a sibling ../client/dist).`
+      );
+    }
+
     if (process.env.NODE_ENV !== "production") {
       try {
         const { createServer: createViteServer } = await import("vite");
+        const viteRoot = resolveClientViteRoot(__dirname, clientPath);
         const vite = await createViteServer({
           server: { middlewareMode: true },
           appType: "spa",
-          root: path.resolve(__dirname, "../../../client"),
+          root: viteRoot,
         });
         app.use(vite.middlewares);
       } catch (e) {

--- a/server/src/tests/clientPaths.test.ts
+++ b/server/src/tests/clientPaths.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveClientDistDir, resolveClientViteRoot } from "../utils/clientPaths.js";
+
+describe("clientPaths", () => {
+  let tmp: string;
+  let prevCwd: string;
+  let prevDist: string | undefined;
+  let prevRoot: string | undefined;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ouro-client-paths-"));
+    prevCwd = process.cwd();
+    prevDist = process.env.CLIENT_DIST_PATH;
+    prevRoot = process.env.CLIENT_ROOT;
+    delete process.env.CLIENT_DIST_PATH;
+    delete process.env.CLIENT_ROOT;
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    if (prevDist === undefined) delete process.env.CLIENT_DIST_PATH;
+    else process.env.CLIENT_DIST_PATH = prevDist;
+    if (prevRoot === undefined) delete process.env.CLIENT_ROOT;
+    else process.env.CLIENT_ROOT = prevRoot;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("uses CLIENT_DIST_PATH when set", () => {
+    const dist = path.join(tmp, "mydist");
+    fs.mkdirSync(dist, { recursive: true });
+    fs.writeFileSync(path.join(dist, "index.html"), "<html></html>");
+    process.env.CLIENT_DIST_PATH = dist;
+    expect(resolveClientDistDir("/fake/server/dist/core")).toBe(path.resolve(dist));
+  });
+
+  it("prefers cwd client/dist when relative path from __dirname has no index", () => {
+    const monorepo = path.join(tmp, "repo");
+    const clientDist = path.join(monorepo, "client", "dist");
+    fs.mkdirSync(clientDist, { recursive: true });
+    fs.writeFileSync(path.join(clientDist, "index.html"), "<html></html>");
+    process.chdir(monorepo);
+    const wrong = resolveClientDistDir("/opt/server/dist/core");
+    expect(wrong).toBe(clientDist);
+  });
+
+  it("resolveClientViteRoot uses CLIENT_ROOT when set", () => {
+    const root = path.join(tmp, "client");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, "vite.config.ts"), "");
+    process.env.CLIENT_ROOT = root;
+    expect(resolveClientViteRoot("/x", "/y/dist")).toBe(path.resolve(root));
+  });
+});

--- a/server/src/utils/clientPaths.ts
+++ b/server/src/utils/clientPaths.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function existsIndexHtml(dir: string): boolean {
+  return fs.existsSync(path.join(dir, "index.html"));
+}
+
+/**
+ * Resolves the directory containing the built SPA (Vite `client/dist`).
+ * On VPS layouts where only `server/` is deployed under `/opt/server`, the
+ * relative path from compiled `dist/core` goes to `/opt/client/dist` instead of
+ * the monorepo's `.../areloria/client/dist`. This checks several candidates and
+ * supports CLIENT_DIST_PATH / CLIENT_ROOT overrides.
+ */
+export function resolveClientDistDir(serverCoreDir: string): string {
+  const env = process.env.CLIENT_DIST_PATH?.trim();
+  if (env) {
+    return path.isAbsolute(env) ? env : path.resolve(process.cwd(), env);
+  }
+
+  const candidates = [
+    path.resolve(serverCoreDir, "../../../client/dist"),
+    path.resolve(process.cwd(), "client/dist"),
+    path.resolve(process.cwd(), "../client/dist"),
+  ];
+
+  for (const dir of candidates) {
+    if (existsIndexHtml(dir)) return dir;
+  }
+
+  return candidates[0];
+}
+
+/** Vite dev server root (`client/`, not `dist`). */
+export function resolveClientViteRoot(serverCoreDir: string, clientDistDir: string): string {
+  const env = process.env.CLIENT_ROOT?.trim();
+  if (env) {
+    return path.isAbsolute(env) ? env : path.resolve(process.cwd(), env);
+  }
+
+  const fromDistParent = path.resolve(clientDistDir, "..");
+  if (
+    existsIndexHtml(fromDistParent) ||
+    fs.existsSync(path.join(fromDistParent, "vite.config.ts")) ||
+    fs.existsSync(path.join(fromDistParent, "vite.config.mts")) ||
+    fs.existsSync(path.join(fromDistParent, "vite.config.js"))
+  ) {
+    return fromDistParent;
+  }
+
+  const candidates = [
+    path.resolve(serverCoreDir, "../../../client"),
+    path.resolve(process.cwd(), "client"),
+    path.resolve(process.cwd(), "../client"),
+  ];
+
+  for (const dir of candidates) {
+    if (
+      existsIndexHtml(dir) ||
+      fs.existsSync(path.join(dir, "vite.config.ts")) ||
+      fs.existsSync(path.join(dir, "vite.config.mts")) ||
+      fs.existsSync(path.join(dir, "vite.config.js"))
+    ) {
+      return dir;
+    }
+  }
+
+  return path.resolve(serverCoreDir, "../../../client");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production static hosting used `path.resolve(__dirname, "../../../client/dist")`, which resolves incorrectly when only the server package lives under a path like `/opt/server` (yielding `/opt/client/dist` instead of the monorepo’s `client/dist`).

## Changes

- **`resolveClientDistDir`**: checks, in order, `CLIENT_DIST_PATH`, the legacy relative path, `process.cwd()/client/dist`, and `../client/dist` from cwd; picks the first directory that contains `index.html`.
- **`resolveClientViteRoot`**: same idea for dev Vite root, with optional `CLIENT_ROOT`.
- **`ServerBootstrap`**: uses the helpers, logs a clear warning if `index.html` is missing.
- **`.env.example`**: documents `CLIENT_DIST_PATH` and `CLIENT_ROOT`.
- **Tests**: `server/src/tests/clientPaths.test.ts`.

## Deployment

If PM2 `cwd` is the monorepo root, behavior stays the same. If the server runs from `/opt/server` with the full repo at `/opt/areloria`, set e.g. `CLIENT_DIST_PATH=/opt/areloria/client/dist` (or point PM2 cwd at the repo root).

## Verification

- `pnpm run lint`
- `pnpm run test` (617 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dd26cb7-ebe7-4b54-840d-5fccc838d5d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dd26cb7-ebe7-4b54-840d-5fccc838d5d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

