### PR TITLE
feat(client): Babylon playground textures for ground (temporary assets)

### DIFF
--- a/client/src/engine/babylon/BabylonAdapter.ts
+++ b/client/src/engine/babylon/BabylonAdapter.ts
@@ -13,6 +13,7 @@ import {
   SceneLoader,
   ShaderMaterial,
   StandardMaterial,
+  Texture,
   TransformNode,
   Vector3,
 } from "@babylonjs/core";
@@ -20,6 +21,11 @@ import "@babylonjs/loaders/glTF";
 import { IEngineBridge } from "../bridge/IEngineBridge";
 import { EntityViewModel } from "../bridge/EntityViewModel";
 import { AssetRegistry } from "../playcanvas/AssetRegistry";
+import {
+  DEFAULT_GROUND_BUMP,
+  DEFAULT_GROUND_DIFFUSE,
+  playgroundTextureUrl,
+} from "./playgroundTextures";
 
 type EntityNode = {
   root: TransformNode;
@@ -198,8 +204,10 @@ export class BabylonAdapter implements IEngineBridge {
     ground.parent = root;
     ground.position.y = -0.01;
     const mat = new StandardMaterial(`Chunk_${chunk.id}_mat`, this.scene);
-    mat.diffuseColor = new Color3(0.22, 0.24, 0.28);
-    mat.specularColor = new Color3(0, 0, 0);
+    mat.diffuseTexture = new Texture(playgroundTextureUrl(DEFAULT_GROUND_DIFFUSE), this.scene, false, false);
+    mat.bumpTexture = new Texture(playgroundTextureUrl(DEFAULT_GROUND_BUMP), this.scene, false, false);
+    mat.diffuseColor = new Color3(0.82, 0.82, 0.82);
+    mat.specularColor = new Color3(0.02, 0.02, 0.02);
     ground.material = mat;
     this.chunks.set(chunk.id, root);
   }

--- a/client/src/engine/babylon/BabylonBoot.ts
+++ b/client/src/engine/babylon/BabylonBoot.ts
@@ -7,8 +7,14 @@ import {
   MeshBuilder,
   Scene,
   StandardMaterial,
+  Texture,
   Vector3,
 } from "@babylonjs/core";
+import {
+  DEFAULT_GROUND_BUMP,
+  DEFAULT_GROUND_DIFFUSE,
+  playgroundTextureUrl,
+} from "./playgroundTextures";
 
 export type BabylonApp = {
   engine: Engine;
@@ -48,8 +54,11 @@ export function createBabylonApp(canvas: HTMLCanvasElement): BabylonApp {
     scene
   );
   const groundMat = new StandardMaterial("world-ground-mat", scene);
-  groundMat.diffuseColor = new Color3(0.16, 0.18, 0.2);
-  groundMat.specularColor = new Color3(0, 0, 0);
+  groundMat.diffuseTexture = new Texture(playgroundTextureUrl(DEFAULT_GROUND_DIFFUSE), scene, false, false);
+  groundMat.bumpTexture = new Texture(playgroundTextureUrl(DEFAULT_GROUND_BUMP), scene, false, false);
+  groundMat.diffuseTexture.level = 1;
+  groundMat.diffuseColor = new Color3(0.85, 0.85, 0.85);
+  groundMat.specularColor = new Color3(0.02, 0.02, 0.02);
   ground.material = groundMat;
   ground.position.y = -0.02;
 

--- a/client/src/engine/babylon/playgroundTextures.ts
+++ b/client/src/engine/babylon/playgroundTextures.ts
@@ -1,0 +1,34 @@
+/**
+ * Babylon.js Playground texture library (same files as in the Babylon repo:
+ * packages/tools/playground/public/textures). Licensed under Apache-2.0 with Babylon.js.
+ *
+ * Served via jsDelivr from GitHub so the game can load them without hosting copies.
+ * Override with VITE_BABYLON_PLAYGROUND_TEXTURES_BASE (must end with /textures/ or full folder URL).
+ *
+ * @see https://github.com/BabylonJS/Babylon.js/tree/master/packages/tools/playground/public/textures
+ * @see https://doc.babylonjs.com/toolsAndResources/assetLibraries/availableTextures
+ */
+const DEFAULT_BASE =
+  "https://cdn.jsdelivr.net/gh/BabylonJS/Babylon.js@master/packages/tools/playground/public/textures/";
+
+function normalizeBase(raw: string): string {
+  const t = raw.trim();
+  if (!t) return DEFAULT_BASE;
+  return t.endsWith("/") ? t : `${t}/`;
+}
+
+export function getPlaygroundTexturesBaseUrl(): string {
+  const env = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env
+    ?.VITE_BABYLON_PLAYGROUND_TEXTURES_BASE;
+  return normalizeBase(env ?? DEFAULT_BASE);
+}
+
+/** Path relative to the textures folder, e.g. "grass.jpg" or "lava/lavatile.jpg" */
+export function playgroundTextureUrl(relativePath: string): string {
+  const path = relativePath.replace(/^\/+/, "");
+  return `${getPlaygroundTexturesBaseUrl()}${path}`;
+}
+
+/** Defaults for world ground until you ship your own assets */
+export const DEFAULT_GROUND_DIFFUSE = "grass.jpg";
+export const DEFAULT_GROUND_BUMP = "grassn.png";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Yes — we can use the [Babylon.js Playground texture library](https://github.com/BabylonJS/Babylon.js/tree/master/packages/tools/playground/public/textures) as **stand-ins** until you ship your own. Those files ship with the Babylon.js repo under **Apache-2.0** (same as the engine); keep attribution/license in mind for a commercial game long-term.

## Implementation

- **`client/src/engine/babylon/playgroundTextures.ts`**: builds URLs from **jsDelivr** (`cdn.jsdelivr.net/gh/BabylonJS/Babylon.js@master/.../textures/`) so the browser can load them with **CORS** (raw GitHub URLs are a poor fit).
- **`BabylonBoot`** (main ground) and **`BabylonAdapter`** (chunk ground tiles) use **`grass.jpg`** + **`grassn.png`** as defaults.
- Override base URL with **`VITE_BABYLON_PLAYGROUND_TEXTURES_BASE`** (must end with the textures folder + `/`).

## Switching to your textures later

- Put files under e.g. `client/public/world-assets/textures/` and set  
  `VITE_BABYLON_PLAYGROUND_TEXTURES_BASE=/world-assets/textures/`  
  or change `DEFAULT_GROUND_DIFFUSE` / `DEFAULT_GROUND_BUMP` in `playgroundTextures.ts`.

## Docs

- [Available textures list](https://doc.babylonjs.com/toolsAndResources/assetLibraries/availableTextures)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

