### PR TITLE
fix(docker): parse lockfile specifier lines correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN pnpm config set network-concurrency 2 && \
 # Self-heal only the Docker build copy of pnpm-lock.yaml.
 # This syncs root override metadata and importer specifiers from package.json,
 # keeping install frozen while avoiding the VPS OOM-prone no-frozen path.
-ARG PNPM_PREFLIGHT_CACHE_BUST=2026-05-15-0015
+ARG PNPM_PREFLIGHT_CACHE_BUST=2026-05-15-0020
 RUN echo "pnpm preflight cache bust: ${PNPM_PREFLIGHT_CACHE_BUST}" && \
     python3 scripts/sync-pnpm-lockfile-for-docker.py
 

--- a/scripts/sync-pnpm-lockfile-for-docker.py
+++ b/scripts/sync-pnpm-lockfile-for-docker.py
@@ -127,11 +127,6 @@ def main() -> None:
             current_dep = None
             continue
 
-        dep_match = re.match(r"^      (.+):\n$", line)
-        if dep_match:
-            current_dep = unquote_yaml_key(dep_match.group(1))
-            continue
-
         if current_importer and current_group and current_dep:
             specifier_match = re.match(r"^(        specifier: ).*(\n?)$", line)
             if specifier_match:
@@ -141,6 +136,12 @@ def main() -> None:
                     if replacement != line:
                         lines[index] = replacement
                         changed += 1
+                continue
+
+        dep_match = re.match(r"^      (\S.+):\n$", line)
+        if dep_match:
+            current_dep = unquote_yaml_key(dep_match.group(1))
+            continue
 
     LOCKFILE.write_text("".join(lines))
     print(f"Docker pnpm lockfile preflight synced {changed} importer specifier(s).")


### PR DESCRIPTION
Fixes the Docker pnpm lockfile preflight parser so `specifier:` lines are handled before dependency-key detection. Also refreshes the preflight cache-bust value so the corrected script runs in the VPS Docker build.