### PR TITLE
Deploy: Paramiko VPS helper, focused prod build, fix CI clone URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,8 @@
+# Optional legacy pipeline: Azure blob upload + SCP artifact deploy.
+# Default production flow is `.github/workflows/main-pipeline.yml` (git sync + `deploy/vps-prod-build.sh` on the VPS).
 name: Deploy Wasd Monorepo
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
 
   workflow_dispatch:
 
@@ -38,43 +41,32 @@ jobs:
 
       - name: Deploy to VPS (Git Sync + Restart)
         run: |
+          REPO_CLONE_URL="https://github.com/${{ github.repository }}.git"
           sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
             -o StrictHostKeyChecking=no \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'EOF'
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} bash -s << EOF
+          set -euo pipefail
 
-            set -e
+          echo "→ Navigating to project"
+          mkdir -p /opt/areloria
+          cd /opt/areloria
 
-            echo "→ Navigating to project"
-            mkdir -p /opt/areloria
-            cd /opt/areloria
+          if [ ! -d ".git" ]; then
+            echo "→ Cloning repo"
+            git clone "${REPO_CLONE_URL}" .
+          fi
 
-            if [ ! -d ".git" ]; then
-              echo "→ Cloning repo"
-              git clone https://github.com/${{ github.repository }} .
-            fi
+          echo "→ Syncing repo"
+          git remote set-url origin "${REPO_CLONE_URL}" || true
+          git fetch origin main
+          git reset --hard origin/main
 
-            echo "→ Syncing repo"
-            git fetch origin main
-            git reset --hard origin/main
+          echo "→ Build + PM2 (Wasd server + client)"
+          corepack enable || true
+          corepack prepare pnpm@9.12.2 --activate
+          bash deploy/vps-prod-build.sh
 
-            echo "→ Installing dependencies"
-            corepack enable || true
-            corepack prepare pnpm@9.12.2 --activate
-            pnpm install --frozen-lockfile
-
-            echo "→ Building project"
-            pnpm build
-
-            echo "→ Restarting services"
-            if command -v pm2 >/dev/null 2>&1; then
-              pm2 restart all || true
-            fi
-
-            if [ -f docker-compose.yml ] || [ -f compose.yml ]; then
-              docker compose up -d --build || true
-            fi
-
-            echo "→ Deploy finished"
+          echo "→ Deploy finished"
           EOF
 
       - name: Health Check

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,21 +16,35 @@ This guide reflects the current live architecture:
    - Copy `deploy/.env.production.template` to `/opt/areloria/.env`
    - Fill all required variables (see `deploy/ENV_SETUP.md`)
 
-## 2) Build + start
+## 2) Build + start (first time on VPS)
 
-From `/opt/areloria`:
+From `/opt/areloria` after `.env` exists:
 
-- `bash deploy/deploy.sh`
+```bash
+bash deploy/vps-prod-build.sh
+```
 
-The deploy script installs dependencies, builds client + server, and (re)starts PM2.
+This installs workspace dependencies, builds `@wasd/server` / `@wasd/client` (and `@wasd/shared`), optionally runs `scripts/sync-world-assets.mjs`, writes `ecosystem.config.cjs`, and starts or restarts the `areloria` PM2 process.
 
 ## 3) Update after new `main` commits
 
 From `/opt/areloria`:
 
-- `bash deploy/pull-and-deploy.sh`
+```bash
+bash deploy/pull-and-deploy.sh
+```
 
-Or CI can deploy automatically on push to `main` (see `.github/workflows/deploy.yml`).
+Or rely on GitHub Actions: pushes to `main` that change real code (not only `docs/**` or `*.md`) run `.github/workflows/main-pipeline.yml`, which SSHs into the VPS, resets to `origin/main`, and runs `deploy/vps-prod-build.sh`.
+
+### Local SSH helper (Paramiko)
+
+```bash
+pip install -r deploy/requirements-vps-tools.txt
+export SSH_PASSWORD='…'   # or use SSH_KEY_PATH + key-based auth
+python3 deploy/vps_paramiko.py deploy
+```
+
+Do not commit passwords. Prefer an SSH key and `SSH_KEY_PATH`, or GitHub Actions secrets (`SSH_HOST`, `SSH_USER`, `SSH_PASSWORD`).
 
 ## 4) Verify runtime
 

--- a/deploy/pull-and-deploy.sh
+++ b/deploy/pull-and-deploy.sh
@@ -7,20 +7,7 @@ cd "$(dirname "$0")/.."
 echo "Pulling latest changes..."
 git pull origin $(git rev-parse --abbrev-ref HEAD)
 
-echo "Installing dependencies..."
-pnpm install --frozen-lockfile
-
-echo "Running build process..."
-pnpm run build
-
-echo "Restarting application..."
-if command -v pm2 &> /dev/null
-then
-    pm2 reload all --update-env
-    echo "PM2 processes reloaded successfully."
-else
-    echo "PM2 not found. Attempting to restart via npm/pnpm start..."
-    pnpm start
-fi
+echo "Build, asset sync, and PM2 (Wasd server + client)..."
+bash deploy/vps-prod-build.sh
 
 echo "Deployment finished successfully."

--- a/deploy/requirements-vps-tools.txt
+++ b/deploy/requirements-vps-tools.txt
@@ -1,0 +1,2 @@
+# Optional local tools: Paramiko SSH helper (deploy/vps_paramiko.py)
+paramiko>=3.4.0,<4

--- a/deploy/vps-prod-build.sh
+++ b/deploy/vps-prod-build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Production build + PM2 restart for Wasd (server + client + shared).
+# Run from repo root after `git pull` / `git reset --hard` (e.g. CI or pull-and-deploy.sh).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export APP_DIR="$ROOT"
+export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}"
+
+echo "→ vps-prod-build: repo root=${ROOT}"
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm not found; enabling corepack…"
+  corepack enable || true
+  corepack prepare pnpm@9.12.2 --activate || true
+fi
+
+echo "→ pnpm install"
+pnpm install --frozen-lockfile
+
+echo "→ build @wasd/server graph + @wasd/client graph"
+pnpm --filter @wasd/server... --filter @wasd/client... run build
+
+if [[ -f scripts/sync-world-assets.mjs ]]; then
+  echo "→ sync world assets (optional)"
+  node scripts/sync-world-assets.mjs || true
+fi
+
+echo "→ PM2 ecosystem"
+bash deploy/write_pm2_ecosystem.sh
+
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo "Error: pm2 is not installed (npm i -g pm2)." >&2
+  exit 1
+fi
+
+if pm2 describe areloria >/dev/null 2>&1; then
+  echo "→ pm2 restart areloria"
+  pm2 restart areloria --update-env
+else
+  echo "→ pm2 start ecosystem.config.cjs"
+  pm2 start ecosystem.config.cjs
+fi
+pm2 save || true
+
+echo "→ vps-prod-build finished"

--- a/deploy/vps_connect.py
+++ b/deploy/vps_connect.py
@@ -6,6 +6,11 @@ This script avoids hardcoding secrets. You can either:
 - use interactive SSH password prompt (default), or
 - use --password / SSH_PASSWORD together with sshpass (optional).
 
+For password auth without `sshpass`, use Paramiko instead:
+
+- `pip install -r deploy/requirements-vps-tools.txt`
+- `python3 deploy/vps_paramiko.py deploy`
+
 Examples:
   python3 deploy/vps_connect.py shell
   python3 deploy/vps_connect.py run "uname -a"

--- a/deploy/vps_paramiko.py
+++ b/deploy/vps_paramiko.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+SSH to the Wasd / Areloria VPS using Paramiko (password or private key).
+
+Do not put passwords in the repo. Use environment variables or a prompt:
+
+  export SSH_PASSWORD='...'   # or use key auth
+  pip install -r deploy/requirements-vps-tools.txt
+  python3 deploy/vps_paramiko.py run "uname -a"
+  python3 deploy/vps_paramiko.py deploy
+  python3 deploy/vps_paramiko.py shell
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import shlex
+import sys
+
+try:
+    import paramiko
+except ImportError:
+    print(
+        "Paramiko is required: pip install -r deploy/requirements-vps-tools.txt",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+DEFAULT_HOST = "46.202.154.25"
+DEFAULT_USER = "root"
+DEFAULT_PORT = 22
+DEFAULT_APP_DIR = "/opt/areloria"
+DEFAULT_REPO = "https://github.com/OuroborosCollective/Wasd.git"
+DEFAULT_BRANCH = "main"
+
+
+def connect_client(args: argparse.Namespace) -> paramiko.SSHClient:
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    password = args.password or os.environ.get("SSH_PASSWORD")
+    key_path = args.identity_file or os.environ.get("SSH_KEY_PATH")
+
+    connect_kw: dict = {
+        "hostname": args.host,
+        "port": args.port,
+        "username": args.user,
+        "timeout": 30,
+        "banner_timeout": 30,
+        "auth_timeout": 30,
+    }
+
+    if key_path:
+        connect_kw["key_filename"] = key_path
+    if password:
+        connect_kw["password"] = password
+
+    if not password and not key_path:
+        password = getpass.getpass(f"SSH password for {args.user}@{args.host}: ")
+        connect_kw["password"] = password
+
+    client.connect(**connect_kw)
+    return client
+
+
+def run_remote(client: paramiko.SSHClient, command: str) -> int:
+    stdin, stdout, stderr = client.exec_command(command, get_pty=True)
+    stdin.close()
+    for line in iter(stdout.readline, ""):
+        sys.stdout.write(line)
+    err = stderr.read().decode()
+    if err:
+        sys.stderr.write(err)
+    return stdout.channel.recv_exit_status()
+
+
+def interactive_shell(client: paramiko.SSHClient, app_dir: str) -> int:
+    """TTY forwarding for an interactive session (Unix terminals only)."""
+    if not sys.stdin.isatty():
+        print("shell mode requires a TTY; use: run '<command>'", file=sys.stderr)
+        return 1
+    try:
+        import select
+        import termios
+        import tty
+    except ImportError:
+        print("shell mode is not supported on this platform; use: run '<command>'", file=sys.stderr)
+        return 1
+
+    chan = client.invoke_shell(term="xterm-256color")
+    chan.send(f"cd {shlex.quote(app_dir)}\n")
+
+    oldtty = termios.tcgetattr(sys.stdin)
+    try:
+        tty.setraw(sys.stdin)
+        chan.settimeout(0.0)
+        while True:
+            r, _, _ = select.select([chan, sys.stdin], [], [], 0.2)
+            if chan in r and chan.recv_ready():
+                chunk = chan.recv(4096)
+                if not chunk:
+                    break
+                sys.stdout.buffer.write(chunk)
+                sys.stdout.flush()
+            if sys.stdin in r:
+                data = os.read(sys.stdin.fileno(), 4096)
+                if not data:
+                    break
+                chan.send(data)
+            if chan.exit_status_ready():
+                break
+    finally:
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, oldtty)
+    try:
+        if chan.exit_status_ready():
+            return chan.recv_exit_status()
+    except EOFError:
+        pass
+    return 0
+
+
+def make_deploy_command(args: argparse.Namespace) -> str:
+    app = shlex.quote(args.app_dir)
+    branch = shlex.quote(args.branch)
+    repo = shlex.quote(args.repo)
+    return (
+        "set -euo pipefail; "
+        f'if [ ! -d "{args.app_dir}/.git" ]; then git clone {repo} {app}; fi; '
+        f"cd {app}; "
+        f"git fetch origin {branch}; "
+        f"git checkout {branch}; "
+        f"git reset --hard origin/{branch}; "
+        "bash deploy/vps-prod-build.sh"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="VPS SSH via Paramiko (Wasd /opt/areloria).")
+    p.add_argument("--host", default=os.environ.get("SSH_HOST", DEFAULT_HOST))
+    p.add_argument("--user", default=os.environ.get("SSH_USER", DEFAULT_USER))
+    p.add_argument("--port", type=int, default=int(os.environ.get("SSH_PORT", str(DEFAULT_PORT))))
+    p.add_argument("--identity-file", help="SSH private key path (or SSH_KEY_PATH).")
+    p.add_argument("--password", help="SSH password (prefer SSH_PASSWORD env).")
+    p.add_argument("--app-dir", default=DEFAULT_APP_DIR)
+    p.add_argument("--repo", default=DEFAULT_REPO)
+    p.add_argument("--branch", default=DEFAULT_BRANCH)
+
+    sub = p.add_subparsers(dest="mode", required=True)
+    sub.add_parser("shell", help="Interactive shell in app directory.")
+
+    rp = sub.add_parser("run", help="Run a single remote command.")
+    rp.add_argument("command", help="Shell command")
+
+    sub.add_parser("deploy", help="Clone or sync repo and run deploy/vps-prod-build.sh.")
+
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    client: paramiko.SSHClient | None = None
+    try:
+        client = connect_client(args)
+
+        if args.mode == "shell":
+            return interactive_shell(client, args.app_dir)
+
+        if args.mode == "run":
+            return run_remote(client, args.command)
+
+        if args.mode == "deploy":
+            return run_remote(client, make_deploy_command(args))
+
+    except (paramiko.SSHException, OSError) as e:
+        print(f"SSH error: {e}", file=sys.stderr)
+        return 1
+    finally:
+        if client:
+            client.close()
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/vps_paramiko.py
+++ b/deploy/vps_paramiko.py
@@ -38,7 +38,8 @@ DEFAULT_BRANCH = "main"
 
 def connect_client(args: argparse.Namespace) -> paramiko.SSHClient:
     client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
     password = args.password or os.environ.get("SSH_PASSWORD")
     key_path = args.identity_file or os.environ.get("SSH_KEY_PATH")

--- a/docs/CI_VPS_RUNBOOK.md
+++ b/docs/CI_VPS_RUNBOOK.md
@@ -2,12 +2,14 @@
 
 ## 1. GitHub Actions prüfen
 
-Nach jedem Push auf `main`:
+Nach jedem Push auf `main` (Code-Änderungen, nicht nur `docs/**` oder `*.md`):
 
-- **CI** (`.github/workflows/ci.yml`): Lint → Tests → Build → Modell-Pfad-Audit → Playwright E2E.
-- **Deploy** (`.github/workflows/deploy.yml`): SSH auf den VPS → `deploy/deploy.sh` (nur Push + manuell `workflow_dispatch`, kein Cron).
+- **CI** (falls vorhanden): Lint/Tests/Build in anderen Workflows.
+- **VPS-Deploy** (`.github/workflows/main-pipeline.yml`): SSH auf den VPS → Repo unter `/opt/areloria` auf `origin/main` → `bash deploy/vps-prod-build.sh` (Wasd Server + Client, PM2 `areloria`).
 
-Bei rotem Step: Log des fehlgeschlagenen Jobs öffnen; häufig E2E, Secrets oder VPS-Build (RAM/Timeout).
+Optional manuell: `.github/workflows/deploy.yml` ist nur noch **workflow_dispatch** (Legacy: Azure/SCP-Pipeline), kein Auto-Deploy auf jeden Push.
+
+Bei rotem Step: Log des fehlgeschlagenen Jobs; häufig Secrets, RAM/Timeout beim Build, oder fehlendes `pm2`.
 
 Lokal vor dem Push (ohne E2E):
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Paramiko-based SSH helper and a single VPS/CI entrypoint (`deploy/vps-prod-build.sh`) that builds only the Wasd server/client graph and restarts PM2 `areloria`. Updates `main-pipeline.yml` to use that script, skips deploy on documentation-only pushes, and fixes the quoted-heredoc bug so `git clone` receives a real GitHub URL on the remote host. The legacy `deploy.yml` workflow is limited to manual dispatch so pushes to `main` are not blocked by missing Azure secrets.

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

`DEPLOYMENT.md` and `docs/CI_VPS_RUNBOOK.md` were updated to match the workflows.

## Verification

- `python3 -m py_compile deploy/vps_paramiko.py`
- Full `pnpm` build not run in this environment (no `node_modules`).

## Ops notes for VPS

Configure GitHub Actions repository secrets: `SSH_HOST` (e.g. `46.202.154.25`), `SSH_USER` (`root` or deploy user), `SSH_PASSWORD` (prefer replacing password auth with an SSH key and `appleboy/ssh-action` key mode in a follow-up). After merging to `main`, pushes that touch code under non-ignored paths trigger `.github/workflows/main-pipeline.yml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96390e79-1af9-4071-80d1-bfda3ef2e8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96390e79-1af9-4071-80d1-bfda3ef2e8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

