### PR TITLE
fix(portal): complete world history echo API

### DIFF
--- a/portal/src/apps/SciencePortal.tsx
+++ b/portal/src/apps/SciencePortal.tsx
@@ -7,6 +7,7 @@ import {
 } from "@wasd/shared";
 import DestinyPathsPanel from "../community/DestinyPathsPanel";
 import EchoTracker from "../community/EchoTracker";
+import ForgePanel from "../community/ForgePanel";
 import InventoryRefinementPanel from "../community/InventoryRefinementPanel";
 import ScienceMascotChat from "./ScienceMascotChat";
 import WarfrontCombatHud from "./WarfrontCombatHud";
@@ -131,6 +132,8 @@ export const SciencePortal: React.FC = () => {
           <EchoTracker />
 
           <InventoryRefinementPanel />
+
+          <ForgePanel />
 
           <DestinyPathsPanel />
         </div>

--- a/portal/src/community/DestinyPathsPanel.tsx
+++ b/portal/src/community/DestinyPathsPanel.tsx
@@ -224,13 +224,14 @@ export const DestinyPathsPanel: React.FC = () => {
               type="button"
               className="mt-3 rounded border border-violet-300/50 bg-violet-400/15 px-3 py-1 text-xs font-semibold text-violet-100 hover:bg-violet-400/25"
               onClick={() => {
-                hist.pushEcho({
-                  kind: "destiny" as never,
-                  summary: `Destiny path released · ${path.title} · reward ${path.rewardQuality.toUpperCase()} ${path.rewardBlueprint}`,
-                  worldLine: {
-                    title: `Destiny released · ${path.severity.toUpperCase()}`,
-                    description: path.emilyBriefing,
-                  },
+                hist.recordDestiny({
+                  destinyId: path.id,
+                  title: path.title,
+                  sector: path.sectorId,
+                  severity: path.severity,
+                  rewardBlueprint: path.rewardBlueprint,
+                  rewardQuality: path.rewardQuality,
+                  destinyHash: path.destinyHash,
                 });
               }}
             >

--- a/portal/src/community/EchoTracker.test.ts
+++ b/portal/src/community/EchoTracker.test.ts
@@ -61,4 +61,61 @@ describe("PortalWorldHistory", () => {
     });
     expect(h.getHead()?.kind).toBe("trade");
   });
+
+  it("recordRefinement appends typed refinement echo", () => {
+    const h = PortalWorldHistory.getInstance();
+    h.recordRefinement({
+      itemId: "rusted_blade",
+      itemName: "Rusted Blade",
+      quality: "common",
+      sector: "12:8",
+      yields: "2 commonEssence",
+      residueHash: "test-residue",
+    });
+    expect(h.getHead()?.kind).toBe("refinement");
+    expect(h.getHead()?.refinement?.itemId).toBe("rusted_blade");
+  });
+
+  it("recordForge appends typed forge echo", () => {
+    const h = PortalWorldHistory.getInstance();
+    h.recordForge({
+      blueprintId: "bp_echo_blade_t2",
+      blueprintName: "Blueprint: Echo Blade",
+      itemId: "echo_blade:abc",
+      itemName: "Echo Blade",
+      quality: "rare",
+      sector: "12:8",
+      stability: 0.94,
+      forgeHash: "forgehash123",
+    });
+    expect(h.getHead()?.kind).toBe("forge");
+    expect(h.getHead()?.forge?.blueprintId).toBe("bp_echo_blade_t2");
+  });
+
+  it("recordDestiny appends typed destiny echo", () => {
+    const h = PortalWorldHistory.getInstance();
+    h.recordDestiny({
+      destinyId: "destiny_alpha",
+      title: "Säuberung von Sektor 12:8",
+      sector: "12:8",
+      severity: "high",
+      rewardBlueprint: "Blueprint: Echo Blade",
+      rewardQuality: "legendary",
+      destinyHash: "destinyhash123",
+    });
+    expect(h.getHead()?.kind).toBe("destiny");
+    expect(h.getHead()?.destiny?.rewardQuality).toBe("legendary");
+  });
+
+  it("digest includes refinement forge and destiny counts", () => {
+    const h = PortalWorldHistory.getInstance();
+    h.recordRefinement({ itemId: "a", itemName: "A", quality: "common", sector: "1:1", yields: "1 commonEssence", residueHash: "r" });
+    h.recordForge({ blueprintId: "bp", blueprintName: "BP", itemId: "i", itemName: "I", quality: "rare", sector: "1:1", stability: 1, forgeHash: "f" });
+    h.recordDestiny({ title: "Destiny", rewardBlueprint: "Blueprint: Echo", rewardQuality: "rare" });
+    const d = h.getEchoDigestSummary(10);
+    expect(d.refinement).toBe(1);
+    expect(d.forge).toBe(1);
+    expect(d.destiny).toBe(1);
+    expect(d.total).toBe(3);
+  });
 });

--- a/portal/src/world/PortalWorldHistory.ts
+++ b/portal/src/world/PortalWorldHistory.ts
@@ -7,7 +7,7 @@
 
 import type { IWorldEvent } from "./portalWorldTypes";
 
-export type EchoKind = "combat" | "trade" | "loot";
+export type EchoKind = "combat" | "trade" | "loot" | "refinement" | "forge" | "destiny";
 export type LootEchoQuality = "epic" | "legendary" | "mythic" | string;
 
 export interface LootEchoMeta {
@@ -20,13 +20,45 @@ export interface LootEchoMeta {
   sourceId?: string;
 }
 
+export interface RefinementEchoMeta {
+  itemId: string;
+  itemName: string;
+  quality: string;
+  sector: string;
+  yields: string;
+  residueHash: string;
+}
+
+export interface ForgeEchoMeta {
+  blueprintId: string;
+  blueprintName: string;
+  itemId: string;
+  itemName: string;
+  quality: string;
+  sector: string;
+  stability: number;
+  forgeHash: string;
+}
+
+export interface DestinyEchoMeta {
+  destinyId?: string;
+  title: string;
+  sector?: string;
+  severity?: string;
+  rewardBlueprint?: string;
+  rewardQuality?: string;
+  destinyHash?: string;
+}
+
 export interface WorldEcho {
   id: string;
   kind: EchoKind;
   summary: string;
   ts: number;
   loot?: LootEchoMeta;
-  /** Optional mirror of server-style world lines */
+  refinement?: RefinementEchoMeta;
+  forge?: ForgeEchoMeta;
+  destiny?: DestinyEchoMeta;
   worldLine?: Pick<IWorldEvent, "title" | "description">;
 }
 
@@ -67,7 +99,6 @@ export class PortalWorldHistory {
     }
   }
 
-  /** O(1) append newest echo (overwrites oldest slot when full). */
   pushEcho(partial: Omit<WorldEcho, "id" | "ts"> & { id?: string; ts?: number }): WorldEcho {
     const id = partial.id ?? `echo_${this.writeSeq}_${partial.kind}`;
     const ts = partial.ts ?? Date.now();
@@ -101,13 +132,51 @@ export class PortalWorldHistory {
     });
   }
 
-  /** O(1) — most recent echo or null. */
+  recordRefinement(meta: RefinementEchoMeta): WorldEcho {
+    const summary = `Refinement echo · ${meta.quality.toUpperCase()} · ${meta.itemName} · sector ${meta.sector}`;
+    return this.pushEcho({
+      kind: "refinement",
+      summary,
+      refinement: meta,
+      worldLine: {
+        title: `Refinement · ${meta.itemName}`,
+        description: `Architekt Thomas, ${meta.itemName} wurde in Sektor ${meta.sector} kontrolliert zerlegt. Gewonnen: ${meta.yields}.`,
+      },
+    });
+  }
+
+  recordForge(meta: ForgeEchoMeta): WorldEcho {
+    const stabilityPct = (meta.stability * 100).toFixed(2);
+    const summary = `Forge echo · ${meta.quality.toUpperCase()} · ${meta.itemName} · sector ${meta.sector} · stability ${stabilityPct}%`;
+    return this.pushEcho({
+      kind: "forge",
+      summary,
+      forge: meta,
+      worldLine: {
+        title: `Forge manifestation · ${meta.quality.toUpperCase()}`,
+        description: `Schmiedevorgang stabil. Blueprint-Kausalität bei ${stabilityPct}%. ${meta.itemName} wurde in Sektor ${meta.sector} manifestiert.`,
+      },
+    });
+  }
+
+  recordDestiny(meta: DestinyEchoMeta): WorldEcho {
+    const summary = `Destiny path released · ${meta.title}`;
+    return this.pushEcho({
+      kind: "destiny",
+      summary,
+      destiny: meta,
+      worldLine: {
+        title: `Destiny released${meta.severity ? ` · ${meta.severity.toUpperCase()}` : ""}`,
+        description: `Emily schlägt den Schicksalspfad ${meta.title}${meta.sector ? ` in Sektor ${meta.sector}` : ""} vor.${meta.rewardBlueprint ? ` Garantierte Blueprint-Belohnung: ${meta.rewardBlueprint}${meta.rewardQuality ? ` (${meta.rewardQuality})` : ""}.` : ""}`,
+      },
+    });
+  }
+
   getHead(): WorldEcho | null {
     if (this.writeSeq === 0) return null;
     return this.ring[(this.writeSeq - 1) % CAP];
   }
 
-  /** O(k) for bounded UI lists (k ≪ CAP). */
   snapshotRecent(max = 32): WorldEcho[] {
     const n = Math.min(max, this.writeSeq, CAP);
     const out: WorldEcho[] = [];
@@ -118,16 +187,17 @@ export class PortalWorldHistory {
     return out;
   }
 
-  /** Snapshot version for useSyncExternalStore (bump each push). */
   getVersion(): number {
     return this.writeSeq;
   }
 
-  /** Compact digest for mascot / stress HUD (bounded window). */
   getEchoDigestSummary(max = 10): {
     combat: number;
     trade: number;
     loot: number;
+    refinement: number;
+    forge: number;
+    destiny: number;
     total: number;
     lines: string[];
   } {
@@ -135,14 +205,22 @@ export class PortalWorldHistory {
     const combat = slice.filter((e) => e.kind === "combat").length;
     const trade = slice.filter((e) => e.kind === "trade").length;
     const loot = slice.filter((e) => e.kind === "loot").length;
+    const refinement = slice.filter((e) => e.kind === "refinement").length;
+    const forge = slice.filter((e) => e.kind === "forge").length;
+    const destiny = slice.filter((e) => e.kind === "destiny").length;
     const lines = slice.slice(0, 5).map((e) => `[${e.kind}] ${e.summary.slice(0, 72)}`);
-    return { combat, trade, loot, total: slice.length, lines };
+    return { combat, trade, loot, refinement, forge, destiny, total: slice.length, lines };
   }
 
-  /** Optional: ingest server-shaped world lines as echo metadata. */
   ingestWorldLine(ev: IWorldEvent): void {
     const t = (ev.title + " " + ev.description).toLowerCase();
-    if (t.includes("loot") || t.includes("drop") || t.includes("legendary") || t.includes("epic")) {
+    if (t.includes("destiny") || t.includes("schicksal")) {
+      this.pushEcho({ kind: "destiny", summary: ev.title, worldLine: { title: ev.title, description: ev.description } });
+    } else if (t.includes("forge") || t.includes("schmied")) {
+      this.pushEcho({ kind: "forge", summary: ev.title, worldLine: { title: ev.title, description: ev.description } });
+    } else if (t.includes("refinement") || t.includes("zerfall") || t.includes("essence")) {
+      this.pushEcho({ kind: "refinement", summary: ev.title, worldLine: { title: ev.title, description: ev.description } });
+    } else if (t.includes("loot") || t.includes("drop") || t.includes("legendary") || t.includes("epic")) {
       this.pushEcho({ kind: "loot", summary: ev.title, worldLine: { title: ev.title, description: ev.description } });
     } else if (t.includes("trade") || t.includes("handel") || t.includes("deal")) {
       this.recordNpcTradeComplete(ev.title, { title: ev.title, description: ev.description });


### PR DESCRIPTION
Fixes the same bug family identified in draft PR #731, but rebased on the current main after the Destiny panel merge.

Changes:
- Extend PortalWorldHistory with refinement, forge, and destiny echo types
- Add recordRefinement(), recordForge(), and recordDestiny()
- Extend digest counts for refinement/forge/destiny
- Remove the `as never` cast in DestinyPathsPanel by using the typed destiny recorder
- Mount ForgePanel inside SciencePortal so the existing Forge UI is visible
- Add Vitest coverage for refinement, forge, destiny, and digest counts

This intentionally avoids dependency or lockfile changes.