### PR TITLE
feat(finance): add PayPal finance gateway for ARE credits

### DIFF
--- a/client/src/design/ThemeEngine.ts
+++ b/client/src/design/ThemeEngine.ts
@@ -30,6 +30,7 @@ export interface AREAutoRepairStatus { active: boolean; healed: boolean; lastPla
 export interface SdkBillingAccount { id: string; displayName: string; credits: number; lifetimeHashes: number; lifetimeCreditsCharged: number; status: "active" | "suspended"; lastUsageTick: number; lastMessage: string | null; }
 export interface SdkBillingStatus { ok: boolean; usage: { hashesInWindow?: number; hashesPerMinute?: number; latestTick?: number } | null; cost: { hashes: number; credits: number; ratePerThousandHashes: number; formula: string }; billing: { suspended: boolean; message: string | null; market: SdkBillingMarket }; market: SdkBillingMarket; }
 export interface SdkBillingMarket { ratePerThousandHashes: number; activeExternalReplits: number; totalCreditsGenerated: number; totalHashesMetered: number; accounts: SdkBillingAccount[]; suspendedAccounts: SdkBillingAccount[]; }
+export interface PayPalCheckoutResult { ok: boolean; orderId?: string; approvalUrl?: string; credits?: number; error?: string; message?: string; }
 
 export interface SovereignTruth {
   ok: boolean;
@@ -88,6 +89,19 @@ export async function fetchAREReplaySnapshot(tick: number): Promise<AREReplaySna
 export async function fetchAREOracleReport(): Promise<AREOracleReport | null> { try { const response = await fetch("/api/are/replay/oracle/prophecy", { cache: "no-store" }); if (!response.ok) return null; const body = await response.json(); return body.oracle ?? null; } catch { return null; } }
 export async function fetchAREAutoRepairStatus(): Promise<AREAutoRepairStatus | null> { try { const response = await fetch("/api/are/replay/repair/status", { cache: "no-store" }); if (!response.ok) return null; const body = await response.json(); return body.autoRepair ?? null; } catch { return null; } }
 export async function fetchSdkBillingStatus(): Promise<SdkBillingStatus | null> { try { const response = await fetch("/api/are/replay/billing/status", { cache: "no-store" }); if (!response.ok) return null; return (await response.json()) as SdkBillingStatus; } catch { return null; } }
+export async function createPayPalCheckout(credits = 25, clientId = "local-engine", displayName = clientId): Promise<PayPalCheckoutResult> {
+  try {
+    const response = await fetch("/api/are/replay/billing/paypal/checkout", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ credits, clientId, displayName }) });
+    return (await response.json()) as PayPalCheckoutResult;
+  } catch (error) {
+    return { ok: false, error: "network_error", message: error instanceof Error ? error.message : String(error) };
+  }
+}
+export async function openPayPalCheckout(credits = 25, clientId = "local-engine", displayName = clientId): Promise<PayPalCheckoutResult> {
+  const result = await createPayPalCheckout(credits, clientId, displayName);
+  if (result.ok && result.approvalUrl) window.open(result.approvalUrl, "_blank", "noopener,noreferrer");
+  return result;
+}
 export async function fetchSovereignTruth(): Promise<SovereignTruth | null> { try { const response = await fetch("/api/sovereign/deploy/truth", { cache: "no-store" }); if (!response.ok) return null; return (await response.json()) as SovereignTruth; } catch { return null; } }
 export async function launchSovereignDeploy(launchKey: string, ref = "main"): Promise<SovereignLaunchResult> {
   try {

--- a/server/src/api/areReplayRoute.ts
+++ b/server/src/api/areReplayRoute.ts
@@ -2,6 +2,7 @@ import express from "express";
 import type { WorldTick } from "../core/WorldTick.js";
 import { attachSovereignBillingBridge } from "../market/SovereignBillingBridge.js";
 import { calculateUsageCost, sovereignMarket } from "../market/SovereignMarket.js";
+import { paypalAdapter } from "../finance/PayPalAdapter.js";
 
 function parseTick(raw: string): number | null {
   const tick = Number(raw);
@@ -47,6 +48,34 @@ export function areReplayRouter(tick: WorldTick) {
     if (!Number.isFinite(credits) || credits <= 0) return res.status(400).json({ ok: false, error: "invalid_credits" });
     const account = sovereignMarket.creditAccount(source, credits, displayName);
     res.json({ ok: true, account, market: sovereignMarket.getStatus() });
+  });
+
+  router.post("/billing/paypal/checkout", express.json({ limit: "64kb" }), async (req, res) => {
+    try {
+      const clientId = String(req.body?.clientId || process.env.ARE_SDK_CLIENT_ID || "local-engine");
+      const displayName = String(req.body?.displayName || process.env.ARE_SDK_DISPLAY_NAME || clientId);
+      const credits = Number(req.body?.credits ?? 25);
+      const checkout = await paypalAdapter.createCheckoutLink({ clientId, displayName, credits, returnUrl: req.body?.returnUrl, cancelUrl: req.body?.cancelUrl });
+      res.json(checkout);
+    } catch (error) {
+      res.status(500).json({ ok: false, error: "paypal_checkout_failed", message: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  router.post("/billing/paypal/webhook", express.json({ limit: "256kb" }), async (req, res) => {
+    try {
+      const result = await paypalAdapter.handleWebhook(req);
+      if (result.credited && result.message) {
+        const ws = (tick as any).ws;
+        if (ws && typeof ws.broadcast === "function") {
+          ws.broadcast({ type: "CHAT_MSG", payload: { channel: "system", sender: "Emily-Finance", text: result.message } });
+          ws.broadcast({ type: "ARE_BILLING", payload: { market: sovereignMarket.getStatus(), paypal: { credited: true, transactionId: result.transactionId, credits: result.credits } } });
+        }
+      }
+      res.json(result);
+    } catch (error) {
+      res.status(500).json({ ok: false, error: "paypal_webhook_failed", message: error instanceof Error ? error.message : String(error) });
+    }
   });
 
   router.get("/oracle/prophecy", (_req, res) => {

--- a/server/src/finance/PayPalAdapter.ts
+++ b/server/src/finance/PayPalAdapter.ts
@@ -1,0 +1,135 @@
+import type { Request } from "express";
+import { SovereignBillingBridge } from "../market/SovereignBillingBridge.js";
+
+export interface PayPalCheckoutRequest {
+  clientId: string;
+  displayName?: string;
+  credits: number;
+  returnUrl?: string;
+  cancelUrl?: string;
+}
+
+export interface PayPalVerificationResult {
+  ok: boolean;
+  transactionId: string | null;
+  clientId: string | null;
+  displayName: string | null;
+  credits: number;
+  status: string;
+  message: string;
+}
+
+const PAYPAL_API_BASE = process.env.PAYPAL_API_BASE || (process.env.PAYPAL_ENV === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com");
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for PayPal finance gateway.`);
+  return value;
+}
+
+function normalizeCredits(raw: unknown): number {
+  const credits = Number(raw);
+  if (!Number.isFinite(credits) || credits <= 0) return 0;
+  return Math.floor(credits * 1000) / 1000;
+}
+
+async function getPayPalAccessToken(): Promise<string> {
+  const clientId = requireEnv("PAYPAL_CLIENT_ID");
+  const secret = requireEnv("PAYPAL_SECRET");
+  const auth = Buffer.from(`${clientId}:${secret}`).toString("base64");
+  const response = await fetch(`${PAYPAL_API_BASE}/v1/oauth2/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${auth}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: "grant_type=client_credentials",
+  });
+  if (!response.ok) throw new Error(`PayPal token request failed: ${response.status}`);
+  const body = await response.json() as { access_token?: string };
+  if (!body.access_token) throw new Error("PayPal token response did not include access_token.");
+  return body.access_token;
+}
+
+export class PayPalAdapter {
+  async createCheckoutLink(input: PayPalCheckoutRequest): Promise<{ ok: true; orderId: string; approvalUrl: string; credits: number }> {
+    const credits = normalizeCredits(input.credits);
+    if (!input.clientId || credits <= 0) throw new Error("clientId and positive credits are required.");
+    const token = await getPayPalAccessToken();
+    const euroPerCredit = Number(process.env.ARE_CREDIT_EUR_PRICE || "1");
+    const amount = Math.max(1, Math.round(credits * euroPerCredit * 100) / 100).toFixed(2);
+    const response = await fetch(`${PAYPAL_API_BASE}/v2/checkout/orders`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "PayPal-Request-Id": `are-${input.clientId}-${credits}-${Date.now()}`,
+      },
+      body: JSON.stringify({
+        intent: "CAPTURE",
+        purchase_units: [{
+          reference_id: input.clientId,
+          custom_id: JSON.stringify({ clientId: input.clientId, displayName: input.displayName || input.clientId, credits }),
+          amount: { currency_code: process.env.PAYPAL_CURRENCY || "EUR", value: amount },
+          description: `${credits} ARE-Credits`,
+        }],
+        application_context: {
+          brand_name: "Areloria Ouroboros Collective",
+          user_action: "PAY_NOW",
+          return_url: input.returnUrl || process.env.PAYPAL_RETURN_URL || "https://arelorian.de/portal/?billing=success",
+          cancel_url: input.cancelUrl || process.env.PAYPAL_CANCEL_URL || "https://arelorian.de/portal/?billing=cancelled",
+        },
+      }),
+    });
+    if (!response.ok) throw new Error(`PayPal order creation failed: ${response.status}`);
+    const body = await response.json() as { id?: string; links?: Array<{ href: string; rel: string }> };
+    const approvalUrl = body.links?.find((link) => link.rel === "approve")?.href;
+    if (!body.id || !approvalUrl) throw new Error("PayPal order response missing approval link.");
+    return { ok: true, orderId: body.id, approvalUrl, credits };
+  }
+
+  async verifyTransaction(transactionId: string): Promise<PayPalVerificationResult> {
+    if (!transactionId) return { ok: false, transactionId: null, clientId: null, displayName: null, credits: 0, status: "missing", message: "Missing PayPal transaction id." };
+    const token = await getPayPalAccessToken();
+    const response = await fetch(`${PAYPAL_API_BASE}/v2/checkout/orders/${encodeURIComponent(transactionId)}`, {
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    });
+    if (!response.ok) return { ok: false, transactionId, clientId: null, displayName: null, credits: 0, status: `paypal_${response.status}`, message: "Could not verify PayPal transaction." };
+    const body = await response.json() as any;
+    const unit = body.purchase_units?.[0] ?? {};
+    let custom: any = {};
+    try { custom = unit.custom_id ? JSON.parse(unit.custom_id) : {}; } catch { custom = {}; }
+    const status = String(body.status || "UNKNOWN");
+    const captureStatus = String(unit.payments?.captures?.[0]?.status || status);
+    const ok = status === "COMPLETED" || captureStatus === "COMPLETED";
+    return {
+      ok,
+      transactionId,
+      clientId: String(custom.clientId || unit.reference_id || ""),
+      displayName: String(custom.displayName || custom.clientId || unit.reference_id || ""),
+      credits: normalizeCredits(custom.credits),
+      status: captureStatus,
+      message: ok ? "PayPal transaction verified." : `PayPal transaction not completed: ${captureStatus}`,
+    };
+  }
+
+  async handleWebhook(req: Request): Promise<PayPalVerificationResult & { credited?: boolean; account?: unknown }> {
+    const event = req.body ?? {};
+    const eventType = String(event.event_type || "");
+    const transactionId = String(event.resource?.supplementary_data?.related_ids?.order_id || event.resource?.id || event.resource?.invoice_id || "");
+    if (!eventType.includes("CHECKOUT") && !eventType.includes("PAYMENT")) {
+      return { ok: false, transactionId: transactionId || null, clientId: null, displayName: null, credits: 0, status: eventType || "ignored", message: "Webhook event ignored." };
+    }
+    const verified = await this.verifyTransaction(transactionId);
+    if (!verified.ok || !verified.clientId || verified.credits <= 0) return verified;
+    const account = SovereignBillingBridge.addCredits(verified.clientId, verified.credits, verified.displayName || verified.clientId);
+    return {
+      ...verified,
+      credited: true,
+      account,
+      message: "Architekt, externe Ressourcen wurden erfolgreich in Kausalitäts-Credits umgewandelt. Systemstatus: Operational.",
+    };
+  }
+}
+
+export const paypalAdapter = new PayPalAdapter();

--- a/server/src/market/SovereignBillingBridge.ts
+++ b/server/src/market/SovereignBillingBridge.ts
@@ -2,6 +2,14 @@ import type { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import { areValidationState } from "../are/AREValidationState.js";
 import { sovereignMarket } from "./SovereignMarket.js";
 
+export function addCredits(clientId: string, amount: number, displayName = clientId): any {
+  return sovereignMarket.creditAccount(clientId, amount, displayName);
+}
+
+export const SovereignBillingBridge = {
+  addCredits,
+};
+
 function buildSuspendedGuard(tickCount: number, payload: any, message: string): any {
   return {
     ok: false,


### PR DESCRIPTION
## Summary
- Add isolated PayPalAdapter service for checkout creation and webhook handling
- Verify PayPal transaction/order state via PayPal API using PAYPAL_CLIENT_ID and PAYPAL_SECRET from env
- Convert verified external payments into internal ARE credits through SovereignBillingBridge.addCredits
- Broadcast Emily-Finance success notifications when credits are credited
- Add client helpers for Buy Credits checkout popup/link flow

## Security
- No PayPal tokens or credentials are committed
- Secrets are read only from environment variables
- Browser receives only checkout approval URLs and transaction results, never PAYPAL_SECRET

## Required env
- PAYPAL_CLIENT_ID
- PAYPAL_SECRET
- PAYPAL_ENV=sandbox|live
- PAYPAL_WEBHOOK_ID optional for later signature-hardening
- PAYPAL_RETURN_URL
- PAYPAL_CANCEL_URL
- PAYPAL_CURRENCY=EUR
- ARE_CREDIT_EUR_PRICE=1