### PR TITLE
fix(replit): isolate SDK demo tsconfig

### DIFF
--- a/packages/sdk-examples/replit-demo/tsconfig.json
+++ b/packages/sdk-examples/replit-demo/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}


### PR DESCRIPTION
Fixes the Replit SDK Smoke Vite failure where the demo build climbed to the root tsconfig and tried to resolve missing project references such as projects/health-tech.

Adds a local tsconfig.json to packages/sdk-examples/replit-demo with no project references.