### PR TITLE
fix(ci): build SDK demo as workspace package

### DIFF
--- a/.github/workflows/replit-sdk-smoke.yml
+++ b/.github/workflows/replit-sdk-smoke.yml
@@ -63,10 +63,5 @@ jobs:
           pnpm --filter @wasd/shared --if-present build
           pnpm --filter @wasd/server --if-present build
 
-      - name: Install standalone SDK demo
-        working-directory: packages/sdk-examples/replit-demo
-        run: pnpm install --no-frozen-lockfile --prefer-offline
-
-      - name: Build standalone SDK demo
-        working-directory: packages/sdk-examples/replit-demo
-        run: pnpm run build
+      - name: Build SDK demo
+        run: pnpm --filter @wasd/sdk-replit-demo --if-present build

--- a/packages/sdk-examples/replit-demo/package.json
+++ b/packages/sdk-examples/replit-demo/package.json
@@ -13,7 +13,7 @@
     "typescript": "^6.0.3",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "@wasd/core-logic": "file:../../core-logic"
+    "@wasd/core-logic": "workspace:*"
   },
   "devDependencies": {}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "packages/*"
+  - "packages/sdk-examples/*"
   - "apps/*"
   - "projects/*"
   - "client"


### PR DESCRIPTION
Fixes the Replit SDK smoke failure where `vite` was not found during demo build.

Changes:
- Includes packages/sdk-examples/* in pnpm-workspace.yaml.
- Restores @wasd/core-logic to workspace:* for the demo package.
- Builds the demo through pnpm workspace filtering instead of relying on a separate demo node_modules.

No lockfile changes.