### PR TITLE
fix(server): robust client dist path for VPS / split deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 PORT=3000
 NODE_ENV=development
+
+# Optional: absolute path to the `client` package when the server runs outside the monorepo root
+# (e.g. PM2 cwd is /opt/server only). Example: /opt/areloria/client
+# CLIENT_ROOT_DIR=
 MCP_ADMIN_TOKEN=
 MCP_PUBLIC_SSE_URL=https://your-domain.example/api/mcp/sse
 MCP_PUBLIC_MESSAGES_URL=https://your-domain.example/api/mcp/messages?sessionId=<id>

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { createServer } from "node:http";
+import { existsSync } from "node:fs";
 import { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import { WorldTick } from "./WorldTick.js";
 import path from "path";
@@ -9,6 +10,43 @@ import migrationRoute from "../api/migrationRoute.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+/**
+ * Resolves the Vite / static client package root.
+ * When only `server/dist` is deployed under e.g. /opt/server, `__dirname/../../../client`
+ * resolves to /opt/client. Prefer CLIENT_ROOT_DIR, cwd/client, or walking up from __dirname
+ * until a `client` folder with package.json or built dist is found.
+ */
+function resolveClientRoot(): string {
+  const fromEnv = process.env.CLIENT_ROOT_DIR?.trim();
+  if (fromEnv) {
+    return path.isAbsolute(fromEnv) ? fromEnv : path.resolve(process.cwd(), fromEnv);
+  }
+
+  const isClientDir = (dir: string) =>
+    existsSync(path.join(dir, "package.json")) ||
+    existsSync(path.join(dir, "dist", "index.html"));
+
+  const fromCwd = path.resolve(process.cwd(), "client");
+  if (isClientDir(fromCwd)) {
+    return fromCwd;
+  }
+
+  let dir = __dirname;
+  for (let i = 0; i < 10; i++) {
+    const candidate = path.join(dir, "client");
+    if (isClientDir(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
+  return path.resolve(__dirname, "../../../client");
+}
 
 export class ServerBootstrap {
   async start() {
@@ -33,14 +71,24 @@ export class ServerBootstrap {
       next();
     });
 
-    const clientPath = path.resolve(__dirname, "../../../client/dist");
+    const clientRoot = resolveClientRoot();
+    const clientPath = path.join(clientRoot, "dist");
+    if (
+      process.env.NODE_ENV === "production" &&
+      !existsSync(path.join(clientPath, "index.html"))
+    ) {
+      console.warn(
+        `[ServerBootstrap] No index.html under ${clientPath}. ` +
+          "Build the client or set CLIENT_ROOT_DIR to the client package directory (e.g. /opt/areloria/client)."
+      );
+    }
     if (process.env.NODE_ENV !== "production") {
       try {
         const { createServer: createViteServer } = await import("vite");
         const vite = await createViteServer({
           server: { middlewareMode: true },
           appType: "spa",
-          root: path.resolve(__dirname, "../../../client"),
+          root: clientRoot,
         });
         app.use(vite.middlewares);
       } catch (e) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`path.resolve(__dirname, "../../../client/dist")` breaks when the Node process only has `server/dist` deployed (e.g. PM2 `cwd` under `/opt/server`): it resolves to `/opt/client/dist` instead of the monorepo client under `/opt/areloria/client/dist`, so `express.static` serves nothing and the SPA fails to boot.

## Code changes

- **`resolveClientRoot()`** in `ServerBootstrap.ts`: optional `CLIENT_ROOT_DIR`, then `process.cwd()/client` if it looks like the client package, then walk parents from `__dirname` until a `client` folder with `package.json` or `dist/index.html` exists, else fall back to the old relative path.
- **Production warning** if `dist/index.html` is missing after resolution.
- **`.env.example`**: document `CLIENT_ROOT_DIR`.

## Deploy / VPS

- **`deploy/write_pm2_ecosystem.sh`**: writes `ecosystem.config.cjs` with `cwd` = repo root and `CLIENT_ROOT_DIR` = `<APP_DIR>/client` (default `/opt/areloria`).
- **`deploy/deploy.sh`** and **`deploy/update.sh`** call that script so PM2 stays aligned after full deploy or quick update.
- **`DEPLOYMENT.md`**: one-off commands and GitHub Actions notes.

## CI / failed job 69464429731

GitHub Actions logs require sign-in from here; typical failure is **`apt-get upgrade`** over non-interactive SSH (dpkg locks, prompts). Follow-up commits:

- **`deploy.sh`**: skip `apt-get upgrade` when `CI=1` or `SKIP_APT_UPGRADE=1`.
- **`.github/workflows/deploy.yml`**: `export CI=1`; if `/opt/areloria/server/dist/index.js` exists and `pm2` is installed, run **`deploy/update.sh`** instead of full `deploy.sh`.

## Ops note

On VPS: `CLIENT_ROOT_DIR=/opt/areloria/client` in `.env`, or regenerate ecosystem via `APP_DIR=/opt/areloria bash deploy/write_pm2_ecosystem.sh` then `pm2 restart areloria`.

## Verification

- `pnpm exec vitest run` (614 tests)
- `pnpm run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

