### PR TITLE
fix: restore corrupted TypeScript files causing build failures

### DIFF
--- a/apps/api/src/services/WorldTickOptimizationService.ts
+++ b/apps/api/src/services/WorldTickOptimizationService.ts
@@ -1,103 +1,195 @@
-Um die 10Hz-Tick-Synchronisation innerhalb der Arelorian-Engine sicherzustellen, muss die `WorldStateRegistry` den atomaren Austausch des Weltzustands (State-Swap) deterministisch und unter Berücksichtigung der Frame-Kausalität abwickeln.
-
-Hier ist die Implementierung der `WorldStateRegistry` für `apps/api/src/services/WorldStateRegistry.ts`:
-
-typescript
-import { Injectable, Logger } from '@nestjs/common';
-import { WorldState } from '@wasd/shared';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Entity, WorldState, EntityTransformUpdate } from '@wasd/shared';
+import { v4 as uuidv4 } from 'uuid';
 
 /**
- * WorldStateRegistry
+ * WorldTickOptimizationService
  * 
- * Single Source of Truth (SSoT) für den deterministischen Weltzustand.
- * Verwaltet den State-Swap-Mechanismus für die 10Hz-Engine.
- * 
- * REGELN:
- * 1. Frame-Monotonie: Ein neuer State muss immer einen höheren Frame-Index haben.
- * 2. Unveränderlichkeit: Der State wird nach dem Commit als Read-Only behandelt.
+ * Realisiert einen deterministischen 10Hz World-Tick mit diskreten Frame-Nummern
+ * und obligatorischer Sequence-ID Injection zur Gewährleistung der Kausalität.
  */
 @Injectable()
-export class WorldStateRegistry {
-  private readonly logger = new Logger(WorldStateRegistry.name);
+export class WorldTickOptimizationService implements OnModuleDestroy {
+  private readonly logger = new Logger(WorldTickOptimizationService.name);
   
-  // Interner Speicher für den aktuellsten validierten Zustand
+  // 10Hz = 100ms Intervall
+  private readonly TICK_INTERVAL_NS = BigInt(100) * BigInt(1_000_000);
+  private readonly FRAMES_PER_SECOND = 10;
+  
+  private isRunning = false;
+  private nextTickTimeNs: bigint = BigInt(0);
+  private currentFrame: bigint = BigInt(0);
   private currentState: WorldState | null = null;
-  
-  // Letzter erfolgreich kommitteter Frame zur Kausalitätsprüfung
-  private lastCommittedFrame = -1;
+  private onTickCallback: ((state: WorldState) => void) | null = null;
 
-  /**
-   * Gibt den aktuellen globalen Zustand zurück.
-   * Muss von Systemen genutzt werden, die ARE-Axiome berechnen.
-   */
-  public getCurrentState(): WorldState | null {
-    return this.currentState;
+  onModuleDestroy() {
+    this.stopWorldTick();
   }
 
   /**
-   * commitStateSwap
-   * 
-   * Vollzieht den atomaren Wechsel zum nächsten WorldState.
-   * Implementiert die Synchronisations-Barriere für den 10Hz Tick.
-   * 
-   * @param newState Der berechnete und durch den ATO validierte neue Zustand.
+   * Startet den Scheduler mit initialem Frame-Zähler.
    */
-  public commitStateSwap(newState: WorldState): void {
-    if (!newState) {
-      this.logger.error('Null-State-Commit abgelehnt.');
-      return;
+  public startWorldTick(initialState: WorldState, callback: (state: WorldState) => void): void {
+    if (this.isRunning) return;
+
+    this.currentState = initialState;
+    this.onTickCallback = callback;
+    this.isRunning = true;
+    this.currentFrame = BigInt(initialState.frame || 0);
+    this.nextTickTimeNs = process.hrtime.bigint();
+
+    this.logger.log(`Areloria Deterministic 10Hz Tick gestartet. Frame: ${this.currentFrame}`);
+    this.scheduleNext();
+  }
+
+  public stopWorldTick(): void {
+    this.isRunning = false;
+    this.logger.log('WorldTick Scheduler gestoppt.');
+  }
+
+  private scheduleNext(): void {
+    if (!this.isRunning) return;
+
+    const now = process.hrtime.bigint();
+
+    if (now >= this.nextTickTimeNs) {
+      this.executeTick();
+      this.nextTickTimeNs += this.TICK_INTERVAL_NS;
+
+      // Spiral of Death Protection
+      if (now - this.nextTickTimeNs > this.TICK_INTERVAL_NS * BigInt(5)) {
+        this.nextTickTimeNs = now + this.TICK_INTERVAL_NS;
+        this.logger.warn('Kritischer Drift: Frame-Synchronisation erzwungen.');
+      }
     }
 
-    const incomingFrame = newState.frame ?? 0;
+    setImmediate(() => this.scheduleNext());
+  }
 
-    // DETERMINISMUS-CHECK: Frame-Integrität (Axiom: Zeit fließt vorwärts)
-    if (incomingFrame <= this.lastCommittedFrame && this.lastCommittedFrame !== -1) {
-      this.logger.warn(
-        `Synchronisations-Konflikt: Eingehender Frame ${incomingFrame} ist nicht jünger als ${this.lastCommittedFrame}. Swap abgebrochen.`
-      );
-      return;
-    }
+  /**
+   * Pipeline mit Sequence-ID Injection und Frame-Management.
+   */
+  private executeTick(): void {
+    if (!this.currentState || !this.onTickCallback) return;
 
-    // KAPPA-KONFORMITÄT: Sicherstellung, dass Metriken vorhanden sind
-    if (!newState.performanceMetrics) {
-      newState.performanceMetrics = {
-        lastTickDurationMs: 0,
-        thresholdMs: 80
+    const startTime = process.hrtime.bigint();
+    
+    // Inkrementiere diskreten Frame
+    this.currentFrame++;
+    
+    // Generiere eindeutige Sequence-ID für diesen Tick
+    const sequenceId = `seq_${this.currentFrame}_${uuidv4().split('-')[0]}`;
+
+    // 1. AREStateCompiler Phase: Transformation mit Sequence-ID
+    let nextState = this.compileAREState(this.currentState, sequenceId, this.currentFrame);
+
+    // 2. ResonanceGrid Phase: Räumliche Validierung
+    nextState = this.updateResonanceGrid(nextState, sequenceId);
+
+    // 3. Optimization Phase: Frame-basiertes Throttling & Culling
+    nextState = this.optimizeTick(nextState, sequenceId, this.currentFrame);
+    
+    // Performance-Metriken & Finaler State-Sync
+    const endTime = process.hrtime.bigint();
+    const durationMs = Number(endTime - startTime) / 1_000_000;
+
+    nextState.performanceMetrics = {
+      ...nextState.performanceMetrics,
+      lastTickDurationMs: durationMs,
+      thresholdMs: 80
+    };
+
+    this.currentState = nextState;
+    this.onTickCallback(nextState);
+  }
+
+  /**
+   * Injiziert Frame-Metadaten und Sequence-IDs in den WorldState.
+   */
+  private compileAREState(state: WorldState, sequenceId: string, frame: bigint): WorldState {
+    return {
+      ...state,
+      frame: Number(frame),
+      sequenceId: sequenceId,
+      lastProcessedAt: Date.now()
+    };
+  }
+
+  /**
+   * Räumliche Partitionierung unter Berücksichtigung der Sequence-ID.
+   */
+  private updateResonanceGrid(state: WorldState, sequenceId: string): WorldState {
+    // Hier würde die Grid-Logik die sequenceId nutzen, um Cache-Invalidierung zu steuern
+    return { ...state, sequenceId };
+  }
+
+  /**
+   * Kern-Optimierung basierend auf diskreten Frames statt Realzeit-Deltas.
+   */
+  public optimizeTick(currentState: WorldState, sequenceId: string, currentFrame: bigint): WorldState {
+    const entities = currentState.entities as unknown as Record<string, Entity>;
+    const performanceMetrics = currentState.performanceMetrics;
+    const processedEntities: Record<string, Entity> = {};
+    
+    const metrics = performanceMetrics || { lastTickDurationMs: 0, thresholdMs: 80 };
+    const isOverloaded = metrics.lastTickDurationMs > metrics.thresholdMs;
+    
+    // Frame-basierte Timeouts (50 Frames @ 10Hz = 5 Sekunden)
+    const ZOMBIE_FRAME_THRESHOLD = BigInt(50);
+    const entityEntries = Object.entries(entities);
+
+    for (let i = 0; i < entityEntries.length; i++) {
+      const [id, entity] = entityEntries[i];
+      const lastUpdateFrame = BigInt(entity.lastUpdateFrame || currentFrame);
+      
+      // 1. Zombie-Check via Frame-Differenz
+      if (currentFrame - lastUpdateFrame > ZOMBIE_FRAME_THRESHOLD) {
+        continue;
+      }
+
+      let updatedEntity: Entity = { 
+        ...entity,
+        sequenceId: sequenceId // Mandatory Sequence Injection
       };
+      let modified = false;
+
+      // 2. Throttling-Logik
+      const cpuCost = entity.cpuCost ?? 0;
+      const priority = entity.priority ?? 0;
+
+      if (isOverloaded && cpuCost > 15 && priority < 2) {
+        updatedEntity.status = 'throttled';
+        updatedEntity.cpuCost = cpuCost * 0.5;
+        modified = true;
+      } else if (!isOverloaded && updatedEntity.status === 'throttled') {
+        if (metrics.lastTickDurationMs < (metrics.thresholdMs * 0.6)) {
+          updatedEntity.status = 'active';
+          updatedEntity.cpuCost = Math.min(100, cpuCost * 1.2);
+          modified = true;
+        }
+      }
+
+      // 3. Frame-basierte Regeneration (alle X Frames)
+      // Jede 10 Frames (1s) 1 HP regenerieren
+      if (currentFrame % BigInt(10) === BigInt(0)) {
+        if ((updatedEntity.health ?? 0) < 100) {
+          updatedEntity.health = Math.min(100, (updatedEntity.health ?? 0) + 1);
+          modified = true;
+        }
+      }
+
+      if (modified || currentFrame % BigInt(10) === BigInt(0)) {
+        updatedEntity.lastUpdateFrame = Number(currentFrame);
+      }
+
+      processedEntities[id] = updatedEntity;
     }
 
-    // Atomarer Swap
-    this.currentState = Object.freeze(newState);
-    this.lastCommittedFrame = incomingFrame;
-
-    // Debugging für High-Load Szenarien (Logging nur bei Abweichung vom 10Hz Ideal)
-    if (newState.performanceMetrics.lastTickDurationMs > newState.performanceMetrics.thresholdMs) {
-      this.logger.warn(
-        `Tick-Budget Überschreitung in Frame ${incomingFrame}: ${newState.performanceMetrics.lastTickDurationMs}ms`
-      );
-    }
-  }
-
-  /**
-   * Initialisiert die Registry beim Serverstart oder nach einem World-Reset.
-   */
-  public initializeState(initialState: WorldState): void {
-    this.logger.log(`Initialisiere WorldStateRegistry. Start-Frame: ${initialState.frame}`);
-    this.currentState = Object.freeze(initialState);
-    this.lastCommittedFrame = initialState.frame ?? 0;
-  }
-
-  /**
-   * Ermöglicht das Abrufen des aktuellen Frames ohne den gesamten State zu klonen.
-   */
-  public get currentFrame(): number {
-    return this.lastCommittedFrame;
+    return {
+      ...currentState,
+      entities: processedEntities,
+      sequenceId: sequenceId,
+      frame: Number(currentFrame)
+    };
   }
 }
-
-
-### Spezifikations-Details:
-1.  **Frame-Monotonie**: Die Methode prüft, ob `incomingFrame <= lastCommittedFrame`. Dies verhindert, dass durch asynchrone Race-Conditions oder ATO-Verzögerungen alte Zustände einen neueren Zustand überschreiben.
-2.  **Object.freeze**: Der State wird eingefroren, um sicherzustellen, dass nachfolgende Services (z.B. Broadcast-Service) den Zustand nicht versehentlich mutieren (Stateless Determinism).
-3.  **Performance-Tracking**: Die Registry überwacht das 80ms-Budget des 10Hz-Ticks (100ms Gesamtintervall minus Puffer) und loggt Warnungen, falls die Engine den Kappa-Standard unterschreitet.
-4.  **NestJS Integration**: Nutzt `@Injectable` für die korrekte Dependency Injection in den `WorldTickOptimizationService`.

--- a/apps/web/src/renderers/RendererManager.ts
+++ b/apps/web/src/renderers/RendererManager.ts
@@ -1,42 +1,24 @@
-Hier ist die korrigierte Fassung der `RendererManager.ts`. Der Fokus liegt auf der korrekten Typisierung der `AREPayload` und der Sicherstellung, dass die Schnittstelle zwischen der deterministischen Engine (Kappa-Konform) und der visuellen Interpretation (Renderers) sauber definiert ist.
-
-typescript
-/**
- * @file apps/web/src/renderers/RendererManager.ts
- * @description Zentrales Management-Subsystem für die visuelle Interpretation des ARE-States.
- * @vision Arelorian - Deterministische 10Hz-Logic trifft auf adaptive Visualisierung.
- */
-
 import { AREPayload } from "@wasd/types";
 import { BabylonRenderer } from "./BabylonRenderer";
 import { ThreeRenderer } from "./ThreeRenderer";
 import { ProxyRenderer } from "./ProxyRenderer";
 import { PlexityGate } from "../utils/PlexityGate";
 
-/**
- * Definiert den Standard für alle visuellen Interpreter.
- * Renderers sind zustandslose Schalen, die Kappa-Werte (Fixed-Point)
- * in Gleitkommazahlen für die GPU umrechnen.
- */
+export type RendererType = "WEBGPU" | "WEBGL" | "DOM";
+
 export interface IRenderer {
   initialize(canvas: HTMLCanvasElement): Promise<void>;
-  /**
-   * Die render-Methode verarbeitet den AREPayload.
-   * Der Payload enthält deterministische Daten (Tick-Nummer, Entity-States).
-   */
   render(payload: AREPayload): void;
   resize(width: number, height: number): void;
   dispose(): void;
 }
 
-export type RendererType = "WEBGPU" | "WEBGL" | "DOM";
-
 /**
  * RendererManager
  * 
- * Orchestriert den Lebenszyklus des visuellen Backends.
- * Wählt basierend auf PlexityGate (Komplexitätsanalyse) und Device-Fähigkeiten
- * zwischen WebGPU (Babylon), WebGL (Three) oder DOM (Proxy).
+ * Orchestrates the selection and lifecycle of the visual interpreter.
+ * It selects between Babylon (WebGPU), Three (WebGL), or Proxy (DOM) 
+ * based on the device's capability and complexity requirements determined by PlexityGate.
  */
 export class RendererManager {
   private currentRenderer: IRenderer | null = null;
@@ -46,13 +28,12 @@ export class RendererManager {
   constructor() {}
 
   /**
-   * Initialisiert den optimalen Renderer.
-   * Der Prozess ist asynchron, blockiert aber nicht den World-Tick.
+   * Initializes the appropriate renderer based on environment and PlexityGate.
    */
   public async initialize(canvas: HTMLCanvasElement): Promise<void> {
     this.canvas = canvas;
     
-    // PlexityGate entscheidet basierend auf Hardware-Abstraktion
+    // Determine the optimal renderer type
     this.type = await PlexityGate.determineOptimalRenderer();
 
     switch (this.type) {
@@ -69,34 +50,22 @@ export class RendererManager {
     }
 
     if (this.currentRenderer) {
-      try {
-        await this.currentRenderer.initialize(this.canvas);
-        console.log(`[RendererManager] Backend ${this.type} erfolgreich initialisiert.`);
-      } catch (error) {
-        console.error(`[RendererManager] Fehler bei Initialisierung von ${this.type}:`, error);
-        // Fallback auf DOM-Renderer bei kritischem GPU-Fehler
-        if (this.type !== "DOM") {
-          await this.switchRenderer("DOM");
-        }
-      }
+      await this.currentRenderer.initialize(this.canvas);
+      console.log(`[RendererManager] Initialized with ${this.type} backend.`);
     }
   }
 
   /**
-   * Routet den AREPayload an den aktiven Renderer.
-   * Diese Methode wird im Takt des World-Update-Loops aufgerufen (interpolation möglich).
-   * @param payload Der aktuelle State-Diff oder Full-State aus der WorldStateRegistry.
+   * Routes the AREPayload to the active renderer for visual interpretation.
+   * Renderers remain stateless visual shells; logic resides in the core engine.
    */
   public update(payload: AREPayload): void {
-    if (!this.currentRenderer || !payload) return;
-
-    // Stateless Interpretation: Der Renderer speichert keine Business-Logik.
-    // Er mappt lediglich payload.entities auf grafische Instanzen.
+    if (!this.currentRenderer) return;
     this.currentRenderer.render(payload);
   }
 
   /**
-   * Passt die Projektionsmatrizen des aktiven Renderers an.
+   * Handles canvas resizing.
    */
   public handleResize(width: number, height: number): void {
     if (this.currentRenderer) {
@@ -105,21 +74,18 @@ export class RendererManager {
   }
 
   /**
-   * Ermöglicht den dynamischen Wechsel des Renderers zur Laufzeit
-   * (z.B. bei Performance-Einbruch oder User-Wunsch).
+   * Switches renderer at runtime if needed (e.g., performance degradation).
    */
   public async switchRenderer(newType: RendererType): Promise<void> {
     if (this.type === newType || !this.canvas) return;
 
-    console.warn(`[RendererManager] Switching Renderer: ${this.type} -> ${newType}`);
-    
     this.dispose();
     this.type = newType;
     await this.initialize(this.canvas);
   }
 
   /**
-   * Ressourcen-Cleanup zur Vermeidung von Memory-Leaks in der Web-App.
+   * Clean up resources.
    */
   public dispose(): void {
     if (this.currentRenderer) {
@@ -128,22 +94,9 @@ export class RendererManager {
     }
   }
 
-  /**
-   * Gibt den aktuell aktiven Backend-Typ zurück.
-   */
   public getActiveRendererType(): RendererType {
     return this.type;
   }
 }
 
-/**
- * Singleton-Instanz für den globalen Zugriff im App-Scope.
- */
 export const rendererManager = new RendererManager();
-
-
-### Key Fixes & Design Decisions:
-1.  **Expliziter Import:** `AREPayload` wird sauber aus `@wasd/types` bezogen. Dies setzt voraus, dass die `index.ts` des `@wasd/types` Pakets diesen Typ exportiert.
-2.  **Stateless Render Loop:** Die `update`-Methode nimmt den `AREPayload` entgegen, was dem ARE-Prinzip entspricht, dass Visualisierung nur eine Projektion des deterministischen Zustands ist.
-3.  **Error-Handling:** Falls `initialize` fehlschlägt (z.B. WebGPU nicht verfügbar trotz Detektion), erfolgt ein automatischer Fallback auf den `ProxyRenderer`.
-4.  **Kappa-Konformität:** Der Code bereitet die Brücke vor, auf der Fixed-Point-Koordinaten aus dem Payload für die GPU in Floats transformiert werden (innerhalb der konkreten Renderer-Implementierungen).


### PR DESCRIPTION
The TypeScript build failed during deployment due to two files containing non-TypeScript content (German documentation text) at their start:

- apps/api/src/services/WorldTickOptimizationService.ts
- apps/web/src/renderers/RendererManager.ts

Both files were corrupted by an automated tool that injected documentation text instead of valid TypeScript code.

Fixed by restoring the correct TypeScript source from the last known good commit (audit-standardization-oct-2026 branch).

Deployment error: TS1434 (Unexpected keyword or identifier) and TS1003