### PR TITLE
Potential fix for code scanning alert no. 7: Server-side request forgery

### DIFF
--- a/server/src/modules/payment/PayPalService.ts
+++ b/server/src/modules/payment/PayPalService.ts
@@ -27,6 +27,13 @@ export const GLB_SUBSCRIPTION = {
 };
 
 // ── HTTP helper ───────────────────────────────────────────────────────────────
+function assertValidPayPalOrderId(orderId: string): void {
+  // PayPal order IDs are opaque identifiers; restrict to safe token characters.
+  if (!/^[A-Za-z0-9-]{1,64}$/.test(orderId)) {
+    throw new Error("Invalid PayPal orderId format");
+  }
+}
+
 async function paypalRequest(method: string, path: string, body?: any, token?: string): Promise<any> {
   const bodyStr = body ? JSON.stringify(body) : undefined;
   const headers: Record<string, string> = {
@@ -139,8 +146,10 @@ export async function capturePayPalOrder(orderId: string): Promise<{
   amount?: string;
   currency?: string;
 }> {
+  assertValidPayPalOrderId(orderId);
+  const safeOrderId = encodeURIComponent(orderId);
   const token = await getPayPalToken();
-  const result = await paypalRequest("POST", `/v2/checkout/orders/${orderId}/capture`, {}, token);
+  const result = await paypalRequest("POST", `/v2/checkout/orders/${safeOrderId}/capture`, {}, token);
 
   if (result.status !== "COMPLETED") {
     return { success: false };


### PR DESCRIPTION
Potential fix for [https://github.com/OuroborosCollective/Wasd/security/code-scanning/7](https://github.com/OuroborosCollective/Wasd/security/code-scanning/7)

Use strict input validation for PayPal order IDs before they are interpolated into API paths, and URL-encode the value when building the path segment.

Best concrete fix (minimal behavior change):
1. In `server/src/modules/payment/PayPalService.ts`, add a small validator for PayPal order IDs (allow only expected characters and length).
2. In `capturePayPalOrder`, validate `orderId` first; reject invalid values early.
3. Encode the validated ID with `encodeURIComponent` before embedding in `/v2/checkout/orders/{id}/capture`.
4. Keep `PAYPAL_BASE` fixed as-is; no need to change routing logic.

This addresses both alert variants (`req.body.orderId` and `req.query.token`) through one centralized sanitization point.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
