### PR TITLE
ci(deploy): verify VPS deploy with /health; fix PM2 env on update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,3 +34,7 @@ jobs:
           else
             ./deploy/update.sh
           fi
+          if [ "${SKIP_DEPLOY_HEALTH_CHECK:-}" != "1" ]; then
+            sleep 2
+            curl -sf --max-time 15 http://127.0.0.1:3000/health | grep -q '"ok"' && echo "Deploy health check: OK" || { echo "Deploy health check: FAILED (is the server listening on 3000?)"; exit 1; }
+          fi

--- a/ContinuousDeploymenttoVPS.yml
+++ b/ContinuousDeploymenttoVPS.yml
@@ -33,3 +33,7 @@ jobs:
           else
             ./deploy/update.sh
           fi
+          if [ "${SKIP_DEPLOY_HEALTH_CHECK:-}" != "1" ]; then
+            sleep 2
+            curl -sf --max-time 15 http://127.0.0.1:3000/health | grep -q '"ok"' && echo "Deploy health check: OK" || { echo "Deploy health check: FAILED (is the server listening on 3000?)"; exit 1; }
+          fi

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -27,9 +27,14 @@ nano /opt/areloria/.env
 ```
 
 ### 4. Server starten
+
+Nach Änderungen an `ecosystem.config.cjs` oder `CLIENT_ROOT_DIR` reicht `pm2 restart` oft nicht (alte `cwd`/Env). Besser wie im Repo-Skript:
+
 ```bash
-pm2 restart areloria
+cd /opt/areloria && ./deploy/update.sh
 ```
+
+Oder manuell: `pm2 stop areloria && pm2 delete areloria && pm2 start ecosystem.config.cjs`
 
 ### Client-Pfad auf dem VPS (schwarze / leere Seite)
 
@@ -40,14 +45,16 @@ Nach `git pull` auf dem VPS (Branch mit dem Fix):
 ```bash
 cd /opt/areloria
 APP_DIR=/opt/areloria bash deploy/write_pm2_ecosystem.sh
-pm2 restart areloria
+pm2 stop areloria 2>/dev/null; pm2 delete areloria 2>/dev/null; pm2 start ecosystem.config.cjs
 ```
 
 Oder dauerhaft in `/opt/areloria/.env` ergänzen: `CLIENT_ROOT_DIR=/opt/areloria/client`
 
 ### GitHub Actions „Continuous Deployment to VPS“
 
-Der Workflow setzt `CI=1`, sodass `deploy.sh` kein `apt-get upgrade` mehr ausführt (das bricht oft bei SSH ohne TTY). Für manuelle Runs auf dem Server: `SKIP_APT_UPGRADE=1 ./deploy/deploy.sh`. Nach dem ersten Setup nutzt der Workflow `deploy/update.sh` (Pull, Build, PM2).
+Der Workflow setzt `CI=1`, sodass `deploy.sh` kein `apt-get upgrade` mehr ausführt (das bricht oft bei SSH ohne TTY). Für manuelle Runs auf dem Server: `SKIP_APT_UPGRADE=1 ./deploy/deploy.sh`. Nach dem ersten Setup nutzt der Workflow `deploy/update.sh` (Pull, Build, PM2 neu starten aus `ecosystem.config.cjs`).
+
+Am Ende des SSH-Skripts: **`curl http://127.0.0.1:3000/health`** – schlägt fehl, wenn der Dienst nicht lauscht (Job wird rot). Zum Überspringen in `.github/workflows/deploy.yml` vor dem Deploy z. B. `export SKIP_DEPLOY_HEALTH_CHECK=1` setzen (nur wenn der Server auf einem anderen Port läuft o. Ä.).
 
 Wenn der Client-Build mit **„JavaScript heap out of memory“** abbricht, nutzt `client` bereits ein erhöhtes Limit (`--max-old-space-size=6144` im `build`-Script). Bei sehr kleinen VPS-Plänen ggf. Swap erhöhen oder Build lokal/GitHub Actions ausführen und nur `client/dist` deployen.
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -22,12 +22,10 @@ npm run build
 cd "$APP_DIR"
 APP_DIR="$APP_DIR" bash "$APP_DIR/deploy/write_pm2_ecosystem.sh"
 
-# Restart or first start PM2
-if pm2 describe areloria >/dev/null 2>&1; then
-  pm2 restart areloria
-else
-  pm2 start "$APP_DIR/ecosystem.config.cjs"
-fi
+# Same as deploy.sh: plain "restart" often keeps old cwd/env; recreate from ecosystem file
+pm2 stop areloria 2>/dev/null || true
+pm2 delete areloria 2>/dev/null || true
+pm2 start "$APP_DIR/ecosystem.config.cjs"
 pm2 save 2>/dev/null || true
 
 echo "✅ Update complete!"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Review summary

The SSH deploy flow was logically consistent (`git reset --hard origin/main` → `deploy.sh` or `update.sh`), but two gaps showed up in practice:

1. **`update.sh` used `pm2 restart`**, which often keeps the **old process definition** (cwd / `CLIENT_ROOT_DIR` from ecosystem file changes may not apply).
2. **No automated verification** after deploy — a green Action could still mean a crashed Node process.

## Changes

- **`deploy/update.sh`**: same PM2 cycle as **`deploy.sh`** — `stop` → `delete` → `start ecosystem.config.cjs` so cwd and env match the generated file.
- **`.github/workflows/deploy.yml`** and **`ContinuousDeploymenttoVPS.yml`**: after deploy, `curl -sf http://127.0.0.1:3000/health` and grep `"ok"`; failure fails the job. Opt-out: `export SKIP_DEPLOY_HEALTH_CHECK=1` at the top of the script block if PORT differs.
- **`DEPLOYMENT.md`**: manual verification notes and corrected PM2 guidance (avoid bare `restart` after ecosystem changes).

## Manual checks (on VPS)

```bash
cd /opt/areloria && git rev-parse HEAD
pm2 describe areloria
curl -s http://127.0.0.1:3000/health
ls -la client/dist/index.html server/dist/index.js
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

