### PR TITLE
feat(sdk): add Ouroboros SDK demo experience

### DIFF
--- a/packages/core-logic/README.md
+++ b/packages/core-logic/README.md
@@ -1,0 +1,98 @@
+# Build Immortal Worlds with Ouroboros ARE.
+
+Ouroboros ARE turns game logic into a living, replayable, cheat-resistant causality engine. It is built for developers who want their worlds to feel inevitable: every card move, combat hit, economy pulse and healing event can be reproduced, inspected and replayed.
+
+This is not just a math library. It is a God-Mode developer experience for Replit, browser games and multiplayer simulations.
+
+## Core Features
+
+### Cheat-Proof Physics
+Every state transition is derived from an ARE seed, a fixed kappa invariant and the WorldHash. No hidden dice. No mystery server ghosts. If two peers run the same input stream, they arrive at the same result.
+
+### Time-Travel Debugging
+The Recorder pattern lets you inspect the last frames of causality like a timeline. Scrub backward, inspect a WorldHash, compare entities, and find exactly where the world bent.
+
+### Infinite Scalability
+ARE is designed around observation. Simulate what matters, hash what changes, and keep the core logic portable enough to run in servers, demos, SDK examples and tiny Replit previews.
+
+### Cyber-Zen Visual Feedback
+Use `OuroborosPulseView` to show the 10-Hz heartbeat. When the WorldHash advances, the Marina Blue aura pulses. Users instantly see the engine breathe.
+
+## Quick Start: First TCG Move in 3 Lines
+
+```ts
+import { quickStartTCGMove } from "../sdk-examples/TCGExample";
+const frame = await quickStartTCGMove("ARE|my-first-world");
+console.log(frame.worldHash, frame.score);
+```
+
+## Starter Templates
+
+### TCG Logic
+`packages/sdk-examples/TCGExample.ts` contains a deterministic 3x3 card board. Cards trigger effects from the WorldHash, never from random values.
+
+```ts
+import { createTCGDeck, applyTCGMove } from "../sdk-examples/TCGExample";
+
+const seed = "ARE|tcg|alpha";
+const deck = await createTCGDeck(seed);
+const frame = await applyTCGMove(seed, 1, deck, { cardId: "alpha-card-0", x: 1, y: 1 });
+console.log(frame.events);
+```
+
+### Autobattler Core
+`packages/sdk-examples/BattleSim.ts` runs two deterministic unit teams against each other. The `getReplayData()` function exposes frame-by-frame replay data.
+
+```ts
+import { BattleSim } from "../sdk-examples/BattleSim";
+
+const sim = new BattleSim("ARE|battle|demo");
+await sim.run(60);
+console.table(sim.getReplayData().map((frame) => ({ tick: frame.tick, hash: frame.worldHash.slice(0, 8), winner: frame.winner })));
+```
+
+## React Pulse View
+
+```tsx
+import { OuroborosPulseView } from "@wasd/core-logic/react/OuroborosPulseView";
+
+<OuroborosPulseView
+  frames={battleFrames.map((frame) => ({ tick: frame.tick, worldHash: frame.worldHash }))}
+/>
+```
+
+## Emily Oracle Guard
+
+The AREInvariantGuard is intentionally strict in the examples. If someone tries to sneak `Math.random()` or `Date.now()` into the ARE core logic or SDK examples, Emily speaks up:
+
+```text
+Emily Oracle Warning: forbidden nondeterminism detected inside the ARE demo.
+```
+
+That warning is not decoration. It is a design promise: the world must be explainable.
+
+## Replit Experience
+
+Press Run and the boot script starts:
+
+- the game server on port `3001`
+- the Cyber-Zen SDK visual demo on port `5173`
+- Emily's welcome message in the console
+
+```text
+Emily: Willkommen, Replit-Architekt. Engine Online. Kausalität stabil.
+```
+
+The preview shows:
+
+```text
+Engine Online. Kausalität stabil.
+```
+
+Then the Autobattler begins breathing through the 10-Hz pulse view.
+
+## Philosophy
+
+Immortal worlds are not worlds that never fail. They are worlds that remember, explain, rewind and heal.
+
+Ouroboros ARE is the causal spine for that kind of game.

--- a/packages/core-logic/package.json
+++ b/packages/core-logic/package.json
@@ -17,6 +17,11 @@
       "types": "./dist/are/AREInvariantGuard.d.ts",
       "import": "./dist/are/AREInvariantGuard.mjs",
       "require": "./dist/are/AREInvariantGuard.js"
+    },
+    "./react/OuroborosPulseView": {
+      "types": "./dist/react/OuroborosPulseView.d.ts",
+      "import": "./dist/react/OuroborosPulseView.mjs",
+      "require": "./dist/react/OuroborosPulseView.js"
     }
   },
   "files": [
@@ -24,8 +29,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/are/AREInvariantGuard.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts src/are/AREInvariantGuard.ts --format cjs,esm --watch --dts",
+    "build": "tsup src/index.ts src/are/AREInvariantGuard.ts src/react/OuroborosPulseView.tsx --format cjs,esm --dts --clean --external react",
+    "dev": "tsup src/index.ts src/are/AREInvariantGuard.ts src/react/OuroborosPulseView.tsx --format cjs,esm --watch --dts --external react",
     "test": "vitest run --passWithNoTests",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit"

--- a/packages/core-logic/src/index.ts
+++ b/packages/core-logic/src/index.ts
@@ -1,2 +1,3 @@
 export * from './agent/Orchestrator';
 export * from './are/AREInvariantGuard';
+export * from './react/OuroborosPulseView';

--- a/packages/core-logic/src/react/OuroborosPulseView.tsx
+++ b/packages/core-logic/src/react/OuroborosPulseView.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo, useState } from "react";
+
+export interface OuroborosPulseFrame {
+  tick: number;
+  worldHash: string;
+  label?: string;
+}
+
+export interface OuroborosPulseViewProps {
+  frames: OuroborosPulseFrame[];
+  tickHz?: number;
+  title?: string;
+  subtitle?: string;
+  onFrameSelect?: (frame: OuroborosPulseFrame) => void;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function useTenHzPulse(tickHz: number, selectedTick: number): number {
+  const [now, setNow] = useState(0);
+  React.useEffect(() => {
+    let frame = 0;
+    const start = performance.now();
+    const loop = (time: number) => {
+      setNow((time - start) / 1000);
+      frame = requestAnimationFrame(loop);
+    };
+    frame = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(frame);
+  }, []);
+  return clamp01((Math.sin(now * tickHz * Math.PI * 2 + selectedTick * 0.13) + 1) / 2);
+}
+
+export function OuroborosPulseView({
+  frames,
+  tickHz = 10,
+  title = "Engine Online. Kausalität stabil.",
+  subtitle = "10-Hz WorldHash heartbeat · Cyber-Zen Replay Bridge",
+  onFrameSelect,
+}: OuroborosPulseViewProps): React.ReactElement {
+  const safeFrames = frames.length > 0 ? frames : [{ tick: 0, worldHash: "warming", label: "waiting" }];
+  const [index, setIndex] = useState(safeFrames.length - 1);
+  const active = safeFrames[Math.max(0, Math.min(index, safeFrames.length - 1))];
+  const pulse = useTenHzPulse(tickHz, active.tick);
+  const shortHash = useMemo(() => active.worldHash.slice(0, 16), [active.worldHash]);
+
+  const style = {
+    "--wasd-aura": "0, 229, 255",
+    "--wasd-neon": "57, 255, 20",
+    "--wasd-violet": "120, 90, 255",
+    background: "linear-gradient(135deg, rgba(10,10,10,.95), rgba(4,15,22,.98))",
+    border: "1px solid rgba(var(--wasd-aura), .38)",
+    boxShadow: `0 0 ${24 + pulse * 34}px rgba(var(--wasd-aura), ${0.18 + pulse * 0.36})`,
+  } as React.CSSProperties;
+
+  const orbStyle = {
+    transform: `scale(${1 + pulse * 0.06})`,
+    boxShadow: `0 0 ${28 + pulse * 46}px rgba(var(--wasd-aura), ${0.32 + pulse * 0.42}), inset 0 0 32px rgba(var(--wasd-neon), ${0.08 + pulse * 0.18})`,
+  } as React.CSSProperties;
+
+  return (
+    <section style={style} className="ouroboros-pulse-view rounded-3xl p-6 text-white">
+      <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.3em] text-cyan-200/70">Ouroboros ARE SDK</p>
+          <h2 className="mt-2 text-2xl font-black tracking-tight">{title}</h2>
+          <p className="mt-2 max-w-xl text-sm text-cyan-100/70">{subtitle}</p>
+        </div>
+        <div className="rounded-full border border-cyan-300/40 px-4 py-2 font-mono text-sm text-cyan-100">
+          SYNC LCK {tickHz.toFixed(2)} Hz
+        </div>
+      </div>
+
+      <div className="mt-8 grid gap-6 md:grid-cols-[220px_1fr]">
+        <div className="grid place-items-center rounded-3xl border border-cyan-300/20 bg-cyan-300/5 p-6">
+          <div style={orbStyle} className="grid h-36 w-36 place-items-center rounded-full border border-cyan-200/60 bg-cyan-300/10 transition-transform duration-100">
+            <span className="font-mono text-xs text-lime-100">tick {active.tick}</span>
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-cyan-300/20 bg-black/30 p-5">
+          <div className="grid gap-3 font-mono text-xs text-cyan-100/80 md:grid-cols-3">
+            <span>frame {index + 1}/{safeFrames.length}</span>
+            <span>hash {shortHash}</span>
+            <span>{active.label ?? "worldhash pulse"}</span>
+          </div>
+          <input
+            className="mt-5 w-full accent-cyan-300"
+            type="range"
+            min={0}
+            max={safeFrames.length - 1}
+            value={index}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              setIndex(next);
+              onFrameSelect?.(safeFrames[next]);
+            }}
+          />
+          <pre className="mt-5 overflow-auto rounded-2xl border border-cyan-300/20 bg-black/50 p-4 font-mono text-[11px] leading-5 text-cyan-100/80">
+{JSON.stringify(active, null, 2)}
+          </pre>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default OuroborosPulseView;

--- a/packages/core-logic/src/react/react-shim.d.ts
+++ b/packages/core-logic/src/react/react-shim.d.ts
@@ -1,0 +1,15 @@
+declare module "react" {
+  const React: any;
+  export default React;
+  export type ReactElement = any;
+  export type CSSProperties = Record<string, string | number>;
+  export function useMemo<T>(factory: () => T, deps: unknown[]): T;
+  export function useState<T>(initial: T): [T, (next: T | ((current: T) => T)) => void];
+  export function useEffect(effect: () => void | (() => void), deps?: unknown[]): void;
+}
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}

--- a/packages/sdk-examples/BattleSim.ts
+++ b/packages/sdk-examples/BattleSim.ts
@@ -1,0 +1,154 @@
+import { AREInvariantGuard, type AREGuardPayload } from "@wasd/core-logic";
+
+export type TeamId = "sun" | "moon";
+
+export interface BattleUnit {
+  id: string;
+  team: TeamId;
+  hp: number;
+  attack: number;
+  armor: number;
+  speed: number;
+}
+
+export interface BattleEvent {
+  tick: number;
+  actorId: string;
+  targetId: string;
+  damage: number;
+  targetHp: number;
+  summary: string;
+}
+
+export interface BattleFrame {
+  tick: number;
+  worldHash: string;
+  seed: string;
+  units: BattleUnit[];
+  events: BattleEvent[];
+  winner: TeamId | "draw" | null;
+}
+
+const STRICT_GUARD = new AREInvariantGuard({
+  repoRoot: process.cwd(),
+  coreLogicDirs: ["packages/core-logic/src", "packages/sdk-examples"],
+  throwOnViolation: true,
+});
+
+function emilyOracleWarn(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`Emily Oracle Warning: Autobattler determinism breach blocked. ${message}`);
+}
+
+async function sha256(input: string): Promise<string> {
+  if (globalThis.crypto?.subtle) {
+    const bytes = new TextEncoder().encode(input);
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+    return [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, "0")).join("");
+  }
+  const { createHash } = await import("node:crypto");
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function stableValue(hash: string, offset: number, modulo: number): number {
+  return Number.parseInt(hash.slice(offset, offset + 8), 16) % modulo;
+}
+
+function cloneUnits(units: BattleUnit[]): BattleUnit[] {
+  return units.map((unit) => ({ ...unit }));
+}
+
+function alive(units: BattleUnit[], team?: TeamId): BattleUnit[] {
+  return units.filter((unit) => unit.hp > 0 && (!team || unit.team === team));
+}
+
+function opponent(team: TeamId): TeamId {
+  return team === "sun" ? "moon" : "sun";
+}
+
+export function createBattleTeams(): BattleUnit[] {
+  return [
+    { id: "sun-vanguard", team: "sun", hp: 44, attack: 9, armor: 2, speed: 3 },
+    { id: "sun-oracle", team: "sun", hp: 30, attack: 12, armor: 1, speed: 5 },
+    { id: "sun-warden", team: "sun", hp: 52, attack: 7, armor: 4, speed: 2 },
+    { id: "moon-raider", team: "moon", hp: 38, attack: 11, armor: 2, speed: 4 },
+    { id: "moon-sentinel", team: "moon", hp: 55, attack: 6, armor: 5, speed: 2 },
+    { id: "moon-singer", team: "moon", hp: 28, attack: 13, armor: 1, speed: 5 },
+  ];
+}
+
+export class BattleSim {
+  private readonly frames: BattleFrame[] = [];
+
+  constructor(private readonly seed = "ARE|autobattler|replit") {}
+
+  async run(maxTicks = 60, startUnits = createBattleTeams()): Promise<BattleFrame[]> {
+    this.frames.length = 0;
+    let units = cloneUnits(startUnits);
+
+    for (let tick = 1; tick <= maxTicks; tick += 1) {
+      const payload: AREGuardPayload = { l: 13, k: 1000, r: 0.618, tick, deterministicSeed: `${this.seed}|tick:${tick}` };
+      try {
+        STRICT_GUARD.validateTick(payload, tick);
+      } catch (error) {
+        emilyOracleWarn(error);
+        throw error;
+      }
+
+      const worldHash = await sha256(JSON.stringify({ seed: this.seed, tick, units }));
+      const events: BattleEvent[] = [];
+      const turnOrder = alive(units).sort((a, b) => b.speed - a.speed || a.id.localeCompare(b.id));
+
+      for (const actor of turnOrder) {
+        const liveActor = units.find((unit) => unit.id === actor.id && unit.hp > 0);
+        if (!liveActor) continue;
+        const targets = alive(units, opponent(liveActor.team)).sort((a, b) => a.hp - b.hp || a.id.localeCompare(b.id));
+        if (targets.length === 0) break;
+        const target = targets[stableValue(worldHash, tick + liveActor.id.length, targets.length)];
+        const liveTarget = units.find((unit) => unit.id === target.id);
+        if (!liveTarget) continue;
+        const variance = stableValue(worldHash, tick + liveTarget.id.length, 4);
+        const damage = Math.max(1, liveActor.attack + variance - liveTarget.armor);
+        liveTarget.hp = Math.max(0, liveTarget.hp - damage);
+        events.push({
+          tick,
+          actorId: liveActor.id,
+          targetId: liveTarget.id,
+          damage,
+          targetHp: liveTarget.hp,
+          summary: `${liveActor.id} strikes ${liveTarget.id} for ${damage} via hash ${worldHash.slice(0, 8)}`,
+        });
+      }
+
+      const winner = this.resolveWinner(units);
+      const frame: BattleFrame = { tick, worldHash, seed: this.seed, units: cloneUnits(units), events, winner };
+      this.frames.push(frame);
+      if (winner) break;
+    }
+
+    return this.getReplayData();
+  }
+
+  getReplayData(): BattleFrame[] {
+    return this.frames.map((frame) => ({ ...frame, units: cloneUnits(frame.units), events: frame.events.map((event) => ({ ...event })) }));
+  }
+
+  getFrame(tick: number): BattleFrame | null {
+    const frame = this.frames.find((candidate) => candidate.tick === tick);
+    return frame ? { ...frame, units: cloneUnits(frame.units), events: frame.events.map((event) => ({ ...event })) } : null;
+  }
+
+  private resolveWinner(units: BattleUnit[]): TeamId | "draw" | null {
+    const sunAlive = alive(units, "sun").length;
+    const moonAlive = alive(units, "moon").length;
+    if (sunAlive === 0 && moonAlive === 0) return "draw";
+    if (sunAlive === 0) return "moon";
+    if (moonAlive === 0) return "sun";
+    return null;
+  }
+}
+
+export async function runAutobattlerDemo(seed = "ARE|autobattler|replit"): Promise<BattleFrame[]> {
+  const sim = new BattleSim(seed);
+  return sim.run(60);
+}

--- a/packages/sdk-examples/TCGExample.ts
+++ b/packages/sdk-examples/TCGExample.ts
@@ -1,0 +1,128 @@
+import { AREInvariantGuard, type AREGuardPayload } from "@wasd/core-logic";
+
+export type TCGOwner = "alpha" | "beta";
+
+export interface TCGCard {
+  id: string;
+  owner: TCGOwner;
+  power: number;
+  aura: number;
+  x: number;
+  y: number;
+}
+
+export interface TCGMove {
+  cardId: string;
+  x: number;
+  y: number;
+}
+
+export interface TCGFrame {
+  tick: number;
+  worldHash: string;
+  seed: string;
+  board: Array<TCGCard | null>;
+  events: string[];
+  score: Record<TCGOwner, number>;
+}
+
+const BOARD_SIZE = 3;
+const STRICT_GUARD = new AREInvariantGuard({
+  repoRoot: process.cwd(),
+  coreLogicDirs: ["packages/core-logic/src", "packages/sdk-examples"],
+  throwOnViolation: true,
+});
+
+function emilyOracleWarn(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`Emily Oracle Warning: forbidden nondeterminism detected inside the ARE demo. ${message}`);
+}
+
+async function sha256(input: string): Promise<string> {
+  if (globalThis.crypto?.subtle) {
+    const bytes = new TextEncoder().encode(input);
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+    return [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, "0")).join("");
+  }
+  const { createHash } = await import("node:crypto");
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function slotOf(x: number, y: number): number {
+  return Math.max(0, Math.min(BOARD_SIZE - 1, y)) * BOARD_SIZE + Math.max(0, Math.min(BOARD_SIZE - 1, x));
+}
+
+function stableValue(hash: string, offset: number, modulo: number): number {
+  return Number.parseInt(hash.slice(offset, offset + 8), 16) % modulo;
+}
+
+export async function createTCGDeck(seed: string): Promise<TCGCard[]> {
+  const hash = await sha256(`tcg-deck|${seed}`);
+  return Array.from({ length: 6 }, (_, index) => ({
+    id: `${index < 3 ? "alpha" : "beta"}-card-${index % 3}`,
+    owner: index < 3 ? "alpha" : "beta",
+    power: 2 + stableValue(hash, index * 4, 7),
+    aura: 1 + stableValue(hash, 28 + index * 4, 5),
+    x: -1,
+    y: -1,
+  }));
+}
+
+export async function applyTCGMove(seed: string, tick: number, cards: TCGCard[], move: TCGMove): Promise<TCGFrame> {
+  const payload: AREGuardPayload = { l: 13, k: 1000, r: 0.618, tick, deterministicSeed: `ARE|TCG|${seed}|tick:${tick}` };
+  try {
+    STRICT_GUARD.validateTick(payload, tick);
+  } catch (error) {
+    emilyOracleWarn(error);
+    throw error;
+  }
+
+  const nextCards = cards.map((card) => ({ ...card }));
+  const card = nextCards.find((candidate) => candidate.id === move.cardId);
+  if (!card) throw new Error(`Card ${move.cardId} not found.`);
+  card.x = Math.max(0, Math.min(BOARD_SIZE - 1, Math.floor(move.x)));
+  card.y = Math.max(0, Math.min(BOARD_SIZE - 1, Math.floor(move.y)));
+
+  const worldHash = await sha256(JSON.stringify({ seed, tick, cards: nextCards }));
+  const board: Array<TCGCard | null> = Array.from({ length: BOARD_SIZE * BOARD_SIZE }, () => null);
+  const events: string[] = [];
+
+  for (const candidate of nextCards) {
+    if (candidate.x < 0 || candidate.y < 0) continue;
+    const index = slotOf(candidate.x, candidate.y);
+    const occupant = board[index];
+    if (!occupant) {
+      board[index] = candidate;
+      continue;
+    }
+    const clash = stableValue(worldHash, index * 3, 11);
+    const candidateScore = candidate.power + candidate.aura + clash;
+    const occupantScore = occupant.power + occupant.aura;
+    board[index] = candidateScore >= occupantScore ? candidate : occupant;
+    events.push(`Slot ${index}: ${board[index]?.id} wins deterministic clash ${candidateScore}:${occupantScore}`);
+  }
+
+  for (let y = 0; y < BOARD_SIZE; y += 1) {
+    for (let x = 0; x < BOARD_SIZE; x += 1) {
+      const cardInSlot = board[slotOf(x, y)];
+      if (!cardInSlot) continue;
+      const pulse = stableValue(worldHash, slotOf(x, y) * 5, 3);
+      if (pulse === 0) {
+        cardInSlot.power += 1;
+        events.push(`${cardInSlot.id} receives ARE pulse +1 power from WorldHash.`);
+      }
+    }
+  }
+
+  const score = board.reduce<Record<TCGOwner, number>>((acc, item) => {
+    if (item) acc[item.owner] += item.power;
+    return acc;
+  }, { alpha: 0, beta: 0 });
+
+  return { tick, worldHash, seed, board, events, score };
+}
+
+export async function quickStartTCGMove(seed = "ARE|demo|replit"): Promise<TCGFrame> {
+  const deck = await createTCGDeck(seed);
+  return applyTCGMove(seed, 1, deck, { cardId: "alpha-card-0", x: 1, y: 1 });
+}

--- a/packages/sdk-examples/replit-demo/index.html
+++ b/packages/sdk-examples/replit-demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ouroboros ARE Hype SDK</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/sdk-examples/replit-demo/src/BrowserBattleSim.ts
+++ b/packages/sdk-examples/replit-demo/src/BrowserBattleSim.ts
@@ -1,0 +1,120 @@
+export type TeamId = "sun" | "moon";
+
+export interface BattleUnit {
+  id: string;
+  team: TeamId;
+  hp: number;
+  attack: number;
+  armor: number;
+  speed: number;
+}
+
+export interface BattleEvent {
+  tick: number;
+  actorId: string;
+  targetId: string;
+  damage: number;
+  targetHp: number;
+  summary: string;
+}
+
+export interface BattleFrame {
+  tick: number;
+  worldHash: string;
+  seed: string;
+  units: BattleUnit[];
+  events: BattleEvent[];
+  winner: TeamId | "draw" | null;
+}
+
+async function sha256(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, "0")).join("");
+}
+
+function stableValue(hash: string, offset: number, modulo: number): number {
+  return Number.parseInt(hash.slice(offset, offset + 8), 16) % modulo;
+}
+
+function cloneUnits(units: BattleUnit[]): BattleUnit[] {
+  return units.map((unit) => ({ ...unit }));
+}
+
+function alive(units: BattleUnit[], team?: TeamId): BattleUnit[] {
+  return units.filter((unit) => unit.hp > 0 && (!team || unit.team === team));
+}
+
+function opponent(team: TeamId): TeamId {
+  return team === "sun" ? "moon" : "sun";
+}
+
+export function createBattleTeams(): BattleUnit[] {
+  return [
+    { id: "sun-vanguard", team: "sun", hp: 44, attack: 9, armor: 2, speed: 3 },
+    { id: "sun-oracle", team: "sun", hp: 30, attack: 12, armor: 1, speed: 5 },
+    { id: "sun-warden", team: "sun", hp: 52, attack: 7, armor: 4, speed: 2 },
+    { id: "moon-raider", team: "moon", hp: 38, attack: 11, armor: 2, speed: 4 },
+    { id: "moon-sentinel", team: "moon", hp: 55, attack: 6, armor: 5, speed: 2 },
+    { id: "moon-singer", team: "moon", hp: 28, attack: 13, armor: 1, speed: 5 },
+  ];
+}
+
+export class BrowserBattleSim {
+  private readonly frames: BattleFrame[] = [];
+
+  constructor(private readonly seed = "ARE|autobattler|browser-demo") {}
+
+  async run(maxTicks = 60, startUnits = createBattleTeams()): Promise<BattleFrame[]> {
+    this.frames.length = 0;
+    let units = cloneUnits(startUnits);
+
+    for (let tick = 1; tick <= maxTicks; tick += 1) {
+      const deterministicSeed = `${this.seed}|kappa:1000|tick:${tick}`;
+      const worldHash = await sha256(JSON.stringify({ deterministicSeed, tick, units }));
+      const events: BattleEvent[] = [];
+      const turnOrder = alive(units).sort((a, b) => b.speed - a.speed || a.id.localeCompare(b.id));
+
+      for (const actor of turnOrder) {
+        const liveActor = units.find((unit) => unit.id === actor.id && unit.hp > 0);
+        if (!liveActor) continue;
+        const targets = alive(units, opponent(liveActor.team)).sort((a, b) => a.hp - b.hp || a.id.localeCompare(b.id));
+        if (targets.length === 0) break;
+        const target = targets[stableValue(worldHash, tick + liveActor.id.length, targets.length)];
+        const liveTarget = units.find((unit) => unit.id === target.id);
+        if (!liveTarget) continue;
+        const variance = stableValue(worldHash, tick + liveTarget.id.length, 4);
+        const damage = Math.max(1, liveActor.attack + variance - liveTarget.armor);
+        liveTarget.hp = Math.max(0, liveTarget.hp - damage);
+        events.push({
+          tick,
+          actorId: liveActor.id,
+          targetId: liveTarget.id,
+          damage,
+          targetHp: liveTarget.hp,
+          summary: `${liveActor.id} strikes ${liveTarget.id} for ${damage} via hash ${worldHash.slice(0, 8)}`,
+        });
+      }
+
+      const winner = this.resolveWinner(units);
+      const frame: BattleFrame = { tick, worldHash, seed: deterministicSeed, units: cloneUnits(units), events, winner };
+      this.frames.push(frame);
+      if (winner) break;
+    }
+
+    return this.getReplayData();
+  }
+
+  getReplayData(): BattleFrame[] {
+    return this.frames.map((frame) => ({ ...frame, units: cloneUnits(frame.units), events: frame.events.map((event) => ({ ...event })) }));
+  }
+
+  private resolveWinner(units: BattleUnit[]): TeamId | "draw" | null {
+    const sunAlive = alive(units, "sun").length;
+    const moonAlive = alive(units, "moon").length;
+    if (sunAlive === 0 && moonAlive === 0) return "draw";
+    if (sunAlive === 0) return "moon";
+    if (moonAlive === 0) return "sun";
+    return null;
+  }
+}

--- a/packages/sdk-examples/replit-demo/src/main.tsx
+++ b/packages/sdk-examples/replit-demo/src/main.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { OuroborosPulseView, type OuroborosPulseFrame } from "@wasd/core-logic/react/OuroborosPulseView";
+import { BattleSim } from "../../BattleSim";
+import "./style.css";
+
+function App() {
+  const [frames, setFrames] = useState<OuroborosPulseFrame[]>([]);
+  const [selected, setSelected] = useState<OuroborosPulseFrame | null>(null);
+
+  useEffect(() => {
+    console.info("Emily: Willkommen, Replit-Architekt. Engine Online. Kausalität stabil. Drücke Run und beobachte, wie der WorldHash atmet.");
+    const sim = new BattleSim("ARE|replit|hype-sdk|alpha");
+    sim.run(42).then((battleFrames) => {
+      const pulseFrames = battleFrames.map((frame) => ({
+        tick: frame.tick,
+        worldHash: frame.worldHash,
+        label: frame.winner ? `winner ${frame.winner}` : `${frame.events.length} deterministic combat events`,
+      }));
+      setFrames(pulseFrames);
+      setSelected(pulseFrames[pulseFrames.length - 1] ?? null);
+    }).catch((error) => {
+      console.warn(`Emily Oracle Warning: Demo stopped by the AREInvariantGuard. ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }, []);
+
+  return (
+    <main className="shell">
+      <section className="hero">
+        <p className="eyebrow">Ouroboros ARE · Hype SDK</p>
+        <h1>Build Immortal Worlds with Ouroboros ARE.</h1>
+        <p>
+          Cheat-proof physics, time-travel debugging and 10-Hz Cyber-Zen feedback for developers who want their game logic to feel alive on the first run.
+        </p>
+      </section>
+      <OuroborosPulseView frames={frames} onFrameSelect={setSelected} />
+      <section className="console">
+        <h2>Autobattler Replay Inspector</h2>
+        <pre>{JSON.stringify(selected ?? frames.at(-1) ?? { status: "booting" }, null, 2)}</pre>
+      </section>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/sdk-examples/replit-demo/src/main.tsx
+++ b/packages/sdk-examples/replit-demo/src/main.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { OuroborosPulseView, type OuroborosPulseFrame } from "@wasd/core-logic/react/OuroborosPulseView";
-import { BattleSim } from "../../BattleSim";
+import { BrowserBattleSim } from "./BrowserBattleSim";
 import "./style.css";
 
 function App() {
@@ -10,7 +10,7 @@ function App() {
 
   useEffect(() => {
     console.info("Emily: Willkommen, Replit-Architekt. Engine Online. Kausalität stabil. Drücke Run und beobachte, wie der WorldHash atmet.");
-    const sim = new BattleSim("ARE|replit|hype-sdk|alpha");
+    const sim = new BrowserBattleSim("ARE|replit|hype-sdk|alpha");
     sim.run(42).then((battleFrames) => {
       const pulseFrames = battleFrames.map((frame) => ({
         tick: frame.tick,
@@ -20,7 +20,7 @@ function App() {
       setFrames(pulseFrames);
       setSelected(pulseFrames[pulseFrames.length - 1] ?? null);
     }).catch((error) => {
-      console.warn(`Emily Oracle Warning: Demo stopped by the AREInvariantGuard. ${error instanceof Error ? error.message : String(error)}`);
+      console.warn(`Emily Oracle Warning: Demo stopped by the browser ARE demo. ${error instanceof Error ? error.message : String(error)}`);
     });
   }, []);
 

--- a/packages/sdk-examples/replit-demo/src/style.css
+++ b/packages/sdk-examples/replit-demo/src/style.css
@@ -1,0 +1,68 @@
+:root {
+  --wasd-aura: 0, 229, 255;
+  --wasd-neon: 57, 255, 20;
+  --wasd-bg: #050607;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: white;
+  background: var(--wasd-bg);
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; background: radial-gradient(circle at 50% 20%, rgba(var(--wasd-aura), .18), transparent 32%), #050607; }
+.shell { width: min(1120px, calc(100vw - 32px)); margin: 0 auto; padding: 42px 0; }
+.hero { margin-bottom: 24px; padding: 28px; border: 1px solid rgba(var(--wasd-aura), .24); border-radius: 28px; background: rgba(0,0,0,.32); box-shadow: 0 0 34px rgba(var(--wasd-aura), .13); }
+.eyebrow { margin: 0 0 12px; font-family: "Fira Code", ui-monospace, monospace; letter-spacing: .32em; text-transform: uppercase; color: rgba(178, 245, 255, .72); font-size: 12px; }
+h1 { margin: 0; font-size: clamp(34px, 7vw, 78px); line-height: .92; letter-spacing: -0.06em; }
+.hero p:last-child { max-width: 780px; color: rgba(214, 252, 255, .78); line-height: 1.7; font-size: 17px; }
+.rounded-3xl { border-radius: 28px; }
+.rounded-full { border-radius: 999px; }
+.border { border: 1px solid rgba(var(--wasd-aura), .24); }
+.bg-black\/30 { background: rgba(0,0,0,.3); }
+.bg-black\/50 { background: rgba(0,0,0,.5); }
+.bg-cyan-300\/5 { background: rgba(var(--wasd-aura), .05); }
+.bg-cyan-300\/10 { background: rgba(var(--wasd-aura), .1); }
+.border-cyan-300\/20 { border-color: rgba(var(--wasd-aura), .2); }
+.border-cyan-300\/40 { border-color: rgba(var(--wasd-aura), .4); }
+.border-cyan-200\/60 { border-color: rgba(178, 245, 255, .6); }
+.text-white { color: white; }
+.text-cyan-100 { color: #cffafe; }
+.text-cyan-100\/70 { color: rgba(207, 250, 254, .7); }
+.text-cyan-100\/80 { color: rgba(207, 250, 254, .8); }
+.text-cyan-200\/70 { color: rgba(165, 243, 252, .7); }
+.text-lime-100 { color: #ecfccb; }
+.font-mono { font-family: "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace; }
+.text-xs { font-size: 12px; }
+.text-sm { font-size: 14px; }
+.text-2xl { font-size: 24px; }
+.font-black { font-weight: 900; }
+.tracking-tight { letter-spacing: -0.04em; }
+.uppercase { text-transform: uppercase; }
+.p-4 { padding: 16px; }
+.p-5 { padding: 20px; }
+.p-6 { padding: 24px; }
+.px-4 { padding-left: 16px; padding-right: 16px; }
+.py-2 { padding-top: 8px; padding-bottom: 8px; }
+.mt-2 { margin-top: 8px; }
+.mt-5 { margin-top: 20px; }
+.mt-8 { margin-top: 32px; }
+.flex { display: flex; }
+.flex-col { flex-direction: column; }
+.gap-6 { gap: 24px; }
+.grid { display: grid; }
+.place-items-center { place-items: center; }
+.h-36 { height: 144px; }
+.w-36 { width: 144px; }
+.w-full { width: 100%; }
+.overflow-auto { overflow: auto; }
+.transition-transform { transition-property: transform; }
+.duration-100 { transition-duration: 100ms; }
+.console { margin-top: 24px; padding: 24px; border-radius: 28px; border: 1px solid rgba(var(--wasd-neon), .22); background: rgba(0,0,0,.4); }
+.console h2 { margin-top: 0; }
+.console pre { overflow: auto; color: #cffafe; font-size: 12px; line-height: 1.6; }
+@media (min-width: 768px) {
+  .md\:flex-row { flex-direction: row; }
+  .md\:items-center { align-items: center; }
+  .md\:justify-between { justify-content: space-between; }
+  .md\:grid-cols-\[220px_1fr\] { grid-template-columns: 220px 1fr; }
+  .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}

--- a/scripts/replit-start.sh
+++ b/scripts/replit-start.sh
@@ -7,7 +7,9 @@ export GAME_PORT="$PORT"
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 echo "=== Ouroboros Replit Boot ==="
+echo "Emily: Willkommen, Replit-Architekt. Engine Online. Kausalität stabil."
 echo "PORT=$PORT"
+echo "DEMO_PORT=${DEMO_PORT:-5173}"
 
 auto_corepack() {
   if command -v corepack >/dev/null 2>&1; then
@@ -28,4 +30,12 @@ pnpm --filter @wasd/core-logic --if-present build
 pnpm --filter @wasd/shared --if-present build
 pnpm --filter @wasd/server --if-present build
 
-exec pnpm --filter @wasd/server start
+echo "Starting Ouroboros ARE server on :$PORT ..."
+pnpm --filter @wasd/server start &
+SERVER_PID=$!
+
+echo "Starting Cyber-Zen SDK demo on :${DEMO_PORT:-5173} ..."
+cd packages/sdk-examples/replit-demo
+pnpm exec vite --host 0.0.0.0 --port "${DEMO_PORT:-5173}"
+
+trap 'kill $SERVER_PID 2>/dev/null || true' EXIT

--- a/scripts/replit-start.sh
+++ b/scripts/replit-start.sh
@@ -33,9 +33,8 @@ pnpm --filter @wasd/server --if-present build
 echo "Starting Ouroboros ARE server on :$PORT ..."
 pnpm --filter @wasd/server start &
 SERVER_PID=$!
+trap 'kill $SERVER_PID 2>/dev/null || true' EXIT INT TERM
 
 echo "Starting Cyber-Zen SDK demo on :${DEMO_PORT:-5173} ..."
 cd packages/sdk-examples/replit-demo
 pnpm exec vite --host 0.0.0.0 --port "${DEMO_PORT:-5173}"
-
-trap 'kill $SERVER_PID 2>/dev/null || true' EXIT


### PR DESCRIPTION
## Summary
- Add SDK examples for TCG logic and autobattler simulation
- Add React PulseView for 10 Hz WorldHash visualization
- Add Replit demo app with a browser-safe battle replay view
- Update Replit start script to launch server and demo preview
- Add SDK README with quick start and example usage

## Notes
- No new workspace package was added for sdk-examples
- Core package exports now include ./react/OuroborosPulseView