### PR TITLE
fix(docker): run recursive build outside root lifecycle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app ./
 
 # Copy source. This overwrites pnpm-lock.yaml with the repository copy, so run
-# the same preflight again before invoking pnpm build.
+# the same preflight again before invoking the workspace build.
 COPY . .
 ARG PNPM_BUILDER_PREFLIGHT_CACHE_BUST=2026-05-15-0035
 RUN echo "pnpm builder preflight cache bust: ${PNPM_BUILDER_PREFLIGHT_CACHE_BUST}" && \
@@ -94,10 +94,12 @@ ENV NODE_OPTIONS="--max-old-space-size=12288"
 
 # Parallelism optimization
 ENV CI=true
-ENV TURBO_CONCURRENCY=4
+ENV TURBO_CONCURRENCY=2
 
-# Build
-RUN pnpm build
+# Build with the Corepack pnpm binary directly. Do not run the root `build`
+# lifecycle script, because that script resolves the local pnpm devDependency
+# from node_modules and tries to recreate node_modules inside the Docker build.
+RUN pnpm -r --workspace-concurrency=1 --if-present build
 
 # Prune dev dependencies
 RUN pnpm prune --prod


### PR DESCRIPTION
Replaces the Docker build step `pnpm build` with a direct recursive workspace build. This avoids running the root lifecycle script, which resolves the local pnpm devDependency from node_modules and attempts to recreate node_modules inside the Docker build.