### PR TITLE
fix(docker): wire redis soketi service dns

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,31 @@ services:
       PORT: "3001"
       GAME_PORT: "3001"
       HOST: "0.0.0.0"
+
+      # Redis: internal Docker DNS. Override in .env or GitHub/VPS env if needed.
+      REDIS_URL: "${REDIS_URL:-}"
+      REDIS_HOST: "${REDIS_HOST:-redis-comn-redis-1}"
+      REDIS_PORT: "${REDIS_PORT:-6379}"
+      REDIS_USER: "${REDIS_USER:-}"
+      REDIS_USERNAME: "${REDIS_USERNAME:-}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:-}"
+      REDIS_TLS: "${REDIS_TLS:-false}"
+
+      # Soketi / websocket bridge: internal Docker DNS defaults.
+      SOKETI_HOST: "${SOKETI_HOST:-soketi-9eoa-soketi-1}"
+      SOKETI_PORT: "${SOKETI_PORT:-6001}"
+      SOKETI_URL: "${SOKETI_URL:-http://soketi-9eoa-soketi-1:6001}"
+      PUSHER_HOST: "${PUSHER_HOST:-soketi-9eoa-soketi-1}"
+      PUSHER_PORT: "${PUSHER_PORT:-6001}"
+      PUSHER_SCHEME: "${PUSHER_SCHEME:-http}"
+      NEXT_PUBLIC_WEBSOCKET_URL: "${NEXT_PUBLIC_WEBSOCKET_URL:-wss://arelorian.de/ws}"
+
+      # Supabase: prefer an internal Docker URL when Supabase is containerized.
+      SUPABASE_URL: "${SUPABASE_URL:-}"
+      SUPABASE_PUBLIC_URL: "${SUPABASE_PUBLIC_URL:-}"
+      SUPABASE_PROXY_URL: "${SUPABASE_PROXY_URL:-}"
+      SUPABASE_ANON_KEY: "${SUPABASE_ANON_KEY:-}"
+      ANON_KEY: "${ANON_KEY:-}"
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3001/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"]
       interval: 30s
@@ -53,4 +78,5 @@ services:
 
 networks:
   arelorian-network:
-    driver: bridge
+    external: true
+    name: "${ARELORIAN_DOCKER_NETWORK:-areloria_arelorian-network}"

--- a/scripts/deploy-vps-docker.sh
+++ b/scripts/deploy-vps-docker.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 ARELORIAN_PORT="${ARELORIAN_PORT:-3001}"
-export ARELORIAN_PORT
+ARELORIAN_DOCKER_NETWORK="${ARELORIAN_DOCKER_NETWORK:-areloria_arelorian-network}"
+export ARELORIAN_PORT ARELORIAN_DOCKER_NETWORK
 cd "$REPO_ROOT"
 
 LOCK_PATH="${DEPLOY_LOCK_PATH:-/tmp/wasd-vps-docker-deploy.lock}"
@@ -44,6 +45,15 @@ else
   echo "ERROR: Install Docker Compose v2 (docker compose) or docker-compose v1."
   exit 1
 fi
+
+ensure_external_network() {
+  if docker network inspect "$ARELORIAN_DOCKER_NETWORK" >/dev/null 2>&1; then
+    echo "Docker network OK: $ARELORIAN_DOCKER_NETWORK"
+    return 0
+  fi
+  echo "Creating Docker network: $ARELORIAN_DOCKER_NETWORK"
+  docker network create "$ARELORIAN_DOCKER_NETWORK" >/dev/null
+}
 
 free_engine_port() {
   local ids pids port
@@ -141,6 +151,7 @@ echo "=== WASD monorepo deploy (Docker) ==="
 echo "Repo: $REPO_ROOT"
 echo "Branch: $DEPLOY_BRANCH"
 echo "Engine port: $ARELORIAN_PORT"
+echo "Docker network: $ARELORIAN_DOCKER_NETWORK"
 
 fetch_and_reset
 
@@ -151,6 +162,7 @@ export BUILDKIT_STEP_LOG_MAX_SIZE="${BUILDKIT_STEP_LOG_MAX_SIZE:-10485760}"
 export BUILDKIT_STEP_LOG_MAX_SPEED="${BUILDKIT_STEP_LOG_MAX_SPEED:-1048576}"
 export COMPOSE_PARALLEL_LIMIT="${COMPOSE_PARALLEL_LIMIT:-1}"
 
+ensure_external_network
 ensure_swap_headroom
 prune_docker_build_pressure
 


### PR DESCRIPTION
Wires Areloria into the shared external Docker network used by Redis and Soketi.

Changes:
- docker-compose.yml uses external network areloria_arelorian-network by default.
- Adds Redis Docker DNS defaults: redis-comn-redis-1:6379 with REDIS_TLS=false.
- Adds Soketi Docker DNS defaults: soketi-9eoa-soketi-1:6001.
- Keeps Supabase URL fields configurable through env.
- deploy-vps-docker.sh creates the external network if missing and exports ARELORIAN_DOCKER_NETWORK.

No secrets are committed.