### PR TITLE
fix(replit): harden SDK release demo startup

### DIFF
--- a/packages/sdk-examples/replit-demo/package.json
+++ b/packages/sdk-examples/replit-demo/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview --host 0.0.0.0"
   },
   "dependencies": {
-    "@vitejs/plugin-react": "^6.0.1",
     "vite": "^6.4.2",
     "typescript": "^6.0.3",
     "react": "^19.2.6",

--- a/scripts/replit-start.sh
+++ b/scripts/replit-start.sh
@@ -26,7 +26,7 @@ if ! command -v pnpm >/dev/null 2>&1; then
 fi
 
 pnpm install --no-frozen-lockfile --prefer-offline
-pnpm --filter @wasd/core-logic --if-present build
+pnpm --filter @wasd/core-logic --if-present run build:runtime
 pnpm --filter @wasd/shared --if-present build
 pnpm --filter @wasd/server --if-present build
 


### PR DESCRIPTION
Release gate fix for the Replit SDK demo.

Changes:
- Use core-logic build:runtime in replit-start.sh so Replit does not hit DTS build failures.
- Remove @vitejs/plugin-react 6.x from the demo package to avoid the known Vite export-path issue.

No lockfile changes.