### PR TITLE
fix(docker): reduce VPS pnpm memory usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,55 @@
 # Dependencies
 node_modules
+**/node_modules
+.pnpm-store
+.pnpm
+.yarn
+.yarn-cache
+npm-cache
 
 # Build outputs
 **/dist
 **/.next
 **/.nuxt
+**/build
 build
+out
+.tmp
+tmp
+.cache
+**/.cache
+
+# VCS / repo metadata
+.git
+.gitignore
+.github
+
+# Docker / local artifacts
+*.tar
+*.tar.gz
+*.tgz
+*.zip
+*.7z
+*.rar
+image.tar
+image.tar.gz
+docker-cache
+
+# Logs
+**/*.log
+logs
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Test coverage
+coverage
+**/coverage
+.nyc_output
+.playwright
+playwright-report
+test-results
 
 # IDE
 .idea
@@ -17,26 +61,14 @@ build
 .DS_Store
 Thumbs.db
 
-# Git
-.git
-.gitignore
-
-# Logs
-**/*.log
-logs
-npm-debug.log*
-pnpm-debug.log*
-
-# Test coverage
-coverage
-.nyc_output
-
 # Docs
 *.md
 !README.md
 docs
+conversation_data
 
-# Misc
-.env*.local
+# Env / local secrets
+.env
+.env.*
+!.env.example
 .vscode-test
-.playwright

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,19 +47,20 @@ RUN find packages apps projects -type f ! -name 'package.json' -delete || true
 RUN find packages apps projects -type d -empty -delete || true
 
 # VPS optimized dependency install.
-ENV NODE_OPTIONS="--max-old-space-size=1024"
+ENV NODE_OPTIONS="--max-old-space-size=768"
 ENV CI=true
-RUN pnpm config set network-concurrency 4 && \
-    pnpm config set child-concurrency 1
+ENV npm_config_jobs=1
+RUN pnpm config set network-concurrency 2 && \
+    pnpm config set child-concurrency 1 && \
+    pnpm config set side-effects-cache false
 
 # Self-heal only the Docker build copy of pnpm-lock.yaml.
 # This syncs root override metadata and importer specifiers from package.json,
-# keeping install frozen/offline and avoiding the VPS OOM-prone no-frozen path.
+# keeping install frozen while avoiding the VPS OOM-prone no-frozen path.
 RUN python3 scripts/sync-pnpm-lockfile-for-docker.py
 
-# Split fetch/install to lower memory pressure and keep final install offline.
-RUN pnpm fetch --frozen-lockfile --prefer-offline
-RUN pnpm install --frozen-lockfile --offline --ignore-scripts
+# Single frozen install. A separate pnpm fetch step was OOM-killed on the VPS.
+RUN pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
 # =========================================================
 # BUILDER


### PR DESCRIPTION
Reduces memory pressure in the VPS Docker build.

Changes:
- Remove the separate `pnpm fetch` step that was killed with exit 137.
- Use a single low-memory frozen pnpm install path.
- Lower pnpm concurrency and Node heap during dependency install.
- Expand `.dockerignore` to keep dependency caches, build outputs, archives, test artifacts, and local data out of the Docker build context.

This keeps the lockfile preflight and avoids the high-memory install paths.