### PR TITLE
VPS Docker deploy workflow (monorepo) + Paramiko helper

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -1,0 +1,60 @@
+# Production VPS: pull monorepo + Docker Compose rebuild.
+# Configure GitHub repo secrets (Settings → Secrets → Actions):
+#   VPS_HOST          e.g. 46.202.154.25
+#   VPS_USER          e.g. deploy  (recommended; user in docker group) or root
+#   VPS_SSH_KEY       private key PEM (full multiline OpenSSH / RSA)
+# Optional:
+#   VPS_DEPLOY_PATH   default /opt/areloria
+#
+# Do NOT store VPS passwords in GitHub or in this repo — use SSH keys only.
+
+name: VPS Docker Deploy (monorepo)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'projects/**'
+      - 'client/**'
+      - 'server/**'
+      - 'portal/**'
+      - 'engine/**'
+      - 'docker/**'
+      - 'Dockerfile'
+      - 'Dockerfile.*'
+      - 'docker-compose.yml'
+      - 'docker-compose.*.yml'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'package.json'
+      - 'scripts/deploy-vps-docker.sh'
+  workflow_dispatch:
+
+concurrency:
+  group: vps-docker-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            DEPLOY_PATH="${{ secrets.VPS_DEPLOY_PATH }}"
+            DEPLOY_PATH="${DEPLOY_PATH:-/opt/areloria}"
+            cd "$DEPLOY_PATH"
+            chmod +x scripts/deploy-vps-docker.sh 2>/dev/null || true
+            bash scripts/deploy-vps-docker.sh

--- a/docs/VPS_GITHUB_DEPLOY.md
+++ b/docs/VPS_GITHUB_DEPLOY.md
@@ -5,7 +5,7 @@ This repo is a **pnpm monorepo** (`apps/`, `packages/`, `projects/`, `server/`, 
 ## Security first
 
 - If a root password was shared in chat, email, or tickets, **change it immediately**.
-- Prefer a dedicated **`deploy` user** in the `docker` group, **SSH keys only**, `PasswordAuthentication no` in `sshd_config`.
+- Prefer a dedicated **`deploy` user** in the `docker` group, **SSH keys only**, `PasswordAuthentication no` in `sshd_config`. If you use **`root`** (common on small VPS), still use **SSH keys** for GitHub Actions — same setup, but put the public key in **`/root/.ssh/authorized_keys`**.
 - **Never** commit VPS passwords or paste them into GitHub Secrets as `SSH_PASSWORD` long-term.
 
 ## One-time VPS bootstrap
@@ -45,19 +45,19 @@ It runs on **push to `main`** when files under the monorepo change (apps, server
 | Secret | Description |
 |--------|-------------|
 | `VPS_HOST` | VPS IP or DNS |
-| `VPS_USER` | SSH user (e.g. `deploy`) |
+| `VPS_USER` | SSH user: e.g. **`root`** or `deploy` |
 | `VPS_SSH_KEY` | **Private** key (full PEM / OpenSSH block) |
 | `VPS_SSH_PORT` | Optional, default `22` |
 | `VPS_DEPLOY_PATH` | Optional, default `/opt/areloria` |
 
-Generate a **deploy-only** key pair on your laptop, put the **public** key in `~/.ssh/authorized_keys` on the VPS for `VPS_USER`, and paste the **private** key into `VPS_SSH_KEY`.
+Generate a **deploy-only** key pair on your laptop, put the **public** key in **`/root/.ssh/authorized_keys`** (if `VPS_USER` is `root`) or **`~/.ssh/authorized_keys`** for that user, then paste the **private** key into `VPS_SSH_KEY`.
 
 ## Local trigger with Python Paramiko (optional)
 
 ```bash
 pip install paramiko
 export VPS_HOST=your.vps.host
-export VPS_USER=deploy
+export VPS_USER=root
 export SSH_PRIVATE_KEY="$(cat ~/.ssh/id_ed25519)"
 export VPS_DEPLOY_PATH=/opt/areloria
 python3 tools/deploy_vps_paramiko.py

--- a/docs/VPS_GITHUB_DEPLOY.md
+++ b/docs/VPS_GITHUB_DEPLOY.md
@@ -1,0 +1,72 @@
+# VPS deployment (`/opt/areloria`) — WASD monorepo
+
+This repo is a **pnpm monorepo** (`apps/`, `packages/`, `projects/`, `server/`, `client/`, …). Production on a VPS uses **Docker Compose** (`docker-compose.yml`, service `arelorian-engine`).
+
+## Security first
+
+- If a root password was shared in chat, email, or tickets, **change it immediately**.
+- Prefer a dedicated **`deploy` user** in the `docker` group, **SSH keys only**, `PasswordAuthentication no` in `sshd_config`.
+- **Never** commit VPS passwords or paste them into GitHub Secrets as `SSH_PASSWORD` long-term.
+
+## One-time VPS bootstrap
+
+On the server (as root or with sudo):
+
+```bash
+apt-get update && apt-get install -y git curl ca-certificates
+# Install Docker (official docs) + ensure your user can run `docker ps`
+
+mkdir -p /opt/areloria
+cd /opt
+
+# Read-only deploy key recommended: add public key in GitHub → Deploy keys
+git clone https://github.com/<ORG>/<REPO>.git areloria
+cd /opt/areloria
+
+chmod +x scripts/deploy-vps-docker.sh
+```
+
+Create `.env` or configure Compose env as needed for your stack (see `docker-compose.yml`).
+
+Smoke test:
+
+```bash
+bash scripts/deploy-vps-docker.sh
+```
+
+## GitHub Actions — automatic deploy on new code
+
+Workflow: [`.github/workflows/vps-docker-deploy.yml`](../.github/workflows/vps-docker-deploy.yml)
+
+It runs on **push to `main`** when files under the monorepo change (apps, server, Docker, lockfile, etc.), and on **manual** `workflow_dispatch`.
+
+### GitHub secrets
+
+| Secret | Description |
+|--------|-------------|
+| `VPS_HOST` | VPS IP or DNS |
+| `VPS_USER` | SSH user (e.g. `deploy`) |
+| `VPS_SSH_KEY` | **Private** key (full PEM / OpenSSH block) |
+| `VPS_SSH_PORT` | Optional, default `22` |
+| `VPS_DEPLOY_PATH` | Optional, default `/opt/areloria` |
+
+Generate a **deploy-only** key pair on your laptop, put the **public** key in `~/.ssh/authorized_keys` on the VPS for `VPS_USER`, and paste the **private** key into `VPS_SSH_KEY`.
+
+## Local trigger with Python Paramiko (optional)
+
+```bash
+pip install paramiko
+export VPS_HOST=your.vps.host
+export VPS_USER=deploy
+export SSH_PRIVATE_KEY="$(cat ~/.ssh/id_ed25519)"
+export VPS_DEPLOY_PATH=/opt/areloria
+python3 tools/deploy_vps_paramiko.py
+```
+
+This runs the same remote script as CI: `scripts/deploy-vps-docker.sh`.
+
+## Related files
+
+- `scripts/deploy-vps-docker.sh` — canonical VPS pull + `docker compose` rebuild
+- `scripts/deploy-vps.sh` — alternative path (pnpm build + PM2); use if you intentionally run without Docker
+- `deploy.sh` / root `docker-compose.yml` — engine + monitor images

--- a/scripts/deploy-vps-docker.sh
+++ b/scripts/deploy-vps-docker.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Run on the VPS inside the monorepo root (e.g. /opt/areloria).
+# Pulls latest main, rebuilds Docker images, restarts stack, health-checks.
+set -euo pipefail
+
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$REPO_ROOT"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "ERROR: git is required."
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "ERROR: Docker daemon not reachable. Is Docker installed and running?"
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "ERROR: Install Docker Compose v2 (docker compose) or docker-compose v1."
+  exit 1
+fi
+
+echo "=== WASD monorepo deploy (Docker) ==="
+echo "Repo: $REPO_ROOT"
+echo "Branch: $DEPLOY_BRANCH"
+
+echo "[1/4] git fetch + hard reset to origin/${DEPLOY_BRANCH}"
+git fetch origin "$DEPLOY_BRANCH"
+git reset --hard "origin/${DEPLOY_BRANCH}"
+
+export DOCKER_BUILDKIT="${DOCKER_BUILDKIT:-1}"
+
+echo "[2/4] Build images (monorepo context)"
+"${DC[@]}" -f docker-compose.yml build arelorian-engine monitor-bridge
+
+echo "[3/4] Recreate containers"
+"${DC[@]}" -f docker-compose.yml up -d arelorian-engine monitor-bridge
+
+echo "[4/4] Health check (engine :3000)"
+ok=0
+for i in $(seq 1 24); do
+  if curl -sf "http://127.0.0.1:3000/health" >/dev/null; then
+    ok=1
+    break
+  fi
+  echo "  waiting... ($i/24)"
+  sleep 5
+done
+
+if [[ "$ok" != "1" ]]; then
+  echo "ERROR: Health check failed. Showing last logs:"
+  "${DC[@]}" -f docker-compose.yml logs --tail=80 arelorian-engine || true
+  exit 1
+fi
+
+docker image prune -f >/dev/null 2>&1 || true
+echo "=== Deploy OK ($(git rev-parse --short HEAD)) ==="

--- a/tools/deploy_vps_paramiko.py
+++ b/tools/deploy_vps_paramiko.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Optional local deploy trigger using Paramiko (SSH).
+
+Security:
+  - Do NOT hardcode passwords. Prefer SSH keys.
+  - If you must use a password, pass it only via env SSH_PASSWORD for one-off runs
+    and rotate credentials afterwards.
+
+Environment:
+  VPS_HOST          required
+  VPS_USER          required (e.g. root or deploy)
+  VPS_DEPLOY_PATH   default /opt/areloria
+  SSH_PRIVATE_KEY   PEM / OpenSSH private key contents (recommended)
+  SSH_KEY_FILE      path to private key file (alternative to SSH_PRIVATE_KEY)
+  SSH_PASSWORD      optional (discouraged)
+  VPS_SSH_PORT      default 22
+
+Usage:
+  export VPS_HOST=your.server
+  export VPS_USER=deploy
+  export SSH_PRIVATE_KEY="$(cat ~/.ssh/id_ed25519)"
+  export VPS_DEPLOY_PATH=/opt/areloria
+  python3 tools/deploy_vps_paramiko.py
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from io import StringIO
+from typing import Any
+
+
+def _try_load_pkey(paramiko: Any, password: str | None) -> Any:
+    key_data = os.environ.get("SSH_PRIVATE_KEY", "").strip()
+    key_file = os.environ.get("SSH_KEY_FILE", "").strip()
+    classes = (
+        paramiko.Ed25519Key,
+        paramiko.RSAKey,
+        paramiko.ECDSAKey,
+    )
+    if key_file:
+        for cls in classes:
+            try:
+                return cls.from_private_key_file(key_file, password=password)
+            except Exception:
+                continue
+    if key_data:
+        buf = StringIO(key_data)
+        for cls in classes:
+            try:
+                buf.seek(0)
+                return cls.from_private_key(buf, password=password)
+            except Exception:
+                continue
+    return None
+
+
+def main() -> int:
+    try:
+        import paramiko  # type: ignore
+    except ImportError:
+        print("Install paramiko:  pip install paramiko", file=sys.stderr)
+        return 1
+
+    host = os.environ.get("VPS_HOST", "").strip()
+    user = os.environ.get("VPS_USER", "").strip()
+    path = os.environ.get("VPS_DEPLOY_PATH", "/opt/areloria").strip()
+    port = int(os.environ.get("VPS_SSH_PORT", "22"))
+
+    if not host or not user:
+        print("VPS_HOST and VPS_USER are required.", file=sys.stderr)
+        return 1
+
+    password = os.environ.get("SSH_PASSWORD")
+    pkey = _try_load_pkey(paramiko, password)
+
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    try:
+        client.connect(
+            hostname=host,
+            port=port,
+            username=user,
+            pkey=pkey,
+            password=password if pkey is None else None,
+            look_for_keys=pkey is None and password is None,
+            allow_agent=pkey is None and password is None,
+            timeout=30,
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"SSH connect failed: {e}", file=sys.stderr)
+        return 1
+
+    remote = f"set -euo pipefail; cd {shlex.quote(path)}; bash scripts/deploy-vps-docker.sh"
+    _stdin, stdout, stderr = client.exec_command(remote, get_pty=True)
+    out = stdout.read().decode(errors="replace")
+    err = stderr.read().decode(errors="replace")
+    code = stdout.channel.recv_exit_status()
+    client.close()
+
+    if out:
+        sys.stdout.write(out)
+    if err:
+        sys.stderr.write(err)
+    return 0 if code == 0 else code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `scripts/deploy-vps-docker.sh`: on the VPS, `git fetch/reset` to `main`, `docker compose` build + up for `arelorian-engine` + `monitor-bridge`, health check on `:3000/health`, image prune.
- Adds `.github/workflows/vps-docker-deploy.yml`: runs on **push to `main`** when monorepo-relevant paths change (apps, packages, projects, server, Docker, lockfile, etc.) and `workflow_dispatch`. Uses **SSH private key** secrets (`VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`, optional `VPS_DEPLOY_PATH`).
- Adds `tools/deploy_vps_paramiko.py` for optional local deploys via Paramiko (env-based keys; no hardcoded credentials).
- Documents bootstrap + secrets in `docs/VPS_GITHUB_DEPLOY.md`.

## Notes
- **Do not** store VPS passwords in the repo or GitHub; use SSH keys and rotate any password that was exposed.
- Coexists with existing `deploy.yml` (Azure/PM2 path). Disable or narrow that workflow if it fails on missing Azure secrets.

## Post-merge checklist
1. Clone repo to `/opt/areloria` on VPS, install Docker.
2. Add GitHub Actions secrets: `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY` (+ optional `VPS_DEPLOY_PATH`).
3. Run `bash scripts/deploy-vps-docker.sh` once manually to verify.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af66eed5-e754-4554-8225-0c7699e6b2a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af66eed5-e754-4554-8225-0c7699e6b2a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

