### PR TITLE
test(replit): add SDK demo smoke gate

### DIFF
--- a/.github/workflows/replit-sdk-smoke.yml
+++ b/.github/workflows/replit-sdk-smoke.yml
@@ -2,6 +2,19 @@ name: Replit SDK Smoke
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/replit-sdk-smoke.yml'
+      - 'scripts/replit-start.sh'
+      - '.replit'
+      - 'packages/core-logic/**'
+      - 'packages/sdk-examples/**'
+      - 'packages/shared/**'
+      - 'server/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
   pull_request:
     paths:
       - '.github/workflows/replit-sdk-smoke.yml'

--- a/.github/workflows/replit-sdk-smoke.yml
+++ b/.github/workflows/replit-sdk-smoke.yml
@@ -1,0 +1,59 @@
+name: Replit SDK Smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/replit-sdk-smoke.yml'
+      - 'scripts/replit-start.sh'
+      - '.replit'
+      - 'packages/core-logic/**'
+      - 'packages/sdk-examples/**'
+      - 'packages/shared/**'
+      - 'server/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: replit-sdk-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
+
+      - name: Install monorepo dependencies
+        run: pnpm install --no-frozen-lockfile --prefer-offline
+
+      - name: Build Replit runtime targets
+        run: |
+          pnpm --filter @wasd/core-logic --if-present run build:runtime
+          pnpm --filter @wasd/shared --if-present build
+          pnpm --filter @wasd/server --if-present build
+
+      - name: Install standalone SDK demo
+        working-directory: packages/sdk-examples/replit-demo
+        run: pnpm install --no-frozen-lockfile --prefer-offline
+
+      - name: Build standalone SDK demo
+        working-directory: packages/sdk-examples/replit-demo
+        run: pnpm run build

--- a/packages/sdk-examples/replit-demo/package.json
+++ b/packages/sdk-examples/replit-demo/package.json
@@ -13,7 +13,7 @@
     "typescript": "^6.0.3",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "@wasd/core-logic": "workspace:*"
+    "@wasd/core-logic": "file:../../core-logic"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Adds a Replit SDK smoke workflow and makes the standalone demo consume core-logic through a local file link.

Checks covered:
- core-logic runtime build
- shared build
- server build
- standalone SDK demo install
- standalone SDK demo Vite build

No lockfile changes.