### PR TITLE
feat(epoch): add sovereign epoch engine

### DIFF
--- a/packages/core-logic/package.json
+++ b/packages/core-logic/package.json
@@ -23,6 +23,11 @@
       "import": "./dist/destiny/SovereignDestinyEngine.js",
       "require": "./dist/destiny/SovereignDestinyEngine.js"
     },
+    "./epoch/SovereignEpochs": {
+      "types": "./dist/epoch/SovereignEpochs.d.ts",
+      "import": "./dist/epoch/SovereignEpochs.js",
+      "require": "./dist/epoch/SovereignEpochs.js"
+    },
     "./loot": {
       "types": "./dist/loot/index.d.ts",
       "import": "./dist/loot/index.js",
@@ -39,9 +44,9 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --dts --clean --external react",
-    "build:runtime": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --clean --external react",
-    "dev": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --watch --dts --external react",
+    "build": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --dts --clean --external react",
+    "build:runtime": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --clean --external react",
+    "dev": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --watch --dts --external react",
     "test": "vitest run --passWithNoTests",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit"

--- a/packages/core-logic/src/epoch/SovereignEpochs.ts
+++ b/packages/core-logic/src/epoch/SovereignEpochs.ts
@@ -1,0 +1,165 @@
+export type EpochId = "awakening" | "strife" | "synthesis" | "ascension";
+
+export interface EpochProgressInput {
+  seed: string;
+  worldHash: string;
+  currentEpoch: EpochId;
+  completedDestinyQuests: number;
+  globalQuorum: number;
+  heroicPeers?: HeroicPeer[];
+  sectors: EpochSectorState[];
+  tick: number;
+}
+
+export interface HeroicPeer {
+  peerId: string;
+  role: string;
+  score: number;
+}
+
+export interface EpochSectorState {
+  sectorId: string;
+  corruption: number;
+  scarcity: number;
+  synthesis: number;
+  threat: number;
+}
+
+export interface EpochGlobalModifiers {
+  lootBias: number;
+  blueprintBias: number;
+  npcDifficulty: number;
+  healingPriority: number;
+  synthesisYield: number;
+}
+
+export interface EpochDefinition {
+  id: EpochId;
+  label: string;
+  minDestinyQuests: number;
+  minGlobalQuorum: number;
+  modifiers: EpochGlobalModifiers;
+  unlockedBlueprints: string[];
+}
+
+export interface EpochShiftPayload {
+  shifted: boolean;
+  previousEpoch: EpochId;
+  nextEpoch: EpochId;
+  epochHash: string;
+  resetHash: string;
+  modifiers: EpochGlobalModifiers;
+  archivedHeroes: HeroicPeer[];
+  sectors: EpochSectorState[];
+  emilyChronicle: string;
+}
+
+export const SOVEREIGN_EPOCHS: EpochDefinition[] = [
+  {
+    id: "awakening",
+    label: "Age of Awakening",
+    minDestinyQuests: 0,
+    minGlobalQuorum: 0,
+    modifiers: { lootBias: 1, blueprintBias: 1, npcDifficulty: 1, healingPriority: 1, synthesisYield: 1 },
+    unlockedBlueprints: ["echo_blade"],
+  },
+  {
+    id: "strife",
+    label: "Age of Strife",
+    minDestinyQuests: 12,
+    minGlobalQuorum: 0.42,
+    modifiers: { lootBias: 1.08, blueprintBias: 1.04, npcDifficulty: 1.2, healingPriority: 1.1, synthesisYield: 0.96 },
+    unlockedBlueprints: ["echo_blade", "warden_aegis", "scarcity_lance"],
+  },
+  {
+    id: "synthesis",
+    label: "Age of Synthesis",
+    minDestinyQuests: 34,
+    minGlobalQuorum: 0.64,
+    modifiers: { lootBias: 1.14, blueprintBias: 1.12, npcDifficulty: 1.32, healingPriority: 1.24, synthesisYield: 1.22 },
+    unlockedBlueprints: ["sovereign_circuit", "ouroboros_anvil_core", "healer_matrix"],
+  },
+  {
+    id: "ascension",
+    label: "Age of Ascension",
+    minDestinyQuests: 89,
+    minGlobalQuorum: 0.81,
+    modifiers: { lootBias: 1.22, blueprintBias: 1.2, npcDifficulty: 1.55, healingPriority: 1.42, synthesisYield: 1.36 },
+    unlockedBlueprints: ["epoch_crown", "white_gold_chronicle", "collective_starforge"],
+  },
+];
+
+function hashText(input: string): string {
+  let h1 = 0x811c9dc5;
+  let h2 = 0x01000193;
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    h1 ^= code;
+    h1 = Math.imul(h1, 0x01000193) >>> 0;
+    h2 ^= code + i;
+    h2 = Math.imul(h2, 0x85ebca6b) >>> 0;
+  }
+  return `${h1.toString(16).padStart(8, "0")}${h2.toString(16).padStart(8, "0")}`;
+}
+
+function definition(id: EpochId): EpochDefinition {
+  return SOVEREIGN_EPOCHS.find((epoch) => epoch.id === id) ?? SOVEREIGN_EPOCHS[0];
+}
+
+function nextDefinition(current: EpochId): EpochDefinition {
+  const index = Math.max(0, SOVEREIGN_EPOCHS.findIndex((epoch) => epoch.id === current));
+  return SOVEREIGN_EPOCHS[Math.min(SOVEREIGN_EPOCHS.length - 1, index + 1)];
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function resetSector(sector: EpochSectorState, epoch: EpochDefinition, salt: string): EpochSectorState {
+  const h = parseInt(hashText(`${salt}|${sector.sectorId}|${epoch.id}`).slice(0, 8), 16) / 0xffffffff;
+  return {
+    sectorId: sector.sectorId,
+    corruption: Number(clamp01(sector.corruption * 0.24 + h * 0.09).toFixed(4)),
+    scarcity: Number(clamp01(sector.scarcity * 0.34 + (1 - h) * 0.12).toFixed(4)),
+    synthesis: Number(clamp01(epoch.modifiers.synthesisYield / 2.4 + h * 0.18).toFixed(4)),
+    threat: Number(clamp01(sector.threat * epoch.modifiers.npcDifficulty * 0.28 + h * 0.11).toFixed(4)),
+  };
+}
+
+function archiveHeroes(peers: HeroicPeer[] = []): HeroicPeer[] {
+  return [...peers].sort((a, b) => b.score - a.score || a.peerId.localeCompare(b.peerId)).slice(0, 7);
+}
+
+export function evaluateEpochShift(input: EpochProgressInput): EpochShiftPayload {
+  const current = definition(input.currentEpoch);
+  const next = nextDefinition(input.currentEpoch);
+  const canShift = next.id !== current.id && input.completedDestinyQuests >= next.minDestinyQuests && input.globalQuorum >= next.minGlobalQuorum;
+  const selected = canShift ? next : current;
+  const epochHash = hashText(`${input.seed}|${input.worldHash}|${current.id}|${selected.id}|${input.completedDestinyQuests}|${input.globalQuorum}|${input.tick}`);
+  const resetHash = hashText(`${epochHash}|reset|${input.sectors.map((sector) => sector.sectorId).join(",")}`);
+  const sectors = canShift ? input.sectors.map((sector) => resetSector(sector, selected, resetHash)) : input.sectors;
+  const archivedHeroes = canShift ? archiveHeroes(input.heroicPeers) : [];
+  const label = selected.label;
+
+  return {
+    shifted: canShift,
+    previousEpoch: current.id,
+    nextEpoch: selected.id,
+    epochHash,
+    resetHash,
+    modifiers: selected.modifiers,
+    archivedHeroes,
+    sectors,
+    emilyChronicle: canShift
+      ? `Emily Chronistin: Das ${label} beginnt. Die Kausalität wurde in Weiß/Gold neu gefaltet. ${archivedHeroes.length} Peers wurden archiviert.`
+      : `Emily Chronistin: ${current.label} bleibt stabil. Destiny ${input.completedDestinyQuests}/${next.minDestinyQuests}, Quorum ${input.globalQuorum.toFixed(2)}/${next.minGlobalQuorum.toFixed(2)}.`,
+  };
+}
+
+export function getEpochDefinition(id: EpochId): EpochDefinition {
+  return definition(id);
+}
+
+export function listEpochDefinitions(): EpochDefinition[] {
+  return [...SOVEREIGN_EPOCHS];
+}

--- a/packages/core-logic/src/index.ts
+++ b/packages/core-logic/src/index.ts
@@ -1,5 +1,6 @@
 export * from './agent/Orchestrator';
 export * from './are/AREInvariantGuard';
 export * from './destiny/SovereignDestinyEngine';
+export * from './epoch/SovereignEpochs';
 export * from './loot';
 export * from './react/OuroborosPulseView';

--- a/portal/src/apps/SciencePortal.tsx
+++ b/portal/src/apps/SciencePortal.tsx
@@ -7,6 +7,7 @@ import {
 } from "@wasd/shared";
 import DestinyPathsPanel from "../community/DestinyPathsPanel";
 import EchoTracker from "../community/EchoTracker";
+import EpochChroniclePanel from "../community/EpochChroniclePanel";
 import ForgePanel from "../community/ForgePanel";
 import InventoryRefinementPanel from "../community/InventoryRefinementPanel";
 import ScienceMascotChat from "./ScienceMascotChat";
@@ -136,6 +137,8 @@ export const SciencePortal: React.FC = () => {
           <ForgePanel />
 
           <DestinyPathsPanel />
+
+          <EpochChroniclePanel />
         </div>
 
         <div className="lg:sticky lg:top-2">

--- a/portal/src/community/EpochChroniclePanel.tsx
+++ b/portal/src/community/EpochChroniclePanel.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+
+type EpochId = 'awakening' | 'strife' | 'synthesis' | 'ascension';
+
+const labels: Record<EpochId, string> = {
+  awakening: 'Age of Awakening',
+  strife: 'Age of Strife',
+  synthesis: 'Age of Synthesis',
+  ascension: 'Age of Ascension',
+};
+
+const heroes = [
+  { peerId: 'thomas-architect', role: 'Architect', score: 1440 },
+  { peerId: 'guardian-12-8', role: 'Guardian', score: 910 },
+  { peerId: 'trader-circuit', role: 'Trader', score: 780 },
+];
+
+function nextEpoch(current: EpochId): EpochId {
+  if (current === 'awakening') return 'strife';
+  if (current === 'strife') return 'synthesis';
+  if (current === 'synthesis') return 'ascension';
+  return 'ascension';
+}
+
+function tinyHash(input: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+export function EpochChroniclePanel(): JSX.Element {
+  const [epoch, setEpoch] = useState<EpochId>('awakening');
+  const [quests, setQuests] = useState(12);
+  const [quorum, setQuorum] = useState(0.42);
+  const next = nextEpoch(epoch);
+  const ready = next !== epoch && quests >= 12 && quorum >= 0.42;
+  const epochHash = tinyHash(`${epoch}|${next}|${quests}|${quorum}`);
+
+  return (
+    <section className="rounded-3xl border border-yellow-100/30 bg-white/[0.04] p-5 shadow-[0_0_34px_rgba(255,245,180,0.18)]">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.32em] text-yellow-100/70">Emily · Chronistin</p>
+          <h2 className="mt-1 text-xl font-black text-white">Sovereign Epochs</h2>
+        </div>
+        <button type="button" className="rounded-full border border-yellow-100/40 bg-yellow-100/10 px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-yellow-50" onClick={() => setEpoch(next)}>
+          Epoch Shift
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        <label className="rounded-2xl border border-white/10 bg-black/20 p-3 text-xs text-white/70">
+          Destiny Quests
+          <input className="mt-2 w-full accent-yellow-200" type="range" min={0} max={100} value={quests} onChange={(event) => setQuests(Number(event.target.value))} />
+          <strong className="text-yellow-100">{quests}</strong>
+        </label>
+        <label className="rounded-2xl border border-white/10 bg-black/20 p-3 text-xs text-white/70">
+          Global Quorum
+          <input className="mt-2 w-full accent-yellow-200" type="range" min={0} max={1} step={0.01} value={quorum} onChange={(event) => setQuorum(Number(event.target.value))} />
+          <strong className="text-yellow-100">{quorum.toFixed(2)}</strong>
+        </label>
+        <div className="rounded-2xl border border-yellow-100/20 bg-yellow-100/5 p-3 font-mono text-xs text-yellow-50/80">
+          <div>current {labels[epoch]}</div>
+          <div>next {labels[next]}</div>
+          <div>epochHash {epochHash}</div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-2xl border border-yellow-100/20 bg-yellow-100/10 p-4 text-sm text-yellow-50">
+        {ready ? `Emily: ${labels[next]} begins. Sector states and global modifiers are ready for a deterministic reset.` : `Emily: ${labels[epoch]} remains stable. The Collective is still gathering destiny signals.`}
+      </div>
+
+      <div className="mt-4 grid gap-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-white/50">Archived Heroes</p>
+        {heroes.map((hero) => (
+          <div key={hero.peerId} className="flex items-center justify-between rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-white/80">
+            <span>{hero.peerId} · {hero.role}</span>
+            <strong className="text-yellow-100">{hero.score}</strong>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default EpochChroniclePanel;


### PR DESCRIPTION
Adds the Ascension Update / Sovereign Epochs layer.

Changes:
- Adds browser-safe deterministic SovereignEpochs engine to @wasd/core-logic.
- Exports @wasd/core-logic/epoch/SovereignEpochs and includes it in build/runtime/dev entries.
- Adds EpochChroniclePanel to the Science Portal.
- Mounts the panel after DestinyPathsPanel.

No lockfile changes.