### PR TITLE
fix(sdk): align core logic exports with generated js files

### DIFF
--- a/packages/core-logic/package.json
+++ b/packages/core-logic/package.json
@@ -5,22 +5,22 @@
   "description": "Ouroboros ARE deterministic core logic SDK",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.js"
     },
     "./are/AREInvariantGuard": {
       "types": "./dist/are/AREInvariantGuard.d.ts",
-      "import": "./dist/are/AREInvariantGuard.mjs",
+      "import": "./dist/are/AREInvariantGuard.js",
       "require": "./dist/are/AREInvariantGuard.js"
     },
     "./react/OuroborosPulseView": {
       "types": "./dist/react/OuroborosPulseView.d.ts",
-      "import": "./dist/react/OuroborosPulseView.mjs",
+      "import": "./dist/react/OuroborosPulseView.js",
       "require": "./dist/react/OuroborosPulseView.js"
     }
   },


### PR DESCRIPTION
## Summary
- Point @wasd/core-logic ESM exports to generated `.js` artifacts
- Remove stale `.mjs` references from the package export map

## Why
The Docker runtime imports @wasd/core-logic/are/AREInvariantGuard. The package export map pointed to dist/are/AREInvariantGuard.mjs, but the runtime build generated dist/are/AREInvariantGuard.js. Node correctly suggested the .js path, so the export map now matches the actual artifact.