### PR TITLE
fix(client): resolve mobile crashes in procedural generation and physics

### DIFF
--- a/client/src/game/world/services/PhysicsService.ts
+++ b/client/src/game/world/services/PhysicsService.ts
@@ -75,16 +75,32 @@ export class PhysicsService {
     return this.initFailed;
   }
 
-  /** Validates that mesh transforms are finite to prevent Havok crashes. */
+  /** Validates that mesh transforms are finite and bounded to prevent Havok crashes. */
   private isValidTransform(mesh: Mesh | TransformNode): boolean {
     const p = mesh.position;
     const r = mesh.rotation;
     const s = mesh.scaling;
-    return (
+
+    // Check for finite numbers
+    const isFinite = (
       Number.isFinite(p.x) && Number.isFinite(p.y) && Number.isFinite(p.z) &&
       Number.isFinite(r.x) && Number.isFinite(r.y) && Number.isFinite(r.z) &&
       Number.isFinite(s.x) && Number.isFinite(s.y) && Number.isFinite(s.z)
     );
+    if (!isFinite) return false;
+
+    // Guard against extreme values that can cause engine instability
+    // World is approx 400x400, so 10000 is a safe upper bound
+    const MAX_COORD = 10000;
+    const MAX_SCALE = 1000;
+
+    if (Math.abs(p.x) > MAX_COORD || Math.abs(p.y) > MAX_COORD || Math.abs(p.z) > MAX_COORD) return false;
+    if (Math.abs(s.x) > MAX_SCALE || Math.abs(s.y) > MAX_SCALE || Math.abs(s.z) > MAX_SCALE) return false;
+
+    // Guard against zero scale (Havok can crash or throw on degenerate shapes)
+    if (Math.abs(s.x) < 1e-5 || Math.abs(s.y) < 1e-5 || Math.abs(s.z) < 1e-5) return false;
+
+    return true;
   }
 
   /** Add a static collider for a world object (house, wall, etc.). */

--- a/client/src/game/world/services/WorldGeneratorService.ts
+++ b/client/src/game/world/services/WorldGeneratorService.ts
@@ -237,8 +237,8 @@ export class WorldGeneratorService {
       const u = (localX / chunkSize) * (chunkData.resolution - 1);
       const v = (localZ / chunkSize) * (chunkData.resolution - 1);
 
-      const x0 = Math.floor(u);
-      const z0 = Math.floor(v);
+      const x0 = Math.max(0, Math.min(Math.floor(u), chunkData.resolution - 1));
+      const z0 = Math.max(0, Math.min(Math.floor(v), chunkData.resolution - 1));
       const x1 = Math.min(x0 + 1, chunkData.resolution - 1);
       const z1 = Math.min(z0 + 1, chunkData.resolution - 1);
       const fx = u - x0;
@@ -251,10 +251,12 @@ export class WorldGeneratorService {
       const h01 = data[(z1 * res + x0) * 3 + 1];
       const h11 = data[(z1 * res + x1) * 3 + 1];
 
-      return h00 * (1 - fx) * (1 - fz) + h10 * fx * (1 - fz) + h01 * (1 - fx) * fz + h11 * fx * fz;
+      const h = h00 * (1 - fx) * (1 - fz) + h10 * fx * (1 - fz) + h01 * (1 - fx) * fz + h11 * fx * fz;
+      return Number.isFinite(h) ? h : 0;
     }
 
-    return this.terrain ? this.terrain.getHeightFromMap(x, z) : 0;
+    const h = this.terrain ? this.terrain.getHeightFromMap(x, z) : 0;
+    return Number.isFinite(h) ? h : 0;
   }
 
   // ── Chunk-Based Tree Generation ───────────────────────────────────
@@ -405,6 +407,7 @@ export class WorldGeneratorService {
         if (mat.emissiveTexture) mat.emissiveTexture.dispose();
         mat.dispose();
       }
+      physicsService.removeBody(tree.name);
       tree.dispose(false, true);
     }
     this.treesByChunk.delete(key);
@@ -437,7 +440,8 @@ export class WorldGeneratorService {
     return {
       getHeightAt(x: number, y: number): number {
         try {
-          return terrain.getHeightFromMap(x, y);
+          const h = terrain.getHeightFromMap(x, y);
+          return Number.isFinite(h) ? h : 0;
         } catch {
           return 0;
         }
@@ -447,7 +451,8 @@ export class WorldGeneratorService {
         const h0 = terrain.getHeightFromMap(x, y);
         const hx = terrain.getHeightFromMap(x + d, y);
         const hy = terrain.getHeightFromMap(x, y + d);
-        return Math.sqrt(((hx - h0) / d) ** 2 + ((hy - h0) / d) ** 2);
+        const s = Math.sqrt(((hx - h0) / d) ** 2 + ((hy - h0) / d) ** 2);
+        return Number.isFinite(s) ? s : 0;
       },
       async flattenArea(x: number, y: number, width: number, depth: number, targetHeight: number): Promise<void> {
         const mapData = terrain.mapData as Float32Array;

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,6 @@
+fix(client): resolve mobile crashes in procedural generation and physics
+
+- Fixed a memory leak in `WorldGeneratorService.removeTreesForChunk` by explicitly removing physics bodies from the Havok engine before disposing of tree meshes.
+- Added `Number.isFinite` guards to heightmap and slope queries in `WorldGeneratorService` to prevent NaN values from causing physics engine crashes.
+- Enhanced transform validation in `PhysicsService` with bounds checks and zero-scale protection.
+- Optimized mobile performance by ensuring proper cleanup during chunk unloading.

--- a/world_gen_patch.txt
+++ b/world_gen_patch.txt
@@ -1,0 +1,19 @@
+<<<<<<< SEARCH
+      const h11 = data[(z1 * res + x1) * 3 + 1];
+
+      return h00 * (1 - fx) * (1 - fz) + h10 * fx * (1 - fz) + h01 * (1 - fx) * fz + h11 * fx * fz;
+    }
+
+    return this.terrain ? this.terrain.getHeightFromMap(x, z) : 0;
+  }
+=======
+      const h11 = data[(z1 * res + x1) * 3 + 1];
+
+      const h = h00 * (1 - fx) * (1 - fz) + h10 * fx * (1 - fz) + h01 * (1 - fx) * fz + h11 * fx * fz;
+      return Number.isFinite(h) ? h : 0;
+    }
+
+    const h = this.terrain ? this.terrain.getHeightFromMap(x, z) : 0;
+    return Number.isFinite(h) ? h : 0;
+  }
+>>>>>>> REPLACE


### PR DESCRIPTION
This PR addresses several critical issues causing crashes on mobile devices, particularly during game start and procedural chunk generation.

Key changes:
- Fixed a memory leak in WorldGeneratorService.removeTreesForChunk by explicitly removing physics bodies from the Havok engine before disposing of tree meshes.
- Added Number.isFinite guards to heightmap and slope queries in WorldGeneratorService to prevent NaN values from causing hard crashes in the physics engine.
- Implemented array bounds checks for bilinear heightmap sampling in WorldGeneratorService to ensure safe terrain data access.
- Enhanced transform validation in PhysicsService with finite number checks, coordinate/scaling bounds (max 10,000 / 1,000), and zero-scale protection (min 1e-5) to prevent Havok instability.
- Verified stability with unit tests for BabylonAdapter, chunk systems, and world generation.

---
*PR created automatically by Jules for task [3838901778818207670](https://jules.google.com/task/3838901778818207670) started by @OuroborosCollective*