### PR TITLE
feat: Millbrook starter village — NPC dialogue, quests, props

### DIFF
--- a/client/src/core/MMORPGClientCore.ts
+++ b/client/src/core/MMORPGClientCore.ts
@@ -104,8 +104,8 @@ export class MMORPGClientCore {
     }
   }
 
-  public handleDialogue(text: string) {
-    this.events.emit('dialogue', text);
+  public handleDialogue(payload: string | Record<string, unknown>) {
+    this.events.emit("dialogue", payload);
   }
 
   public attack() {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -119,8 +119,8 @@ try {
   };
   requestAnimationFrame(tick);
 
-  core.events.on("dialogue", (text: string) => {
-    showDialogue(text);
+  core.events.on("dialogue", (payload: unknown) => {
+    showDialogue(payload);
   });
 
   console.log("Areloria Client Initialized");

--- a/client/src/networking/websocketClient.ts
+++ b/client/src/networking/websocketClient.ts
@@ -221,8 +221,15 @@ export function connectSocket(core: MMORPGClientCore, options: ConnectionOptions
           spawnPosition: data.spawnPosition,
         });
       }
-      if (data.type === 'dialogue') {
-        core.handleDialogue(data.text);
+      if (data.type === "dialogue") {
+        core.handleDialogue({
+          source: data.source,
+          text: data.text,
+          questId: data.questId,
+          choices: data.choices,
+          npcId: data.npcId,
+          nodeId: data.nodeId,
+        });
       }
     } catch (e) {
       console.warn("Failed to parse server message:", msg.data);
@@ -230,9 +237,22 @@ export function connectSocket(core: MMORPGClientCore, options: ConnectionOptions
   };
 }
 
-export function sendDialogueChoice(npcId: string, choiceId: string) {
+export function sendDialogueChoice(npcId: string, choiceId: string, nodeId?: string) {
   if (globalWs && globalWs.readyState === WebSocket.OPEN) {
-    globalWs.send(JSON.stringify({ type: 'dialogue_choice', npcId, choiceId }));
+    globalWs.send(
+      JSON.stringify({
+        type: "dialogue_choice",
+        npcId,
+        choiceId,
+        ...(nodeId ? { nodeId } : {}),
+      })
+    );
+  }
+}
+
+export function sendQuestAccept(npcId: string, nodeId?: string) {
+  if (globalWs && globalWs.readyState === WebSocket.OPEN) {
+    globalWs.send(JSON.stringify({ type: "quest_accept", npcId, ...(nodeId ? { nodeId } : {}) }));
   }
 }
 

--- a/client/src/ui/hud.ts
+++ b/client/src/ui/hud.ts
@@ -1,4 +1,5 @@
 import { auth } from "../auth/firebase";
+import { sendDialogueChoice, sendQuestAccept } from "../networking/websocketClient";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 
 export function renderHUD() {
@@ -39,51 +40,129 @@ export function renderHUD() {
   hud.appendChild(loginBtn);
 }
 
-export function showDialogue(text: string) {
-  let dialogueBox = document.getElementById('dialogue-box');
+export type DialoguePayload = {
+  source?: string;
+  text?: string;
+  questId?: string | null;
+  choices?: Array<{ id: string; text: string }>;
+  npcId?: string;
+  nodeId?: string;
+};
+
+export function showDialogue(payload: string | DialoguePayload) {
+  const data: DialoguePayload =
+    typeof payload === "string" ? { text: payload } : payload || {};
+  const body = data.text ?? "";
+
+  let dialogueBox = document.getElementById("dialogue-box");
   if (!dialogueBox) {
-    dialogueBox = document.createElement('div');
-    dialogueBox.id = 'dialogue-box';
-    dialogueBox.style.position = 'fixed';
-    dialogueBox.style.top = '20%';
-    dialogueBox.style.left = '50%';
-    dialogueBox.style.transform = 'translate(-50%, -20%)';
-    dialogueBox.style.background = 'rgba(0, 0, 0, 0.85)';
-    dialogueBox.style.color = 'white';
-    dialogueBox.style.padding = '20px';
-    dialogueBox.style.borderRadius = '12px';
-    dialogueBox.style.border = '2px solid #f27d26';
-    dialogueBox.style.maxWidth = '80%';
-    dialogueBox.style.width = '400px';
-    dialogueBox.style.textAlign = 'center';
-    dialogueBox.style.zIndex = '2000';
-    dialogueBox.style.fontFamily = 'sans-serif';
-    dialogueBox.style.boxShadow = '0 10px 25px rgba(0,0,0,0.5)';
-    dialogueBox.style.cursor = 'pointer';
+    dialogueBox = document.createElement("div");
+    dialogueBox.id = "dialogue-box";
+    dialogueBox.style.position = "fixed";
+    dialogueBox.style.top = "18%";
+    dialogueBox.style.left = "50%";
+    dialogueBox.style.transform = "translateX(-50%)";
+    dialogueBox.style.background = "rgba(0, 0, 0, 0.88)";
+    dialogueBox.style.color = "white";
+    dialogueBox.style.padding = "18px 20px";
+    dialogueBox.style.borderRadius = "12px";
+    dialogueBox.style.border = "2px solid #f27d26";
+    dialogueBox.style.maxWidth = "min(520px, 92vw)";
+    dialogueBox.style.width = "min(520px, 92vw)";
+    dialogueBox.style.textAlign = "left";
+    dialogueBox.style.zIndex = "2000";
+    dialogueBox.style.fontFamily = "sans-serif";
+    dialogueBox.style.boxShadow = "0 10px 25px rgba(0,0,0,0.5)";
     document.body.appendChild(dialogueBox);
 
-    const textEl = document.createElement('div');
-    textEl.id = 'dialogue-text';
+    const titleEl = document.createElement("div");
+    titleEl.id = "dialogue-title";
+    titleEl.style.fontSize = "11px";
+    titleEl.style.textTransform = "uppercase";
+    titleEl.style.letterSpacing = "0.08em";
+    titleEl.style.opacity = "0.75";
+    titleEl.style.marginBottom = "8px";
+    dialogueBox.appendChild(titleEl);
+
+    const textEl = document.createElement("div");
+    textEl.id = "dialogue-text";
+    textEl.style.lineHeight = "1.45";
+    textEl.style.whiteSpace = "pre-wrap";
     dialogueBox.appendChild(textEl);
 
-    const closeBtn = document.createElement('div');
-    closeBtn.innerText = 'Click to close';
-    closeBtn.style.fontSize = '11px';
-    closeBtn.style.marginTop = '15px';
-    closeBtn.style.opacity = '0.6';
-    closeBtn.style.textTransform = 'uppercase';
-    closeBtn.style.letterSpacing = '1px';
-    dialogueBox.appendChild(closeBtn);
+    const choicesEl = document.createElement("div");
+    choicesEl.id = "dialogue-choices";
+    choicesEl.style.marginTop = "14px";
+    choicesEl.style.display = "flex";
+    choicesEl.style.flexDirection = "column";
+    choicesEl.style.gap = "8px";
+    dialogueBox.appendChild(choicesEl);
 
-    dialogueBox.onclick = () => {
-      dialogueBox!.style.display = 'none';
+    const closeRow = document.createElement("div");
+    closeRow.style.marginTop = "14px";
+    closeRow.style.display = "flex";
+    closeRow.style.justifyContent = "flex-end";
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.textContent = "Close";
+    closeBtn.style.padding = "6px 14px";
+    closeBtn.style.borderRadius = "8px";
+    closeBtn.style.border = "1px solid rgba(255,255,255,0.25)";
+    closeBtn.style.background = "rgba(40,40,40,0.9)";
+    closeBtn.style.color = "#eee";
+    closeBtn.style.cursor = "pointer";
+    closeBtn.onclick = (e) => {
+      e.stopPropagation();
+      dialogueBox!.style.display = "none";
     };
+    closeRow.appendChild(closeBtn);
+    dialogueBox.appendChild(closeRow);
   }
 
-  const textEl = document.getElementById('dialogue-text');
-  if (textEl) {
-    textEl.textContent = text;
+  const titleEl = document.getElementById("dialogue-title");
+  if (titleEl) {
+    titleEl.textContent = data.source ? data.source : " ";
   }
-  
-  dialogueBox.style.display = 'block';
+
+  const textEl = document.getElementById("dialogue-text");
+  if (textEl) {
+    textEl.textContent = body;
+  }
+
+  const choicesEl = document.getElementById("dialogue-choices");
+  if (choicesEl) {
+    choicesEl.innerHTML = "";
+    const choices = Array.isArray(data.choices) ? data.choices : [];
+    const npcId = typeof data.npcId === "string" ? data.npcId : "";
+    const nodeId = typeof data.nodeId === "string" ? data.nodeId : "root";
+
+    if (choices.length > 0) {
+      for (const c of choices) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.textContent = c.text || c.id;
+        btn.style.textAlign = "left";
+        btn.style.padding = "10px 12px";
+        btn.style.borderRadius = "8px";
+        btn.style.border = "1px solid rgba(242,125,38,0.45)";
+        btn.style.background = "rgba(30,35,50,0.95)";
+        btn.style.color = "#e8ecf5";
+        btn.style.cursor = "pointer";
+        btn.onclick = (e) => {
+          e.stopPropagation();
+          if (!npcId) return;
+          if (c.id === "sys_quest_accept") {
+            sendQuestAccept(npcId, nodeId);
+          } else if (c.id === "sys_quest_decline") {
+            sendDialogueChoice(npcId, "sys_quest_decline", nodeId);
+          } else {
+            sendDialogueChoice(npcId, c.id, nodeId);
+          }
+        };
+        choicesEl.appendChild(btn);
+      }
+    }
+  }
+
+  dialogueBox.style.display = "block";
 }

--- a/game-data/content-manifest.json
+++ b/game-data/content-manifest.json
@@ -3,6 +3,7 @@
     {
       "name": "Core Content",
       "npcIds": [
+        "npc_guide",
         "npc_1",
         "npc_2",
         "npc_dummy",
@@ -15,6 +16,8 @@
         "npc_8_apprentice"
       ],
       "questIds": [
+        "starter_welcome",
+        "village_tour",
         "first_steps",
         "missing_letter",
         "dummy_slayer",
@@ -29,6 +32,7 @@
         "apprentice_quest"
       ],
       "dialogueIds": [
+        "dialogue_guide",
         "dialogue_npc_1",
         "dialogue_npc_2",
         "dialogue_npc_3",

--- a/game-data/dialogue/dialogues.json
+++ b/game-data/dialogue/dialogues.json
@@ -1,7 +1,27 @@
 [
   {
+    "id": "dialogue_guide",
+    "greeting": "Hey! You look new here.",
+    "questStartLines": {
+      "starter_welcome": "This is Millbrook — small, but friendly. Go see Quartermaster Mara by the east hut; she hands out real work to newcomers.",
+      "village_tour": "You've met Mara? Good. Elder Rowan is by the well — listen to what they say about the village."
+    },
+    "questProgressLines": {
+      "starter_welcome": "Mara's the one with the supply crates — you can't miss her.",
+      "village_tour": "The Elder waits near the well. Don't keep them waiting."
+    },
+    "questCompleteLines": {
+      "starter_welcome": "Nice — Mara will take care of you from here.",
+      "village_tour": "Rowan's wise. If they trust you, the village will too."
+    },
+    "questPrerequisiteLines": {
+      "village_tour": "Talk to Mara first — she'll point you in the right direction."
+    },
+    "fallback": "Walk around, say hello. Millbrook grows on you."
+  },
+  {
     "id": "dialogue_npc_1",
-    "greeting": "Hello, I am Test NPC. Welcome to Areloria!",
+    "greeting": "Quartermaster Mara, at your service.",
     "entryNodes": [
       { "nodeId": "helped", "conditionFlag": "helped_test_npc" }
     ],

--- a/game-data/npc/npcs.json
+++ b/game-data/npc/npcs.json
@@ -1,7 +1,15 @@
 [
   {
+    "id": "npc_guide",
+    "name": "Linnea",
+    "role": "Village Guide",
+    "dialogueId": "dialogue_guide",
+    "questHooks": ["starter_welcome", "village_tour"],
+    "faction": "Neutral"
+  },
+  {
     "id": "npc_1",
-    "name": "Test NPC",
+    "name": "Quartermaster Mara",
     "role": "Quest Giver",
     "dialogueId": "dialogue_npc_1",
     "questHooks": ["first_steps", "missing_letter"],

--- a/game-data/quests/quests.json
+++ b/game-data/quests/quests.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "starter_welcome",
+    "title": "Welcome to Millbrook",
+    "giverNpcId": "npc_guide",
+    "targetNpcId": "npc_1",
+    "objectiveType": "talk_to",
+    "reward": {
+      "gold": 25,
+      "xp": 40
+    }
+  },
+  {
+    "id": "village_tour",
+    "title": "The Elder's Word",
+    "giverNpcId": "npc_guide",
+    "targetNpcId": "npc_3",
+    "objectiveType": "talk_to",
+    "prerequisiteQuestIds": ["starter_welcome"],
+    "reward": {
+      "gold": 35,
+      "xp": 60
+    }
+  },
+  {
     "id": "first_steps",
     "title": "First Steps",
     "giverNpcId": "npc_1",

--- a/game-data/spawns/npc-spawns.json
+++ b/game-data/spawns/npc-spawns.json
@@ -2,6 +2,7 @@
   {
     "regionId": "didis_hub_village",
     "spawns": [
+      { "npcId": "npc_guide", "x": 1.5, "y": 1.5 },
       { "npcId": "npc_1", "x": 4, "y": 2 },
       { "npcId": "npc_dummy", "x": -3, "y": 3 },
       { "npcId": "npc_3", "x": 6, "y": -2 },

--- a/game-data/world/objects.json
+++ b/game-data/world/objects.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "sv_well",
+    "type": "prop",
+    "name": "Village Well",
+    "position": { "x": 0, "y": 5 },
+    "rotation": 0,
+    "scale": 2.5,
+    "glbPath": "/assets/models/objects/chest.glb"
+  },
+  {
+    "id": "sv_hut_a",
+    "type": "building",
+    "name": "Hut",
+    "position": { "x": -10, "y": 4 },
+    "rotation": 0.4,
+    "scale": 4,
+    "glbPath": "/assets/models/objects/chest.glb"
+  },
+  {
+    "id": "sv_hut_b",
+    "type": "building",
+    "name": "Hut",
+    "position": { "x": 10, "y": 4 },
+    "rotation": -0.35,
+    "scale": 4,
+    "glbPath": "/assets/models/objects/chest.glb"
+  },
+  {
+    "id": "sv_hut_c",
+    "type": "building",
+    "name": "Hut",
+    "position": { "x": -6, "y": -10 },
+    "rotation": 2.2,
+    "scale": 3.5,
+    "glbPath": "/assets/models/objects/chest.glb"
+  },
+  {
+    "id": "sv_hut_d",
+    "type": "building",
+    "name": "Hut",
+    "position": { "x": 8, "y": -9 },
+    "rotation": -2.0,
+    "scale": 3.5,
+    "glbPath": "/assets/models/objects/chest.glb"
+  },
+  {
+    "id": "sv_fence_n",
+    "type": "prop",
+    "name": "Fence",
+    "position": { "x": 0, "y": 14 },
+    "rotation": 0,
+    "scale": 2,
+    "glbPath": "/assets/models/objects/chest.glb"
+  },
+  {
+    "id": "sv_fence_s",
+    "type": "prop",
+    "name": "Fence",
+    "position": { "x": 0, "y": -14 },
+    "rotation": 0,
+    "scale": 2,
+    "glbPath": "/assets/models/objects/chest.glb"
+  }
+]

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -261,6 +261,55 @@ export class WorldTick {
   private areMode: AREMode = "shader";
   private eventTemplates: GMTemplateDefinition[] = Object.values(GM_EVENT_TEMPLATES);
   private pendingTemplateSteps: ScheduledGMTemplateStep[] = [];
+  /** Last dialogue state per player for dialogue_choice / quest accept */
+  private dialogueContext: Map<
+    string,
+    { npcId: string; pendingQuestId: string | null; nodeId: string }
+  > = new Map();
+
+  private findNearestNpcForInteract(player: any) {
+    const px = player.position.x;
+    const py = player.position.y;
+    const maxD = GameConfig.interactDistance;
+    let best: { npc: any; d2: number } | null = null;
+    for (const npc of this.npcSystem.getAllNPCs()) {
+      const dx = npc.position.x - px;
+      const dy = npc.position.y - py;
+      const d2 = dx * dx + dy * dy;
+      if (d2 <= maxD * maxD && (!best || d2 < best.d2)) {
+        best = { npc, d2 };
+      }
+    }
+    return best?.npc ?? null;
+  }
+
+  private sendDialogueToPlayer(
+    socketId: string,
+    playerId: string,
+    interaction: {
+      source: string;
+      text: string;
+      questId: string | null;
+      choices: any[];
+      npcId: string;
+      nodeId: string;
+    }
+  ) {
+    this.dialogueContext.set(playerId, {
+      npcId: interaction.npcId,
+      pendingQuestId: interaction.questId,
+      nodeId: interaction.nodeId,
+    });
+    this.ws.sendToPlayer(socketId, {
+      type: "dialogue",
+      source: interaction.source,
+      text: interaction.text,
+      questId: interaction.questId,
+      choices: interaction.choices || [],
+      npcId: interaction.npcId,
+      nodeId: interaction.nodeId,
+    });
+  }
 
   private getSceneProfile(sceneId: string | undefined): { sceneId: string; profile: SceneProfile } {
     const resolvedSceneId = sceneId && this.sceneProfiles[sceneId] ? sceneId : DEFAULT_SCENE_ID;
@@ -1132,6 +1181,7 @@ export class WorldTick {
         this.playerToSocket.delete(uid);
         this.playerKeysDown.delete(uid);
         this.playerAnalogMove.delete(uid);
+        this.dialogueContext.delete(uid);
         await this.saveAll();
         console.log(`Player ${player.name} (Socket ${id}) disconnected. Character remains in world.`);
       }
@@ -1278,8 +1328,83 @@ export class WorldTick {
       }
 
       if (msg.type === "interact") {
-        // Interaction logic...
-        this.ws.sendToPlayer(id, { type: 'dialogue', text: "Hello traveler!" });
+        if (!player.flags) player.flags = {};
+        const npc = this.findNearestNpcForInteract(player);
+        if (!npc) {
+          this.ws.sendToPlayer(id, {
+            type: "dialogue",
+            source: "…",
+            text: "There is no one in range to talk to. Move closer to an NPC and try again.",
+            questId: null,
+            choices: [],
+            npcId: "",
+            nodeId: "root",
+          });
+          return;
+        }
+        const defs = this.questSystem.getQuestDefinitions();
+        const interaction = this.npcSystem.handleInteraction(npc.id, player, defs);
+        if (!interaction) return;
+
+        let text = interaction.text;
+        const talkRewards = this.questSystem.checkTalkToQuests(player, npc.id);
+        for (const r of talkRewards) {
+          text += `\n\nQuest completed: ${r.quest.title || r.quest.id}`;
+        }
+
+        this.sendDialogueToPlayer(id, player.id, {
+          source: interaction.source,
+          text,
+          questId: interaction.questId,
+          choices: interaction.choices || [],
+          npcId: interaction.npcId,
+          nodeId: interaction.nodeId || "root",
+        });
+      }
+
+      if (msg.type === "dialogue_choice" || msg.type === "quest_accept") {
+        const ctx = this.dialogueContext.get(player.id);
+        if (!ctx || !ctx.npcId) {
+          return;
+        }
+        const choiceId =
+          msg.type === "quest_accept" ? "sys_quest_accept" : String(msg.choiceId || "");
+        const nodeId = isNonEmptyString(msg.nodeId) ? msg.nodeId.trim() : ctx.nodeId;
+
+        const choice = this.npcSystem.handleChoice(
+          ctx.npcId,
+          nodeId,
+          choiceId,
+          player,
+          ctx.pendingQuestId
+        );
+        if (!choice) {
+          return;
+        }
+
+        if (choice.startQuestId) {
+          this.questSystem.startQuest(player, choice.startQuestId);
+        }
+
+        let text = choice.text;
+        const talkRewards = this.questSystem.checkTalkToQuests(player, ctx.npcId);
+        for (const r of talkRewards) {
+          text += `\n\nQuest completed: ${r.quest.title || r.quest.id}`;
+        }
+
+        const nextPending =
+          choiceId === "sys_quest_accept" || choiceId === "sys_quest_decline"
+            ? null
+            : choice.questId;
+
+        this.sendDialogueToPlayer(id, player.id, {
+          source: choice.source,
+          text,
+          questId: nextPending,
+          choices: choice.choices || [],
+          npcId: choice.npcId,
+          nodeId: choice.nodeId || "root",
+        });
       }
     };
   }

--- a/server/src/modules/npc/NPCSystem.ts
+++ b/server/src/modules/npc/NPCSystem.ts
@@ -21,17 +21,26 @@ export class NPCSystem {
     this.loadData();
   }
 
+  private resolveGameDataPath(file: string): string | null {
+    const cwd = process.cwd();
+    const a = path.resolve(cwd, `game-data/${file}`);
+    const b = path.resolve(cwd, `../game-data/${file}`);
+    if (fs.existsSync(a)) return a;
+    if (fs.existsSync(b)) return b;
+    return null;
+  }
+
   private loadData() {
     try {
-      const npcsPath = path.resolve(process.cwd(), "game-data/npc/npcs.json");
-      const dialoguesPath = path.resolve(process.cwd(), "game-data/dialogue/dialogues.json");
+      const npcsPath = this.resolveGameDataPath("npc/npcs.json");
+      const dialoguesPath = this.resolveGameDataPath("dialogue/dialogues.json");
 
-      if (fs.existsSync(npcsPath)) {
+      if (npcsPath) {
         const npcData = JSON.parse(fs.readFileSync(npcsPath, "utf-8"));
         npcData.forEach((npc: any) => this.npcDefinitions.set(npc.id, npc));
       }
 
-      if (fs.existsSync(dialoguesPath)) {
+      if (dialoguesPath) {
         const dialogueData = JSON.parse(fs.readFileSync(dialoguesPath, "utf-8"));
         dialogueData.forEach((dialogue: any) => this.dialogues.set(dialogue.id, dialogue));
       }
@@ -106,7 +115,10 @@ export class NPCSystem {
       return {
         source: npc.name,
         text: `Hello, I am ${npc.name}. Welcome to Areloria!`,
-        questId: null
+        questId: null,
+        choices: [] as any[],
+        npcId,
+        nodeId: "root",
       };
     }
 
@@ -127,6 +139,14 @@ export class NPCSystem {
             for (const preId of questDef.prerequisiteQuestIds) {
               const preQuest = playerQuests.find((q: any) => q.id === preId);
               if (!preQuest || !preQuest.completed) {
+                prereqsMet = false;
+                break;
+              }
+            }
+          }
+          if (prereqsMet && questDef?.requiredFlags?.length) {
+            for (const flag of questDef.requiredFlags) {
+              if (!playerFlags[flag]) {
                 prereqsMet = false;
                 break;
               }
@@ -160,13 +180,9 @@ export class NPCSystem {
       }
     }
 
-    // New Logic: Branching Nodes
-    if (dialogue.nodes) {
-      // Determine which node to show
-      let activeNodeId = "root";
-      
-      // If we have quest-specific nodes, we could prioritize them here
-      // For now, let's just use "root" as default or check for state-based entry nodes
+    // Branching nodes — but do not overwrite quest-offer / progress lines from hooks above
+    let activeNodeId = "root";
+    if (!questId && dialogue.nodes) {
       if (dialogue.entryNodes) {
         for (const entry of dialogue.entryNodes) {
           let match = true;
@@ -202,6 +218,13 @@ export class NPCSystem {
           return true;
         });
       }
+    } else if (questId && dialogue.nodes) {
+      // Quest is being offered: keep hook text, add accept / decline
+      activeNodeId = "root";
+      choices = [
+        { id: "sys_quest_accept", text: "Accept quest", nextNodeId: "__accept__" },
+        { id: "sys_quest_decline", text: "Not now", nextNodeId: "__decline__" },
+      ];
     }
 
     return {
@@ -209,13 +232,44 @@ export class NPCSystem {
       text,
       questId,
       choices,
-      npcId
+      npcId,
+      nodeId: activeNodeId,
     };
   }
 
-  handleChoice(npcId: string, nodeId: string, choiceId: string, player: any) {
+  handleChoice(
+    npcId: string,
+    nodeId: string,
+    choiceId: string,
+    player: any,
+    pendingQuestId: string | null
+  ) {
     const npc = this.npcs.get(npcId);
     if (!npc) return null;
+
+    if (!player.flags) player.flags = {};
+
+    if (choiceId === "sys_quest_accept" && pendingQuestId) {
+      return {
+        source: npc.name,
+        text: "Good luck — I'll be here if you need anything.",
+        questId: null,
+        choices: [] as any[],
+        npcId,
+        nodeId: "root",
+        startQuestId: pendingQuestId,
+      };
+    }
+    if (choiceId === "sys_quest_decline") {
+      return {
+        source: npc.name,
+        text: "Alright. Come back when you're ready.",
+        questId: null,
+        choices: [] as any[],
+        npcId,
+        nodeId: "root",
+      };
+    }
 
     const dialogue = this.dialogues.get(npc.dialogueId);
     if (!dialogue || !dialogue.nodes) return null;
@@ -226,14 +280,12 @@ export class NPCSystem {
     const choice = (node.choices || []).find((c: any) => c.id === choiceId);
     if (!choice) return null;
 
-    // Check if choice is already used (if it changes reputation)
     if (choice.changeReputation) {
       if (!player.usedChoices) player.usedChoices = [];
-      if (player.usedChoices.includes(choiceId)) return null; // Already used
+      if (player.usedChoices.includes(choiceId)) return null;
       player.usedChoices.push(choiceId);
     }
 
-    // Apply effects of the choice
     if (choice.setFlag) {
       player.flags[choice.setFlag] = true;
     }
@@ -246,7 +298,11 @@ export class NPCSystem {
     const nextNode = dialogue.nodes[choice.nextNodeId];
     if (!nextNode) return null;
 
-    let questId = nextNode.triggerQuestId || null;
+    if (nextNode.setFlag) {
+      player.flags[nextNode.setFlag] = true;
+    }
+
+    const triggeredQuestId = nextNode.triggerQuestId || null;
     let text = nextNode.text;
     let choices = (nextNode.choices || []).filter((c: any) => {
       if (c.conditionFlag && !player.flags[c.conditionFlag]) return false;
@@ -261,9 +317,11 @@ export class NPCSystem {
     return {
       source: npc.name,
       text,
-      questId,
+      questId: triggeredQuestId,
       choices,
-      npcId
+      npcId,
+      nodeId: choice.nextNodeId,
+      startQuestId: triggeredQuestId,
     };
   }
 

--- a/server/src/modules/quest/QuestEngine.ts
+++ b/server/src/modules/quest/QuestEngine.ts
@@ -17,10 +17,19 @@ export class QuestEngine {
     this.loadData();
   }
 
+  private resolveQuestsPath(): string | null {
+    const cwd = process.cwd();
+    const a = path.resolve(cwd, "game-data/quests/quests.json");
+    const b = path.resolve(cwd, "../game-data/quests/quests.json");
+    if (fs.existsSync(a)) return a;
+    if (fs.existsSync(b)) return b;
+    return null;
+  }
+
   private loadData() {
     try {
-      const questsPath = path.resolve(process.cwd(), "game-data/quests/quests.json");
-      if (fs.existsSync(questsPath)) {
+      const questsPath = this.resolveQuestsPath();
+      if (questsPath) {
         const questData = JSON.parse(fs.readFileSync(questsPath, "utf-8"));
         questData.forEach((quest: any) => {
           // Map to internal format if needed
@@ -185,6 +194,28 @@ export class QuestEngine {
 
     this.invalidateCache(player);
     return q.reward;
+  }
+
+  /**
+   * Complete active talk_to quests when the player talks to the target NPC (after dialogue flow).
+   */
+  checkTalkToQuests(player: any, npcId: string): { quest: any; reward: any }[] {
+    const completedQuestRewards: { quest: any; reward: any }[] = [];
+    if (!player.quests) return completedQuestRewards;
+    const activeQuests = player.quests.filter((q: any) => !q.completed);
+
+    for (const q of activeQuests) {
+      const obj = q.objectiveType || q.objective;
+      if (obj !== "talk_to") continue;
+      const target = q.targetNpcId || q.targetId;
+      if (target && target === npcId) {
+        const reward = this.completeQuest(player, q.id);
+        if (reward) {
+          completedQuestRewards.push({ quest: q, reward });
+        }
+      }
+    }
+    return completedQuestRewards;
   }
 
   updateCombatQuests(player: any, npcId: string, npcInstanceId: string): { quest: any; reward: any }[] {

--- a/server/src/modules/world/WorldObjectSystem.ts
+++ b/server/src/modules/world/WorldObjectSystem.ts
@@ -19,7 +19,10 @@ export class WorldObjectSystem {
 
   constructor(persistence?: PersistenceManager) {
     this.persistence = persistence || null;
-    this.dataPath = path.resolve(process.cwd(), "game-data/world/objects.json");
+    const cwd = process.cwd();
+    const a = path.resolve(cwd, "game-data/world/objects.json");
+    const b = path.resolve(cwd, "../game-data/world/objects.json");
+    this.dataPath = fs.existsSync(a) ? a : b;
     this.load();
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

### Gameplay (starter arc **Millbrook**)

1. **Linnea** (`npc_guide`) near spawn — offers **`starter_welcome`**: talk to **Quartermaster Mara** (`npc_1`).
2. After that completes, **`village_tour`**: talk to **Elder Rowan** (`npc_3`).
3. Existing chain (**Mara → Guard → Elder → …**) still works; `first_steps` still requires flag `helped_test_npc` from dialogue choices.

### Server (previously broken)

- **`interact`** finds the **nearest NPC** within `GameConfig.interactDistance` and runs real dialogue + quest hooks (not a hardcoded string).
- **`dialogue_choice`** / **`quest_accept`** with per-player **dialogue context**; **`startQuest`** on accept.
- **`talk_to` objectives** now **complete** when the player successfully talks to the target NPC (`QuestEngine.checkTalkToQuests`).
- **NPC/dialogue/quests** file paths: **`game-data/...` or `../game-data/...`** (VPS cwd under `server/`).
- **`requiredFlags`** on quest defs gate **quest offer** text (fixes `first_steps` showing before flag).

### Client

- Dialogue panel: **source**, **text**, **choice buttons**; sends `dialogue_choice` with **`nodeId`**; **`quest_accept`** for system accept.

### World props

- **`game-data/world/objects.json`**: placeholder **chest.glb** instances as huts/fence/well layout (replace with real GLBs when ready). `WorldObjectSystem` uses the same cwd fallback.

## Files touched

- `server/src/core/WorldTick.ts`, `NPCSystem.ts`, `QuestEngine.ts`, `WorldObjectSystem.ts`
- `client/src/ui/hud.ts`, `websocketClient.ts`, `MMORPGClientCore.ts`, `main.ts`
- `game-data`: npcs, quests, dialogue, spawns, `world/objects.json`, manifest

## Deploy

Merge + deploy **server + client**; ensure **`game-data/world/objects.json`** is on the VPS.

## Follow-ups (not in this PR)

- Replace chest placeholders with real building/well models.
- Wire **Quest Log UI** to server quest list.
- Optional: `collect` / `combat` quest completion hooks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75e3bfa1-3338-4a3d-aed0-7aed96b1004e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

