### PR TITLE
fix(client): Vite build OOM on VPS (heap limit)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,18 @@ jobs:
         password: ${{ secrets.VPS_SSH_PASSWORD }}
         port: 22
         script: |
+          set -e
+          export CI=1
           if [ ! -d "/opt/areloria/.git" ]; then
             git clone https://github.com/OuroborosCollective/Wasd.git /opt/areloria
           fi
           cd /opt/areloria
           git fetch origin main
           git reset --hard origin/main
-          chmod +x deploy/deploy.sh
-          ./deploy/deploy.sh
+          chmod +x deploy/deploy.sh deploy/update.sh deploy/write_pm2_ecosystem.sh 2>/dev/null || true
+          # Full bootstrap only when Node/server build is missing; else quick update (no apt upgrade)
+          if [ ! -f /opt/areloria/server/dist/index.js ] || ! command -v pm2 >/dev/null 2>&1; then
+            ./deploy/deploy.sh
+          else
+            ./deploy/update.sh
+          fi

--- a/ContinuousDeploymenttoVPS.yml
+++ b/ContinuousDeploymenttoVPS.yml
@@ -19,11 +19,17 @@ jobs:
         password: ${{ secrets.VPS_SSH_PASSWORD }}
         port: 22
         script: |
+          set -e
+          export CI=1
           if [ ! -d "/opt/areloria/.git" ]; then
             git clone https://github.com/OuroborosCollective/Wasd.git /opt/areloria
           fi
           cd /opt/areloria
           git fetch origin main
           git reset --hard origin/main
-          chmod +x deploy/deploy.sh
-          ./deploy/deploy.sh
+          chmod +x deploy/deploy.sh deploy/update.sh deploy/write_pm2_ecosystem.sh 2>/dev/null || true
+          if [ ! -f /opt/areloria/server/dist/index.js ] || ! command -v pm2 >/dev/null 2>&1; then
+            ./deploy/deploy.sh
+          else
+            ./deploy/update.sh
+          fi

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -31,6 +31,20 @@ nano /opt/areloria/.env
 pm2 restart areloria
 ```
 
+### Client-Pfad auf dem VPS (schwarze / leere Seite)
+
+Wenn der Node-Prozess nur unter `server/` läuft oder `cwd` nicht das Repo-Root ist, kann der Server fälschlich `/opt/client/dist` statt `/opt/areloria/client/dist` bedienen. Abgeholfen wird durch **Repo-Root als `cwd`** und optional **`CLIENT_ROOT_DIR`**.
+
+Nach `git pull` auf dem VPS (Branch mit dem Fix):
+
+```bash
+cd /opt/areloria
+APP_DIR=/opt/areloria bash deploy/write_pm2_ecosystem.sh
+pm2 restart areloria
+```
+
+Oder dauerhaft in `/opt/areloria/.env` ergänzen: `CLIENT_ROOT_DIR=/opt/areloria/client`
+
 ---
 
 ## Tastenkürzel im Spiel

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -45,6 +45,10 @@ pm2 restart areloria
 
 Oder dauerhaft in `/opt/areloria/.env` ergänzen: `CLIENT_ROOT_DIR=/opt/areloria/client`
 
+### GitHub Actions „Continuous Deployment to VPS“
+
+Der Workflow setzt `CI=1`, sodass `deploy.sh` kein `apt-get upgrade` mehr ausführt (das bricht oft bei SSH ohne TTY). Für manuelle Runs auf dem Server: `SKIP_APT_UPGRADE=1 ./deploy/deploy.sh`. Nach dem ersten Setup nutzt der Workflow `deploy/update.sh` (Pull, Build, PM2).
+
 ---
 
 ## Tastenkürzel im Spiel

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -49,6 +49,8 @@ Oder dauerhaft in `/opt/areloria/.env` ergänzen: `CLIENT_ROOT_DIR=/opt/areloria
 
 Der Workflow setzt `CI=1`, sodass `deploy.sh` kein `apt-get upgrade` mehr ausführt (das bricht oft bei SSH ohne TTY). Für manuelle Runs auf dem Server: `SKIP_APT_UPGRADE=1 ./deploy/deploy.sh`. Nach dem ersten Setup nutzt der Workflow `deploy/update.sh` (Pull, Build, PM2).
 
+Wenn der Client-Build mit **„JavaScript heap out of memory“** abbricht, nutzt `client` bereits ein erhöhtes Limit (`--max-old-space-size=6144` im `build`-Script). Bei sehr kleinen VPS-Plänen ggf. Swap erhöhen oder Build lokal/GitHub Actions ausführen und nur `client/dist` deployen.
+
 ---
 
 ## Tastenkürzel im Spiel

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node --max-old-space-size=6144 ./node_modules/vite/bin/vite.js build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -18,8 +18,13 @@ echo "  Areloria MMORPG – Deployment v0.4.0"
 echo "======================================================"
 
 # ── 1. Update system ──────────────────────────────────────
-echo "[1/10] Updating system packages..."
-apt-get update -qq && apt-get upgrade -y -qq
+# Skip full apt upgrade in CI / non-interactive SSH (often fails: locks, prompts, non-root).
+if [ -n "${CI:-}" ] || [ "${SKIP_APT_UPGRADE:-}" = "1" ]; then
+  echo "[1/10] Skipping apt upgrade (CI or SKIP_APT_UPGRADE=1)."
+else
+  echo "[1/10] Updating system packages..."
+  apt-get update -qq && apt-get upgrade -y -qq
+fi
 
 # ── 2. Install Node.js ────────────────────────────────────
 echo "[2/10] Installing Node.js ${NODE_VERSION}..."

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -109,31 +109,8 @@ fi
 # ── 10. Start with PM2 ───────────────────────────────────
 echo "[10/10] Starting server with PM2..."
 cd "$APP_DIR"
-
-# Create PM2 ecosystem config
-cat > "$APP_DIR/ecosystem.config.cjs" << 'PM2EOF'
-module.exports = {
-  apps: [{
-    name: 'areloria',
-    script: './server/dist/index.js',
-    cwd: '/opt/areloria',
-    instances: 1,
-    autorestart: true,
-    watch: false,
-    max_memory_restart: '512M',
-    env: {
-      NODE_ENV: 'production',
-      PORT: 3000
-    },
-    env_file: '/opt/areloria/.env',
-    error_file: '/var/log/areloria/error.log',
-    out_file: '/var/log/areloria/out.log',
-    log_date_format: 'YYYY-MM-DD HH:mm:ss',
-  }]
-};
-PM2EOF
-
-mkdir -p /var/log/areloria
+# cwd + CLIENT_ROOT_DIR avoid serving from /opt/client/dist when script lives under server/dist only
+APP_DIR="$APP_DIR" bash "$APP_DIR/deploy/write_pm2_ecosystem.sh"
 
 # Stop existing instance if running
 pm2 stop areloria 2>/dev/null || true

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -18,6 +18,10 @@ cd "$APP_DIR/server"
 npm install
 npx tsc
 
+# Keep PM2 cwd + CLIENT_ROOT_DIR aligned with repo (fixes wrong /opt/client static path)
+cd "$APP_DIR"
+APP_DIR="$APP_DIR" bash "$APP_DIR/deploy/write_pm2_ecosystem.sh"
+
 # Restart PM2
 pm2 restart areloria
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -13,17 +13,22 @@ cd "$APP_DIR/client"
 npm install
 npx vite build
 
-# Rebuild server
+# Rebuild server (includes content validation like deploy.sh)
 cd "$APP_DIR/server"
 npm install
-npx tsc
+npm run build
 
 # Keep PM2 cwd + CLIENT_ROOT_DIR aligned with repo (fixes wrong /opt/client static path)
 cd "$APP_DIR"
 APP_DIR="$APP_DIR" bash "$APP_DIR/deploy/write_pm2_ecosystem.sh"
 
-# Restart PM2
-pm2 restart areloria
+# Restart or first start PM2
+if pm2 describe areloria >/dev/null 2>&1; then
+  pm2 restart areloria
+else
+  pm2 start "$APP_DIR/ecosystem.config.cjs"
+fi
+pm2 save 2>/dev/null || true
 
 echo "✅ Update complete!"
 pm2 status

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -8,10 +8,10 @@ echo "🔄 Updating Areloria MMORPG..."
 cd "$APP_DIR"
 git pull origin main
 
-# Rebuild client
+# Rebuild client (heap limit set in client/package.json "build" for large Vite bundles)
 cd "$APP_DIR/client"
 npm install
-npx vite build
+npm run build
 
 # Rebuild server (includes content validation like deploy.sh)
 cd "$APP_DIR/server"

--- a/deploy/write_pm2_ecosystem.sh
+++ b/deploy/write_pm2_ecosystem.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Writes PM2 ecosystem for Areloria with correct repo root cwd and CLIENT_ROOT_DIR.
+# Usage: APP_DIR=/opt/areloria ./deploy/write_pm2_ecosystem.sh
+#        (default APP_DIR: /opt/areloria)
+
+set -e
+APP_DIR="${APP_DIR:-/opt/areloria}"
+
+mkdir -p /var/log/areloria
+
+cat > "$APP_DIR/ecosystem.config.cjs" << EOF
+module.exports = {
+  apps: [{
+    name: 'areloria',
+    script: './server/dist/index.js',
+    cwd: '${APP_DIR}',
+    instances: 1,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '512M',
+    env: {
+      NODE_ENV: 'production',
+      PORT: 3000,
+      CLIENT_ROOT_DIR: '${APP_DIR}/client',
+    },
+    env_file: '${APP_DIR}/.env',
+    error_file: '/var/log/areloria/error.log',
+    out_file: '/var/log/areloria/out.log',
+    log_date_format: 'YYYY-MM-DD HH:mm:ss',
+  }]
+};
+EOF
+
+echo "Wrote $APP_DIR/ecosystem.config.cjs (cwd=${APP_DIR}, CLIENT_ROOT_DIR=${APP_DIR}/client)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

GitHub Action SSH deploy failed during `vite build` with:

`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

## Fix

- **`client/package.json`**: run Vite via `node --max-old-space-size=6144` so the production bundle (large Babylon chunk) can complete on memory-tight VPS nodes.
- **`deploy/update.sh`**: use `npm run build` for the client (same as `deploy.sh`).
- **`DEPLOYMENT.md`**: short note on OOM / small VPS (swap or off-VPS build).

## Note

If the VPS has very little RAM and almost no swap, the kernel may still kill Node even with a higher heap cap—add swap or build in CI and rsync `client/dist`.

## Check

Local: `cd client && npm run build` completes (same Vite path as VPS).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

