### PR TITLE
fix(ci): VPS deploy diagnostics + troubleshooting docs

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -44,17 +44,46 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # Fails fast with a clear message (values are GitHub-masked; do not echo secrets).
+      - name: Verify VPS secrets are set
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          ok=true
+          if [ -z "${VPS_HOST:-}" ]; then echo "::error::Secret VPS_HOST is missing or empty (Settings → Secrets and variables → Actions)."; ok=false; fi
+          if [ -z "${VPS_USER:-}" ]; then echo "::error::Secret VPS_USER is missing or empty."; ok=false; fi
+          if [ -z "${VPS_SSH_KEY:-}" ]; then echo "::error::Secret VPS_SSH_KEY is missing or empty."; ok=false; fi
+          if [ "$ok" != true ]; then
+            echo "::error::If secrets live in a GitHub Environment, add the environment key to this job and grant the workflow access."
+            exit 1
+          fi
+
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          timeout: 2m
+          command_timeout: 45m
           script_stop: true
           script: |
             set -euo pipefail
             DEPLOY_PATH="${{ secrets.VPS_DEPLOY_PATH }}"
             DEPLOY_PATH="${DEPLOY_PATH:-/opt/areloria}"
+            echo "Using DEPLOY_PATH=$DEPLOY_PATH"
+            if [ ! -d "$DEPLOY_PATH" ]; then
+              echo "ERROR: Directory does not exist: $DEPLOY_PATH"
+              echo "Fix: on the VPS clone the repo once, e.g. git clone <url> $DEPLOY_PATH"
+              exit 1
+            fi
+            if [ ! -f "$DEPLOY_PATH/scripts/deploy-vps-docker.sh" ]; then
+              echo "ERROR: Missing $DEPLOY_PATH/scripts/deploy-vps-docker.sh (incomplete clone or wrong path)."
+              exit 1
+            fi
             cd "$DEPLOY_PATH"
             chmod +x scripts/deploy-vps-docker.sh 2>/dev/null || true
             bash scripts/deploy-vps-docker.sh

--- a/docs/VPS_GITHUB_DEPLOY.md
+++ b/docs/VPS_GITHUB_DEPLOY.md
@@ -65,6 +65,13 @@ python3 tools/deploy_vps_paramiko.py
 
 This runs the same remote script as CI: `scripts/deploy-vps-docker.sh`.
 
+## Troubleshooting (workflow fails in seconds)
+
+1. **Missing secrets** — The workflow checks `VPS_HOST`, `VPS_USER`, and `VPS_SSH_KEY` are non-empty. Add them under **Repository** secrets, not only in an Environment, unless you add `environment: …` to the job.
+2. **SSH permission denied** — Ensure the **public** half of `VPS_SSH_KEY` is in `/root/.ssh/authorized_keys` (if `VPS_USER=root`), permissions `600` / `700`, and `PermitRootLogin` allows pubkey (`prohibit-password` or `yes`).
+3. **`Directory does not exist: /opt/areloria`** — Clone the repo on the VPS to that path once (see bootstrap above).
+4. **Firewall** — GitHub Actions runners use dynamic IPs; allow **SSH (22)** from the internet on the VPS (or use a self-hosted runner in your network).
+
 ## Related files
 
 - `scripts/deploy-vps-docker.sh` — canonical VPS pull + `docker compose` rebuild


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context
Could not read logs from the linked Actions job (GitHub requires sign-in). A **~6 second** failure is usually: empty/missing `VPS_*` secrets, SSH key mismatch, or `/opt/areloria` not cloned yet.

## Changes
- **Preflight step** — fails with `::error::` hints if `VPS_HOST`, `VPS_USER`, or `VPS_SSH_KEY` are empty (incl. note about Environment vs repository secrets).
- **appleboy/ssh-action** — `timeout: 2m` (connect), `command_timeout: 45m` (Docker build).
- **Remote script** — explicit errors if deploy path or `scripts/deploy-vps-docker.sh` is missing.
- **docs/VPS_GITHUB_DEPLOY.md** — troubleshooting section for quick failures.

## For the user
Re-run the workflow after merge; the first step log line should now say exactly what is wrong if secrets are missing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af66eed5-e754-4554-8225-0c7699e6b2a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af66eed5-e754-4554-8225-0c7699e6b2a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

