### PR TITLE
fix(server): robust client dist path for production deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 PORT=3000
 NODE_ENV=development
+
+# Optional: absolute paths when the server runs outside the monorepo root (e.g. only server/dist on a VPS).
+# CLIENT_ROOT_PATH=/opt/areloria/client
+# CLIENT_DIST_PATH=/opt/areloria/client/dist
 MCP_ADMIN_TOKEN=
 MCP_PUBLIC_SSE_URL=https://your-domain.example/api/mcp/sse
 MCP_PUBLIC_MESSAGES_URL=https://your-domain.example/api/mcp/messages?sessionId=<id>

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -1,14 +1,12 @@
 import express from "express";
 import { createServer } from "node:http";
+import fs from "node:fs";
 import { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import { WorldTick } from "./WorldTick.js";
 import path from "path";
-import { fileURLToPath } from "url";
 import { mcpRoute } from "../api/mcpRoute.js";
 import migrationRoute from "../api/migrationRoute.js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { resolveClientPaths } from "./clientPaths.js";
 
 export class ServerBootstrap {
   async start() {
@@ -33,22 +31,27 @@ export class ServerBootstrap {
       next();
     });
 
-    const clientPath = path.resolve(__dirname, "../../../client/dist");
+    const { root: clientRoot, dist: clientDist } = resolveClientPaths();
+    if (!fs.existsSync(path.join(clientDist, "index.html"))) {
+      console.warn(
+        `Client build missing at ${clientDist} (no index.html). Set CLIENT_DIST_PATH or run from the monorepo root.`
+      );
+    }
     if (process.env.NODE_ENV !== "production") {
       try {
         const { createServer: createViteServer } = await import("vite");
         const vite = await createViteServer({
           server: { middlewareMode: true },
           appType: "spa",
-          root: path.resolve(__dirname, "../../../client"),
+          root: clientRoot,
         });
         app.use(vite.middlewares);
       } catch (e) {
         console.error("Failed to start Vite middleware", e);
-        app.use(express.static(clientPath));
+        app.use(express.static(clientDist));
       }
     } else {
-      app.use(express.static(clientPath));
+      app.use(express.static(clientDist));
     }
 
     const ws = new GameWebSocketServer(httpServer);

--- a/server/src/core/clientPaths.ts
+++ b/server/src/core/clientPaths.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export type ClientPaths = { root: string; dist: string };
+
+/**
+ * Resolves client Vite root and production `dist` for static hosting.
+ * Deployments that only copy `server/` under e.g. `/opt/server` break a naive
+ * `../../../client/dist` from `server/dist/core` (that points at `/opt/client/dist`).
+ * Prefer CLIENT_DIST_PATH / CLIENT_ROOT_PATH, then cwd, then extra parent segments.
+ */
+export function resolveClientPaths(): ClientPaths {
+  const envRoot = process.env.CLIENT_ROOT_PATH?.trim();
+  const envDist = process.env.CLIENT_DIST_PATH?.trim();
+
+  if (envDist) {
+    const dist = path.resolve(envDist);
+    const root = envRoot ? path.resolve(envRoot) : path.resolve(dist, "..");
+    return { root, dist };
+  }
+
+  if (envRoot) {
+    const root = path.resolve(envRoot);
+    return { root, dist: path.join(root, "dist") };
+  }
+
+  const cwdClient = path.join(process.cwd(), "client");
+  const coreDir = __dirname;
+
+  const rootCandidates = [
+    path.resolve(coreDir, "../../../client"),
+    path.resolve(coreDir, "../../../../client"),
+    cwdClient,
+  ];
+
+  for (const root of rootCandidates) {
+    if (!fs.existsSync(path.join(root, "vite.config.ts"))) {
+      continue;
+    }
+    const dist = path.join(root, "dist");
+    return { root, dist };
+  }
+
+  const distCandidates = [
+    path.resolve(coreDir, "../../../client/dist"),
+    path.resolve(coreDir, "../../../../client/dist"),
+    path.join(cwdClient, "dist"),
+  ];
+
+  for (const dist of distCandidates) {
+    if (fs.existsSync(path.join(dist, "index.html"))) {
+      return { root: path.resolve(dist, ".."), dist: path.resolve(dist) };
+    }
+  }
+
+  const fallbackRoot = path.resolve(coreDir, "../../../client");
+  return { root: fallbackRoot, dist: path.join(fallbackRoot, "dist") };
+}

--- a/server/src/tests/clientPaths.test.ts
+++ b/server/src/tests/clientPaths.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveClientPaths } from "../core/clientPaths.js";
+
+describe("resolveClientPaths", () => {
+  it("finds the monorepo client package (vite root + dist)", () => {
+    const { root, dist } = resolveClientPaths();
+    expect(fs.existsSync(path.join(root, "vite.config.ts"))).toBe(true);
+    expect(dist).toBe(path.join(root, "dist"));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production static hosting used `path.resolve(__dirname, "../../../client/dist")` from compiled `server/dist/core`. When only the server subtree is deployed under a path like `/opt/server`, that resolves to `/opt/client/dist` instead of the monorepo’s `client/dist`, so `express.static` served nothing useful.

## Changes

- Introduce `resolveClientPaths()` in `server/src/core/clientPaths.ts`: optional `CLIENT_DIST_PATH` / `CLIENT_ROOT_PATH`, then probe `process.cwd()/client`, then extra parent segments, with existence checks for `vite.config.ts` / `index.html`.
- `ServerBootstrap` uses the resolved paths for Vite (dev) and `express.static` (prod/fallback) and logs a warning if `index.html` is missing.
- Document the env vars in `.env.example`.
- Add a small Vitest that asserts the monorepo client is discovered.

## Verification

- `pnpm run lint`
- `pnpm run test` (615 tests)

## Ops note

On a VPS where the app root is e.g. `/opt/areloria`, either run Node with `cwd` set to that directory or set `CLIENT_DIST_PATH=/opt/areloria/client/dist` (and optionally `CLIENT_ROOT_PATH`) in the environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1de6161e-92ac-4e82-a231-a3b3f18c9b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1de6161e-92ac-4e82-a231-a3b3f18c9b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

