### PR TITLE
Fix CI E2E step and npm lockfile sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "node server/dist/index.js",
     "lint": "eslint .",
     "clean": "next clean",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "npx playwright test",
+    "test:e2e:install": "npx playwright install --with-deps chromium",
+    "test:e2e:ci": "npx playwright install --with-deps chromium && npx playwright test"
   },
   "dependencies": {
     "@genkit-ai/firebase": "^1.30.1",
@@ -39,6 +42,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.1",
     "@tailwindcss/typography": "^0.5.19",
     "@types/express": "^5.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4.2.1
         version: 4.2.1
@@ -8885,7 +8888,6 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
-    optional: true
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -12686,15 +12688,13 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  playwright-core@1.59.1:
-    optional: true
+  playwright-core@1.59.1: {}
 
   playwright@1.59.1:
     dependencies:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
-    optional: true
 
   portfinder@1.0.38:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failing run linked in this thread (`actions/runs/23935681467`, job `69811538743`).

Root cause of that failure:
- `are-tests` uses `npm ci`
- after adding Playwright scripts/dependency, root `package-lock.json` was not updated yet
- CI failed with lockfile mismatch (`Missing: @playwright/test`, `playwright`, `playwright-core`)

Changes in this update:
- `package-lock.json`
  - synchronized root npm lockfile with current `package.json` (including Playwright entries)

Context from prior commit on this branch:
- `package.json` now includes:
  - scripts: `test:e2e`, `test:e2e:install`, `test:e2e:ci`
  - devDependency: `@playwright/test`

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

- `npm ci`
- `npm ci --prefix client`
- `npm ci --prefix server`
- `npm run build`
- `pnpm run test:e2e:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82ff7175-beef-46a6-8e14-2614089a7703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ff7175-beef-46a6-8e14-2614089a7703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

