### PR TITLE
fix: mobile movement, sharper ground tiles, skybox, starter NPCs near hub

### DIFF
--- a/client/src/engine/babylon/BabylonAdapter.ts
+++ b/client/src/engine/babylon/BabylonAdapter.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_GROUND_DIFFUSE,
   playgroundTextureUrl,
 } from "./playgroundTextures";
+import { applyTiledGroundTextures, chunkGroundUvScale } from "./groundTextureUtils";
 
 type EntityNode = {
   root: TransformNode;
@@ -206,7 +207,8 @@ export class BabylonAdapter implements IEngineBridge {
     const mat = new StandardMaterial(`Chunk_${chunk.id}_mat`, this.scene);
     mat.diffuseTexture = new Texture(playgroundTextureUrl(DEFAULT_GROUND_DIFFUSE), this.scene, false, false);
     mat.bumpTexture = new Texture(playgroundTextureUrl(DEFAULT_GROUND_BUMP), this.scene, false, false);
-    mat.diffuseColor = new Color3(0.82, 0.82, 0.82);
+    applyTiledGroundTextures(mat, chunkGroundUvScale());
+    mat.diffuseColor = new Color3(0.75, 0.78, 0.72);
     mat.specularColor = new Color3(0.02, 0.02, 0.02);
     ground.material = mat;
     this.chunks.set(chunk.id, root);

--- a/client/src/engine/babylon/BabylonBoot.ts
+++ b/client/src/engine/babylon/BabylonBoot.ts
@@ -2,6 +2,7 @@ import {
   ArcRotateCamera,
   Color3,
   Color4,
+  CubeTexture,
   Engine,
   HemisphericLight,
   MeshBuilder,
@@ -13,8 +14,10 @@ import {
 import {
   DEFAULT_GROUND_BUMP,
   DEFAULT_GROUND_DIFFUSE,
+  getPlaygroundTexturesBaseUrl,
   playgroundTextureUrl,
 } from "./playgroundTextures";
+import { applyTiledGroundTextures, MAIN_GROUND_UV_SCALE } from "./groundTextureUtils";
 
 export type BabylonApp = {
   engine: Engine;
@@ -30,7 +33,8 @@ export function createBabylonApp(canvas: HTMLCanvasElement): BabylonApp {
   });
 
   const scene = new Scene(engine);
-  scene.clearColor = new Color4(0.05, 0.06, 0.09, 1);
+  scene.clearColor = new Color4(0.15, 0.22, 0.38, 1);
+  scene.ambientColor = new Color3(0.22, 0.26, 0.34);
 
   const camera = new ArcRotateCamera(
     "MainCamera",
@@ -46,7 +50,25 @@ export function createBabylonApp(canvas: HTMLCanvasElement): BabylonApp {
   camera.wheelDeltaPercentage = 0.01;
 
   const light = new HemisphericLight("sun", new Vector3(0.2, 1, 0.1), scene);
-  light.intensity = 0.9;
+  light.intensity = 1.05;
+  light.groundColor = new Color3(0.2, 0.22, 0.28);
+
+  // Simple skybox from Babylon playground assets (Apache-2.0, same repo as textures)
+  try {
+    const skyBase = `${getPlaygroundTexturesBaseUrl().replace(/\/+$/, "")}/TropicalSunnyDay`;
+    const skyTex = new CubeTexture(skyBase, scene);
+    const skybox = MeshBuilder.CreateBox("world-skybox", { size: 800 }, scene);
+    const skyMat = new StandardMaterial("world-skybox-mat", scene);
+    skyMat.backFaceCulling = false;
+    skyMat.reflectionTexture = skyTex;
+    skyMat.diffuseColor = new Color3(0, 0, 0);
+    skyMat.specularColor = new Color3(0, 0, 0);
+    skybox.material = skyMat;
+    skybox.infiniteDistance = true;
+    skybox.isPickable = false;
+  } catch (e) {
+    console.warn("Skybox load failed, using clear color only", e);
+  }
 
   const ground = MeshBuilder.CreateGround(
     "world-ground",
@@ -57,7 +79,8 @@ export function createBabylonApp(canvas: HTMLCanvasElement): BabylonApp {
   groundMat.diffuseTexture = new Texture(playgroundTextureUrl(DEFAULT_GROUND_DIFFUSE), scene, false, false);
   groundMat.bumpTexture = new Texture(playgroundTextureUrl(DEFAULT_GROUND_BUMP), scene, false, false);
   groundMat.diffuseTexture.level = 1;
-  groundMat.diffuseColor = new Color3(0.85, 0.85, 0.85);
+  applyTiledGroundTextures(groundMat, MAIN_GROUND_UV_SCALE);
+  groundMat.diffuseColor = new Color3(0.75, 0.78, 0.72);
   groundMat.specularColor = new Color3(0.02, 0.02, 0.02);
   ground.material = groundMat;
   ground.position.y = -0.02;

--- a/client/src/engine/babylon/groundTextureUtils.ts
+++ b/client/src/engine/babylon/groundTextureUtils.ts
@@ -1,0 +1,24 @@
+import { Texture, type StandardMaterial } from "@babylonjs/core";
+
+/** Texture repeats across the main 128×128 ground (higher = smaller texels, sharper when viewed from above). */
+export const MAIN_GROUND_UV_SCALE = 32;
+/** Chunk tiles are 16m; keep similar texel density as main ground */
+export function chunkGroundUvScale(): number {
+  return MAIN_GROUND_UV_SCALE * (16 / 128);
+}
+
+export function applyTiledGroundTextures(mat: StandardMaterial, uScale: number, vScale?: number): void {
+  const v = vScale ?? uScale;
+  if (mat.diffuseTexture) {
+    mat.diffuseTexture.uScale = uScale;
+    mat.diffuseTexture.vScale = v;
+    mat.diffuseTexture.wrapU = Texture.WRAP_ADDRESSMODE;
+    mat.diffuseTexture.wrapV = Texture.WRAP_ADDRESSMODE;
+  }
+  if (mat.bumpTexture) {
+    mat.bumpTexture.uScale = uScale;
+    mat.bumpTexture.vScale = v;
+    mat.bumpTexture.wrapU = Texture.WRAP_ADDRESSMODE;
+    mat.bumpTexture.wrapV = Texture.WRAP_ADDRESSMODE;
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -6,7 +6,7 @@ import { MMORPGClientCore } from "./core/MMORPGClientCore";
 import { connectSocket, requestSceneChange, type ConnectionOptions } from "./networking/websocketClient";
 import { IEngineBridge } from "./engine/bridge/IEngineBridge";
 import { renderHUD, showDialogue } from "./ui/hud";
-import { initMobileControls } from "./ui/mobileControls";
+import { getJoystickState, initMobileControls, isMobile } from "./ui/mobileControls";
 import { renderInventory } from "./ui/inventory";
 import { renderSkillsPanel } from "./ui/skillsPanel";
 import { renderQuestLog } from "./ui/questLog";
@@ -109,6 +109,12 @@ try {
     const dt = Math.min((now - lastFrameTime) / 1000, 0.1);
     lastFrameTime = now;
     core.update(dt);
+    if (isMobile()) {
+      const j = getJoystickState();
+      if (j.active && (Math.abs(j.dx) > 0.04 || Math.abs(j.dy) > 0.04)) {
+        core.events.emit("move_intent", { dx: j.dx, dy: j.dy });
+      }
+    }
     requestAnimationFrame(tick);
   };
   requestAnimationFrame(tick);

--- a/client/src/networking/websocketClient.ts
+++ b/client/src/networking/websocketClient.ts
@@ -138,6 +138,12 @@ export function connectSocket(core: MMORPGClientCore, options: ConnectionOptions
       }
     });
 
+    core.events.on("move_intent", (payload: { dx: number; dy: number }) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "move_intent", dx: payload.dx, dy: payload.dy }));
+      }
+    });
+
     core.events.on('attack', () => {
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: 'attack' }));

--- a/client/src/ui/mobileControls.ts
+++ b/client/src/ui/mobileControls.ts
@@ -343,6 +343,58 @@ export function initMobileControls(
   let joystickOriginX = 0;
   let joystickOriginY = 0;
 
+  const updateJoystickFromTouch = (touch: Touch) => {
+    if (touch.identifier !== joystickTouchId) return;
+    const rawDx = touch.clientX - joystickOriginX;
+    const rawDy = touch.clientY - joystickOriginY;
+    const dist = Math.hypot(rawDx, rawDy);
+    const clampedDist = Math.min(dist, JOYSTICK_RADIUS);
+    const angle = Math.atan2(rawDy, rawDx);
+    const clampedX = Math.cos(angle) * clampedDist;
+    const clampedY = Math.sin(angle) * clampedDist;
+    joystickThumb.style.transform = `translate(calc(-50% + ${clampedX}px), calc(-50% + ${clampedY}px))`;
+    joystickState.dx = clampedX / JOYSTICK_RADIUS;
+    joystickState.dy = clampedY / JOYSTICK_RADIUS;
+  };
+
+  joystickZone.addEventListener("touchmove", (e) => {
+    e.preventDefault();
+    for (let i = 0; i < e.changedTouches.length; i++) {
+      updateJoystickFromTouch(e.changedTouches[i]);
+    }
+  }, { passive: false });
+
+  // iOS: touchmove on the zone may not fire when finger leaves the element — follow on document
+  const onDocTouchMove = (e: TouchEvent) => {
+    if (joystickTouchId === null || !joystickState.active) return;
+    for (let i = 0; i < e.changedTouches.length; i++) {
+      if (e.changedTouches[i].identifier === joystickTouchId) {
+        e.preventDefault();
+        updateJoystickFromTouch(e.changedTouches[i]);
+        break;
+      }
+    }
+  };
+  const onDocTouchEnd = (e: TouchEvent) => {
+    for (let i = 0; i < e.changedTouches.length; i++) {
+      if (e.changedTouches[i].identifier === joystickTouchId) {
+        resetJoystick();
+        break;
+      }
+    }
+  };
+
+  const resetJoystick = () => {
+    joystickTouchId = null;
+    joystickState.active = false;
+    joystickState.dx = 0;
+    joystickState.dy = 0;
+    joystickThumb.style.transform = "translate(-50%, -50%)";
+    document.removeEventListener("touchmove", onDocTouchMove, true);
+    document.removeEventListener("touchend", onDocTouchEnd, true);
+    document.removeEventListener("touchcancel", onDocTouchEnd, true);
+  };
+
   joystickZone.addEventListener("touchstart", (e) => {
     e.preventDefault();
     const touch = e.changedTouches[0];
@@ -351,73 +403,20 @@ export function initMobileControls(
     joystickOriginX = rect.left + rect.width / 2;
     joystickOriginY = rect.top + rect.height / 2;
     joystickState.active = true;
+    document.addEventListener("touchmove", onDocTouchMove, { passive: false, capture: true });
+    document.addEventListener("touchend", onDocTouchEnd, { passive: false, capture: true });
+    document.addEventListener("touchcancel", onDocTouchEnd, { passive: false, capture: true });
+    updateJoystickFromTouch(touch);
   }, { passive: false });
 
-  let currentKeyX: string | null = null;
-  let currentKeyY: string | null = null;
-
-  joystickZone.addEventListener("touchmove", (e) => {
-    e.preventDefault();
+  joystickZone.addEventListener("touchend", (e) => {
     for (let i = 0; i < e.changedTouches.length; i++) {
-      const touch = e.changedTouches[i];
-      if (touch.identifier !== joystickTouchId) continue;
-      const rawDx = touch.clientX - joystickOriginX;
-      const rawDy = touch.clientY - joystickOriginY;
-      const dist = Math.hypot(rawDx, rawDy);
-      const clampedDist = Math.min(dist, JOYSTICK_RADIUS);
-      const angle = Math.atan2(rawDy, rawDx);
-      const clampedX = Math.cos(angle) * clampedDist;
-      const clampedY = Math.sin(angle) * clampedDist;
-      joystickThumb.style.transform = `translate(calc(-50% + ${clampedX}px), calc(-50% + ${clampedY}px))`;
-      joystickState.dx = clampedX / JOYSTICK_RADIUS;
-      joystickState.dy = clampedY / JOYSTICK_RADIUS;
-
-      // Map to WASD inputs
-      const threshold = 0.5;
-      const nx = joystickState.dx;
-      const ny = joystickState.dy;
-
-      let newKeyX: string | null = null;
-      let newKeyY: string | null = null;
-
-      if (nx > threshold) newKeyX = 'd';
-      else if (nx < -threshold) newKeyX = 'a';
-
-      if (ny > threshold) newKeyY = 's';
-      else if (ny < -threshold) newKeyY = 'w';
-
-      if (newKeyX !== currentKeyX) {
-        if (currentKeyX) core.events.emit('input', { type: 'keyup', key: currentKeyX });
-        if (newKeyX) core.events.emit('input', { type: 'keydown', key: newKeyX });
-        currentKeyX = newKeyX;
-      }
-
-      if (newKeyY !== currentKeyY) {
-        if (currentKeyY) core.events.emit('input', { type: 'keyup', key: currentKeyY });
-        if (newKeyY) core.events.emit('input', { type: 'keydown', key: newKeyY });
-        currentKeyY = newKeyY;
+      if (e.changedTouches[i].identifier === joystickTouchId) {
+        resetJoystick();
+        break;
       }
     }
   }, { passive: false });
-
-  const resetJoystick = () => {
-    joystickTouchId = null;
-    joystickState.active = false;
-    joystickState.dx = 0;
-    joystickState.dy = 0;
-    joystickThumb.style.transform = "translate(-50%, -50%)";
-
-    if (currentKeyX) {
-      core.events.emit('input', { type: 'keyup', key: currentKeyX });
-      currentKeyX = null;
-    }
-    if (currentKeyY) {
-      core.events.emit('input', { type: 'keyup', key: currentKeyY });
-      currentKeyY = null;
-    }
-  };
-
-  joystickZone.addEventListener("touchend", resetJoystick, { passive: false });
   joystickZone.addEventListener("touchcancel", resetJoystick, { passive: false });
 
   // ── ACTION BUTTONS ──────────────────────────────────────────────────────────
@@ -493,7 +492,9 @@ export function initMobileControls(
   });
 
   // ── CAMERA DRAG (two-finger or right-area single finger) ────────────────────
-  const canvas = document.getElementById("game-canvas") as HTMLCanvasElement || document.querySelector("canvas");
+  const canvas =
+    (document.getElementById("application-canvas") as HTMLCanvasElement | null) ||
+    (document.querySelector("canvas") as HTMLCanvasElement | null);
   if (canvas) {
     let cameraTouchId: number | null = null;
     let lastCamX = 0;

--- a/game-data/spawns/npc-spawns.json
+++ b/game-data/spawns/npc-spawns.json
@@ -1,17 +1,22 @@
 [
   {
-    "regionId": "starting_zone",
+    "regionId": "didis_hub_village",
     "spawns": [
-      { "npcId": "npc_1", "x": 32, "y": 32 },
-      { "npcId": "npc_dummy", "x": 64, "y": 64 },
-      { "npcId": "npc_2", "x": 500, "y": 500 },
-      { "npcId": "npc_3", "x": 100, "y": 100 },
-      { "npcId": "npc_4", "x": 150, "y": 150 },
-      { "npcId": "npc_5", "x": 200, "y": 200 },
-      { "npcId": "npc_wolf", "x": 250, "y": 250 },
-      { "npcId": "npc_6_hermit", "x": 300, "y": 300 },
-      { "npcId": "npc_7_merchant", "x": 350, "y": 350 },
-      { "npcId": "npc_8_apprentice", "x": 400, "y": 400 }
+      { "npcId": "npc_1", "x": 4, "y": 2 },
+      { "npcId": "npc_dummy", "x": -3, "y": 3 },
+      { "npcId": "npc_3", "x": 6, "y": -2 },
+      { "npcId": "npc_7_merchant", "x": -5, "y": -1 },
+      { "npcId": "npc_8_apprentice", "x": 2, "y": -5 }
+    ]
+  },
+  {
+    "regionId": "outskirts",
+    "spawns": [
+      { "npcId": "npc_2", "x": 22, "y": 8 },
+      { "npcId": "npc_4", "x": -18, "y": 12 },
+      { "npcId": "npc_5", "x": 30, "y": -10 },
+      { "npcId": "npc_wolf", "x": 40, "y": -20 },
+      { "npcId": "npc_6_hermit", "x": -35, "y": 25 }
     ]
   }
 ]

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -235,6 +235,10 @@ export class WorldTick {
   private lootEntities: Map<string, any> = new Map();
 
   private socketToPlayer: Map<string, string> = new Map(); // socketId -> characterName
+  /** WASD held per player (uid) — movement applied each tick so hold-to-move works on mobile + desktop */
+  private playerKeysDown: Map<string, Set<string>> = new Map();
+  /** Last analog stick vector from move_intent (-1..1), cleared after each tick */
+  private playerAnalogMove: Map<string, { dx: number; dy: number }> = new Map();
   private lastActionTimes: Map<string, number> = new Map(); // charName -> timestamp
   private sceneTriggerCooldowns: Map<string, number> = new Map();
   private sceneProfiles: Record<string, SceneProfile> = { ...DEFAULT_SCENE_PROFILES };
@@ -1126,6 +1130,8 @@ export class WorldTick {
         this.observerEngine.unregister(id);
         this.socketToPlayer.delete(id);
         this.playerToSocket.delete(uid);
+        this.playerKeysDown.delete(uid);
+        this.playerAnalogMove.delete(uid);
         await this.saveAll();
         console.log(`Player ${player.name} (Socket ${id}) disconnected. Character remains in world.`);
       }
@@ -1240,16 +1246,28 @@ export class WorldTick {
         return;
       }
 
-      if (msg.type === "input" || msg.type === "move_intent") {
-        const dx = msg.input?.key === 'a' ? -1 : msg.input?.key === 'd' ? 1 : msg.dx || 0;
-        const dy = msg.input?.key === 'w' ? -1 : msg.input?.key === 's' ? 1 : msg.dy || 0;
+      if (msg.type === "input") {
+        const keyRaw = typeof msg.input?.key === "string" ? msg.input.key.toLowerCase() : "";
+        const evType = msg.input?.type;
+        if (["w", "a", "s", "d"].includes(keyRaw)) {
+          let set = this.playerKeysDown.get(player.id);
+          if (!set) {
+            set = new Set();
+            this.playerKeysDown.set(player.id, set);
+          }
+          if (evType === "keydown") {
+            set.add(keyRaw);
+          } else if (evType === "keyup") {
+            set.delete(keyRaw);
+          }
+        }
+      }
 
+      if (msg.type === "move_intent") {
+        const dx = Math.max(-1, Math.min(1, Number(msg.dx ?? 0)));
+        const dy = Math.max(-1, Math.min(1, Number(msg.dy ?? 0)));
         if (dx !== 0 || dy !== 0) {
-          const speed = 0.5;
-          player.position.x += dx * speed;
-          player.position.y += dy * speed;
-          this.observerEngine.updatePosition(id, player.position);
-          this.processSceneTriggers(id, player);
+          this.playerAnalogMove.set(player.id, { dx, dy });
         }
       }
 
@@ -1384,16 +1402,25 @@ export class WorldTick {
 
   private loadSpawns() {
     try {
-      const spawnsPath = path.resolve(process.cwd(), "game-data/spawns/npc-spawns.json");
-      if (fs.existsSync(spawnsPath)) {
-        const spawnData = JSON.parse(fs.readFileSync(spawnsPath, "utf-8"));
-        spawnData.forEach((region: any) => {
-          region.spawns.forEach((spawn: any) => {
-            this.npcSystem.createNPC(spawn.npcId, "", spawn.x, spawn.y);
-          });
-        });
+      const cwd = process.cwd();
+      const candidates = [
+        path.resolve(cwd, "game-data/spawns/npc-spawns.json"),
+        path.resolve(cwd, "../game-data/spawns/npc-spawns.json"),
+      ];
+      const spawnsPath = candidates.find((p) => fs.existsSync(p));
+      if (!spawnsPath) {
+        return;
       }
-    } catch (e) {}
+      const spawnData = JSON.parse(fs.readFileSync(spawnsPath, "utf-8"));
+      spawnData.forEach((region: any) => {
+        region.spawns.forEach((spawn: any) => {
+          this.npcSystem.createNPC(spawn.npcId, "", spawn.x, spawn.y);
+        });
+      });
+      console.log(`[NPC Spawns] Loaded from ${spawnsPath}`);
+    } catch (e) {
+      console.warn("[NPC Spawns] Failed to load npc-spawns.json", e);
+    }
   }
 
   async saveAll() {
@@ -1417,6 +1444,44 @@ export class WorldTick {
     this.tickCount += 1;
     this.processTemplateQueue();
     const onlinePlayers = this.playerSystem.getAllPlayers().filter(p => !p.isOffline);
+
+    const moveSpeed = GameConfig.playerSpeed;
+    const step = (moveSpeed * GameConfig.tickRateMs) / 1000;
+
+    for (const player of onlinePlayers) {
+      const socketId = this.playerToSocket.get(player.id);
+      if (!socketId) {
+        continue;
+      }
+
+      let mx = 0;
+      let my = 0;
+      const analog = this.playerAnalogMove.get(player.id);
+      if (analog && (analog.dx !== 0 || analog.dy !== 0)) {
+        mx = analog.dx;
+        my = analog.dy;
+      } else {
+        const keys = this.playerKeysDown.get(player.id);
+        if (keys) {
+          if (keys.has("a")) mx -= 1;
+          if (keys.has("d")) mx += 1;
+          if (keys.has("w")) my -= 1;
+          if (keys.has("s")) my += 1;
+        }
+      }
+
+      if (mx !== 0 || my !== 0) {
+        const len = Math.hypot(mx, my);
+        const nx = mx / len;
+        const ny = my / len;
+        player.position.x += nx * step;
+        player.position.y += ny * step;
+        this.observerEngine.updatePosition(socketId, player.position);
+        this.processSceneTriggers(socketId, player);
+      }
+    }
+    this.playerAnalogMove.clear();
+
     this.npcSystem.tick(onlinePlayers, this.worldSystem.worldTime);
     this.worldSystem.tick();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problems addressed

- **Mobile**: Character moved ~2 steps then stopped — server only applied movement on discrete `input` messages and only **one axis at a time** (WASD conflict). Joystick also lost `touchmove` when finger left the small zone (iOS).
- **Ground**: Grass stretched over 128m → huge blurry texels.
- **Sky**: Flat dark clear color only.
- **NPCs / “village”**: Spawns were far from default hub spawn `(0,0)`; on VPS, `loadSpawns` often looked under `server/game-data` and silently skipped — **no NPCs**.

## Changes

### Server (`WorldTick.ts`)

- Per-player **held keys** (`w/a/s/d`) updated from `input` keydown/keyup.
- **`move_intent`** with `dx`/`dy` (-1..1), applied each tick with **normalized** direction × `GameConfig.playerSpeed` × tick delta.
- **`loadSpawns`**: try `game-data/...` and `../game-data/...` from cwd; log success/failure.

### Client

- **`move_intent`** WebSocket messages from joystick (each animation frame while active).
- **Document-level** touch listeners during joystick drag (iOS).
- **Canvas id** `#application-canvas` for pinch/drag (was wrong).

### Babylon

- **`groundTextureUtils`**: tile diffuse + bump (`uScale`/`vScale` ≈ 32 on main ground; proportional on chunks), `WRAP` mode.
- **Skybox**: `CubeTexture` **TropicalSunnyDay** from same playground CDN base as textures.
- Slightly brighter **ambient** / **clearColor**.

### Data

- **`game-data/spawns/npc-spawns.json`**: small cluster near origin for “starter hub” + farther outskirts.

## Deploy

Merge and redeploy **server + client** (game-data must be on VPS next to server or repo root as before).

## Tuning

- Sharper/softer ground: `MAIN_GROUND_UV_SCALE` in `client/src/engine/babylon/groundTextureUtils.ts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

