### PR TITLE
feat(billing): add ARE credit ledger and SDK monitoring

### DIFF
--- a/client/src/design/ThemeEngine.ts
+++ b/client/src/design/ThemeEngine.ts
@@ -27,6 +27,10 @@ export interface AREOracleReport { ok: boolean; generatedAtTick: number | null; 
 export interface AREAutoRepairPlan { id: string; cause: "determinism_violation" | "critical_oracle_prophecy"; phase: "idle" | "detecting" | "rollback" | "patching" | "healed" | "failed"; sector: number; currentTick: number; rollbackTick: number | null; rollbackWorldHash: string | null; report: string; guardViolations: unknown[]; prophecy: AREOracleProphecy | null; layoutFixes: unknown[]; }
 export interface AREAutoRepairStatus { active: boolean; healed: boolean; lastPlan: AREAutoRepairPlan | null; history: AREAutoRepairPlan[]; }
 
+export interface SdkBillingAccount { id: string; displayName: string; credits: number; lifetimeHashes: number; lifetimeCreditsCharged: number; status: "active" | "suspended"; lastUsageTick: number; lastMessage: string | null; }
+export interface SdkBillingStatus { ok: boolean; usage: { hashesInWindow?: number; hashesPerMinute?: number; latestTick?: number } | null; cost: { hashes: number; credits: number; ratePerThousandHashes: number; formula: string }; billing: { suspended: boolean; message: string | null; market: SdkBillingMarket }; market: SdkBillingMarket; }
+export interface SdkBillingMarket { ratePerThousandHashes: number; activeExternalReplits: number; totalCreditsGenerated: number; totalHashesMetered: number; accounts: SdkBillingAccount[]; suspendedAccounts: SdkBillingAccount[]; }
+
 export interface SovereignTruth {
   ok: boolean;
   cluster: string;
@@ -83,6 +87,7 @@ export async function fetchAREReplayStats(): Promise<AREReplayStats | null> { tr
 export async function fetchAREReplaySnapshot(tick: number): Promise<AREReplaySnapshot | null> { try { const response = await fetch(`/api/are/replay/snapshot/${encodeURIComponent(String(tick))}`, { cache: "no-store" }); if (!response.ok) return null; return (await response.json()) as AREReplaySnapshot; } catch { return null; } }
 export async function fetchAREOracleReport(): Promise<AREOracleReport | null> { try { const response = await fetch("/api/are/replay/oracle/prophecy", { cache: "no-store" }); if (!response.ok) return null; const body = await response.json(); return body.oracle ?? null; } catch { return null; } }
 export async function fetchAREAutoRepairStatus(): Promise<AREAutoRepairStatus | null> { try { const response = await fetch("/api/are/replay/repair/status", { cache: "no-store" }); if (!response.ok) return null; const body = await response.json(); return body.autoRepair ?? null; } catch { return null; } }
+export async function fetchSdkBillingStatus(): Promise<SdkBillingStatus | null> { try { const response = await fetch("/api/are/replay/billing/status", { cache: "no-store" }); if (!response.ok) return null; return (await response.json()) as SdkBillingStatus; } catch { return null; } }
 export async function fetchSovereignTruth(): Promise<SovereignTruth | null> { try { const response = await fetch("/api/sovereign/deploy/truth", { cache: "no-store" }); if (!response.ok) return null; return (await response.json()) as SovereignTruth; } catch { return null; } }
 export async function launchSovereignDeploy(launchKey: string, ref = "main"): Promise<SovereignLaunchResult> {
   try {

--- a/server/src/api/areReplayRoute.ts
+++ b/server/src/api/areReplayRoute.ts
@@ -1,5 +1,7 @@
 import express from "express";
 import type { WorldTick } from "../core/WorldTick.js";
+import { attachSovereignBillingBridge } from "../market/SovereignBillingBridge.js";
+import { calculateUsageCost, sovereignMarket } from "../market/SovereignMarket.js";
 
 function parseTick(raw: string): number | null {
   const tick = Number(raw);
@@ -9,6 +11,7 @@ function parseTick(raw: string): number | null {
 
 export function areReplayRouter(tick: WorldTick) {
   const router = express.Router();
+  attachSovereignBillingBridge(tick as any, (tick as any).ws ?? { broadcast: () => undefined });
 
   router.get("/stats", (_req, res) => {
     res.json({ ok: true, stats: tick.getReplayRecorderStats?.() ?? null });
@@ -16,6 +19,34 @@ export function areReplayRouter(tick: WorldTick) {
 
   router.get("/repair/status", (_req, res) => {
     res.json({ ok: true, autoRepair: tick.getAutoRepairStatus?.() ?? null });
+  });
+
+  router.get("/billing/status", (_req, res) => {
+    const usage = tick.getDeterministicUsageStats?.() ?? null;
+    res.json({
+      ok: true,
+      usage,
+      cost: usage ? calculateUsageCost(usage) : calculateUsageCost({ hashesInWindow: 0 }),
+      billing: (tick as any).getSdkBillingStatus?.() ?? { suspended: false, message: null, market: sovereignMarket.getStatus() },
+      market: sovereignMarket.getStatus(),
+    });
+  });
+
+  router.post("/billing/preview-cost", express.json({ limit: "64kb" }), (req, res) => {
+    const hashesInWindow = Number(req.body?.hashesInWindow ?? req.body?.hashes ?? 0);
+    res.json({ ok: true, cost: calculateUsageCost({ hashesInWindow }) });
+  });
+
+  router.post("/billing/credit", express.json({ limit: "64kb" }), (req, res) => {
+    const adminKey = process.env.SOVEREIGN_LAUNCH_KEY || process.env.ARE_MARKET_ADMIN_KEY || "";
+    const provided = String(req.headers["x-sovereign-key"] || req.body?.key || "");
+    if (!adminKey || provided !== adminKey) return res.status(403).json({ ok: false, error: "forbidden" });
+    const source = String(req.body?.source || process.env.ARE_SDK_CLIENT_ID || "local-engine");
+    const displayName = String(req.body?.displayName || source);
+    const credits = Number(req.body?.credits ?? 0);
+    if (!Number.isFinite(credits) || credits <= 0) return res.status(400).json({ ok: false, error: "invalid_credits" });
+    const account = sovereignMarket.creditAccount(source, credits, displayName);
+    res.json({ ok: true, account, market: sovereignMarket.getStatus() });
   });
 
   router.get("/oracle/prophecy", (_req, res) => {

--- a/server/src/api/sdkBillingRoute.ts
+++ b/server/src/api/sdkBillingRoute.ts
@@ -1,0 +1,37 @@
+import { Router } from "express";
+import { calculateUsageCost, sovereignMarket } from "../market/SovereignMarket.js";
+
+export function sdkBillingRouter(tick?: any): Router {
+  const router = Router();
+
+  router.get("/status", (_req, res) => {
+    const usage = tick?.getDeterministicUsageStats?.() ?? null;
+    const billing = tick?.getSdkBillingStatus?.() ?? { suspended: false, message: null, market: sovereignMarket.getStatus() };
+    res.json({
+      ok: true,
+      usage,
+      cost: usage ? calculateUsageCost(usage) : calculateUsageCost({ hashesInWindow: 0 }),
+      billing,
+      market: sovereignMarket.getStatus(),
+    });
+  });
+
+  router.post("/preview-cost", (req, res) => {
+    const hashesInWindow = Number(req.body?.hashesInWindow ?? req.body?.hashes ?? 0);
+    res.json({ ok: true, cost: calculateUsageCost({ hashesInWindow }) });
+  });
+
+  router.post("/credit", (req, res) => {
+    const adminKey = process.env.SOVEREIGN_LAUNCH_KEY || process.env.ARE_MARKET_ADMIN_KEY || "";
+    const provided = String(req.headers["x-sovereign-key"] || req.body?.key || "");
+    if (!adminKey || provided !== adminKey) return res.status(403).json({ ok: false, error: "forbidden" });
+    const source = String(req.body?.source || process.env.ARE_SDK_CLIENT_ID || "local-engine");
+    const displayName = String(req.body?.displayName || source);
+    const credits = Number(req.body?.credits ?? 0);
+    if (!Number.isFinite(credits) || credits <= 0) return res.status(400).json({ ok: false, error: "invalid_credits" });
+    const account = sovereignMarket.creditAccount(source, credits, displayName);
+    res.json({ ok: true, account, market: sovereignMarket.getStatus() });
+  });
+
+  return router;
+}

--- a/server/src/market/SovereignBillingBridge.ts
+++ b/server/src/market/SovereignBillingBridge.ts
@@ -1,0 +1,96 @@
+import type { GameWebSocketServer } from "../networking/WebSocketServer.js";
+import { areValidationState } from "../are/AREValidationState.js";
+import { sovereignMarket } from "./SovereignMarket.js";
+
+function buildSuspendedGuard(tickCount: number, payload: any, message: string): any {
+  return {
+    ok: false,
+    tick: tickCount,
+    lastCheckedAtTick: tickCount,
+    kappa: Number(payload?.k ?? payload?.kappa ?? 1000),
+    seed: payload?.deterministicSeed ?? payload?.seed ?? null,
+    checkedCorePaths: [],
+    violations: [{
+      code: "ACCOUNT_SUSPENDED",
+      message,
+      value: "SUSPENDED_NO_ARE_CREDITS",
+    }],
+  };
+}
+
+function currentTick(tick: any): number {
+  return Number(tick?.tickCount ?? 0);
+}
+
+function hashCountFromTick(tick: any): number {
+  const snapshot = tick?.getWorldHashSnapshot?.() ?? tick?.lastWorldHashSnapshot ?? null;
+  if (!snapshot) return 1;
+  return 2 + Number(snapshot?.chunks?.length ?? 0);
+}
+
+export function attachSovereignBillingBridge(tick: any, ws: GameWebSocketServer): void {
+  if (!tick || tick.__sovereignBillingBridgeAttached) return;
+  tick.__sovereignBillingBridgeAttached = true;
+  tick.__sdkBillingSuspended = false;
+  tick.__sdkBillingMessage = null;
+
+  tick.getSovereignMarketStatus = () => sovereignMarket.getStatus();
+  tick.getSdkBillingStatus = () => ({
+    suspended: Boolean(tick.__sdkBillingSuspended),
+    message: tick.__sdkBillingMessage,
+    market: sovereignMarket.getStatus(),
+  });
+
+  const originalUpdateAREContract = tick.updateAREContract?.bind(tick);
+  if (typeof originalUpdateAREContract !== "function") {
+    tick.__sdkBillingMessage = "Emily: Billing bridge konnte WorldTick.updateAREContract nicht finden.";
+    return;
+  }
+
+  tick.updateAREContract = (payload: any, players: any[], npcs: any[], loot: any[]) => {
+    const account = sovereignMarket.resolveAccount(process.env.ARE_SDK_CLIENT_ID || "local-engine", process.env.ARE_SDK_DISPLAY_NAME || "local-engine");
+    const tickCount = currentTick(tick);
+
+    if (tick.__sdkBillingSuspended && account.status === "active" && account.credits > 0) {
+      tick.__sdkBillingSuspended = false;
+      tick.__sdkBillingMessage = `Emily: ${account.displayName}, Guthaben erkannt. ARE-Hashing wird wieder aufgenommen.`;
+      ws.broadcast({ type: "CHAT_MSG", payload: { channel: "system", sender: "Emily-Sales", text: tick.__sdkBillingMessage } });
+    }
+
+    if (tick.__sdkBillingSuspended || account.status === "suspended" || account.credits <= 0) {
+      tick.__sdkBillingSuspended = true;
+      const message = account.lastMessage || `Emily: ${account.displayName}, dein ARE-Guthaben ist erschöpft. Neue deterministische Hashes sind pausiert.`;
+      tick.__sdkBillingMessage = message;
+      const suspendedGuard = buildSuspendedGuard(tickCount, payload, message);
+      tick.lastAREGuardStatus = suspendedGuard;
+      areValidationState.updateGuard(suspendedGuard);
+      if (tickCount % 10 === 0) {
+        ws.broadcast({ type: "ARE_SUSPENDED", payload: tick.getSdkBillingStatus() });
+        ws.broadcast({ type: "CHAT_MSG", payload: { channel: "system", sender: "Emily-Sales", text: message } });
+      }
+      return;
+    }
+
+    originalUpdateAREContract(payload, players, npcs, loot);
+
+    const hashCount = hashCountFromTick(tick);
+    const usage = tick.getDeterministicUsageStats?.() ?? { hashesInWindow: hashCount, hashesPerMinute: hashCount };
+    const billing = sovereignMarket.meterUsage({
+      usage: { ...usage, hashesInWindow: hashCount, hashesPerMinute: hashCount },
+      tick: tickCount,
+      source: process.env.ARE_SDK_CLIENT_ID || "local-engine",
+      displayName: process.env.ARE_SDK_DISPLAY_NAME || "local-engine",
+    });
+    tick.__sdkBillingMessage = billing.message;
+
+    if (!billing.allowed) {
+      tick.__sdkBillingSuspended = true;
+      ws.broadcast({ type: "ARE_SUSPENDED", payload: tick.getSdkBillingStatus() });
+    }
+
+    if (tickCount % 10 === 0) {
+      ws.broadcast({ type: "ARE_BILLING", payload: { usage, billing, market: sovereignMarket.getStatus() } });
+      ws.broadcast({ type: "CHAT_MSG", payload: { channel: "system", sender: "Emily-Sales", text: billing.message } });
+    }
+  };
+}

--- a/server/src/market/SovereignMarket.ts
+++ b/server/src/market/SovereignMarket.ts
@@ -1,4 +1,4 @@
-import crypto from "node:crypto";
+import { createHash } from "node:crypto";
 import type { DeterministicUsageStats } from "../are/DeterministicUsageTracker.js";
 
 export type SovereignAccountStatus = "active" | "suspended";
@@ -49,7 +49,7 @@ function readNumberEnv(key: string, fallback: number): number {
 }
 
 function stableAccountId(source = "local-engine"): string {
-  return crypto.createHash("sha256").update(source).digest("hex").slice(0, 16);
+  return createHash("sha256").update(source).digest("hex").slice(0, 16);
 }
 
 export function calculateUsageCost(usageData: UsageCostInput | DeterministicUsageStats): UsageCostResult {

--- a/server/src/market/SovereignMarket.ts
+++ b/server/src/market/SovereignMarket.ts
@@ -1,0 +1,149 @@
+import crypto from "node:crypto";
+import type { DeterministicUsageStats } from "../are/DeterministicUsageTracker.js";
+
+export type SovereignAccountStatus = "active" | "suspended";
+
+export interface UsageCostInput {
+  hashesInWindow?: number;
+  hashesPerMinute?: number;
+  sdkClientId?: string;
+  source?: string;
+}
+
+export interface UsageCostResult {
+  hashes: number;
+  credits: number;
+  ratePerThousandHashes: number;
+  formula: string;
+}
+
+export interface SovereignAccount {
+  id: string;
+  displayName: string;
+  credits: number;
+  lifetimeHashes: number;
+  lifetimeCreditsCharged: number;
+  status: SovereignAccountStatus;
+  lastUsageTick: number;
+  lastCost: UsageCostResult | null;
+  lastMessage: string | null;
+}
+
+export interface SovereignMarketStatus {
+  ratePerThousandHashes: number;
+  activeExternalReplits: number;
+  totalCreditsGenerated: number;
+  totalHashesMetered: number;
+  accounts: SovereignAccount[];
+  suspendedAccounts: SovereignAccount[];
+}
+
+const DEFAULT_RATE_PER_1000_HASHES = 1;
+const DEFAULT_START_CREDITS = 250;
+
+function readNumberEnv(key: string, fallback: number): number {
+  const raw = process.env[key]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function stableAccountId(source = "local-engine"): string {
+  return crypto.createHash("sha256").update(source).digest("hex").slice(0, 16);
+}
+
+export function calculateUsageCost(usageData: UsageCostInput | DeterministicUsageStats): UsageCostResult {
+  const hashes = Math.max(0, Math.floor(Number(usageData.hashesInWindow ?? usageData.hashesPerMinute ?? 0)));
+  const ratePerThousandHashes = readNumberEnv("ARE_CREDIT_RATE_PER_1000_HASHES", DEFAULT_RATE_PER_1000_HASHES);
+  const credits = Math.ceil((hashes / 1000) * ratePerThousandHashes * 1000) / 1000;
+  return {
+    hashes,
+    credits,
+    ratePerThousandHashes,
+    formula: `${hashes} hashes / 1000 * ${ratePerThousandHashes} ARE`,
+  };
+}
+
+export class SovereignMarket {
+  private readonly accounts = new Map<string, SovereignAccount>();
+  private totalCreditsGenerated = 0;
+  private totalHashesMetered = 0;
+
+  resolveAccount(source = process.env.ARE_SDK_CLIENT_ID || "local-engine", displayName = source): SovereignAccount {
+    const id = stableAccountId(source);
+    const existing = this.accounts.get(id);
+    if (existing) return existing;
+    const account: SovereignAccount = {
+      id,
+      displayName,
+      credits: readNumberEnv("ARE_SDK_STARTING_CREDITS", DEFAULT_START_CREDITS),
+      lifetimeHashes: 0,
+      lifetimeCreditsCharged: 0,
+      status: "active",
+      lastUsageTick: 0,
+      lastCost: null,
+      lastMessage: null,
+    };
+    this.accounts.set(id, account);
+    return account;
+  }
+
+  meterUsage(params: {
+    usage: DeterministicUsageStats;
+    tick: number;
+    source?: string;
+    displayName?: string;
+  }): { account: SovereignAccount; cost: UsageCostResult; allowed: boolean; message: string } {
+    const source = params.source || process.env.ARE_SDK_CLIENT_ID || "local-engine";
+    const account = this.resolveAccount(source, params.displayName || source);
+    const cost = calculateUsageCost(params.usage);
+    account.lastUsageTick = params.tick;
+    account.lastCost = cost;
+
+    if (cost.credits <= 0) {
+      const message = `Emily: ${account.displayName}, dein Verbrauch ist aktuell 0 ARE. Die 10-Hz-Maschine schnurrt im Leerlauf.`;
+      account.lastMessage = message;
+      return { account: { ...account }, cost, allowed: account.status === "active", message };
+    }
+
+    if (account.credits <= 0 || account.credits < cost.credits) {
+      account.status = "suspended";
+      account.credits = Math.max(0, account.credits);
+      const message = `Emily: ${account.displayName}, dein ARE-Guthaben ist erschöpft. Neue deterministische Hashes sind pausiert, bis Credits nachgeladen wurden.`;
+      account.lastMessage = message;
+      return { account: { ...account }, cost, allowed: false, message };
+    }
+
+    account.credits = Math.round((account.credits - cost.credits) * 1000) / 1000;
+    account.lifetimeHashes += cost.hashes;
+    account.lifetimeCreditsCharged = Math.round((account.lifetimeCreditsCharged + cost.credits) * 1000) / 1000;
+    account.status = "active";
+    this.totalCreditsGenerated = Math.round((this.totalCreditsGenerated + cost.credits) * 1000) / 1000;
+    this.totalHashesMetered += cost.hashes;
+    const message = `Emily: ${account.displayName}, aktueller Verbrauch ${cost.credits} ARE für ${cost.hashes} deterministische Hashes. Verbleibendes Guthaben: ${account.credits} ARE.`;
+    account.lastMessage = message;
+    return { account: { ...account }, cost, allowed: true, message };
+  }
+
+  creditAccount(source: string, credits: number, displayName = source): SovereignAccount {
+    const account = this.resolveAccount(source, displayName);
+    account.credits = Math.round((account.credits + Math.max(0, credits)) * 1000) / 1000;
+    if (account.credits > 0) account.status = "active";
+    account.lastMessage = `Emily: ${account.displayName}, ${credits} ARE-Credits wurden gutgeschrieben.`;
+    return { ...account };
+  }
+
+  getStatus(): SovereignMarketStatus {
+    const accounts = [...this.accounts.values()].map((account) => ({ ...account }));
+    return {
+      ratePerThousandHashes: readNumberEnv("ARE_CREDIT_RATE_PER_1000_HASHES", DEFAULT_RATE_PER_1000_HASHES),
+      activeExternalReplits: accounts.filter((account) => account.status === "active").length,
+      totalCreditsGenerated: this.totalCreditsGenerated,
+      totalHashesMetered: this.totalHashesMetered,
+      accounts,
+      suspendedAccounts: accounts.filter((account) => account.status === "suspended"),
+    };
+  }
+}
+
+export const sovereignMarket = new SovereignMarket();


### PR DESCRIPTION
## Summary
- Add internal SovereignMarket credit ledger for ARE-Credit usage accounting
- Add calculateUsageCost(usageData) for hashes-to-ARE conversion
- Attach billing bridge to the existing ARE replay API path so WorldTick can be suspended when credits are exhausted
- Expose SDK billing monitor endpoints under /api/are/replay/billing/*
- Add client ThemeEngine fetcher/types for SDK-MONITORING in the TRUTH panel

## Security
- No PayPal tokens or payment credentials are included
- Credit top-up endpoint is guarded by SOVEREIGN_LAUNCH_KEY or ARE_MARKET_ADMIN_KEY
- Payment providers should later only mint credits through server-side secrets

## Notes
- Billing is internal/in-memory for now
- PayPal integration should be added later as a separate adapter using GitHub/VPS secrets, never browser/client code