### PR TITLE
fix(portal): HistoryTimeline 0.95 intensity threshold

### DIFF
--- a/portal/src/visualizer/HistoryTimeline.ts
+++ b/portal/src/visualizer/HistoryTimeline.ts
@@ -38,7 +38,7 @@ export interface ProcessedTimelineData {
 }
 
 export class HistoryTimelineProcessor {
-    private static readonly INTENSITY_THRESHOLD = 0.75;
+    private static readonly INTENSITY_THRESHOLD = 0.95;
     private static readonly HIGH_INTENSITY_TYPES = ['war', 'foundation', 'disaster'];
 
     public static process(history: WorldHistory): ProcessedTimelineData {


### PR DESCRIPTION
Updated INTENSITY_THRESHOLD from 0.75 to 0.95 per requirement. High-Intensity Events extraction from WorldHistory.