### PR TITLE
feat(drop): add golden loot display and simulator

### DIFF
--- a/packages/sdk-examples/replit-demo/package.json
+++ b/packages/sdk-examples/replit-demo/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@wasd/sdk-replit-demo",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "^6.0.1",
+    "vite": "^6.4.2",
+    "typescript": "^6.0.3",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "@wasd/core-logic": "workspace:*"
+  },
+  "devDependencies": {}
+}

--- a/packages/sdk-examples/replit-demo/src/LootSimulator.tsx
+++ b/packages/sdk-examples/replit-demo/src/LootSimulator.tsx
@@ -1,0 +1,125 @@
+import React, { useMemo, useState } from "react";
+import { rollDefaultAreloriaLoot, type LootDrop } from "@wasd/core-logic/loot";
+
+interface LootStats {
+  iterations: number;
+  totalDrops: number;
+  qualityCounts: Record<string, number>;
+  itemCounts: Record<string, number>;
+  highTierDrops: LootDrop[];
+  lastHash: string;
+}
+
+const ROOT_TC = "tc_oracle_cache";
+const ITERATIONS = 10_000;
+
+function runLootSimulation(): LootStats {
+  const qualityCounts: Record<string, number> = {};
+  const itemCounts: Record<string, number> = {};
+  const highTierDrops: LootDrop[] = [];
+  let totalDrops = 0;
+  let lastHash = "boot";
+
+  for (let i = 0; i < ITERATIONS; i += 1) {
+    const result = rollDefaultAreloriaLoot(ROOT_TC, {
+      seed: "ARE|sdk|loot-simulator|alpha",
+      worldHash: `world-${Math.floor(i / 100)}`,
+      chunkHash: `chunk-12-8-${i % 64}`,
+      chunkId: "12:8",
+      tick: i,
+      actorId: "replit-developer",
+      sourceId: ROOT_TC,
+      playerPublicKey: "sdk-public-key-demo",
+    });
+
+    lastHash = result.finalHash;
+    for (const drop of result.drops) {
+      totalDrops += drop.quantity;
+      qualityCounts[drop.quality] = (qualityCounts[drop.quality] ?? 0) + drop.quantity;
+      itemCounts[drop.itemId] = (itemCounts[drop.itemId] ?? 0) + drop.quantity;
+      if (["epic", "legendary", "mythic"].includes(drop.quality)) {
+        highTierDrops.push(drop);
+      }
+    }
+  }
+
+  return { iterations: ITERATIONS, totalDrops, qualityCounts, itemCounts, highTierDrops: highTierDrops.slice(-12), lastHash };
+}
+
+export function LootSimulator(): JSX.Element {
+  const initial = useMemo(() => runLootSimulation(), []);
+  const [stats, setStats] = useState<LootStats>(initial);
+
+  const qualityRows = Object.entries(stats.qualityCounts).sort(([a], [b]) => a.localeCompare(b));
+  const itemRows = Object.entries(stats.itemCounts).sort((a, b) => b[1] - a[1]).slice(0, 8);
+
+  return (
+    <section className="loot-sim">
+      <div className="loot-head">
+        <div>
+          <p className="eyebrow">Treasure Matrix Lab</p>
+          <h2>Loot Simulator · 10,000 deterministic rolls</h2>
+        </div>
+        <button type="button" onClick={() => setStats(runLootSimulation())}>
+          Re-run Matrix
+        </button>
+      </div>
+
+      <div className="loot-grid">
+        <div className="metric">
+          <span>Root TC</span>
+          <strong>{ROOT_TC}</strong>
+        </div>
+        <div className="metric">
+          <span>Iterations</span>
+          <strong>{stats.iterations.toLocaleString()}</strong>
+        </div>
+        <div className="metric">
+          <span>Total drops</span>
+          <strong>{stats.totalDrops.toLocaleString()}</strong>
+        </div>
+        <div className="metric">
+          <span>Last finalHash</span>
+          <strong>{stats.lastHash.slice(0, 16)}</strong>
+        </div>
+      </div>
+
+      <div className="loot-columns">
+        <div>
+          <h3>Quality Distribution</h3>
+          {qualityRows.map(([quality, count]) => (
+            <div className="bar-row" key={quality}>
+              <span>{quality}</span>
+              <meter min={0} max={stats.totalDrops || 1} value={count} />
+              <code>{((count / Math.max(1, stats.totalDrops)) * 100).toFixed(4)}%</code>
+            </div>
+          ))}
+        </div>
+        <div>
+          <h3>Top Items</h3>
+          {itemRows.map(([itemId, count]) => (
+            <div className="bar-row" key={itemId}>
+              <span>{itemId}</span>
+              <meter min={0} max={stats.totalDrops || 1} value={count} />
+              <code>{count}</code>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="high-tier">
+        <h3>Recent High-Tier Echoes</h3>
+        {stats.highTierDrops.length === 0 ? (
+          <p>No epic-or-better drops in this deterministic sample.</p>
+        ) : (
+          stats.highTierDrops.map((drop, index) => (
+            <div className="drop-card" key={`${drop.rollHash}-${index}`}>
+              <strong>{drop.quality.toUpperCase()} · {drop.name}</strong>
+              <code>{drop.rollHash.slice(0, 24)}</code>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/sdk-examples/replit-demo/src/main.tsx
+++ b/packages/sdk-examples/replit-demo/src/main.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { OuroborosPulseView, type OuroborosPulseFrame } from "@wasd/core-logic/react/OuroborosPulseView";
 import { BrowserBattleSim } from "./BrowserBattleSim";
+import { LootSimulator } from "./LootSimulator";
 import "./style.css";
 
 function App() {
@@ -30,10 +31,11 @@ function App() {
         <p className="eyebrow">Ouroboros ARE · Hype SDK</p>
         <h1>Build Immortal Worlds with Ouroboros ARE.</h1>
         <p>
-          Cheat-proof physics, time-travel debugging and 10-Hz Cyber-Zen feedback for developers who want their game logic to feel alive on the first run.
+          Cheat-proof physics, time-travel debugging, deterministic loot and 10-Hz Cyber-Zen feedback for developers who want their game logic to feel alive on the first run.
         </p>
       </section>
       <OuroborosPulseView frames={frames} onFrameSelect={setSelected} />
+      <LootSimulator />
       <section className="console">
         <h2>Autobattler Replay Inspector</h2>
         <pre>{JSON.stringify(selected ?? frames.at(-1) ?? { status: "booting" }, null, 2)}</pre>

--- a/packages/sdk-examples/replit-demo/src/style.css
+++ b/packages/sdk-examples/replit-demo/src/style.css
@@ -1,6 +1,7 @@
 :root {
   --wasd-aura: 0, 229, 255;
   --wasd-neon: 57, 255, 20;
+  --wasd-gold: 255, 215, 106;
   --wasd-bg: #050607;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: white;
@@ -8,7 +9,7 @@
 }
 
 * { box-sizing: border-box; }
-body { margin: 0; min-height: 100vh; background: radial-gradient(circle at 50% 20%, rgba(var(--wasd-aura), .18), transparent 32%), #050607; }
+body { margin: 0; min-height: 100vh; background: radial-gradient(circle at 50% 20%, rgba(var(--wasd-aura), .18), transparent 32%), radial-gradient(circle at 90% 70%, rgba(var(--wasd-gold), .08), transparent 28%), #050607; }
 .shell { width: min(1120px, calc(100vw - 32px)); margin: 0 auto; padding: 42px 0; }
 .hero { margin-bottom: 24px; padding: 28px; border: 1px solid rgba(var(--wasd-aura), .24); border-radius: 28px; background: rgba(0,0,0,.32); box-shadow: 0 0 34px rgba(var(--wasd-aura), .13); }
 .eyebrow { margin: 0 0 12px; font-family: "Fira Code", ui-monospace, monospace; letter-spacing: .32em; text-transform: uppercase; color: rgba(178, 245, 255, .72); font-size: 12px; }
@@ -56,9 +57,29 @@ h1 { margin: 0; font-size: clamp(34px, 7vw, 78px); line-height: .92; letter-spac
 .overflow-auto { overflow: auto; }
 .transition-transform { transition-property: transform; }
 .duration-100 { transition-duration: 100ms; }
-.console { margin-top: 24px; padding: 24px; border-radius: 28px; border: 1px solid rgba(var(--wasd-neon), .22); background: rgba(0,0,0,.4); }
+.console, .loot-sim { margin-top: 24px; padding: 24px; border-radius: 28px; background: rgba(0,0,0,.4); }
+.console { border: 1px solid rgba(var(--wasd-neon), .22); }
 .console h2 { margin-top: 0; }
 .console pre { overflow: auto; color: #cffafe; font-size: 12px; line-height: 1.6; }
+.loot-sim { border: 1px solid rgba(var(--wasd-gold), .34); box-shadow: 0 0 34px rgba(var(--wasd-gold), .12), inset 0 0 24px rgba(var(--wasd-gold), .05); }
+.loot-head { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 16px; }
+.loot-head h2, .high-tier h3, .loot-columns h3 { margin: 0 0 12px; }
+.loot-head button { cursor: pointer; border: 1px solid rgba(var(--wasd-gold), .58); color: #fff5c4; background: rgba(96, 62, 0, .42); border-radius: 999px; padding: 10px 14px; font-weight: 800; box-shadow: 0 0 18px rgba(var(--wasd-gold), .18); }
+.loot-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin-top: 18px; }
+.metric { border: 1px solid rgba(var(--wasd-gold), .24); border-radius: 18px; background: rgba(255, 215, 106, .06); padding: 14px; }
+.metric span { display: block; color: rgba(255, 245, 196, .62); font-size: 11px; text-transform: uppercase; letter-spacing: .12em; }
+.metric strong { display: block; margin-top: 6px; color: #fff5c4; font-family: "Fira Code", ui-monospace, monospace; overflow-wrap: anywhere; }
+.loot-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; margin-top: 22px; }
+.bar-row { display: grid; grid-template-columns: 130px 1fr 82px; align-items: center; gap: 10px; padding: 7px 0; color: rgba(255,255,255,.84); }
+.bar-row span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bar-row code, .drop-card code { color: #ffd76a; font-family: "Fira Code", ui-monospace, monospace; font-size: 11px; }
+meter { width: 100%; height: 10px; }
+.high-tier { margin-top: 22px; }
+.high-tier p { color: rgba(255,245,196,.68); }
+.drop-card { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 8px; margin-top: 8px; padding: 10px 12px; border-radius: 16px; border: 1px solid rgba(var(--wasd-gold), .28); background: rgba(255, 215, 106, .08); animation: lootGoldPulse 1.2s ease-in-out infinite; }
+.drop-card strong { color: #fff5c4; }
+@keyframes lootGoldPulse { 0%, 100% { filter: brightness(1); box-shadow: 0 0 8px rgba(var(--wasd-gold), .12); } 50% { filter: brightness(1.22); box-shadow: 0 0 18px rgba(var(--wasd-gold), .25); } }
+@media (max-width: 760px) { .loot-grid, .loot-columns { grid-template-columns: 1fr; } .bar-row { grid-template-columns: 1fr; } }
 @media (min-width: 768px) {
   .md\:flex-row { flex-direction: row; }
   .md\:items-center { align-items: center; }

--- a/portal/src/community/EchoTracker.tsx
+++ b/portal/src/community/EchoTracker.tsx
@@ -1,13 +1,15 @@
 /**
  * Quest Echo Tracker — Screen 10 style feed.
  * - O(1) head reads via PortalWorldHistory ring buffer
- * - ThemeEngine colours: combat → fire-glitch pulse, trade → marina calm
+ * - ThemeEngine colours: combat → fire-glitch pulse, trade → marina calm, loot → golden glitch aura
  */
 
 import React, { useEffect, useMemo, useSyncExternalStore, useState } from "react";
 import {
+  getLootLegendaryVisualState,
   getVisualState,
   pushLiveTickerHazard,
+  pushLootAura,
   subscribeVisualTheme,
   visualStateToCssVars,
   type VisualThemeState,
@@ -15,6 +17,17 @@ import {
 import { PortalWorldHistory, type WorldEcho } from "../world/PortalWorldHistory";
 
 function echoVisual(echo: WorldEcho, live: VisualThemeState): VisualThemeState {
+  if (echo.kind === "loot" && echo.loot) {
+    return getLootLegendaryVisualState({
+      quality: echo.loot.quality,
+      itemId: echo.loot.itemId,
+      itemName: echo.loot.itemName,
+      sector: echo.loot.sector,
+      probability: echo.loot.probability,
+      rollHash: echo.loot.rollHash,
+      sourceId: echo.loot.sourceId,
+    });
+  }
   if (echo.kind === "combat") {
     return getVisualState(Math.max(0.78, live.hazardIndex), Math.max(0.0005, live.aggressionTrend));
   }
@@ -38,6 +51,8 @@ const EchoTracker: React.FC = () => {
       setLiveTheme(v);
       const prev = last;
       last = v;
+
+      if (v.mode === "loot_legendary") return;
 
       const enteredFire = v.mode === "fire_glitch" && prev?.mode !== "fire_glitch";
       const hazardSpike = prev != null && v.hazardIndex - prev.hazardIndex > 0.12;
@@ -87,6 +102,25 @@ const EchoTracker: React.FC = () => {
           </button>
           <button
             type="button"
+            className="rounded border border-amber-400/60 bg-amber-950/50 px-2 py-1 text-[11px] font-semibold text-amber-100 hover:bg-amber-900/60"
+            onClick={() => {
+              const meta = {
+                itemId: "ouroboros_core",
+                itemName: "Ouroboros Core",
+                quality: "legendary",
+                sector: "12:8",
+                probability: 0.000004,
+                rollHash: "demo-golden-roll-12-8",
+                sourceId: "tc_oracle_cache",
+              };
+              pushLootAura(meta);
+              hist.recordLootDrop(meta);
+            }}
+          >
+            + Legendary drop
+          </button>
+          <button
+            type="button"
             className="rounded border border-amber-500/50 bg-amber-950/40 px-2 py-1 text-[11px] font-semibold text-amber-100 hover:bg-amber-900/50"
             onClick={() => {
               let i = 0;
@@ -118,30 +152,36 @@ const EchoTracker: React.FC = () => {
       <ul className="max-h-72 space-y-2 overflow-y-auto pr-1">
         {echoes.length === 0 ? (
           <li className="rounded-lg border border-dashed border-slate-700 p-4 text-center text-sm text-slate-500">
-            Waiting for NPC trade / combat echoes…
+            Waiting for NPC trade / combat / loot echoes…
           </li>
         ) : (
           echoes.map((echo) => {
             const vis = echoVisual(echo, liveTheme);
             const vars = visualStateToCssVars(vis);
             const isCombat = echo.kind === "combat";
+            const isLoot = echo.kind === "loot";
             const firePulse = isCombat && vis.mode === "fire_glitch";
+            const goldenPulse = isLoot && vis.mode === "loot_legendary";
 
             return (
               <li
                 key={echo.id}
                 className={`flex items-start gap-3 rounded-lg border px-3 py-2 text-sm ${
-                  firePulse ? "border-red-500/50" : "border-cyan-500/30"
+                  goldenPulse ? "border-amber-300/70" : firePulse ? "border-red-500/50" : "border-cyan-500/30"
                 }`}
                 style={{
                   ...vars,
-                  backgroundColor: "rgba(15,23,42,0.72)",
-                  boxShadow: firePulse
-                    ? `0 0 14px ${vis.auraHex}, inset 0 0 8px rgba(230,0,0,0.12)`
-                    : `0 0 10px ${vis.auraHex}33`,
-                  animation: firePulse
-                    ? `echoFirePulse var(--wasd-phase-period, 0.9s) ease-in-out infinite`
-                    : `echoMarinaPulse var(--wasd-phase-period, 1.4s) ease-in-out infinite`,
+                  backgroundColor: goldenPulse ? "rgba(44,32,4,0.74)" : "rgba(15,23,42,0.72)",
+                  boxShadow: goldenPulse
+                    ? `0 0 22px ${vis.auraHex}, inset 0 0 18px rgba(255,215,106,0.18)`
+                    : firePulse
+                      ? `0 0 14px ${vis.auraHex}, inset 0 0 8px rgba(230,0,0,0.12)`
+                      : `0 0 10px ${vis.auraHex}33`,
+                  animation: goldenPulse
+                    ? `echoGoldPulse var(--wasd-phase-period, 0.65s) ease-in-out infinite`
+                    : firePulse
+                      ? `echoFirePulse var(--wasd-phase-period, 0.9s) ease-in-out infinite`
+                      : `echoMarinaPulse var(--wasd-phase-period, 1.4s) ease-in-out infinite`,
                 }}
               >
                 <span
@@ -156,6 +196,11 @@ const EchoTracker: React.FC = () => {
                     {echo.kind} · {new Date(echo.ts).toLocaleTimeString()}
                   </div>
                   <div className="text-slate-100">{echo.summary}</div>
+                  {echo.loot ? (
+                    <div className="mt-1 rounded border border-amber-300/30 bg-black/30 px-2 py-1 font-mono text-[10px] text-amber-100">
+                      Emily: Architekt Thomas, die Kausalität hat ein Fragment der Stufe {echo.loot.quality} in Sektor {echo.loot.sector} manifestiert. Wahrscheinlichkeit: {(echo.loot.probability * 100).toFixed(4)}%.
+                    </div>
+                  ) : null}
                 </div>
               </li>
             );
@@ -171,6 +216,10 @@ const EchoTracker: React.FC = () => {
         @keyframes echoMarinaPulse {
           0%, 100% { filter: brightness(1); }
           50% { filter: brightness(1.08); }
+        }
+        @keyframes echoGoldPulse {
+          0%, 100% { filter: brightness(1) saturate(1); transform: translateX(0) scale(1); }
+          50% { filter: brightness(1.34) saturate(1.35); transform: translateX(0.5px) scale(1.006); }
         }
       `}</style>
     </div>

--- a/portal/src/world/PortalWorldHistory.ts
+++ b/portal/src/world/PortalWorldHistory.ts
@@ -7,13 +7,25 @@
 
 import type { IWorldEvent } from "./portalWorldTypes";
 
-export type EchoKind = "combat" | "trade";
+export type EchoKind = "combat" | "trade" | "loot";
+export type LootEchoQuality = "epic" | "legendary" | "mythic" | string;
+
+export interface LootEchoMeta {
+  itemId: string;
+  itemName: string;
+  quality: LootEchoQuality;
+  sector: string;
+  probability: number;
+  rollHash?: string;
+  sourceId?: string;
+}
 
 export interface WorldEcho {
   id: string;
   kind: EchoKind;
   summary: string;
   ts: number;
+  loot?: LootEchoMeta;
   /** Optional mirror of server-style world lines */
   worldLine?: Pick<IWorldEvent, "title" | "description">;
 }
@@ -75,6 +87,20 @@ export class PortalWorldHistory {
     return this.pushEcho({ kind: "trade", summary, worldLine });
   }
 
+  recordLootDrop(meta: LootEchoMeta): WorldEcho {
+    const probabilityPct = (meta.probability * 100).toFixed(4);
+    const summary = `Golden loot echo · ${meta.quality.toUpperCase()} · ${meta.itemName} · sector ${meta.sector} · p=${probabilityPct}%`;
+    return this.pushEcho({
+      kind: "loot",
+      summary,
+      loot: meta,
+      worldLine: {
+        title: `Loot manifestation · ${meta.quality.toUpperCase()}`,
+        description: `Architekt Thomas, die Kausalität hat ${meta.itemName} in Sektor ${meta.sector} manifestiert. Wahrscheinlichkeit: ${probabilityPct}%.`,
+      },
+    });
+  }
+
   /** O(1) — most recent echo or null. */
   getHead(): WorldEcho | null {
     if (this.writeSeq === 0) return null;
@@ -101,20 +127,24 @@ export class PortalWorldHistory {
   getEchoDigestSummary(max = 10): {
     combat: number;
     trade: number;
+    loot: number;
     total: number;
     lines: string[];
   } {
     const slice = this.snapshotRecent(max);
     const combat = slice.filter((e) => e.kind === "combat").length;
     const trade = slice.filter((e) => e.kind === "trade").length;
+    const loot = slice.filter((e) => e.kind === "loot").length;
     const lines = slice.slice(0, 5).map((e) => `[${e.kind}] ${e.summary.slice(0, 72)}`);
-    return { combat, trade, total: slice.length, lines };
+    return { combat, trade, loot, total: slice.length, lines };
   }
 
   /** Optional: ingest server-shaped world lines as echo metadata. */
   ingestWorldLine(ev: IWorldEvent): void {
     const t = (ev.title + " " + ev.description).toLowerCase();
-    if (t.includes("trade") || t.includes("handel") || t.includes("deal")) {
+    if (t.includes("loot") || t.includes("drop") || t.includes("legendary") || t.includes("epic")) {
+      this.pushEcho({ kind: "loot", summary: ev.title, worldLine: { title: ev.title, description: ev.description } });
+    } else if (t.includes("trade") || t.includes("handel") || t.includes("deal")) {
       this.recordNpcTradeComplete(ev.title, { title: ev.title, description: ev.description });
     } else if (t.includes("combat") || t.includes("kampf") || t.includes("kill")) {
       this.recordNpcCombatComplete(ev.title, { title: ev.title, description: ev.description });


### PR DESCRIPTION
## Summary
- Add `loot_legendary` visual aura support in the shared ThemeEngine
- Add loot echoes to PortalWorldHistory with item, quality, sector, probability and roll hash metadata
- Render golden glitch loot echoes in EchoTracker with Emily commentary
- Add a Replit SDK Loot Simulator that runs 10,000 deterministic rolls for Treasure Class testing

## Notes
- No new external runtime dependency added beyond workspace package usage in the existing Replit demo
- Uses the existing ARE Recursive Treasure Matrix from @wasd/core-logic/loot
- Portal demo button can trigger a deterministic Legendary drop echo for visual verification