### PR TITLE
fix(vps): default docker deployment to port 3001

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -1,6 +1,11 @@
 # Production VPS: pull monorepo + Docker Compose rebuild.
-# Secrets: VPS_HOST / VPS_USER / VPS_SSH_KEY (or legacy SSH_HOST / SSH_USER / SSH_PRIVATE_KEY).
-# Optional: SSH_PASSWORD if no key; VPS_DEPLOY_PATH or DEPLOY_PATH (default /opt/areloria).
+# Required GitHub secrets:
+#   VPS_HOST or SSH_HOST
+#   VPS_USER or SSH_USER
+#   VPS_SSH_KEY or SSH_PRIVATE_KEY, or SSH_PASSWORD
+# Optional GitHub secrets:
+#   VPS_DEPLOY_PATH or DEPLOY_PATH, defaults to /opt/areloria
+#   VPS_ARELORIAN_PORT, defaults to 3001
 # Do NOT commit passwords to the repo.
 
 name: VPS Docker Deploy (monorepo)
@@ -34,6 +39,10 @@ on:
         description: 'Sovereign launch reason'
         required: false
         default: 'Manual sovereign launch'
+      arelorian_port:
+        description: 'Engine host port on VPS. Default keeps Supabase free on 3000.'
+        required: false
+        default: '3001'
 
 concurrency:
   group: vps-docker-deploy-${{ github.ref }}
@@ -45,6 +54,8 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_ARELORIAN_PORT: '3001'
     steps:
       # Fails fast with a clear message (values are GitHub-masked; do not echo secrets).
       - name: Verify VPS secrets are set
@@ -89,7 +100,11 @@ jobs:
             DEPLOY_PRIMARY='${{ secrets.VPS_DEPLOY_PATH }}'
             DEPLOY_ALT='${{ secrets.DEPLOY_PATH }}'
             DEPLOY_PATH="${DEPLOY_PRIMARY:-${DEPLOY_ALT:-/opt/areloria}}"
+            SECRET_PORT='${{ secrets.VPS_ARELORIAN_PORT }}'
+            INPUT_PORT='${{ github.event.inputs.arelorian_port }}'
+            export ARELORIAN_PORT="${SECRET_PORT:-${INPUT_PORT:-3001}}"
             echo "Using DEPLOY_PATH=$DEPLOY_PATH"
+            echo "Using ARELORIAN_PORT=$ARELORIAN_PORT"
             if [ ! -d "$DEPLOY_PATH" ]; then
               echo "ERROR: Directory does not exist: $DEPLOY_PATH"
               echo "Fix: on the VPS clone the repo once, e.g. git clone <url> $DEPLOY_PATH"
@@ -101,4 +116,4 @@ jobs:
             fi
             cd "$DEPLOY_PATH"
             chmod +x scripts/deploy-vps-docker.sh 2>/dev/null || true
-            bash scripts/deploy-vps-docker.sh
+            ARELORIAN_PORT="$ARELORIAN_PORT" bash scripts/deploy-vps-docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,9 @@ RUN apk add --no-cache \
 
 # Environment
 ENV NODE_ENV=production
-ENV PORT=3000
+ENV PORT=3001
+ENV GAME_PORT=3001
+ENV HOST=0.0.0.0
 
 # Runtime Node memory options. Do not include --optimize-for-size; Node 22
 # rejects it inside NODE_OPTIONS.
@@ -143,7 +145,7 @@ RUN chown -R nodeuser:nodejs /app
 USER nodeuser
 
 # Exposed ports
-EXPOSE 3000
+EXPOSE 3001
 EXPOSE 8080
 EXPOSE 443
 
@@ -153,7 +155,7 @@ HEALTHCHECK --interval=30s \
     --start-period=20s \
     --retries=5 \
     CMD node -e "\
-    fetch('http://127.0.0.1:3000/health')\
+    fetch('http://127.0.0.1:3001/health')\
     .then(r => r.ok ? process.exit(0) : process.exit(1))\
     .catch(() => process.exit(1))"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   arelorian-engine:
     build:
@@ -7,21 +5,28 @@ services:
       dockerfile: Dockerfile
     image: arelorian-engine:latest
     container_name: arelorian-engine
-    restart: always
+    restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "127.0.0.1:${ARELORIAN_PORT:-3001}:3001"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
     environment:
-      - NODE_ENV=production
-      - PORT=3000
+      NODE_ENV: production
+      PORT: "3001"
+      GAME_PORT: "3001"
+      HOST: "0.0.0.0"
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3001/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 40s
+      retries: 5
+      start_period: 60s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     networks:
       - arelorian-network
 
@@ -31,10 +36,18 @@ services:
       dockerfile: Dockerfile.monitor
     image: monitor-bridge:latest
     container_name: monitor-bridge
-    restart: always
+    restart: unless-stopped
     environment:
-      - ENGINE_URL=http://arelorian-engine:3000
-      - CHECK_INTERVAL=60
+      ENGINE_URL: "http://arelorian-engine:3001"
+      CHECK_INTERVAL: "60"
+    depends_on:
+      arelorian-engine:
+        condition: service_healthy
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     networks:
       - arelorian-network
 

--- a/scripts/deploy-vps-docker.sh
+++ b/scripts/deploy-vps-docker.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+ARELORIAN_PORT="${ARELORIAN_PORT:-3001}"
+export ARELORIAN_PORT
 cd "$REPO_ROOT"
 
 LOCK_PATH="${DEPLOY_LOCK_PATH:-/tmp/wasd-vps-docker-deploy.lock}"
@@ -43,27 +45,28 @@ else
   exit 1
 fi
 
-free_port_3000() {
-  local ids pids
+free_engine_port() {
+  local ids pids port
+  port="$ARELORIAN_PORT"
 
-  ids="$(docker ps -a --format '{{.ID}} {{.Ports}}' | awk '/(:|0\.0\.0\.0:)3000->|:::3000->|0\.0\.0\.0:3000-|:::3000-/ {print $1}' | tr '\n' ' ')"
+  ids="$(docker ps -a --format '{{.ID}} {{.Ports}}' | awk -v port="$port" '$0 ~ ":" port "->" || $0 ~ "0.0.0.0:" port "-" || $0 ~ ":::" port "-" {print $1}' | tr '\n' ' ')"
   if [ -n "${ids// }" ]; then
-    echo "Removing Docker container(s) publishing port 3000: $ids"
+    echo "Removing Docker container(s) publishing port ${port}: $ids"
     docker rm -f $ids >/dev/null 2>&1 || true
   fi
 
   if command -v fuser >/dev/null 2>&1; then
-    pids="$(fuser -n tcp 3000 2>/dev/null || true)"
+    pids="$(fuser -n tcp "$port" 2>/dev/null || true)"
     if [ -n "${pids// }" ]; then
-      echo "Stopping host process(es) listening on port 3000: $pids"
+      echo "Stopping host process(es) listening on port ${port}: $pids"
       kill $pids >/dev/null 2>&1 || true
       sleep 2
       kill -9 $pids >/dev/null 2>&1 || true
     fi
   elif command -v lsof >/dev/null 2>&1; then
-    pids="$(lsof -ti tcp:3000 2>/dev/null | tr '\n' ' ')"
+    pids="$(lsof -ti tcp:"$port" 2>/dev/null | tr '\n' ' ')"
     if [ -n "${pids// }" ]; then
-      echo "Stopping host process(es) listening on port 3000: $pids"
+      echo "Stopping host process(es) listening on port ${port}: $pids"
       kill $pids >/dev/null 2>&1 || true
       sleep 2
       kill -9 $pids >/dev/null 2>&1 || true
@@ -137,6 +140,7 @@ fetch_and_reset() {
 echo "=== WASD monorepo deploy (Docker) ==="
 echo "Repo: $REPO_ROOT"
 echo "Branch: $DEPLOY_BRANCH"
+echo "Engine port: $ARELORIAN_PORT"
 
 fetch_and_reset
 
@@ -156,13 +160,13 @@ echo "[2/4] Build images (monorepo context, sequential to avoid OOM)"
 
 echo "[3/4] Recreate containers"
 "${DC[@]}" -f docker-compose.yml down --remove-orphans || true
-free_port_3000
+free_engine_port
 "${DC[@]}" -f docker-compose.yml up -d --remove-orphans arelorian-engine monitor-bridge
 
-echo "[4/4] Health check (engine :3000)"
+echo "[4/4] Health check (engine :${ARELORIAN_PORT})"
 ok=0
 for i in $(seq 1 24); do
-  if curl -sf "http://127.0.0.1:3000/health" >/dev/null; then
+  if curl -sf "http://127.0.0.1:${ARELORIAN_PORT}/health" >/dev/null; then
     ok=1
     break
   fi


### PR DESCRIPTION
Makes the VPS Docker stack deterministic and removes Hostinger YAML guesswork.

Changes:
- docker-compose.yml defaults arelorian-engine to 127.0.0.1:3001:3001.
- Dockerfile runtime defaults to PORT/GAME_PORT 3001 and healthchecks 3001.
- deploy-vps-docker.sh uses ARELORIAN_PORT with default 3001 for port cleanup and healthcheck.
- vps-docker-deploy workflow exposes optional arelorian_port input and VPS_ARELORIAN_PORT secret override, defaulting to 3001.

This keeps Supabase free to use 3000 and removes the need to edit Hostinger YAML manually.