### PR TITLE
fix: remove path-to-regexp override breaking Express 5, add pnpm onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,19 @@
     "ci:verify": "pnpm run lint && pnpm run test && pnpm run build && pnpm run audit:model-paths"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "protobufjs",
+      "sharp",
+      "@firebase/util",
+      "re2",
+      "unrs-resolver"
+    ],
     "overrides": {
       "handlebars": "^4.7.9",
       "lodash": "^4.18.0",
       "basic-ftp": "^5.2.2",
       "node-forge": "^1.4.0",
-      "path-to-regexp": "^0.1.13",
       "fast-xml-parser": "^5.5.6",
       "flatted": "^3.4.2",
       "picomatch": "^4.0.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   lodash: ^4.18.0
   basic-ftp: ^5.2.2
   node-forge: ^1.4.0
-  path-to-regexp: ^0.1.13
   fast-xml-parser: ^5.5.6
   flatted: ^3.4.2
   picomatch: ^4.0.4
@@ -4623,6 +4622,9 @@ packages:
     resolution: {integrity: sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==}
     engines: {node: '>=v0.10.0'}
 
+  isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -5532,6 +5534,12 @@ packages:
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
+  path-to-regexp@1.9.0:
+    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -12263,6 +12271,8 @@ snapshots:
       ip-regex: 4.3.0
       is-url: 1.2.4
 
+  isarray@0.0.1: {}
+
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
@@ -13135,6 +13145,12 @@ snapshots:
 
   path-to-regexp@0.1.13: {}
 
+  path-to-regexp@1.9.0:
+    dependencies:
+      isarray: 0.0.1
+
+  path-to-regexp@8.4.2: {}
+
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
@@ -13569,7 +13585,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 0.1.13
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13986,7 +14002,7 @@ snapshots:
       morgan: 1.10.1
       on-finished: 2.4.1
       on-headers: 1.1.0
-      path-to-regexp: 0.1.13
+      path-to-regexp: 1.9.0
       router: 2.2.0
       update-notifier-cjs: 5.1.7
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the server startup crash (`pathRegexp.match is not a function`) by removing the `path-to-regexp` pnpm override that forced v0.1.x — incompatible with Express 5's `router@2.2.0` which requires v8.x. Also adds `pnpm.onlyBuiltDependencies` so `pnpm install` runs non-interactively (esbuild, protobufjs, sharp, etc.).

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

- `pnpm run lint` — passes (1 pre-existing warning)
- `pnpm run test` — **769/769 tests pass** (previously 12 failed due to the same `pathRegexp.match` error)
- `pnpm run build` — passes (client Vite build + server TypeScript compile)
- Dev server starts on port 3000, WebSocket game loop operational (login → entity_sync → move_intent)

**WebSocket game loop test:**

[websocket_game_loop_test.log](https://cursor.com/agents/bc-80a60164-a02a-428d-9d2a-a1cd5b208499/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebsocket_game_loop_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80a60164-a02a-428d-9d2a-a1cd5b208499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80a60164-a02a-428d-9d2a-a1cd5b208499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

