### PR TITLE
feat(alchemy): add deterministic item refinement

### DIFF
--- a/packages/core-logic/src/loot/AREAlchemist.ts
+++ b/packages/core-logic/src/loot/AREAlchemist.ts
@@ -1,0 +1,185 @@
+import type { LootDrop, LootQuality, LootRollContext } from "./ARELootTypes";
+import { stableHash } from "./ARELootEngine";
+
+export type EssenceKind = "commonEssence" | "arcaneEssence" | "sovereignEssence" | "legendaryResidue";
+
+export type EssenceWallet = Record<EssenceKind, number>;
+
+export interface DecompositionContext extends Pick<LootRollContext, "seed" | "worldHash" | "chunkHash" | "chunkId" | "tick" | "actorId" | "playerPublicKey"> {
+  reason?: "manual" | "auto_salvage" | "selfheal";
+}
+
+export interface DecompositionYield {
+  kind: EssenceKind;
+  amount: number;
+}
+
+export interface DecompositionResult {
+  destroyedItem: Pick<LootDrop, "itemId" | "name" | "quality" | "tier" | "quantity" | "rollHash">;
+  yields: DecompositionYield[];
+  residueHash: string;
+  echo: {
+    sector: string;
+    summary: string;
+    emily: string;
+  };
+}
+
+export interface EssenceBuffRequest {
+  wallet: EssenceWallet;
+  spend: Partial<EssenceWallet>;
+  context: Pick<LootRollContext, "seed" | "worldHash" | "chunkHash" | "tick" | "actorId" | "sourceId" | "playerPublicKey">;
+}
+
+export interface EssenceBuffResult {
+  acceptedSpend: EssenceWallet;
+  remainingWallet: EssenceWallet;
+  modifiers: NonNullable<LootRollContext["modifiers"]>;
+  buffHash: string;
+  summary: string;
+}
+
+const ZERO_WALLET: EssenceWallet = {
+  commonEssence: 0,
+  arcaneEssence: 0,
+  sovereignEssence: 0,
+  legendaryResidue: 0,
+};
+
+const QUALITY_MULTIPLIER: Record<LootQuality, number> = {
+  common: 1,
+  magic: 2,
+  rare: 4,
+  epic: 8,
+  legendary: 16,
+  mythic: 32,
+};
+
+export class AREAlchemist {
+  decompose(drop: LootDrop, context: DecompositionContext): DecompositionResult {
+    const residueHash = stableHash([
+      "ARE_ALCHEMY",
+      context.seed,
+      context.worldHash,
+      context.chunkHash,
+      context.chunkId,
+      context.tick,
+      context.actorId,
+      context.playerPublicKey ?? "solo",
+      drop.itemId,
+      drop.quality,
+      drop.tier,
+      drop.quantity,
+      drop.rollHash,
+    ].join("|"));
+
+    const base = Math.max(1, drop.tier) * Math.max(1, drop.quantity);
+    const q = QUALITY_MULTIPLIER[drop.quality] ?? 1;
+    const pulse = hashToRange(residueHash, 0, Math.max(2, q));
+    const commonEssence = Math.max(1, base + pulse);
+    const yields: DecompositionYield[] = [{ kind: "commonEssence", amount: commonEssence }];
+
+    if (["magic", "rare", "epic", "legendary", "mythic"].includes(drop.quality)) {
+      yields.push({ kind: "arcaneEssence", amount: Math.max(1, Math.floor((base * q) / 4) + hashToRange(residueHash, 8, 3)) });
+    }
+    if (["epic", "legendary", "mythic"].includes(drop.quality)) {
+      yields.push({ kind: "sovereignEssence", amount: Math.max(1, Math.floor((base * q) / 12) + hashToRange(residueHash, 16, 2)) });
+    }
+    if (["legendary", "mythic"].includes(drop.quality)) {
+      yields.push({ kind: "legendaryResidue", amount: Math.max(1, Math.floor((base * q) / 24) + hashToRange(residueHash, 24, 2)) });
+    }
+
+    const sector = context.chunkId;
+    return {
+      destroyedItem: {
+        itemId: drop.itemId,
+        name: drop.name,
+        quality: drop.quality,
+        tier: drop.tier,
+        quantity: drop.quantity,
+        rollHash: drop.rollHash,
+      },
+      yields,
+      residueHash,
+      echo: {
+        sector,
+        summary: `Molecular refinement · ${drop.quality.toUpperCase()} ${drop.name} → ${formatYields(yields)}`,
+        emily: `Architekt Thomas, ${drop.name} wurde in Sektor ${sector} kontrolliert zerlegt. Molekularer Zerfall stabil. Gewonnen: ${formatYields(yields)}.`,
+      },
+    };
+  }
+
+  applyYields(wallet: Partial<EssenceWallet>, yields: DecompositionYield[]): EssenceWallet {
+    const next = normalizeWallet(wallet);
+    for (const y of yields) {
+      next[y.kind] += Math.max(0, Math.floor(y.amount));
+    }
+    return next;
+  }
+
+  createEssenceBuff(request: EssenceBuffRequest): EssenceBuffResult {
+    const wallet = normalizeWallet(request.wallet);
+    const spend = normalizeWallet(request.spend);
+    const acceptedSpend: EssenceWallet = { ...ZERO_WALLET };
+    const remainingWallet: EssenceWallet = { ...wallet };
+
+    for (const key of Object.keys(ZERO_WALLET) as EssenceKind[]) {
+      acceptedSpend[key] = Math.max(0, Math.min(wallet[key], Math.floor(spend[key])));
+      remainingWallet[key] = wallet[key] - acceptedSpend[key];
+    }
+
+    const buffPower =
+      acceptedSpend.commonEssence * 1 +
+      acceptedSpend.arcaneEssence * 3 +
+      acceptedSpend.sovereignEssence * 9 +
+      acceptedSpend.legendaryResidue * 25;
+
+    const cappedPower = Math.min(250, buffPower);
+    const buffHash = stableHash([
+      "ARE_ESSENCE_BUFF",
+      request.context.seed,
+      request.context.worldHash,
+      request.context.chunkHash,
+      request.context.tick,
+      request.context.actorId,
+      request.context.sourceId,
+      request.context.playerPublicKey ?? "solo",
+      JSON.stringify(acceptedSpend),
+    ].join("|"));
+
+    const modifiers: NonNullable<LootRollContext["modifiers"]> = {
+      noDrop: Math.max(0.72, 1 - cappedPower / 2000),
+      magic: 1 + acceptedSpend.arcaneEssence / 250,
+      rare: 1 + acceptedSpend.sovereignEssence / 180,
+      epic: 1 + acceptedSpend.sovereignEssence / 420,
+      legendary: 1 + acceptedSpend.legendaryResidue / 260,
+      mythic: 1 + acceptedSpend.legendaryResidue / 900,
+      quantity: 1,
+    };
+
+    return {
+      acceptedSpend,
+      remainingWallet,
+      modifiers,
+      buffHash,
+      summary: `Essence buff accepted · power=${cappedPower} · hash=${buffHash.slice(0, 12)}`,
+    };
+  }
+}
+
+export function normalizeWallet(wallet: Partial<EssenceWallet> = {}): EssenceWallet {
+  return {
+    commonEssence: Math.max(0, Math.floor(wallet.commonEssence ?? 0)),
+    arcaneEssence: Math.max(0, Math.floor(wallet.arcaneEssence ?? 0)),
+    sovereignEssence: Math.max(0, Math.floor(wallet.sovereignEssence ?? 0)),
+    legendaryResidue: Math.max(0, Math.floor(wallet.legendaryResidue ?? 0)),
+  };
+}
+
+export function formatYields(yields: DecompositionYield[]): string {
+  return yields.map((y) => `${y.amount} ${y.kind}`).join(", ");
+}
+
+function hashToRange(hash: string, offset: number, modulo: number): number {
+  return Number.parseInt(hash.slice(offset, offset + 8), 16) % Math.max(1, modulo);
+}

--- a/packages/core-logic/src/loot/index.ts
+++ b/packages/core-logic/src/loot/index.ts
@@ -1,3 +1,4 @@
 export * from "./ARELootTypes";
 export * from "./ARELootEngine";
 export * from "./DefaultLootMatrix";
+export * from "./AREAlchemist";

--- a/portal/src/apps/SciencePortal.tsx
+++ b/portal/src/apps/SciencePortal.tsx
@@ -6,6 +6,7 @@ import {
   type VisualThemeState,
 } from "@wasd/shared";
 import EchoTracker from "../community/EchoTracker";
+import InventoryRefinementPanel from "../community/InventoryRefinementPanel";
 import ScienceMascotChat from "./ScienceMascotChat";
 import WarfrontCombatHud from "./WarfrontCombatHud";
 
@@ -25,11 +26,16 @@ export const SciencePortal: React.FC = () => {
   const cssVars = useMemo(() => visualStateToCssVars(visual), [visual]);
 
   const isFire = visual.mode === "fire_glitch";
+  const isLoot = visual.mode === "loot_legendary";
 
   return (
     <div
       className={`relative overflow-hidden rounded-xl border p-4 transition-colors duration-300 ${
-        isFire ? "border-red-500/60 shadow-[0_0_24px_rgba(230,0,0,0.35)]" : "border-cyan-500/40 shadow-[0_0_20px_rgba(0,229,255,0.2)]"
+        isLoot
+          ? "border-amber-300/70 shadow-[0_0_28px_rgba(255,215,106,0.32)]"
+          : isFire
+            ? "border-red-500/60 shadow-[0_0_24px_rgba(230,0,0,0.35)]"
+            : "border-cyan-500/40 shadow-[0_0_20px_rgba(0,229,255,0.2)]"
       }`}
       style={
         {
@@ -37,9 +43,11 @@ export const SciencePortal: React.FC = () => {
           background:
             visual.mode === "marina"
               ? "linear-gradient(145deg, #0f172a 0%, #0c4a6e 55%, #0f172a 100%)"
-              : visual.mode === "fire_glitch"
-                ? "linear-gradient(145deg, #1a0505 0%, #450a0a 50%, #0f172a 100%)"
-                : "linear-gradient(145deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)",
+              : visual.mode === "loot_legendary"
+                ? "linear-gradient(145deg, #140f02 0%, #3f2f05 48%, #0f172a 100%)"
+                : visual.mode === "fire_glitch"
+                  ? "linear-gradient(145deg, #1a0505 0%, #450a0a 50%, #0f172a 100%)"
+                  : "linear-gradient(145deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)",
         } as React.CSSProperties
       }
     >
@@ -82,7 +90,7 @@ export const SciencePortal: React.FC = () => {
           </div>
 
           <p className="text-sm text-slate-200">
-            Dashboard physisch gekoppelt an NPC-Aggression & Hazard-Index via{" "}
+            Dashboard physisch gekoppelt an NPC-Aggression, Hazard-Index, Loot-Aura und Alchemical Refinement via{" "}
             <code className="rounded bg-black/30 px-1">@wasd/shared</code> ThemeEngine.
           </p>
 
@@ -114,11 +122,14 @@ export const SciencePortal: React.FC = () => {
             />
             Aura <code>{visual.auraHex}</code>
             {isFire && <span className="text-red-400"> · glitch {visual.glitchIntensity.toFixed(2)}</span>}
+            {isLoot && <span className="text-amber-200"> · loot aura {visual.glitchIntensity.toFixed(2)}</span>}
           </div>
 
           <WarfrontCombatHud visual={visual} active={active} />
 
           <EchoTracker />
+
+          <InventoryRefinementPanel />
         </div>
 
         <div className="lg:sticky lg:top-2">

--- a/portal/src/community/EchoTracker.tsx
+++ b/portal/src/community/EchoTracker.tsx
@@ -2,6 +2,7 @@
  * Quest Echo Tracker — Screen 10 style feed.
  * - O(1) head reads via PortalWorldHistory ring buffer
  * - ThemeEngine colours: combat → fire-glitch pulse, trade → marina calm, loot → golden glitch aura
+ * - refinement → molecular decay aura
  */
 
 import React, { useEffect, useMemo, useSyncExternalStore, useState } from "react";
@@ -16,6 +17,18 @@ import {
 } from "@wasd/shared";
 import { PortalWorldHistory, type WorldEcho } from "../world/PortalWorldHistory";
 
+function refinementVisual(): VisualThemeState {
+  return {
+    auraHex: "#39FF14",
+    secondaryHex: "#3d0505",
+    mode: "balanced",
+    glitchIntensity: 0.64,
+    phaseShiftPulseHz: 1.35,
+    hazardIndex: 0.44,
+    aggressionTrend: 0,
+  };
+}
+
 function echoVisual(echo: WorldEcho, live: VisualThemeState): VisualThemeState {
   if (echo.kind === "loot" && echo.loot) {
     return getLootLegendaryVisualState({
@@ -28,6 +41,7 @@ function echoVisual(echo: WorldEcho, live: VisualThemeState): VisualThemeState {
       sourceId: echo.loot.sourceId,
     });
   }
+  if (echo.kind === "refinement") return refinementVisual();
   if (echo.kind === "combat") {
     return getVisualState(Math.max(0.78, live.hazardIndex), Math.max(0.0005, live.aggressionTrend));
   }
@@ -121,6 +135,22 @@ const EchoTracker: React.FC = () => {
           </button>
           <button
             type="button"
+            className="rounded border border-lime-400/50 bg-lime-950/40 px-2 py-1 text-[11px] font-semibold text-lime-100 hover:bg-lime-900/50"
+            onClick={() => {
+              hist.recordRefinement({
+                itemId: "rusted_blade",
+                itemName: "Rusted Blade",
+                quality: "common",
+                sector: "12:8",
+                yields: "2 commonEssence",
+                residueHash: "demo-refine-rusted-blade",
+              });
+            }}
+          >
+            + Refine echo
+          </button>
+          <button
+            type="button"
             className="rounded border border-amber-500/50 bg-amber-950/40 px-2 py-1 text-[11px] font-semibold text-amber-100 hover:bg-amber-900/50"
             onClick={() => {
               let i = 0;
@@ -152,7 +182,7 @@ const EchoTracker: React.FC = () => {
       <ul className="max-h-72 space-y-2 overflow-y-auto pr-1">
         {echoes.length === 0 ? (
           <li className="rounded-lg border border-dashed border-slate-700 p-4 text-center text-sm text-slate-500">
-            Waiting for NPC trade / combat / loot echoes…
+            Waiting for NPC trade / combat / loot / refinement echoes…
           </li>
         ) : (
           echoes.map((echo) => {
@@ -160,28 +190,44 @@ const EchoTracker: React.FC = () => {
             const vars = visualStateToCssVars(vis);
             const isCombat = echo.kind === "combat";
             const isLoot = echo.kind === "loot";
+            const isRefinement = echo.kind === "refinement";
             const firePulse = isCombat && vis.mode === "fire_glitch";
             const goldenPulse = isLoot && vis.mode === "loot_legendary";
+            const refinePulse = isRefinement;
 
             return (
               <li
                 key={echo.id}
                 className={`flex items-start gap-3 rounded-lg border px-3 py-2 text-sm ${
-                  goldenPulse ? "border-amber-300/70" : firePulse ? "border-red-500/50" : "border-cyan-500/30"
+                  goldenPulse
+                    ? "border-amber-300/70"
+                    : refinePulse
+                      ? "border-lime-300/60"
+                      : firePulse
+                        ? "border-red-500/50"
+                        : "border-cyan-500/30"
                 }`}
                 style={{
                   ...vars,
-                  backgroundColor: goldenPulse ? "rgba(44,32,4,0.74)" : "rgba(15,23,42,0.72)",
+                  backgroundColor: goldenPulse
+                    ? "rgba(44,32,4,0.74)"
+                    : refinePulse
+                      ? "rgba(4,32,14,0.68)"
+                      : "rgba(15,23,42,0.72)",
                   boxShadow: goldenPulse
                     ? `0 0 22px ${vis.auraHex}, inset 0 0 18px rgba(255,215,106,0.18)`
-                    : firePulse
-                      ? `0 0 14px ${vis.auraHex}, inset 0 0 8px rgba(230,0,0,0.12)`
-                      : `0 0 10px ${vis.auraHex}33`,
+                    : refinePulse
+                      ? `0 0 18px #39FF14, inset 0 0 12px rgba(230,0,0,0.14)`
+                      : firePulse
+                        ? `0 0 14px ${vis.auraHex}, inset 0 0 8px rgba(230,0,0,0.12)`
+                        : `0 0 10px ${vis.auraHex}33`,
                   animation: goldenPulse
                     ? `echoGoldPulse var(--wasd-phase-period, 0.65s) ease-in-out infinite`
-                    : firePulse
-                      ? `echoFirePulse var(--wasd-phase-period, 0.9s) ease-in-out infinite`
-                      : `echoMarinaPulse var(--wasd-phase-period, 1.4s) ease-in-out infinite`,
+                    : refinePulse
+                      ? `echoRefinePulse 0.88s ease-in-out infinite`
+                      : firePulse
+                        ? `echoFirePulse var(--wasd-phase-period, 0.9s) ease-in-out infinite`
+                        : `echoMarinaPulse var(--wasd-phase-period, 1.4s) ease-in-out infinite`,
                 }}
               >
                 <span
@@ -199,6 +245,11 @@ const EchoTracker: React.FC = () => {
                   {echo.loot ? (
                     <div className="mt-1 rounded border border-amber-300/30 bg-black/30 px-2 py-1 font-mono text-[10px] text-amber-100">
                       Emily: Architekt Thomas, die Kausalität hat ein Fragment der Stufe {echo.loot.quality} in Sektor {echo.loot.sector} manifestiert. Wahrscheinlichkeit: {(echo.loot.probability * 100).toFixed(4)}%.
+                    </div>
+                  ) : null}
+                  {echo.refinement ? (
+                    <div className="mt-1 rounded border border-lime-300/30 bg-black/30 px-2 py-1 font-mono text-[10px] text-lime-100">
+                      Emily: Architekt Thomas, {echo.refinement.itemName} wurde in Sektor {echo.refinement.sector} kontrolliert zerlegt. Molekularer Zerfall stabil. Gewonnen: {echo.refinement.yields}.
                     </div>
                   ) : null}
                 </div>
@@ -220,6 +271,10 @@ const EchoTracker: React.FC = () => {
         @keyframes echoGoldPulse {
           0%, 100% { filter: brightness(1) saturate(1); transform: translateX(0) scale(1); }
           50% { filter: brightness(1.34) saturate(1.35); transform: translateX(0.5px) scale(1.006); }
+        }
+        @keyframes echoRefinePulse {
+          0%, 100% { filter: brightness(1) saturate(1); transform: translateX(0); }
+          50% { filter: brightness(1.2) saturate(1.4); transform: translateX(-0.5px); }
         }
       `}</style>
     </div>

--- a/portal/src/community/InventoryRefinementPanel.tsx
+++ b/portal/src/community/InventoryRefinementPanel.tsx
@@ -1,0 +1,214 @@
+import React, { useMemo, useState } from "react";
+import { PortalWorldHistory } from "../world/PortalWorldHistory";
+
+type Quality = "common" | "magic" | "rare" | "epic" | "legendary";
+type EssenceKind = "commonEssence" | "arcaneEssence" | "sovereignEssence" | "legendaryResidue";
+type Wallet = Record<EssenceKind, number>;
+
+interface InventoryItem {
+  itemId: string;
+  name: string;
+  quality: Quality;
+  tier: number;
+  quantity: number;
+  rollHash: string;
+}
+
+interface RefinementResult {
+  yields: Wallet;
+  residueHash: string;
+  summary: string;
+}
+
+const initialInventory: InventoryItem[] = [
+  { itemId: "rusted_blade", name: "Rusted Blade", quality: "common", tier: 1, quantity: 1, rollHash: "inv-rusted-blade-001" },
+  { itemId: "iron_scale", name: "Iron Scale", quality: "magic", tier: 2, quantity: 3, rollHash: "inv-iron-scale-002" },
+  { itemId: "oracle_rune", name: "Oracle Rune", quality: "rare", tier: 3, quantity: 1, rollHash: "inv-oracle-rune-003" },
+  { itemId: "warden_relic", name: "Warden Relic", quality: "epic", tier: 4, quantity: 1, rollHash: "inv-warden-relic-004" },
+];
+
+const zeroWallet: Wallet = {
+  commonEssence: 0,
+  arcaneEssence: 0,
+  sovereignEssence: 0,
+  legendaryResidue: 0,
+};
+
+const qualityPower: Record<Quality, number> = {
+  common: 1,
+  magic: 2,
+  rare: 4,
+  epic: 8,
+  legendary: 16,
+};
+
+function stableHash(input: string): string {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return `${(h2 >>> 0).toString(16).padStart(8, "0")}${(h1 >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+function hashRange(hash: string, offset: number, modulo: number): number {
+  return Number.parseInt(hash.slice(offset, offset + 8).padEnd(8, "0"), 16) % Math.max(1, modulo);
+}
+
+function decomposeItem(item: InventoryItem, tick: number): RefinementResult {
+  const residueHash = stableHash(`ARE_REFINE|${item.itemId}|${item.quality}|${item.tier}|${item.quantity}|${item.rollHash}|${tick}|12:8`);
+  const base = Math.max(1, item.tier) * Math.max(1, item.quantity);
+  const power = qualityPower[item.quality];
+  const yields: Wallet = { ...zeroWallet };
+  yields.commonEssence = Math.max(1, base + hashRange(residueHash, 0, Math.max(2, power)));
+  if (["magic", "rare", "epic", "legendary"].includes(item.quality)) {
+    yields.arcaneEssence = Math.max(1, Math.floor((base * power) / 4) + hashRange(residueHash, 4, 3));
+  }
+  if (["epic", "legendary"].includes(item.quality)) {
+    yields.sovereignEssence = Math.max(1, Math.floor((base * power) / 12) + hashRange(residueHash, 8, 2));
+  }
+  if (item.quality === "legendary") {
+    yields.legendaryResidue = Math.max(1, Math.floor((base * power) / 24) + hashRange(residueHash, 12, 2));
+  }
+  return { yields, residueHash, summary: formatWallet(yields) };
+}
+
+function formatWallet(wallet: Partial<Wallet>): string {
+  return (Object.entries(wallet) as Array<[EssenceKind, number]>)
+    .filter(([, amount]) => amount > 0)
+    .map(([kind, amount]) => `${amount} ${kind}`)
+    .join(", ") || "0 essence";
+}
+
+function addWallet(a: Wallet, b: Partial<Wallet>): Wallet {
+  return {
+    commonEssence: a.commonEssence + Math.max(0, Math.floor(b.commonEssence ?? 0)),
+    arcaneEssence: a.arcaneEssence + Math.max(0, Math.floor(b.arcaneEssence ?? 0)),
+    sovereignEssence: a.sovereignEssence + Math.max(0, Math.floor(b.sovereignEssence ?? 0)),
+    legendaryResidue: a.legendaryResidue + Math.max(0, Math.floor(b.legendaryResidue ?? 0)),
+  };
+}
+
+function spendBuff(wallet: Wallet): { wallet: Wallet; summary: string } {
+  const spend = {
+    commonEssence: Math.min(wallet.commonEssence, 12),
+    arcaneEssence: Math.min(wallet.arcaneEssence, 6),
+    sovereignEssence: Math.min(wallet.sovereignEssence, 2),
+    legendaryResidue: Math.min(wallet.legendaryResidue, 1),
+  };
+  const next = {
+    commonEssence: wallet.commonEssence - spend.commonEssence,
+    arcaneEssence: wallet.arcaneEssence - spend.arcaneEssence,
+    sovereignEssence: wallet.sovereignEssence - spend.sovereignEssence,
+    legendaryResidue: wallet.legendaryResidue - spend.legendaryResidue,
+  };
+  const power = spend.commonEssence + spend.arcaneEssence * 3 + spend.sovereignEssence * 9 + spend.legendaryResidue * 25;
+  return {
+    wallet: next,
+    summary: `Next-tick essence buff armed · power=${power} · noDrop≈-${Math.min(28, power / 2).toFixed(1)}% · rare+ ${(power / 180).toFixed(3)}x`,
+  };
+}
+
+const qualityClass: Record<Quality, string> = {
+  common: "border-slate-500/40 text-slate-100",
+  magic: "border-cyan-400/40 text-cyan-100",
+  rare: "border-violet-400/40 text-violet-100",
+  epic: "border-fuchsia-400/50 text-fuchsia-100",
+  legendary: "border-amber-300/70 text-amber-100",
+};
+
+export default function InventoryRefinementPanel(): JSX.Element {
+  const hist = useMemo(() => PortalWorldHistory.getInstance(), []);
+  const [inventory, setInventory] = useState<InventoryItem[]>(initialInventory);
+  const [wallet, setWallet] = useState<Wallet>({ commonEssence: 4, arcaneEssence: 1, sovereignEssence: 0, legendaryResidue: 0 });
+  const [lastReport, setLastReport] = useState<string>("Emily: Refinement bay standing by. Schrott wartet auf Verwandlung.");
+  const [tick, setTick] = useState(840);
+
+  const canBuff = wallet.commonEssence + wallet.arcaneEssence + wallet.sovereignEssence + wallet.legendaryResidue > 0;
+
+  function refine(item: InventoryItem): void {
+    const result = decomposeItem(item, tick);
+    setTick((current) => current + 1);
+    setWallet((current) => addWallet(current, result.yields));
+    setInventory((current) => current.filter((candidate) => candidate.rollHash !== item.rollHash));
+    const emily = `Emily: Architekt Thomas, ${item.name} wurde in Sektor 12:8 kontrolliert zerlegt. Molekularer Zerfall stabil. Gewonnen: ${result.summary}.`;
+    setLastReport(emily);
+    hist.recordRefinement({
+      itemId: item.itemId,
+      itemName: item.name,
+      quality: item.quality,
+      sector: "12:8",
+      yields: result.summary,
+      residueHash: result.residueHash,
+    });
+  }
+
+  function armBuff(): void {
+    const next = spendBuff(wallet);
+    setWallet(next.wallet);
+    setLastReport(`Emily: ${next.summary}. Die nächste Kausalitätsfalte ist vorbereitet.`);
+    hist.recordNpcTradeComplete(`Essence buff armed · ${next.summary}`);
+  }
+
+  return (
+    <section className="rounded-xl border border-lime-400/30 bg-slate-950/80 p-4 shadow-[0_0_20px_rgba(57,255,20,0.12)]">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-bold uppercase tracking-widest text-lime-200">Inventory & Refinement</h3>
+          <p className="mt-1 text-xs text-slate-400">Alchemical Refiner · deterministic salvage · next-tick essence buff</p>
+        </div>
+        <button
+          type="button"
+          disabled={!canBuff}
+          onClick={armBuff}
+          className="rounded border border-lime-300/50 bg-lime-950/50 px-3 py-1 text-[11px] font-semibold text-lime-100 hover:bg-lime-900/60 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Arm Essence Buff
+        </button>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_250px]">
+        <div className="space-y-2">
+          {inventory.length === 0 ? (
+            <div className="rounded border border-dashed border-slate-700 p-4 text-sm text-slate-500">Inventory empty. Die Esse glüht weiter.</div>
+          ) : (
+            inventory.map((item) => (
+              <div key={item.rollHash} className={`rounded-lg border bg-black/25 p-3 ${qualityClass[item.quality]}`}>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <div className="font-semibold">{item.name}</div>
+                    <div className="font-mono text-[10px] uppercase text-slate-500">{item.quality} · tier {item.tier} · qty {item.quantity}</div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => refine(item)}
+                    className="rounded border border-lime-300/40 bg-lime-950/40 px-2 py-1 text-[11px] font-semibold text-lime-100 hover:bg-lime-900/60"
+                  >
+                    Decompose
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        <aside className="rounded-lg border border-lime-300/20 bg-black/30 p-3">
+          <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-lime-200">Material Wallet</h4>
+          {(Object.entries(wallet) as Array<[EssenceKind, number]>).map(([kind, amount]) => (
+            <div key={kind} className="mb-2 flex items-center justify-between gap-2 font-mono text-[11px]">
+              <span className="text-slate-400">{kind}</span>
+              <span className="text-lime-100">{amount}</span>
+            </div>
+          ))}
+          <div className="mt-3 rounded border border-lime-300/20 bg-lime-950/20 p-2 font-mono text-[10px] text-lime-100">
+            {lastReport}
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add AREAlchemist for deterministic item decomposition into essence materials
- Add essence buff calculation for next-tick loot modifiers
- Add refinement echoes to PortalWorldHistory and EchoTracker
- Add Inventory & Refinement panel to Science Portal

## Notes
- No new dependencies
- No lockfile changes
- Portal panel uses a local display simulation while the reusable deterministic logic lives in @wasd/core-logic/loot