### PR TITLE
feat(destiny): mount destiny panel in science portal

### DIFF
--- a/portal/src/apps/SciencePortal.tsx
+++ b/portal/src/apps/SciencePortal.tsx
@@ -5,6 +5,7 @@ import {
   visualStateToCssVars,
   type VisualThemeState,
 } from "@wasd/shared";
+import DestinyPathsPanel from "../community/DestinyPathsPanel";
 import EchoTracker from "../community/EchoTracker";
 import InventoryRefinementPanel from "../community/InventoryRefinementPanel";
 import ScienceMascotChat from "./ScienceMascotChat";
@@ -130,6 +131,8 @@ export const SciencePortal: React.FC = () => {
           <EchoTracker />
 
           <InventoryRefinementPanel />
+
+          <DestinyPathsPanel />
         </div>
 
         <div className="lg:sticky lg:top-2">


### PR DESCRIPTION
Mount the existing DestinyPathsPanel inside the Science Portal without altering the current layout or theme behavior.

Changes:
- Add DestinyPathsPanel import
- Render DestinyPathsPanel below InventoryRefinementPanel

This is intentionally tiny to avoid rolling back recent portal UI changes.