### PR TITLE
fix(ci): trigger VPS deploy for all script changes

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -18,6 +18,8 @@ on:
       - 'portal/**'
       - 'engine/**'
       - 'docker/**'
+      - 'scripts/**'
+      - '.dockerignore'
       - 'Dockerfile'
       - 'Dockerfile.*'
       - 'docker-compose.yml'
@@ -25,7 +27,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'package.json'
-      - 'scripts/deploy-vps-docker.sh'
+      - '.github/workflows/vps-docker-deploy.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Updates the VPS Docker Deploy workflow path filters so changes under scripts/**, .dockerignore, and the workflow file itself trigger deployment. This ensures Docker helper scripts such as the pnpm lockfile preflight trigger the VPS deploy workflow.