### PR TITLE
fix(deploy): use runtime-only core logic build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ ENV NODE_OPTIONS="--max-old-space-size=12288"
 
 # Server container build only. Do not build browser/demo workspaces here.
 # Core-logic must be built before server because server re-exports AREInvariantGuard
-# from @wasd/core-logic package exports at runtime.
-RUN pnpm --filter @wasd/core-logic --if-present build && \
+# from @wasd/core-logic package exports at runtime. Runtime build intentionally skips DTS.
+RUN pnpm --filter @wasd/core-logic --if-present run build:runtime && \
     pnpm --filter @wasd/shared --if-present build && \
     pnpm --filter @wasd/server --if-present build
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -62,8 +62,8 @@ if command -v pnpm >/dev/null 2>&1; then
   pnpm config set child-concurrency 1
   pnpm install --no-frozen-lockfile --prefer-offline
 
-  echo "Building core-logic, shared package and game server..."
-  NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/core-logic --if-present build
+  echo "Building core-logic runtime, shared package and game server..."
+  NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/core-logic --if-present run build:runtime
   NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/shared --if-present build
   NODE_OPTIONS="$SERVER_BUILD_NODE_OPTIONS" pnpm --filter @wasd/server --if-present build
 

--- a/packages/core-logic/package.json
+++ b/packages/core-logic/package.json
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts src/are/AREInvariantGuard.ts src/react/OuroborosPulseView.tsx --format cjs,esm --dts --clean --external react",
+    "build:runtime": "tsup src/index.ts src/are/AREInvariantGuard.ts src/react/OuroborosPulseView.tsx --format cjs,esm --clean --external react",
     "dev": "tsup src/index.ts src/are/AREInvariantGuard.ts src/react/OuroborosPulseView.tsx --format cjs,esm --watch --dts --external react",
     "test": "vitest run --passWithNoTests",
     "lint": "eslint src",


### PR DESCRIPTION
## Summary
- Add `build:runtime` script to @wasd/core-logic
- Use `build:runtime` in Docker deploy before building server
- Use `build:runtime` in PM2 deploy before building server

## Why
The Docker deploy failed in @wasd/core-logic because tsup DTS generation failed. The server runtime only needs JS/CJS/ESM artifacts, so deploy should build runtime artifacts without blocking on declaration output.