### PR TITLE
docs(AGENTS.md): add cloud agent gotchas from env setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,9 @@ Copy `.env.example` to `.env`. Only `PORT` and `NODE_ENV` are needed for local d
 
 ### Testing the game loop without a browser
 Connect via WebSocket to `ws://localhost:3000/ws` and send `{"type":"login"}`. The server assigns a dev player; **`entity_sync`** is broadcast on a configurable interval (default **200 ms**, sim tick **100 ms**). Use `input` (WASD keydown/keyup), `move_intent` (analog), `interact`, `dialogue_choice`, and `attack` as needed.
+
+### Cloud agent gotchas
+- **`/health` in dev mode:** Vite SPA middleware (registered before Express routes) intercepts `/health`. Use the WebSocket game loop to verify the server is running instead.
+- **GCP metadata warnings:** Without `FIREBASE_SERVICE_ACCOUNT_KEY`, the server emits noisy `MetadataLookupWarning` and `GcpLogger` errors to stderr. These are harmless — the server continues with in-memory/JSON fallback.
+- **pnpm strict `node_modules`:** The `ws` package (and other server deps) is only resolvable from `server/` directory context, not from workspace root. Run WebSocket test scripts with `cd server && node -e "..." --input-type=module`.
+- **Node/pnpm versions:** Node 22.x and pnpm 10.x work with the lockfile (v9.0 format). No `.nvmrc` or `engines` field pins versions.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a "Cloud agent gotchas" section to `AGENTS.md` with non-obvious findings discovered during full development environment setup and validation.

### Changes
- **`/health` in dev mode:** Vite SPA middleware intercepts the `/health` Express route; use WebSocket to verify server health instead.
- **GCP metadata warnings:** Harmless `MetadataLookupWarning` noise when `FIREBASE_SERVICE_ACCOUNT_KEY` is unset.
- **pnpm strict `node_modules`:** `ws` and other server deps only resolve from `server/` context.
- **Node/pnpm versions:** Confirmed Node 22.x + pnpm 10.x work with lockfile v9.0.

### Environment validation performed

| Check | Result |
|-------|--------|
| `pnpm install` | 1338 packages installed |
| `pnpm run lint` | 0 errors, 1 warning (expected) |
| `pnpm run test` | 109 files, 773 tests passed |
| `pnpm run build` | Client + server build success |
| Dev server (`npx tsx server/src/index.ts`) | Listening on :3000 |
| WebSocket game loop | Login → welcome → stats_sync → entity_sync → WASD input accepted |

### Game loop test log
[game_loop_test.log](https://cursor.com/agents/bc-bab35aa0-6135-400c-afe3-0a7bbc8a2167/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgame_loop_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bab35aa0-6135-400c-afe3-0a7bbc8a2167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bab35aa0-6135-400c-afe3-0a7bbc8a2167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

