### PR TITLE
feat(collective): add deterministic public-key ingress

### DIFF
--- a/client/src/collective/CollectiveIngressPanel.tsx
+++ b/client/src/collective/CollectiveIngressPanel.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { fetchCollectiveIngressStatus, type CollectiveIngressStatus } from '../design/ThemeEngine';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function CollectiveIngressPanel() {
+  const [status, setStatus] = useState<CollectiveIngressStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      const next = await fetchCollectiveIngressStatus();
+      if (!cancelled) setStatus(next);
+    };
+    run();
+    const id = window.setInterval(run, 1000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const bounds = useMemo(() => {
+    const peers = status?.peers ?? [];
+    if (peers.length === 0) return { minX: -16, maxX: 16, minY: -16, maxY: 16 };
+    return peers.reduce((acc, peer) => ({
+      minX: Math.min(acc.minX, peer.chunk.x),
+      maxX: Math.max(acc.maxX, peer.chunk.x),
+      minY: Math.min(acc.minY, peer.chunk.y),
+      maxY: Math.max(acc.maxY, peer.chunk.y),
+    }), { minX: peers[0].chunk.x - 4, maxX: peers[0].chunk.x + 4, minY: peers[0].chunk.y - 4, maxY: peers[0].chunk.y + 4 });
+  }, [status]);
+
+  const peers = status?.peers ?? [];
+  const latestWelcome = status?.recentWelcomes?.at(-1);
+
+  return <div className="collective-panel mt-6 rounded-3xl border p-4">
+    <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <p className="font-fira text-xs uppercase tracking-[0.28em] text-cyan-100/70">Collective Ingress · Emily-Willkommens-Modus</p>
+        <h3 className="text-lg font-black text-white">Sovereign Multiverse Live-Map</h3>
+      </div>
+      <span className="rounded-full border px-3 py-2 font-fira text-xs text-lime-100">{status?.peerCount ?? 0} peers · q {status?.queuedInputs ?? 0}</span>
+    </div>
+    {latestWelcome && <div className="collective-welcome mb-4 rounded-2xl border p-3 font-fira text-xs text-cyan-50">{latestWelcome.welcome} · Chunk {latestWelcome.chunk.x}:{latestWelcome.chunk.y}</div>}
+    <div className="collective-map relative h-72 overflow-hidden rounded-3xl border">
+      <div className="absolute inset-0 collective-map-grid" />
+      {peers.map((peer) => {
+        const xSpan = Math.max(1, bounds.maxX - bounds.minX);
+        const ySpan = Math.max(1, bounds.maxY - bounds.minY);
+        const left = clamp(((peer.chunk.x - bounds.minX) / xSpan) * 100, 5, 95);
+        const top = clamp(((peer.chunk.y - bounds.minY) / ySpan) * 100, 5, 95);
+        return <div key={peer.id} className="collective-peer-dot absolute" style={{ left: `${left}%`, top: `${top}%` }} title={`${peer.name} · ${peer.role} · ${peer.chunk.x}:${peer.chunk.y}`}>
+          <span className="collective-peer-core" />
+          <span className="collective-peer-label font-fira text-[10px]">{peer.role.slice(0, 3).toUpperCase()}</span>
+        </div>;
+      })}
+    </div>
+    <div className="mt-4 grid gap-3 md:grid-cols-3">
+      {peers.slice(0, 6).map((peer) => <div key={peer.id} className="cyber-card">
+        <p className="font-fira text-xs text-lime-100">{peer.name}</p>
+        <p className="mt-1 font-fira text-[11px] text-cyan-100/70">{peer.role} · chunk {peer.chunk.x}:{peer.chunk.y}</p>
+        <p className="mt-1 break-all font-fira text-[10px] text-cyan-100/45">{peer.publicKeyHash ?? 'legacy'}</p>
+      </div>)}
+    </div>
+  </div>;
+}

--- a/client/src/design/ThemeEngine.ts
+++ b/client/src/design/ThemeEngine.ts
@@ -42,6 +42,25 @@ export interface SovereignTruth {
 
 export interface SovereignLaunchResult { ok: boolean; dispatched?: boolean; workflow?: string; repo?: string; ref?: string; error?: string; message?: string; detail?: unknown; }
 
+export interface CollectivePeer {
+  id: string;
+  name: string;
+  role: string;
+  publicKeyHash: string | null;
+  deterministicSeed: string | null;
+  position: { x: number; y: number; z: number };
+  chunk: { x: number; y: number; size: 64 };
+}
+export interface CollectiveIngressStatus {
+  ok: boolean;
+  tick: number;
+  peerCount: number;
+  queuedInputs: number;
+  peers: CollectivePeer[];
+  chunks: Array<{ x: number; y: number; size: 64; key: string; peers: string[] }>;
+  recentWelcomes: Array<{ tick: number; playerId: string; role: string; chunk: { x: number; y: number; size: 64 }; welcome: string }>;
+}
+
 export const LOCAL_UI_BUILD_HASH = String((import.meta as any).env?.VITE_UI_BUILD_HASH || (import.meta as any).env?.VITE_BUILD_COMMIT_SHA || "dev");
 
 export function hasVersionDrift(truth: SovereignTruth | null): boolean {
@@ -84,6 +103,7 @@ export async function fetchAREReplaySnapshot(tick: number): Promise<AREReplaySna
 export async function fetchAREOracleReport(): Promise<AREOracleReport | null> { try { const response = await fetch("/api/are/replay/oracle/prophecy", { cache: "no-store" }); if (!response.ok) return null; const body = await response.json(); return body.oracle ?? null; } catch { return null; } }
 export async function fetchAREAutoRepairStatus(): Promise<AREAutoRepairStatus | null> { try { const response = await fetch("/api/are/replay/repair/status", { cache: "no-store" }); if (!response.ok) return null; const body = await response.json(); return body.autoRepair ?? null; } catch { return null; } }
 export async function fetchSovereignTruth(): Promise<SovereignTruth | null> { try { const response = await fetch("/api/sovereign/deploy/truth", { cache: "no-store" }); if (!response.ok) return null; return (await response.json()) as SovereignTruth; } catch { return null; } }
+export async function fetchCollectiveIngressStatus(): Promise<CollectiveIngressStatus | null> { try { const response = await fetch("/api/collective/ingress/status", { cache: "no-store" }); if (!response.ok) return null; return (await response.json()) as CollectiveIngressStatus; } catch { return null; } }
 export async function launchSovereignDeploy(launchKey: string, ref = "main"): Promise<SovereignLaunchResult> {
   try {
     const response = await fetch("/api/sovereign/deploy/launch", { method: "POST", headers: { "Content-Type": "application/json", "X-Sovereign-Launch-Key": launchKey }, body: JSON.stringify({ ref, reason: "Portal Sovereign Launch Button" }) });

--- a/server/src/api/collectiveIngressRoute.ts
+++ b/server/src/api/collectiveIngressRoute.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { createSovereignIdentity } from "../collective/SovereignIdentity.js";
 import { collectiveIngressRuntime } from "../collective/CollectiveIngressRuntime.js";
 
-export function collectiveIngressRouter() {
+export function collectiveIngressRouter(_tick?: unknown) {
   const router = Router();
 
   router.get("/status", (_req, res) => {

--- a/server/src/api/collectiveIngressRoute.ts
+++ b/server/src/api/collectiveIngressRoute.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import type { WorldTick } from "../core/WorldTick.js";
+import { createSovereignIdentity } from "../collective/SovereignIdentity.js";
+
+export function collectiveIngressRouter(tick: WorldTick) {
+  const router = Router();
+
+  router.get("/status", (_req, res) => {
+    res.json(tick.getCollectiveIngressStatus());
+  });
+
+  router.post("/preview", (req, res) => {
+    try {
+      const identity = createSovereignIdentity(req.body?.publicKey ?? req.body?.wallet ?? req.body?.hash, req.body?.alias);
+      res.json({ ok: true, identity });
+    } catch (error) {
+      res.status(400).json({ ok: false, error: error instanceof Error ? error.message : "invalid_identity" });
+    }
+  });
+
+  return router;
+}

--- a/server/src/api/collectiveIngressRoute.ts
+++ b/server/src/api/collectiveIngressRoute.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
-import type { WorldTick } from "../core/WorldTick.js";
 import { createSovereignIdentity } from "../collective/SovereignIdentity.js";
+import { collectiveIngressRuntime } from "../collective/CollectiveIngressRuntime.js";
 
-export function collectiveIngressRouter(tick: WorldTick) {
+export function collectiveIngressRouter() {
   const router = Router();
 
   router.get("/status", (_req, res) => {
-    res.json(tick.getCollectiveIngressStatus());
+    res.json(collectiveIngressRuntime.getStatus());
   });
 
   router.post("/preview", (req, res) => {

--- a/server/src/collective/CollectiveIngressRuntime.ts
+++ b/server/src/collective/CollectiveIngressRuntime.ts
@@ -1,0 +1,100 @@
+import { createSovereignIdentity, type SovereignPeerIdentity } from "./SovereignIdentity.js";
+
+export interface CollectiveIngressPeer {
+  id: string;
+  socketId: string;
+  name: string;
+  role: string;
+  publicKeyHash: string;
+  deterministicSeed: string;
+  position: { x: number; y: number; z: number };
+  chunk: { x: number; y: number; size: 64 };
+  lastSeq: number;
+}
+
+function chunkOf(position: { x: number; y: number; z?: number }) {
+  return { x: Math.floor(position.x / 64), y: Math.floor(position.y / 64), size: 64 as const };
+}
+
+export class CollectiveIngressRuntime {
+  private peers = new Map<string, CollectiveIngressPeer>();
+  private socketToPeer = new Map<string, string>();
+  private welcomes: Array<{ tick: number; playerId: string; role: string; chunk: { x: number; y: number; size: 64 }; welcome: string }> = [];
+  private seq = 0;
+  private tick = 0;
+
+  register(socketId: string, msg: any): { identity: SovereignPeerIdentity; peer: CollectiveIngressPeer; welcome: string } {
+    const identity = createSovereignIdentity(msg.publicKey ?? msg.wallet ?? msg.hash ?? msg.kappaPosHash, msg.alias ?? msg.name);
+    const peer: CollectiveIngressPeer = {
+      id: identity.id,
+      socketId,
+      name: `${identity.role}-${identity.publicKeyHash.slice(0, 6)}`,
+      role: identity.role,
+      publicKeyHash: identity.publicKeyHash,
+      deterministicSeed: identity.deterministicSeed,
+      position: { ...identity.position },
+      chunk: { ...identity.chunk },
+      lastSeq: ++this.seq,
+    };
+    this.peers.set(peer.id, peer);
+    this.socketToPeer.set(socketId, peer.id);
+    const welcome = { tick: this.tick, playerId: peer.id, role: peer.role, chunk: peer.chunk, welcome: identity.welcome };
+    this.welcomes.push(welcome);
+    if (this.welcomes.length > 32) this.welcomes.splice(0, this.welcomes.length - 32);
+    return { identity, peer, welcome: identity.welcome };
+  }
+
+  disconnect(socketId: string): void {
+    const peerId = this.socketToPeer.get(socketId);
+    if (!peerId) return;
+    this.socketToPeer.delete(socketId);
+    this.peers.delete(peerId);
+  }
+
+  updateFromInput(socketId: string, msg: any): void {
+    const peerId = this.socketToPeer.get(socketId);
+    if (!peerId) return;
+    const peer = this.peers.get(peerId);
+    if (!peer) return;
+    const type = String(msg?.type ?? "");
+    if (type !== "move_intent" && type !== "MOVE") return;
+    let dx = Number(msg.dx) || 0;
+    let dy = Number(msg.dy ?? msg.dz) || 0;
+    const magSq = dx * dx + dy * dy;
+    if (magSq > 1) {
+      const mag = Math.sqrt(magSq);
+      dx /= mag;
+      dy /= mag;
+    }
+    peer.position.x = Math.floor((peer.position.x + dx * 5) * 1000) / 1000;
+    peer.position.y = Math.floor((peer.position.y + dy * 5) * 1000) / 1000;
+    peer.chunk = chunkOf(peer.position);
+    peer.lastSeq = ++this.seq;
+  }
+
+  advanceTick(): void {
+    this.tick += 1;
+  }
+
+  getStatus() {
+    const peers = [...this.peers.values()].sort((a, b) => a.id.localeCompare(b.id));
+    const chunks = new Map<string, any>();
+    for (const peer of peers) {
+      const key = `${peer.chunk.x}:${peer.chunk.y}`;
+      const current = chunks.get(key) ?? { ...peer.chunk, key, peers: [] };
+      current.peers.push(peer.id);
+      chunks.set(key, current);
+    }
+    return {
+      ok: true,
+      tick: this.tick,
+      peerCount: peers.length,
+      queuedInputs: 0,
+      peers,
+      chunks: [...chunks.values()].sort((a, b) => a.key.localeCompare(b.key)),
+      recentWelcomes: this.welcomes.slice(-12),
+    };
+  }
+}
+
+export const collectiveIngressRuntime = new CollectiveIngressRuntime();

--- a/server/src/collective/SovereignIdentity.ts
+++ b/server/src/collective/SovereignIdentity.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+
+export type CollectiveRole = "Scavenger" | "Trader" | "Guardian";
+
+export interface SovereignPeerIdentity {
+  id: string;
+  publicKey: string;
+  publicKeyHash: string;
+  deterministicSeed: string;
+  role: CollectiveRole;
+  chunk: { x: number; y: number; size: 64 };
+  position: { x: number; y: number; z: number };
+  starterLoot: Array<{ id: string; name: string; type: string; qty: number }>;
+  welcome: string;
+}
+
+const ROLES: CollectiveRole[] = ["Scavenger", "Trader", "Guardian"];
+
+function byteAt(hash: string, index: number): number {
+  const offset = (index * 2) % Math.max(2, hash.length - 1);
+  return Number.parseInt(hash.slice(offset, offset + 2), 16) || 0;
+}
+
+export function normalizePublicKey(input: unknown): string {
+  const raw = String(input ?? "").trim();
+  if (!raw || raw.length < 8) throw new Error("public_key_required");
+  return raw.replace(/\s+/g, "").slice(0, 256);
+}
+
+export function createSovereignIdentity(publicKeyInput: unknown, aliasInput?: unknown): SovereignPeerIdentity {
+  const publicKey = normalizePublicKey(publicKeyInput);
+  const publicKeyHash = createHash("sha256").update(publicKey).digest("hex");
+  const role = ROLES[byteAt(publicKeyHash, 0) % ROLES.length];
+  const chunkX = (byteAt(publicKeyHash, 1) % 33) - 16;
+  const chunkY = (byteAt(publicKeyHash, 2) % 33) - 16;
+  const localX = byteAt(publicKeyHash, 3) % 64;
+  const localY = byteAt(publicKeyHash, 4) % 64;
+  const deterministicSeed = `ARE|COLLECTIVE|k1000|${publicKeyHash.slice(0, 32)}`;
+  const id = `peer_${publicKeyHash.slice(0, 16)}`;
+  const roleLoot: Record<CollectiveRole, SovereignPeerIdentity["starterLoot"]> = {
+    Scavenger: [
+      { id: `scrap_${publicKeyHash.slice(16, 22)}`, name: "Deterministic Scrap", type: "material", qty: 3 },
+      { id: `torch_${publicKeyHash.slice(22, 28)}`, name: "Marina Torch", type: "tool", qty: 1 },
+    ],
+    Trader: [
+      { id: `coin_${publicKeyHash.slice(16, 22)}`, name: "Matrix Coin", type: "currency", qty: 17 },
+      { id: `ledger_${publicKeyHash.slice(22, 28)}`, name: "Ledger Shard", type: "tool", qty: 1 },
+    ],
+    Guardian: [
+      { id: `ward_${publicKeyHash.slice(16, 22)}`, name: "Kappa Ward", type: "armor", qty: 1 },
+      { id: `rune_${publicKeyHash.slice(22, 28)}`, name: "Guardian Rune", type: "rune", qty: 1 },
+    ],
+  };
+  const alias = String(aliasInput ?? "").trim().slice(0, 32);
+  const display = alias || `${role}-${publicKeyHash.slice(0, 6)}`;
+  return {
+    id,
+    publicKey,
+    publicKeyHash,
+    deterministicSeed,
+    role,
+    chunk: { x: chunkX, y: chunkY, size: 64 },
+    position: { x: chunkX * 64 + localX, y: chunkY * 64 + localY, z: 0 },
+    starterLoot: roleLoot[role],
+    welcome: `Emily welcomes ${display} as ${role} of the Collective.`,
+  };
+}
+
+export function applySovereignStartState(player: any, identity: SovereignPeerIdentity): void {
+  player.id = identity.id;
+  player.name = player.name || `${identity.role}-${identity.publicKeyHash.slice(0, 6)}`;
+  player.class = identity.role;
+  player.collectiveRole = identity.role;
+  player.publicKeyHash = identity.publicKeyHash;
+  player.deterministicSeed = identity.deterministicSeed;
+  player.position = { ...identity.position };
+  player.inventory = Array.isArray(player.inventory) && player.inventory.length > 0 ? player.inventory : identity.starterLoot.map((item) => ({ ...item }));
+  player.flags = { ...(player.flags ?? {}), sovereignIdentity: true, collectiveIngress: true };
+}

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -17,6 +17,7 @@ import { warfrontRouter } from "../api/warfrontRoute.js";
 import { areValidationRouter } from "../api/areValidationRoute.js";
 import { areReplayRouter } from "../api/areReplayRoute.js";
 import { sovereignDeployRouter } from "../api/sovereignDeployRoute.js";
+import { collectiveIngressRouter } from "../api/collectiveIngressRoute.js";
 import { getContentDataSourceLabel, resolveContentDir } from "../modules/content/contentDataRoot.js";
 import { getSupabaseSummary, verifySupabaseToken } from "../config/supabase.js";
 import { resolveWorldAssetsDir } from "./resolveWorldAssetsDir.js";
@@ -127,7 +128,7 @@ export class ServerBootstrap {
       const persistence = tick?.getPersistenceStats() ?? { status: "unknown" };
       const content = getContentDataSourceLabel();
       const selfHealingStatus = selfHealingRuntime.getStatus();
-      res.json({ ok: true, project: "ARELORIAN MMORPG", version: "0.2.0", persistence, content: { mode: content.mode, root: content.root }, supabase: getSupabaseSummary(), auth: { useSupabaseWsLogin: envTruthy("USE_SUPABASE_WS_LOGIN"), requireSupabaseAuth: envTruthy("REQUIRE_SUPABASE_AUTH"), allowGuestLogin: (() => { const v = process.env.ALLOW_GUEST_LOGIN?.trim().toLowerCase(); if (v === "0" || v === "false" || v === "no") return false; return true; })(), allowDevLogin: !["0", "false", "no"].includes(process.env.ALLOW_DEV_LOGIN?.trim().toLowerCase() || "") }, selfHealing: { active: selfHealingStatus.active, patchMode: selfHealingStatus.config?.patchMode ?? "disabled", totalErrors: selfHealingStatus.totalErrors, totalHealed: selfHealingStatus.totalHealed, healingRate: selfHealingStatus.healingRate, featuresProtected: selfHealingStatus.featuresProtected }, are: { guard: tick?.getAREGuardStatus?.() ?? null, worldHash: tick?.getWorldHashSnapshot?.()?.worldHash ?? null, replay: tick?.getReplayRecorderStats?.() ?? null } });
+      res.json({ ok: true, project: "ARELORIAN MMORPG", version: "0.2.0", persistence, content: { mode: content.mode, root: content.root }, supabase: getSupabaseSummary(), auth: { useSupabaseWsLogin: envTruthy("USE_SUPABASE_WS_LOGIN"), requireSupabaseAuth: envTruthy("REQUIRE_SUPABASE_AUTH"), allowGuestLogin: (() => { const v = process.env.ALLOW_GUEST_LOGIN?.trim().toLowerCase(); if (v === "0" || v === "false" || v === "no") return false; return true; })(), allowDevLogin: !["0", "false", "no"].includes(process.env.ALLOW_DEV_LOGIN?.trim().toLowerCase() || "") }, selfHealing: { active: selfHealingStatus.active, patchMode: selfHealingStatus.config?.patchMode ?? "disabled", totalErrors: selfHealingStatus.totalErrors, totalHealed: selfHealingStatus.totalHealed, healingRate: selfHealingStatus.healingRate, featuresProtected: selfHealingStatus.featuresProtected }, are: { guard: tick?.getAREGuardStatus?.() ?? null, worldHash: tick?.getWorldHashSnapshot?.()?.worldHash ?? null, replay: tick?.getReplayRecorderStats?.() ?? null }, collective: tick?.getCollectiveIngressStatus?.() ?? null });
     });
     app.get("/", (req, res, next) => { if (req.headers["user-agent"]?.includes("GoogleHC")) return res.status(200).send("OK"); next(); });
     app.use("/auth/v1", async (req, res) => {
@@ -162,6 +163,7 @@ export class ServerBootstrap {
     app.use("/api/are/validation", areValidationRouter(tick));
     app.use("/api/are/replay", areReplayRouter(tick));
     app.use("/api/sovereign/deploy", sovereignDeployRouter(tick));
+    app.use("/api/collective/ingress", collectiveIngressRouter(tick));
     const monitorStream = new PlaytesterMonitorStream(httpServer, (options) => tick.buildPlaytesterMonitorPayload(options));
     monitorStream.start();
     const playtesterSignaling = new PlaytesterWebRTCSignaling(httpServer);

--- a/server/src/core/WorldTickCollectiveIngress.ts
+++ b/server/src/core/WorldTickCollectiveIngress.ts
@@ -1,0 +1,16 @@
+import { WorldTick } from "./WorldTick.js";
+import { collectiveIngressRuntime } from "../collective/CollectiveIngressRuntime.js";
+
+declare module "./WorldTick.js" {
+  interface WorldTick {
+    getCollectiveIngressStatus(): ReturnType<typeof collectiveIngressRuntime.getStatus>;
+  }
+}
+
+WorldTick.prototype.getCollectiveIngressStatus = function getCollectiveIngressStatus() {
+  return collectiveIngressRuntime.getStatus();
+};
+
+export function installWorldTickCollectiveIngress(): void {
+  // Import side-effect installs the prototype method. This named function makes the intent explicit.
+}

--- a/server/src/networking/WebSocketServer.ts
+++ b/server/src/networking/WebSocketServer.ts
@@ -2,6 +2,7 @@ import type { Server as HttpServer } from "node:http";
 import { WebSocketServer, WebSocket } from "ws";
 import { randomUUID } from "node:crypto";
 import { GameConfig } from "../config/GameConfig.js";
+import { collectiveIngressRuntime } from "../collective/CollectiveIngressRuntime.js";
 
 const WS_RL_WINDOW_MS = 1000;
 
@@ -77,9 +78,16 @@ export class GameWebSocketServer {
           sock._rlAt.push(now);
 
           const msg = JSON.parse(raw.toString());
-          if (msg?.type === "login") {
+          const isSovereignLogin = (msg?.type === "sovereign_login" || msg?.type === "login") && (msg?.publicKey || msg?.wallet || msg?.hash || msg?.kappaPosHash);
+          if (isSovereignLogin) {
+            const result = collectiveIngressRuntime.register(id, msg);
+            socket.send(JSON.stringify({ type: "COLLECTIVE_WELCOME", identity: result.identity, peer: result.peer, welcome: result.welcome }));
+            this.broadcast({ type: "COLLECTIVE_PEER_JOINED", payload: result.peer });
+            this.socketToPlayerUid.set(id, result.peer.id);
+          } else if (msg?.type === "login") {
             this.socketToPlayerUid.delete(id);
           } else {
+            collectiveIngressRuntime.updateFromInput(id, msg);
             let uid = this.socketToPlayerUid.get(id);
             if (!uid && this.resolveSocketToPlayerUid) {
               uid = this.resolveSocketToPlayerUid(id) ?? undefined;
@@ -110,6 +118,7 @@ export class GameWebSocketServer {
 
       socket.on("close", () => {
         this.socketToPlayerUid.delete(id);
+        collectiveIngressRuntime.disconnect(id);
         if (this.onPlayerDisconnect) {
           this.onPlayerDisconnect(id);
         }


### PR DESCRIPTION
Implements the Collective Ingress layer for deterministic ARE multiplayer onboarding.

Included:
- Sovereign Public-Key identity derivation with deterministic seed, role, spawn chunk, position and starter loot.
- Collective ingress runtime tracking live peers, chunks, welcomes and movement inputs.
- WebSocket handling for `sovereign_login` / public-key login and deterministic movement updates.
- `/api/collective/ingress/status` and `/api/collective/ingress/preview` endpoints.
- Portal-side fetch types and a Collective live-map component for Emily's welcome mode.

Notes:
- The runtime is intentionally isolated from the heavy WorldTick class to reduce deploy risk.
- The live-map component exists but may still need a small App.tsx mount if the current portal layout changed after this branch diverged from main.