### PR TITLE
perf: fix client crash/lag from repeated GLB loads + throttle sync

### DIFF
--- a/client/src/engine/babylon/BabylonAdapter.ts
+++ b/client/src/engine/babylon/BabylonAdapter.ts
@@ -24,6 +24,10 @@ import { AssetRegistry } from "../playcanvas/AssetRegistry";
 type EntityNode = {
   root: TransformNode;
   visual: TransformNode | AbstractMesh;
+  /** Set when a glTF attach succeeded; avoids re-running LoadAsset on every entity_sync. */
+  attachedModelUrl?: string;
+  /** URL currently being loaded (async); prevents duplicate concurrent loads for the same entity. */
+  pendingModelUrl?: string;
   label?: Mesh;
   baseScale: number;
   areKappa: number;
@@ -146,7 +150,11 @@ export class BabylonAdapter implements IEngineBridge {
         node.root
       );
     }
-    if (updates.modelUrl) {
+    if (
+      updates.modelUrl &&
+      updates.modelUrl !== node.attachedModelUrl &&
+      updates.modelUrl !== node.pendingModelUrl
+    ) {
       this.tryAttachModel(id, updates.modelUrl);
     }
     if (updates.type) {
@@ -404,6 +412,7 @@ export class BabylonAdapter implements IEngineBridge {
     if (!entity) return;
 
     this.modelAttachQueue.set(entityId, url);
+    entity.pendingModelUrl = url;
     const expectedUrl = url;
     try {
       const container = await this.loadModelContainer(url);
@@ -426,6 +435,7 @@ export class BabylonAdapter implements IEngineBridge {
         entity.visual.dispose(false, true);
       }
       entity.visual = modelRoot;
+      entity.attachedModelUrl = expectedUrl;
       entity.areMeshes = this.collectRenderableMeshes(modelRoot);
       entity.areBaseMaterials = new Map(
         entity.areMeshes.map((mesh) => [mesh.uniqueId, (mesh.material as Material | null) ?? null])
@@ -434,6 +444,11 @@ export class BabylonAdapter implements IEngineBridge {
       this.updateAREShaderUniforms(entity);
     } catch (error) {
       console.warn(`Failed to load model for ${entityId}:`, url, error);
+    } finally {
+      const latest = this.entities.get(entityId);
+      if (latest && latest.pendingModelUrl === expectedUrl) {
+        latest.pendingModelUrl = undefined;
+      }
     }
   }
 
@@ -478,8 +493,9 @@ export class BabylonAdapter implements IEngineBridge {
         scale = Math.max(0.2, node.baseScale + wave);
       }
       node.root.scaling = new Vector3(scale, scale, scale);
-      if (this.areMode === "shader") {
-        this.updateAREShaderUniforms(node);
+      // uTime-only updates for shader mode; avoid touching uniforms every frame in cpu/off
+      if (this.areMode === "shader" && node.areShader) {
+        node.areShader.setFloat("uTime", this.areWaveClock.t);
       }
     }
   }

--- a/server/src/config/GameConfig.ts
+++ b/server/src/config/GameConfig.ts
@@ -1,6 +1,8 @@
 export const GameConfig = {
   chunkSize: 64,
   tickRateMs: 100,
+  /** How often full entity state is broadcast to clients (lower = smoother but heavier on CPU/network). */
+  stateBroadcastIntervalMs: 200,
   defaultPort: 3000,
   maxObserverRadius: 6,
   matrixCurrency: "matrix_energy",

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -1422,7 +1422,13 @@ export class WorldTick {
 
     if (this.tickCount % 600 === 0) this.saveAll();
 
-    this.broadcastState();
+    const broadcastEveryTicks = Math.max(
+      1,
+      Math.round(GameConfig.stateBroadcastIntervalMs / GameConfig.tickRateMs)
+    );
+    if (this.tickCount % broadcastEveryTicks === 0) {
+      this.broadcastState();
+    }
   }
 
   broadcastState() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Symptoms

Severe lag, feeling like something reloads every ~2s, browser eventually crashes.

## Root cause

1. **BabylonAdapter.updateEntity** called `tryAttachModel` on **every** `entity_sync` whenever `modelUrl` was present. Each tick queued another async `SceneLoader.LoadAssetContainerAsync` / instantiate — a **load storm** that exhausts memory and GPU.
2. **Server** broadcast the full entity list **10× per second** (100ms tick), amplifying JSON parse + client work.
3. In ARE **shader** mode, `updateAREVisuals` called `updateAREShaderUniforms` for **every entity every frame** (including redundant static uniforms).

## Changes

- **BabylonAdapter**: track `attachedModelUrl` / `pendingModelUrl`; only attach when URL actually changes; clear pending in `finally`.
- **Shader mode**: per-frame only `setFloat("uTime", …)`; full uniform refresh stays on state changes via existing `applyAREState` / `applyAREMaterialMode`.
- **GameConfig.stateBroadcastIntervalMs** (default **200**): `WorldTick` still simulates at 100ms but sends `entity_sync` every 200ms (tunable).

## Deploy

Merge and redeploy **server + client** (client bundle includes Babylon changes).

## Note

If movement feels too stepped, lower `stateBroadcastIntervalMs` toward `100` or add client-side prediction later.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

