### PR TITLE
Secure VPS deploy workflow, Paramiko helper without committed secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,8 @@
 name: Deploy Wasd Monorepo
 
+# Manual / optional Azure artifact path. Automatic VPS deploy runs in
+# `.github/workflows/main-pipeline.yml` (git sync + deploy/update.sh on /opt/areloria).
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
 
   workflow_dispatch:
 
@@ -36,43 +39,28 @@ jobs:
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
             "echo 'SSH connection OK' && uname -a"
 
-      - name: Deploy to VPS (Git Sync + Restart)
+      - name: Deploy to VPS (Git sync + deploy/update.sh)
         run: |
           sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
             -o StrictHostKeyChecking=no \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'EOF'
-
-            set -e
-
+            set -euo pipefail
+            APP_DIR="/opt/areloria"
             echo "→ Navigating to project"
-            mkdir -p /opt/areloria
-            cd /opt/areloria
+            mkdir -p "$APP_DIR"
+            cd "$APP_DIR"
 
             if [ ! -d ".git" ]; then
               echo "→ Cloning repo"
-              git clone https://github.com/${{ github.repository }} .
+              git clone "https://github.com/${{ github.repository }}.git" .
             fi
 
-            echo "→ Syncing repo"
+            echo "→ Syncing repo to origin/main"
             git fetch origin main
             git reset --hard origin/main
 
-            echo "→ Installing dependencies"
-            corepack enable || true
-            corepack prepare pnpm@9.12.2 --activate
-            pnpm install --frozen-lockfile
-
-            echo "→ Building project"
-            pnpm build
-
-            echo "→ Restarting services"
-            if command -v pm2 >/dev/null 2>&1; then
-              pm2 restart all || true
-            fi
-
-            if [ -f docker-compose.yml ] || [ -f compose.yml ]; then
-              docker compose up -d --build || true
-            fi
+            echo "→ Build, restart PM2, verify (deploy/update.sh)"
+            bash deploy/update.sh
 
             echo "→ Deploy finished"
           EOF

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ pnpm-debug.log*
 
 # Build artifacts
 *.tsbuildinfo
+
+# Python (deploy helpers)
+__pycache__/
+*.py[cod]

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -28,6 +28,10 @@ The deploy script installs dependencies, builds client + server, and (re)starts 
 
 From `/opt/areloria`:
 
+- `bash deploy/update.sh` (empfohlen: lädt `.env` für Vite-Build-Variablen, baut Client + Server, startet PM2 neu)
+
+Alternativ (ohne `.env`-Sourcing im Skript — nur sinnvoll, wenn die Shell schon exportiert hat):
+
 - `bash deploy/pull-and-deploy.sh`
 
 Or CI can deploy automatically on push to `main` (see `.github/workflows/deploy.yml`).

--- a/deploy/requirements-ssh.txt
+++ b/deploy/requirements-ssh.txt
@@ -1,0 +1,2 @@
+# Optional: local Paramiko helpers (deploy/run_deploy.py)
+paramiko>=3.4,<4

--- a/deploy/run_deploy.py
+++ b/deploy/run_deploy.py
@@ -1,115 +1,179 @@
 #!/usr/bin/env python3
 """
-Arelorian VPS Quick Deploy via Paramiko
+Run remote commands on the Areloria VPS using Paramiko.
+
+Do not put passwords or keys in this file. Set environment variables instead:
+
+  SSH_HOST        VPS hostname or IP (required)
+  SSH_USER        SSH user (default: root)
+  SSH_PASSWORD    password auth (optional if SSH_PRIVATE_KEY is set)
+  SSH_PRIVATE_KEY  PEM text or path to key file (optional)
+  SSH_PORT        port (default: 22)
+  REMOTE_APP_DIR  app path on server (default: /opt/areloria)
+  GIT_REMOTE_BRANCH branch to sync (default: main)
+  GIT_REPO_URL    clone URL when app dir has no .git (optional)
+
+Install once:
+
+  pip install -r deploy/requirements-ssh.txt
+
+Examples:
+
+  SSH_HOST=1.2.3.4 SSH_PASSWORD='...' python3 deploy/run_deploy.py sync
+  SSH_HOST=1.2.3.4 SSH_PRIVATE_KEY=~/.ssh/id_ed25519 python3 deploy/run_deploy.py run "pm2 status"
 """
 
-import paramiko
+from __future__ import annotations
+
+import argparse
+import os
 import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
 
-HOST = "46.202.154.25"
-PORT = 22
-USER = "root"
-PASSWORD = "++2N00py123+++"
+if TYPE_CHECKING:
+    from paramiko import SSHClient
 
-# All setup commands in one script
-SETUP = r'''
-# Install deps
-apt-get update -qq
-apt-get install -y -qq curl git nginx build-essential nodejs npm
+DEFAULT_APP_DIR = "/opt/areloria"
+DEFAULT_BRANCH = "main"
+DEFAULT_REPO = "https://github.com/OuroborosCollective/Wasd.git"
 
-# Install pnpm/pm2  
-npm install -g pnpm pm2 2>/dev/null
 
-# Setup app
-mkdir -p /opt/areloria
-cd /opt/areloria
-git clone https://github.com/OuroborosCollective/Wasd.git . || (git fetch origin main && git checkout main)
-pnpm install --frozen-lockfile
-cd client && pnpm build
+def _require_paramiko():
+    try:
+        import paramiko  # noqa: WPS433 — runtime optional dependency
+    except ImportError as exc:
+        print(
+            "Paramiko is not installed. Run: pip install -r deploy/requirements-ssh.txt",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+    return paramiko
 
-# Create .env
-cat > /opt/areloria/.env << 'EOF'
-NODE_ENV=production
-PORT=3000
-PUBLIC_WEBSOCKET_URL=wss://arelorian.de/ws
-VITE_API_URL=https://arelorian.de
-ALLOW_GUEST_LOGIN=1
-USE_SUPABASE_WS_LOGIN=0
-PERSISTENCE_DRIVER=file
-EOF
 
-# Nginx
-cat > /etc/nginx/sites-available/arelorian << 'EOF'
-server {
-    listen 80;
-    server_name arelorian.de;
-    root /opt/areloria/client/dist;
-    index index.html;
-    try_files $uri $uri/ /index.html;
-    location /api {
-        proxy_pass http://localhost:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
+def _load_private_key(paramiko, key_material: str):
+    """Try common key parsers for PEM or path."""
+    path = Path(os.path.expanduser(key_material))
+    if path.is_file():
+        key_material = path.read_text(encoding="utf-8", errors="replace")
+    for loader in (
+        paramiko.RSAKey.from_private_key,
+        paramiko.Ed25519Key.from_private_key,
+        paramiko.ECDSAKey.from_private_key,
+    ):
+        try:
+            from io import StringIO
+
+            return loader(StringIO(key_material))
+        except Exception:
+            continue
+    print("Could not parse SSH_PRIVATE_KEY as RSA, Ed25519, or ECDSA PEM.", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def connect(paramiko) -> "SSHClient":
+    host = os.environ.get("SSH_HOST", "").strip()
+    if not host:
+        print("SSH_HOST is required.", file=sys.stderr)
+        raise SystemExit(1)
+
+    user = os.environ.get("SSH_USER", "root").strip()
+    port = int(os.environ.get("SSH_PORT", "22"))
+    password = os.environ.get("SSH_PASSWORD")
+    pkey_raw = os.environ.get("SSH_PRIVATE_KEY")
+
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    connect_kw: dict = {
+        "hostname": host,
+        "port": port,
+        "username": user,
+        "timeout": 60,
+        "banner_timeout": 60,
+        "auth_timeout": 60,
     }
-    location /ws {
-        proxy_pass http://localhost:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-    }
-}
-EOF
-ln -sf /etc/nginx/sites-available/arelorian /etc/nginx/sites-enabled/
-nginx -t && systemctl reload nginx
+    if pkey_raw:
+        connect_kw["pkey"] = _load_private_key(paramiko, pkey_raw)
+    if password:
+        connect_kw["password"] = password
+    if not pkey_raw and not password:
+        print("Set SSH_PASSWORD and/or SSH_PRIVATE_KEY for authentication.", file=sys.stderr)
+        raise SystemExit(1)
 
-# PM2
-pm2 start /opt/areloria/deploy/pm2.config.cjs
-pm2 save
+    try:
+        client.connect(**connect_kw)
+    except paramiko.AuthenticationException:
+        print("SSH authentication failed (check SSH_USER / SSH_PASSWORD / SSH_PRIVATE_KEY).", file=sys.stderr)
+        raise SystemExit(1) from None
+    return client
 
-echo "DONE"
-'''
 
-print(f"Connecting to {HOST}...")
-client = paramiko.SSHClient()
-client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-try:
-    client.connect(HOST, port=PORT, username=USER, password=PASSWORD, timeout=60, banner_timeout=60)
-    print("✓ Connected!")
-    
-    print("Running setup (this may take a few minutes)...")
-    stdin, stdout, stderr = client.exec_command(SETUP, get_pty=True)
-    
-    # Stream output
-    while True:
-        if stdout.channel.recv_ready():
-            line = stdout.readline()
-            if line:
-                print(line, end="")
-        if stderr.channel.recv_ready():
-            err = stderr.readline()
-            if err:
-                print(f"ERR: {err}", end="")
+def stream_exec(client: "SSHClient", command: str) -> int:
+    stdin, stdout, stderr = client.exec_command(command, get_pty=True)
+    assert stdin
+    channels = (stdout.channel, stderr.channel)
+    while not stdout.channel.exit_status_ready():
+        for ch in channels:
+            if ch.recv_ready():
+                sys.stdout.buffer.write(ch.recv(4096))
+                sys.stdout.flush()
         if stdout.channel.exit_status_ready():
             break
-    
-    exit_code = stdout.channel.recv_exit_status()
-    print(f"\nExit code: {exit_code}")
-    
-    if exit_code == 0:
-        print("\n✅ VPS Ready!")
-        print("Access: https://arelorian.de")
-    else:
-        print(f"⚠️ Exit code: {exit_code}")
-        
-except paramiko.AuthenticationException:
-    print("❌ Auth failed")
-    sys.exit(1)
-except Exception as e:
-    print(f"❌ {e}")
-    sys.exit(1)
-finally:
-    client.close()
+    # Drain remainder
+    for ch in channels:
+        while ch.recv_ready():
+            sys.stdout.buffer.write(ch.recv(4096))
+            sys.stdout.flush()
+    return int(stdout.channel.recv_exit_status())
+
+
+def remote_sync_script(app_dir: str, branch: str, repo: str) -> str:
+    app_q = app_dir.replace("'", "'\"'\"'")
+    branch_q = branch.replace("'", "'\"'\"'")
+    repo_q = repo.replace("'", "'\"'\"'")
+    return f"""set -euo pipefail
+APP_DIR='{app_q}'
+BRANCH='{branch_q}'
+REPO='{repo_q}'
+mkdir -p "$APP_DIR"
+cd "$APP_DIR"
+if [ ! -d .git ]; then
+  git clone "$REPO" .
+fi
+git fetch origin "$BRANCH"
+git reset --hard "origin/$BRANCH"
+bash deploy/update.sh
+"""
+
+
+def cmd_sync(client: "SSHClient") -> int:
+    app_dir = os.environ.get("REMOTE_APP_DIR", DEFAULT_APP_DIR).strip()
+    branch = os.environ.get("GIT_REMOTE_BRANCH", DEFAULT_BRANCH).strip()
+    repo = os.environ.get("GIT_REPO_URL", DEFAULT_REPO).strip()
+    return stream_exec(client, remote_sync_script(app_dir, branch, repo))
+
+
+def main() -> int:
+    paramiko = _require_paramiko()
+
+    parser = argparse.ArgumentParser(description="Paramiko SSH helper for VPS deploy.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("sync", help="git reset to origin branch + bash deploy/update.sh on REMOTE_APP_DIR")
+    run_p = sub.add_parser("run", help="Run a single remote shell command string")
+    run_p.add_argument("remote_command", help="e.g. 'pm2 status' or 'curl -s http://127.0.0.1:3000/health'")
+
+    args = parser.parse_args()
+    client = connect(paramiko)
+    try:
+        if args.cmd == "sync":
+            return cmd_sync(client)
+        if args.cmd == "run":
+            return stream_exec(client, args.remote_command)
+    finally:
+        client.close()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/run_deploy.py
+++ b/deploy/run_deploy.py
@@ -83,7 +83,12 @@ def connect(paramiko) -> "SSHClient":
     pkey_raw = os.environ.get("SSH_PRIVATE_KEY")
 
     client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.load_system_host_keys()
+    try:
+        client.load_host_keys(os.path.expanduser("~/.ssh/known_hosts"))
+    except Exception:
+        pass
+    client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
     connect_kw: dict = {
         "hostname": host,

--- a/deploy/vps-setup.sh
+++ b/deploy/vps-setup.sh
@@ -63,7 +63,7 @@ cd "$GAME_DIR/client"
 pnpm build
 
 # Setup PM2
-echo "[8/8] Configuring PM2...
+echo "[8/8] Configuring PM2..."
 cd "$GAME_DIR"
 pm2 delete areloria 2>/dev/null || true
 pm2 start deploy/pm2.config.cjs

--- a/deploy/vps_connect.py
+++ b/deploy/vps_connect.py
@@ -2,6 +2,9 @@
 """
 Connect to and operate the Areloria VPS over SSH.
 
+For Paramiko-based automation (Python, no ssh binary), use `deploy/run_deploy.py`
+with `pip install -r deploy/requirements-ssh.txt` and SSH_* environment variables.
+
 This script avoids hardcoding secrets. You can either:
 - use interactive SSH password prompt (default), or
 - use --password / SSH_PASSWORD together with sshpass (optional).

--- a/docs/CI_VPS_RUNBOOK.md
+++ b/docs/CI_VPS_RUNBOOK.md
@@ -5,7 +5,8 @@
 Nach jedem Push auf `main`:
 
 - **CI** (`.github/workflows/ci.yml`): Lint → Tests → Build → Modell-Pfad-Audit → Playwright E2E.
-- **Deploy** (`.github/workflows/deploy.yml`): SSH auf den VPS → `deploy/deploy.sh` (nur Push + manuell `workflow_dispatch`, kein Cron).
+- **Deploy** (`.github/workflows/main-pipeline.yml`): bei Push auf `main` (ohne reine Markdown/Docs-Änderungen) per SSH auf den VPS → `git fetch` / `reset --hard origin/main` → `bash deploy/update.sh` (install, Build inkl. Client-Assets, `pm2 restart areloria`, lokale Health-Checks).
+- **Legacy / manuell** (`.github/workflows/deploy.yml`): nur noch `workflow_dispatch` — optionaler Pfad mit Azure-Blob-Upload und SCP des Server-`dist`; für den Standard-VPS-Flow nicht nötig.
 
 Bei rotem Step: Log des fehlgeschlagenen Jobs öffnen; häufig E2E, Secrets oder VPS-Build (RAM/Timeout).
 
@@ -20,23 +21,24 @@ pnpm run ci:verify
 Auf dem Server (Repo-Root, z. B. `/opt/areloria`):
 
 ```bash
-bash deploy/pull-and-deploy.sh
+bash deploy/update.sh
 ```
 
-(Intern: `git fetch` + `reset --hard origin/main`, `./deploy/deploy.sh`, `verify-vps-local.sh`.)
+(Wechselt nicht selbst den Git-Stand: nach manuellen Änderungen zuerst `git fetch origin main && git reset --hard origin/main`, dann `update.sh`. Der GitHub-Deploy-Workflow macht das Reset vor `update.sh`.)
 
-## 3. Secret `DEPLOY_VERIFY_BASE_URL`
+## 3. Externe Health-Checks (optional)
 
-In **GitHub → Settings → Secrets → Actions** (nicht in `.env` auf dem VPS):
+Der Job `main-pipeline.yml` prüft nach dem Deploy per `curl` die **HTTP**-URL `http://<SSH_HOST>/` (Port 80 muss erreichbar sein, z. B. über Nginx → Node).
 
-| Secret | Wert |
-|--------|------|
-| `DEPLOY_VERIFY_BASE_URL` | Öffentliche Basis-URL **ohne** Slash am Ende, z. B. `https://spiel.example.com` |
+Ein separates Secret `DEPLOY_VERIFY_BASE_URL` für HTTPS-Checks ist im Workflow derzeit **nicht** angebunden; bei Bedarf kann die Health-Check-Step-Logik später darauf umgestellt werden.
 
-Wenn gesetzt, prüft der Deploy-Job nach dem SSH-Schritt per HTTPS: `/health`, `/`, `/gm/`.  
-Ohne Secret: Deploy läuft durch, externe Checks werden übersprungen.
+GitHub **Repository secrets** für den VPS-SSH-Deploy:
 
-Weitere Secrets: `VPS_IP`, `VPS_USER`, `VPS_SSH_PASSWORD` — siehe `DEPLOYMENT.md`.
+| Secret | Bedeutung |
+|--------|-----------|
+| `SSH_HOST` | VPS-IP oder Hostname |
+| `SSH_USER` | z. B. `root` |
+| `SSH_PASSWORD` | Login-Passwort (besser langfristig durch SSH-Key ersetzen) |
 
 ## 4. SpacetimeDB (nächste Implementierung)
 

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -3,7 +3,7 @@ import Redis from 'ioredis';
 export const redis = new Redis({
   host: process.env.REDIS_HOST || 'localhost',
   port: Number(process.env.REDIS_PORT) || 6379,
-  password: process.env.REDIS_PASSWORD || '2N00py123+++',
+  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
 });
 
 redis.on('error', (err) => console.error('Redis Error', err));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR cleans up production deployment so one path is authoritative, removes credentials that were committed to the repo, and documents how automatic deploys from GitHub work.

## Changes

- **`deploy/run_deploy.py`**: Paramiko-based `sync` (git reset to `origin/<branch>` then `bash deploy/update.sh`) and `run` subcommands. All authentication comes from environment variables (`SSH_HOST`, `SSH_USER`, `SSH_PASSWORD` and/or `SSH_PRIVATE_KEY`, optional `REMOTE_APP_DIR`, `GIT_REPO_URL`, `GIT_REMOTE_BRANCH`). No passwords in source.
- **`deploy/requirements-ssh.txt`**: Optional `pip install` list for Paramiko.
- **`.github/workflows/main-pipeline.yml`**: After syncing the repo on the VPS, runs `deploy/update.sh` so dependencies, full monorepo build (including client assets and Vite variables sourced from `/opt/areloria/.env`), and `pm2 restart areloria` match manual production updates. Push trigger ignores markdown-only and `docs/**` changes.
- **`.github/workflows/deploy.yml`**: Limited to `workflow_dispatch` only so it no longer competes with `main-pipeline.yml` on every `main` push or fails when Azure secrets are unset.
- **`deploy/vps-setup.sh`**: Fix broken `echo` line before the PM2 step.
- **`packages/redis/src/index.ts`**: Remove insecure default Redis password; only connect with a password when `REDIS_PASSWORD` is set.
- **`deploy/vps_connect.py`**, **`DEPLOYMENT.md`**, **`docs/CI_VPS_RUNBOOK.md`**: Point operators at `update.sh` and document secrets/health behavior accurately.
- **`.gitignore`**: Ignore `__pycache__/` and `*.py[cod]` so local Paramiko/Python runs under `deploy/` do not leave stray untracked files.

## Operator notes

- **Rotate any password** that was pasted into chat or previously committed; treat it as compromised.
- GitHub Actions needs repository secrets **`SSH_HOST`**, **`SSH_USER`**, and **`SSH_PASSWORD`** (or switch the workflow to key-based auth in a follow-up).
- First-time VPS: clone to `/opt/areloria`, copy `deploy/.env.production.template` to `/opt/areloria/.env`, then merge to `main` or run `bash deploy/update.sh` on the server after a hard reset to `origin/main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b91913b0-88d1-4b07-ae14-0ec4beaa4c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b91913b0-88d1-4b07-ae14-0ec4beaa4c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

