### PR TITLE
feat(collective): add deterministic public-key ingress v2

### DIFF
--- a/server/src/api/collectiveIngressRoute.ts
+++ b/server/src/api/collectiveIngressRoute.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import { createSovereignIdentity } from "../collective/SovereignIdentity.js";
+import { collectiveIngressRuntime } from "../collective/CollectiveIngressRuntime.js";
+
+export function collectiveIngressRouter(_tick?: unknown) {
+  const router = Router();
+
+  router.get("/status", (_req, res) => {
+    res.json(collectiveIngressRuntime.getStatus());
+  });
+
+  router.post("/preview", (req, res) => {
+    try {
+      const identity = createSovereignIdentity(req.body?.publicKey ?? req.body?.wallet ?? req.body?.hash, req.body?.alias);
+      res.json({ ok: true, identity });
+    } catch (error) {
+      res.status(400).json({ ok: false, error: error instanceof Error ? error.message : "invalid_identity" });
+    }
+  });
+
+  return router;
+}

--- a/server/src/collective/CollectiveIngressRuntime.ts
+++ b/server/src/collective/CollectiveIngressRuntime.ts
@@ -1,0 +1,100 @@
+import { createSovereignIdentity, type SovereignPeerIdentity } from "./SovereignIdentity.js";
+
+export interface CollectiveIngressPeer {
+  id: string;
+  socketId: string;
+  name: string;
+  role: string;
+  publicKeyHash: string;
+  deterministicSeed: string;
+  position: { x: number; y: number; z: number };
+  chunk: { x: number; y: number; size: 64 };
+  lastSeq: number;
+}
+
+function chunkOf(position: { x: number; y: number; z?: number }) {
+  return { x: Math.floor(position.x / 64), y: Math.floor(position.y / 64), size: 64 as const };
+}
+
+export class CollectiveIngressRuntime {
+  private peers = new Map<string, CollectiveIngressPeer>();
+  private socketToPeer = new Map<string, string>();
+  private welcomes: Array<{ tick: number; playerId: string; role: string; chunk: { x: number; y: number; size: 64 }; welcome: string }> = [];
+  private seq = 0;
+  private tick = 0;
+
+  register(socketId: string, msg: any): { identity: SovereignPeerIdentity; peer: CollectiveIngressPeer; welcome: string } {
+    const identity = createSovereignIdentity(msg.publicKey ?? msg.wallet ?? msg.hash ?? msg.kappaPosHash, msg.alias ?? msg.name);
+    const peer: CollectiveIngressPeer = {
+      id: identity.id,
+      socketId,
+      name: `${identity.role}-${identity.publicKeyHash.slice(0, 6)}`,
+      role: identity.role,
+      publicKeyHash: identity.publicKeyHash,
+      deterministicSeed: identity.deterministicSeed,
+      position: { ...identity.position },
+      chunk: { ...identity.chunk },
+      lastSeq: ++this.seq,
+    };
+    this.peers.set(peer.id, peer);
+    this.socketToPeer.set(socketId, peer.id);
+    const welcome = { tick: this.tick, playerId: peer.id, role: peer.role, chunk: peer.chunk, welcome: identity.welcome };
+    this.welcomes.push(welcome);
+    if (this.welcomes.length > 32) this.welcomes.splice(0, this.welcomes.length - 32);
+    return { identity, peer, welcome: identity.welcome };
+  }
+
+  disconnect(socketId: string): void {
+    const peerId = this.socketToPeer.get(socketId);
+    if (!peerId) return;
+    this.socketToPeer.delete(socketId);
+    this.peers.delete(peerId);
+  }
+
+  updateFromInput(socketId: string, msg: any): void {
+    const peerId = this.socketToPeer.get(socketId);
+    if (!peerId) return;
+    const peer = this.peers.get(peerId);
+    if (!peer) return;
+    const type = String(msg?.type ?? "");
+    if (type !== "move_intent" && type !== "MOVE") return;
+    let dx = Number(msg.dx) || 0;
+    let dy = Number(msg.dy ?? msg.dz) || 0;
+    const magSq = dx * dx + dy * dy;
+    if (magSq > 1) {
+      const mag = Math.sqrt(magSq);
+      dx /= mag;
+      dy /= mag;
+    }
+    peer.position.x = Math.floor((peer.position.x + dx * 5) * 1000) / 1000;
+    peer.position.y = Math.floor((peer.position.y + dy * 5) * 1000) / 1000;
+    peer.chunk = chunkOf(peer.position);
+    peer.lastSeq = ++this.seq;
+  }
+
+  advanceTick(): void {
+    this.tick += 1;
+  }
+
+  getStatus() {
+    const peers = [...this.peers.values()].sort((a, b) => a.id.localeCompare(b.id));
+    const chunks = new Map<string, any>();
+    for (const peer of peers) {
+      const key = `${peer.chunk.x}:${peer.chunk.y}`;
+      const current = chunks.get(key) ?? { ...peer.chunk, key, peers: [] };
+      current.peers.push(peer.id);
+      chunks.set(key, current);
+    }
+    return {
+      ok: true,
+      tick: this.tick,
+      peerCount: peers.length,
+      queuedInputs: 0,
+      peers,
+      chunks: [...chunks.values()].sort((a, b) => a.key.localeCompare(b.key)),
+      recentWelcomes: this.welcomes.slice(-12),
+    };
+  }
+}
+
+export const collectiveIngressRuntime = new CollectiveIngressRuntime();

--- a/server/src/collective/SovereignIdentity.ts
+++ b/server/src/collective/SovereignIdentity.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+
+export type CollectiveRole = "Scavenger" | "Trader" | "Guardian";
+
+export interface SovereignPeerIdentity {
+  id: string;
+  publicKey: string;
+  publicKeyHash: string;
+  deterministicSeed: string;
+  role: CollectiveRole;
+  chunk: { x: number; y: number; size: 64 };
+  position: { x: number; y: number; z: number };
+  starterLoot: Array<{ id: string; name: string; type: string; qty: number }>;
+  welcome: string;
+}
+
+const ROLES: CollectiveRole[] = ["Scavenger", "Trader", "Guardian"];
+
+function byteAt(hash: string, index: number): number {
+  const offset = (index * 2) % Math.max(2, hash.length - 1);
+  return Number.parseInt(hash.slice(offset, offset + 2), 16) || 0;
+}
+
+export function normalizePublicKey(input: unknown): string {
+  const raw = String(input ?? "").trim();
+  if (!raw || raw.length < 8) throw new Error("public_key_required");
+  return raw.replace(/\s+/g, "").slice(0, 256);
+}
+
+export function createSovereignIdentity(publicKeyInput: unknown, aliasInput?: unknown): SovereignPeerIdentity {
+  const publicKey = normalizePublicKey(publicKeyInput);
+  const publicKeyHash = createHash("sha256").update(publicKey).digest("hex");
+  const role = ROLES[byteAt(publicKeyHash, 0) % ROLES.length];
+  const chunkX = (byteAt(publicKeyHash, 1) % 33) - 16;
+  const chunkY = (byteAt(publicKeyHash, 2) % 33) - 16;
+  const localX = byteAt(publicKeyHash, 3) % 64;
+  const localY = byteAt(publicKeyHash, 4) % 64;
+  const deterministicSeed = `ARE|COLLECTIVE|k1000|${publicKeyHash.slice(0, 32)}`;
+  const id = `peer_${publicKeyHash.slice(0, 16)}`;
+  const roleLoot: Record<CollectiveRole, SovereignPeerIdentity["starterLoot"]> = {
+    Scavenger: [
+      { id: `scrap_${publicKeyHash.slice(16, 22)}`, name: "Deterministic Scrap", type: "material", qty: 3 },
+      { id: `torch_${publicKeyHash.slice(22, 28)}`, name: "Marina Torch", type: "tool", qty: 1 },
+    ],
+    Trader: [
+      { id: `coin_${publicKeyHash.slice(16, 22)}`, name: "Matrix Coin", type: "currency", qty: 17 },
+      { id: `ledger_${publicKeyHash.slice(22, 28)}`, name: "Ledger Shard", type: "tool", qty: 1 },
+    ],
+    Guardian: [
+      { id: `ward_${publicKeyHash.slice(16, 22)}`, name: "Kappa Ward", type: "armor", qty: 1 },
+      { id: `rune_${publicKeyHash.slice(22, 28)}`, name: "Guardian Rune", type: "rune", qty: 1 },
+    ],
+  };
+  const alias = String(aliasInput ?? "").trim().slice(0, 32);
+  const display = alias || `${role}-${publicKeyHash.slice(0, 6)}`;
+  return {
+    id,
+    publicKey,
+    publicKeyHash,
+    deterministicSeed,
+    role,
+    chunk: { x: chunkX, y: chunkY, size: 64 },
+    position: { x: chunkX * 64 + localX, y: chunkY * 64 + localY, z: 0 },
+    starterLoot: roleLoot[role],
+    welcome: `Emily welcomes ${display} as ${role} of the Collective.`,
+  };
+}
+
+export function applySovereignStartState(player: any, identity: SovereignPeerIdentity): void {
+  player.id = identity.id;
+  player.name = player.name || `${identity.role}-${identity.publicKeyHash.slice(0, 6)}`;
+  player.class = identity.role;
+  player.collectiveRole = identity.role;
+  player.publicKeyHash = identity.publicKeyHash;
+  player.deterministicSeed = identity.deterministicSeed;
+  player.position = { ...identity.position };
+  player.inventory = Array.isArray(player.inventory) && player.inventory.length > 0 ? player.inventory : identity.starterLoot.map((item) => ({ ...item }));
+  player.flags = { ...(player.flags ?? {}), sovereignIdentity: true, collectiveIngress: true };
+}

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -17,6 +17,7 @@ import { warfrontRouter } from "../api/warfrontRoute.js";
 import { areValidationRouter } from "../api/areValidationRoute.js";
 import { areReplayRouter } from "../api/areReplayRoute.js";
 import { sovereignDeployRouter } from "../api/sovereignDeployRoute.js";
+import { collectiveIngressRouter } from "../api/collectiveIngressRoute.js";
 import { getContentDataSourceLabel, resolveContentDir } from "../modules/content/contentDataRoot.js";
 import { getSupabaseSummary, verifySupabaseToken } from "../config/supabase.js";
 import { resolveWorldAssetsDir } from "./resolveWorldAssetsDir.js";
@@ -162,6 +163,7 @@ export class ServerBootstrap {
     app.use("/api/are/validation", areValidationRouter(tick));
     app.use("/api/are/replay", areReplayRouter(tick));
     app.use("/api/sovereign/deploy", sovereignDeployRouter(tick));
+    app.use("/api/collective/ingress", express.json({ limit: "256kb" }), collectiveIngressRouter(tick));
     const monitorStream = new PlaytesterMonitorStream(httpServer, (options) => tick.buildPlaytesterMonitorPayload(options));
     monitorStream.start();
     const playtesterSignaling = new PlaytesterWebRTCSignaling(httpServer);

--- a/server/src/networking/WebSocketServer.ts
+++ b/server/src/networking/WebSocketServer.ts
@@ -2,6 +2,7 @@ import type { Server as HttpServer } from "node:http";
 import { WebSocketServer, WebSocket } from "ws";
 import { randomUUID } from "node:crypto";
 import { GameConfig } from "../config/GameConfig.js";
+import { collectiveIngressRuntime } from "../collective/CollectiveIngressRuntime.js";
 
 const WS_RL_WINDOW_MS = 1000;
 
@@ -77,9 +78,16 @@ export class GameWebSocketServer {
           sock._rlAt.push(now);
 
           const msg = JSON.parse(raw.toString());
-          if (msg?.type === "login") {
+          const isSovereignLogin = (msg?.type === "sovereign_login" || msg?.type === "login") && (msg?.publicKey || msg?.wallet || msg?.hash || msg?.kappaPosHash);
+          if (isSovereignLogin) {
+            const result = collectiveIngressRuntime.register(id, msg);
+            this.socketToPlayerUid.set(id, result.peer.id);
+            socket.send(JSON.stringify({ type: "COLLECTIVE_WELCOME", identity: result.identity, peer: result.peer, welcome: result.welcome }));
+            this.broadcast({ type: "COLLECTIVE_PEER_JOINED", payload: result.peer });
+          } else if (msg?.type === "login") {
             this.socketToPlayerUid.delete(id);
           } else {
+            collectiveIngressRuntime.updateFromInput(id, msg);
             let uid = this.socketToPlayerUid.get(id);
             if (!uid && this.resolveSocketToPlayerUid) {
               uid = this.resolveSocketToPlayerUid(id) ?? undefined;
@@ -110,6 +118,7 @@ export class GameWebSocketServer {
 
       socket.on("close", () => {
         this.socketToPlayerUid.delete(id);
+        collectiveIngressRuntime.disconnect(id);
         if (this.onPlayerDisconnect) {
           this.onPlayerDisconnect(id);
         }


### PR DESCRIPTION
Clean V2 on current main.

Implements server-side Collective Ingress:
- Deterministic public-key identity via SHA-256.
- Role assignment: Scavenger, Trader, Guardian.
- Deterministic start chunk, position, seed and starter loot.
- WebSocket `sovereign_login` / public-key login support.
- Live peer runtime with deterministic movement updates.
- `/api/collective/ingress/status` for the portal live map.
- `/api/collective/ingress/preview` for identity preview.

Risk control:
- No heavy WorldTick rewrite.
- No global express JSON parser, so the Supabase auth proxy body stream remains intact.
- Runtime is isolated and merge-safe.