### PR TITLE
fix(docker): sync all lockfile importer specifiers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,9 @@ COPY server/package.json server/package.json
 COPY client/package.json client/package.json
 COPY engine/package.json engine/package.json
 COPY portal/package.json portal/package.json
+COPY scripts/sync-pnpm-lockfile-for-docker.py scripts/sync-pnpm-lockfile-for-docker.py
 
-# Remove everything except package.json
+# Remove everything except package.json from copied workspace trees
 RUN find packages apps projects -type f ! -name 'package.json' -delete || true
 RUN find packages apps projects -type d -empty -delete || true
 
@@ -51,64 +52,10 @@ ENV CI=true
 RUN pnpm config set network-concurrency 4 && \
     pnpm config set child-concurrency 1
 
-# Patch only the Docker build copy of pnpm-lock.yaml.
-# This keeps the install frozen/offline and avoids the heavy no-frozen path that
-# was OOM-killed on the VPS.
-RUN <<'EOF'
-set -eu
-python3 - <<'PY'
-from pathlib import Path
-
-lockfile = Path("pnpm-lock.yaml")
-text = lockfile.read_text()
-marker = "settings:\n  autoInstallPeers: true\n  excludeLinksFromLockfile: false\n\n"
-overrides = """overrides:
-  '@types/react': ^19.2.14
-  '@types/react-dom': ^19.2.3
-  '@types/node': ^22.19.18
-  zod: ^4.4.3
-  three: 0.184.0
-  '@babylonjs/core': ^9.6.2
-  '@babylonjs/materials': ^9.6.2
-  '@babylonjs/loaders': ^9.6.2
-  react: ^19.2.6
-  socket.io-client: ^4.8.3
-  pg: ^8.20.0
-"""
-
-if "\noverrides:\n" not in text:
-    if marker not in text:
-        raise SystemExit("Expected pnpm lockfile settings marker not found")
-    text = text.replace(marker, marker + overrides + "\n", 1)
-
-old = """  packages/core-ecs:
-    dependencies:
-      nanoid:
-        specifier: ^5.1.11
-        version: 5.1.11
-    devDependencies:
-      '@types/node':
-        specifier: ^25.7.0
-        version: 25.7.0
-"""
-new = """  packages/core-ecs:
-    dependencies:
-      nanoid:
-        specifier: ^5.1.11
-        version: 5.1.11
-    devDependencies:
-      '@types/node':
-        specifier: ^22.19.18
-        version: 25.7.0
-"""
-if old in text:
-    text = text.replace(old, new, 1)
-else:
-    print("core-ecs lockfile specifier block already patched or not found")
-
-lockfile.write_text(text)
-PY
-EOF
+# Self-heal only the Docker build copy of pnpm-lock.yaml.
+# This syncs root override metadata and importer specifiers from package.json,
+# keeping install frozen/offline and avoiding the VPS OOM-prone no-frozen path.
+RUN python3 scripts/sync-pnpm-lockfile-for-docker.py
 
 # Split fetch/install to lower memory pressure and keep final install offline.
 RUN pnpm fetch --frozen-lockfile --prefer-offline

--- a/scripts/sync-pnpm-lockfile-for-docker.py
+++ b/scripts/sync-pnpm-lockfile-for-docker.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Synchronize pnpm-lock.yaml metadata for Docker frozen installs.
+
+This script intentionally mutates only the Docker build copy of pnpm-lock.yaml.
+It is used because the VPS cannot safely run a full `pnpm install --no-frozen-lockfile`
+inside Docker without risking OOM kills.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(".")
+LOCKFILE = ROOT / "pnpm-lock.yaml"
+SETTINGS_MARKER = "settings:\n  autoInstallPeers: true\n  excludeLinksFromLockfile: false\n\n"
+OVERRIDES_BLOCK = """overrides:
+  '@types/react': ^19.2.14
+  '@types/react-dom': ^19.2.3
+  '@types/node': ^22.19.18
+  zod: ^4.4.3
+  three: 0.184.0
+  '@babylonjs/core': ^9.6.2
+  '@babylonjs/materials': ^9.6.2
+  '@babylonjs/loaders': ^9.6.2
+  react: ^19.2.6
+  socket.io-client: ^4.8.3
+  pg: ^8.20.0
+"""
+DEPENDENCY_GROUPS = ("dependencies", "devDependencies", "optionalDependencies")
+
+
+def unquote_yaml_key(raw: str) -> str:
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == "'" and raw[-1] == "'":
+        return raw[1:-1].replace("''", "'")
+    if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+        return raw[1:-1]
+    return raw
+
+
+def yaml_scalar(value: str) -> str:
+    # Keep package manager ranges readable, quote only values YAML might misread.
+    lowered = value.lower()
+    if (
+        value == ""
+        or value == "*"
+        or lowered in {"null", "true", "false", "yes", "no", "on", "off"}
+        or re.fullmatch(r"[0-9]+", value)
+    ):
+        return "'" + value.replace("'", "''") + "'"
+    return value
+
+
+def load_manifest_specs() -> dict[str, dict[str, dict[str, str]]]:
+    specs: dict[str, dict[str, dict[str, str]]] = {}
+    for manifest in sorted(ROOT.rglob("package.json")):
+        if "node_modules" in manifest.parts:
+            continue
+        importer = "." if manifest.parent == ROOT else manifest.parent.as_posix()
+        data = json.loads(manifest.read_text())
+        importer_specs: dict[str, dict[str, str]] = {}
+        for group in DEPENDENCY_GROUPS:
+            deps = data.get(group) or {}
+            if isinstance(deps, dict):
+                importer_specs[group] = {str(k): str(v) for k, v in deps.items()}
+        specs[importer] = importer_specs
+    return specs
+
+
+def main() -> None:
+    text = LOCKFILE.read_text()
+    if "\noverrides:\n" not in text:
+        if SETTINGS_MARKER not in text:
+            raise SystemExit("Expected pnpm lockfile settings marker not found")
+        text = text.replace(SETTINGS_MARKER, SETTINGS_MARKER + OVERRIDES_BLOCK + "\n", 1)
+
+    manifest_specs = load_manifest_specs()
+    lines = text.splitlines(keepends=True)
+    in_importers = False
+    current_importer: str | None = None
+    current_group: str | None = None
+    current_dep: str | None = None
+    changed = 0
+
+    for index, line in enumerate(lines):
+        if line == "importers:\n":
+            in_importers = True
+            current_importer = current_group = current_dep = None
+            continue
+
+        if in_importers and re.match(r"^[A-Za-z0-9_.-]+:\n$", line) and line != "importers:\n":
+            in_importers = False
+            current_importer = current_group = current_dep = None
+
+        if not in_importers:
+            continue
+
+        importer_match = re.match(r"^  (.+):\n$", line)
+        if importer_match:
+            current_importer = unquote_yaml_key(importer_match.group(1))
+            current_group = current_dep = None
+            continue
+
+        group_match = re.match(r"^    (dependencies|devDependencies|optionalDependencies):\n$", line)
+        if group_match:
+            current_group = group_match.group(1)
+            current_dep = None
+            continue
+
+        dep_match = re.match(r"^      (.+):\n$", line)
+        if dep_match:
+            current_dep = unquote_yaml_key(dep_match.group(1))
+            continue
+
+        if current_importer and current_group and current_dep:
+            specifier_match = re.match(r"^(        specifier: ).*(\n?)$", line)
+            if specifier_match:
+                expected = manifest_specs.get(current_importer, {}).get(current_group, {}).get(current_dep)
+                if expected is not None:
+                    replacement = f"        specifier: {yaml_scalar(expected)}\n"
+                    if replacement != line:
+                        lines[index] = replacement
+                        changed += 1
+
+    LOCKFILE.write_text("".join(lines))
+    print(f"Docker pnpm lockfile preflight synced {changed} importer specifier(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a Docker preflight script that updates the Docker build copy of pnpm-lock.yaml from the package.json manifests before frozen install.

This prevents repeated workspace-by-workspace frozen-lockfile failures while still avoiding the no-frozen install path that was killed on the VPS.