### PR TITLE
fix(deploy): build core logic package before server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,10 @@ ENV NODE_ENV=production
 ENV NODE_OPTIONS="--max-old-space-size=12288"
 
 # Server container build only. Do not build browser/demo workspaces here.
-RUN pnpm --filter @wasd/shared --if-present build && \
+# Core-logic must be built before server because server re-exports AREInvariantGuard
+# from @wasd/core-logic package exports at runtime.
+RUN pnpm --filter @wasd/core-logic --if-present build && \
+    pnpm --filter @wasd/shared --if-present build && \
     pnpm --filter @wasd/server --if-present build
 
 # Prune dev dependencies

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -62,7 +62,8 @@ if command -v pnpm >/dev/null 2>&1; then
   pnpm config set child-concurrency 1
   pnpm install --no-frozen-lockfile --prefer-offline
 
-  echo "Building shared package and game server..."
+  echo "Building core-logic, shared package and game server..."
+  NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/core-logic --if-present build
   NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/shared --if-present build
   NODE_OPTIONS="$SERVER_BUILD_NODE_OPTIONS" pnpm --filter @wasd/server --if-present build
 


### PR DESCRIPTION
## Summary
- Build @wasd/core-logic before @wasd/server in Docker deploy
- Build @wasd/core-logic before @wasd/server in PM2 deploy

## Why
The server re-exports AREInvariantGuard from @wasd/core-logic. Runtime failed because the deployed server package expected @wasd/core-logic/dist/are/AREInvariantGuard.mjs, but the core package was not built before the server/runtime package was assembled.