### PR TITLE
fix: add local postcss config to override root tailwind config

### DIFF
--- a/apps/client-2d/postcss.config.mjs
+++ b/apps/client-2d/postcss.config.mjs
@@ -1,0 +1,3 @@
+// Minimal config - root has tailwind which isn't needed for 2D client
+const config = { plugins: [] };
+export default config;


### PR DESCRIPTION
## Fix: Local PostCSS config for 2D client

The 2D client doesn't use Tailwind, but the root has a postcss.config.mjs that requires @tailwindcss/postcss. Create a minimal local config to override it.

### Test

```bash
cd apps/client-2d && npm run build
# ✓ built in 3.42s
```

Co-authored-by: openhands <openhands@all-hands.dev>

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d0a93aac-451d-4235-9723-6664e4a87400)