### PR TITLE
chore(tools): add DGCC contract runner and report schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 test-results/
 playwright-report/
+dgcc-artifacts/
 node_modules/
 dist/
 # Optional published content snapshot (scripts/publish-content-pack.mjs)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test:e2e:ci": "npx playwright install --with-deps chromium && npx playwright test",
     "sync:world-assets": "node scripts/sync-world-assets.mjs",
     "audit:model-paths": "npm run audit:model-paths --prefix server",
-    "ci:verify": "pnpm run lint && pnpm run test && pnpm run build && pnpm run audit:model-paths"
+    "ci:verify": "pnpm run lint && pnpm run test && pnpm run build && pnpm run audit:model-paths",
+    "dgcc": "tsx tools/dgcc/run-dgcc.ts",
+    "dgcc:extreme": "tsx tools/dgcc/run-dgcc.ts --mode=extreme"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tools/dgcc/README.md
+++ b/tools/dgcc/README.md
@@ -1,0 +1,13 @@
+# DGCC
+
+Run the repository-wide Design+Gameplay Consistency Contract gate.
+
+## Usage
+
+```bash
+pnpm run dgcc
+pnpm run dgcc:extreme
+DGCC_FIX=1 pnpm run dgcc
+```
+
+Artifacts: `dgcc-artifacts/`

--- a/tools/dgcc/dgcc.contract.json
+++ b/tools/dgcc/dgcc.contract.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "name": "DGCC (Design+Gameplay Consistency Contract)",
+  "version": 1,
+  "modes": {
+    "minimal": {
+      "fix": { "enabled": false },
+      "checks": ["lint", "unit", "e2e", "contentValidate", "assetsAudit", "wsSchemaSmoke", "uiA11ySmoke"]
+    },
+    "extreme": {
+      "fix": { "enabled": true, "allowDangerous": true },
+      "checks": ["lint", "unit", "e2e", "contentValidate", "assetsAudit", "wsSchemaSmoke", "uiA11ySmoke", "clientBuild", "serverBuild"]
+    }
+  },
+  "rules": {
+    "auth": {
+      "requiredLoginErrors": ["invalid_token", "login_required"]
+    },
+    "ws": {
+      "maxMessageBytesEnv": "WS_MAX_MESSAGE_BYTES",
+      "requireWelcomeStatsShape": true
+    },
+    "content": {
+      "validateOnBuild": true
+    },
+    "assets": {
+      "clientModelsDir": "client/public/assets/models",
+      "worldAssetsDir": "world-assets",
+      "allowedExt": [".glb", ".gltf", ".bin", ".png", ".jpg", ".jpeg", ".webp", ".ktx2"]
+    },
+    "ui": {
+      "requireAriaLabelsOnButtons": true,
+      "requireTitleOnIconButtons": true
+    }
+  }
+}

--- a/tools/dgcc/dgcc.report.schema.json
+++ b/tools/dgcc/dgcc.report.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DGCC Report",
+  "type": "object",
+  "required": ["startedAt", "finishedAt", "mode", "ok", "checks", "inconsistencies", "fixes", "artifacts"],
+  "properties": {
+    "startedAt": { "type": "string" },
+    "finishedAt": { "type": "string" },
+    "mode": { "type": "string" },
+    "ok": { "type": "boolean" },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "ok", "durationMs"],
+        "properties": {
+          "name": { "type": "string" },
+          "ok": { "type": "boolean" },
+          "durationMs": { "type": "number" },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "inconsistencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["category", "severity", "message"],
+        "properties": {
+          "category": { "type": "string" },
+          "severity": { "type": "string", "enum": ["info", "warn", "error"] },
+          "message": { "type": "string" },
+          "file": { "type": "string" },
+          "hint": { "type": "string" }
+        }
+      }
+    },
+    "fixes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "message"],
+        "properties": {
+          "kind": { "type": "string" },
+          "message": { "type": "string" },
+          "file": { "type": "string" }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  }
+}

--- a/tools/dgcc/run-dgcc.ts
+++ b/tools/dgcc/run-dgcc.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+type Severity = "info" | "warn" | "error";
+type CheckName =
+  | "lint"
+  | "unit"
+  | "e2e"
+  | "contentValidate"
+  | "assetsAudit"
+  | "wsSchemaSmoke"
+  | "uiA11ySmoke"
+  | "clientBuild"
+  | "serverBuild";
+
+type DgccReport = {
+  startedAt: string;
+  finishedAt: string;
+  mode: string;
+  ok: boolean;
+  checks: Array<{ name: CheckName; ok: boolean; durationMs: number; summary?: string }>;
+  inconsistencies: Array<{ category: string; severity: Severity; message: string; file?: string; hint?: string }>;
+  fixes: Array<{ kind: string; message: string; file?: string }>;
+  artifacts: Record<string, string>;
+};
+
+const ROOT = process.cwd();
+const CONTRACT_PATH = path.join(ROOT, "tools/dgcc/dgcc.contract.json");
+
+function readJson<T>(p: string): T {
+  return JSON.parse(fs.readFileSync(p, "utf8")) as T;
+}
+
+function ensureDir(p: string) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function run(cmd: string, args: string[], opts?: { env?: Record<string, string> }) {
+  return new Promise<{ code: number; stdout: string; stderr: string; durationMs: number }>((resolve) => {
+    const t0 = Date.now();
+    const child = spawn(cmd, args, {
+      cwd: ROOT,
+      shell: process.platform === "win32",
+      env: { ...process.env, ...(opts?.env ?? {}) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += String(d)));
+    child.stderr.on("data", (d) => (stderr += String(d)));
+    child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr, durationMs: Date.now() - t0 }));
+  });
+}
+
+function parseMode() {
+  const arg = process.argv.find((x) => x.startsWith("--mode="));
+  return (arg?.split("=")[1] || process.env.DGCC_MODE || "minimal").trim();
+}
+
+function wantFixes(contract: { modes?: Record<string, { fix?: { enabled?: boolean } }> }, mode: string) {
+  if (process.env.DGCC_FIX === "1") return true;
+  if (process.env.DGCC_FIX === "0") return false;
+  const modeFix = contract.modes?.[mode]?.fix?.enabled;
+  if (typeof modeFix === "boolean") return modeFix;
+  return mode === "extreme";
+}
+
+function printHeader(mode: string, fix: boolean) {
+  console.log(`[DGCC] mode=${mode} fix=${fix ? "on" : "off"}`);
+}
+
+async function assetsAudit(report: DgccReport, contract: any, fix: boolean) {
+  const clientDir = path.join(ROOT, contract.rules.assets.clientModelsDir);
+  if (!fs.existsSync(clientDir)) {
+    report.inconsistencies.push({
+      category: "assets",
+      severity: "warn",
+      message: `Client models dir missing: ${contract.rules.assets.clientModelsDir}`,
+      hint: "If this is expected in CI, ensure assets are present in build artifact or disable this check.",
+    });
+    return;
+  }
+  const mustHave = ["characters", "monsters", "npcs", "objects", "items", "resources"].map((x) =>
+    path.join(clientDir, x)
+  );
+  for (const p of mustHave) {
+    if (!fs.existsSync(p)) {
+      report.inconsistencies.push({
+        category: "assets",
+        severity: "warn",
+        message: `Missing models subfolder: ${path.relative(ROOT, p)}`,
+        hint: "Not fatal, but content linking will be noisier. Create folder or adjust DGCC contract.",
+      });
+      if (fix) {
+        ensureDir(p);
+        report.fixes.push({
+          kind: "assets:create-folder",
+          message: `Created ${path.relative(ROOT, p)}`,
+          file: path.relative(ROOT, p),
+        });
+      }
+    }
+  }
+}
+
+async function wsSchemaSmoke(report: DgccReport) {
+  const p = path.join(ROOT, "client/public/e2e-smoke.html");
+  if (!fs.existsSync(p)) {
+    report.inconsistencies.push({
+      category: "ws",
+      severity: "error",
+      message: "Missing client/public/e2e-smoke.html (required for ws smoke).",
+      file: "client/public/e2e-smoke.html",
+      hint: "Restore e2e smoke page or update DGCC contract.",
+    });
+  }
+}
+
+async function uiA11ySmoke(report: DgccReport) {
+  const p = path.join(ROOT, "client/public/admin-content.html");
+  if (!fs.existsSync(p)) return;
+  const html = fs.readFileSync(p, "utf8");
+  if (!html.includes('<html lang="')) {
+    report.inconsistencies.push({ category: "ui", severity: "warn", message: "admin-content.html missing lang attribute." });
+  }
+  if (!html.includes('name="viewport"')) {
+    report.inconsistencies.push({ category: "ui", severity: "warn", message: "admin-content.html missing viewport meta." });
+  }
+}
+
+async function main() {
+  const mode = parseMode();
+  const contract = readJson<any>(CONTRACT_PATH);
+  const fix = wantFixes(contract, mode);
+  printHeader(mode, fix);
+
+  const modeCfg = contract.modes[mode] ?? contract.modes.minimal;
+
+  const report: DgccReport = {
+    startedAt: nowIso(),
+    finishedAt: nowIso(),
+    mode,
+    ok: true,
+    checks: [],
+    inconsistencies: [],
+    fixes: [],
+    artifacts: {},
+  };
+
+  const outDir = path.join(ROOT, "dgcc-artifacts");
+  ensureDir(outDir);
+
+  async function runCheck(name: CheckName, fn: () => Promise<void>) {
+    const t0 = Date.now();
+    try {
+      await fn();
+      report.checks.push({ name, ok: true, durationMs: Date.now() - t0 });
+    } catch (e: any) {
+      report.ok = false;
+      report.checks.push({ name, ok: false, durationMs: Date.now() - t0, summary: String(e?.message ?? e) });
+    }
+  }
+
+  const checks = modeCfg.checks as CheckName[];
+
+  if (checks.includes("lint")) {
+    await runCheck("lint", async () => {
+      const r = await run("pnpm", ["run", "lint"]);
+      fs.writeFileSync(path.join(outDir, "lint.out.txt"), r.stdout + "\n" + r.stderr);
+      report.artifacts["lint"] = "dgcc-artifacts/lint.out.txt";
+      if (r.code !== 0) throw new Error("lint failed");
+    });
+  }
+
+  if (checks.includes("unit")) {
+    await runCheck("unit", async () => {
+      const r = await run("pnpm", ["run", "test"]);
+      fs.writeFileSync(path.join(outDir, "unit.out.txt"), r.stdout + "\n" + r.stderr);
+      report.artifacts["unit"] = "dgcc-artifacts/unit.out.txt";
+      if (r.code !== 0) throw new Error("unit tests failed");
+    });
+  }
+
+  if (checks.includes("e2e")) {
+    await runCheck("e2e", async () => {
+      const r = await run("pnpm", ["run", "test:e2e:ci"]);
+      fs.writeFileSync(path.join(outDir, "e2e.out.txt"), r.stdout + "\n" + r.stderr);
+      report.artifacts["e2e"] = "dgcc-artifacts/e2e.out.txt";
+      if (r.code !== 0) throw new Error("e2e failed");
+    });
+  }
+
+  if (checks.includes("contentValidate")) {
+    await runCheck("contentValidate", async () => {
+      const r = await run("pnpm", ["--prefix", "server", "run", "validate"]);
+      fs.writeFileSync(path.join(outDir, "content-validate.out.txt"), r.stdout + "\n" + r.stderr);
+      report.artifacts["contentValidate"] = "dgcc-artifacts/content-validate.out.txt";
+      if (r.code !== 0) throw new Error("content validation failed (server validate)");
+    });
+  }
+
+  if (checks.includes("clientBuild")) {
+    await runCheck("clientBuild", async () => {
+      const r = await run("pnpm", ["--prefix", "client", "run", "build"], {
+        env: {
+          NODE_OPTIONS: process.env.NODE_OPTIONS || "--max-old-space-size=6144",
+        },
+      });
+      fs.writeFileSync(path.join(outDir, "client-build.out.txt"), r.stdout + "\n" + r.stderr);
+      report.artifacts["clientBuild"] = "dgcc-artifacts/client-build.out.txt";
+      if (r.code !== 0) throw new Error("client build failed");
+    });
+  }
+
+  if (checks.includes("serverBuild")) {
+    await runCheck("serverBuild", async () => {
+      const r = await run("pnpm", ["--prefix", "server", "run", "build"]);
+      fs.writeFileSync(path.join(outDir, "server-build.out.txt"), r.stdout + "\n" + r.stderr);
+      report.artifacts["serverBuild"] = "dgcc-artifacts/server-build.out.txt";
+      if (r.code !== 0) throw new Error("server build failed");
+    });
+  }
+
+  if (checks.includes("assetsAudit")) {
+    await runCheck("assetsAudit", async () => {
+      await assetsAudit(report, contract, fix);
+      const p = path.join(outDir, "assets-audit.json");
+      fs.writeFileSync(p, JSON.stringify({ inconsistencies: report.inconsistencies.filter((x) => x.category === "assets") }, null, 2));
+      report.artifacts["assetsAudit"] = "dgcc-artifacts/assets-audit.json";
+    });
+  }
+
+  if (checks.includes("wsSchemaSmoke")) {
+    await runCheck("wsSchemaSmoke", async () => {
+      await wsSchemaSmoke(report);
+      const p = path.join(outDir, "ws-smoke.json");
+      fs.writeFileSync(p, JSON.stringify({ inconsistencies: report.inconsistencies.filter((x) => x.category === "ws") }, null, 2));
+      report.artifacts["wsSchemaSmoke"] = "dgcc-artifacts/ws-smoke.json";
+      const hasWsError = report.inconsistencies.some((x) => x.category === "ws" && x.severity === "error");
+      if (hasWsError) throw new Error("ws schema smoke failed");
+    });
+  }
+
+  if (checks.includes("uiA11ySmoke")) {
+    await runCheck("uiA11ySmoke", async () => {
+      await uiA11ySmoke(report);
+      const p = path.join(outDir, "ui-a11y.json");
+      fs.writeFileSync(p, JSON.stringify({ inconsistencies: report.inconsistencies.filter((x) => x.category === "ui") }, null, 2));
+      report.artifacts["uiA11ySmoke"] = "dgcc-artifacts/ui-a11y.json";
+    });
+  }
+
+  report.finishedAt = nowIso();
+  if (report.inconsistencies.some((x) => x.severity === "error")) report.ok = false;
+
+  const reportPath = path.join(outDir, "dgcc.report.json");
+  fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+  console.log(`[DGCC] report: ${path.relative(ROOT, reportPath)}`);
+  console.log(`[DGCC] ok=${report.ok ? "true" : "false"} inconsistencies=${report.inconsistencies.length} fixes=${report.fixes.length}`);
+
+  process.exit(report.ok ? 0 : 2);
+}
+
+main().catch((e) => {
+  console.error("[DGCC] fatal", e);
+  process.exit(3);
+});

--- a/tools/dgcc/selfheal-wrapper.sh
+++ b/tools/dgcc/selfheal-wrapper.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optional wrapper: run DGCC in a self-heal-friendly mode (fixes enabled by default).
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+export DGCC_MODE="${DGCC_MODE:-extreme}"
+export DGCC_FIX="${DGCC_FIX:-1}"
+
+echo "[selfheal-wrapper] DGCC_MODE=${DGCC_MODE} DGCC_FIX=${DGCC_FIX}"
+exec pnpm exec tsx tools/dgcc/run-dgcc.ts "--mode=${DGCC_MODE}"


### PR DESCRIPTION
- Add tools/dgcc contract JSON, report schema, README, and selfheal wrapper
- Implement run-dgcc.ts: lint, unit, e2e, content validate (server), audits, builds
- Wire pnpm dgcc / dgcc:extreme scripts; ignore dgcc-artifacts

## Summary

<!-- What changed and why (1–3 sentences). -->

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

<!-- e.g. `pnpm run lint`, `pnpm run test`, `pnpm run build` -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change that primarily orchestrates existing scripts; main risk is CI/local workflow impact from new gate behavior and optional directory-creating fixes when enabled.
> 
> **Overview**
> Adds a new `tools/dgcc` “Design+Gameplay Consistency Contract” gate, including a contract file (`dgcc.contract.json`), a report JSON schema, and a `run-dgcc.ts` runner that executes repo checks (lint/unit/e2e/server content validation, plus optional client/server builds), writes per-check logs and a consolidated report to `dgcc-artifacts/`, and can optionally apply small “fixes” (e.g., creating missing models subfolders).
> 
> Wires `pnpm run dgcc` and `pnpm run dgcc:extreme` scripts, adds a `selfheal-wrapper.sh` to run in fix-enabled mode by default, and ignores `dgcc-artifacts/` in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54ab73a6d12eeca2b495d8e87138de55ecd0a89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->