### PR TITLE
fix(monitor): tolerate initializing engine readiness

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -1,83 +1,103 @@
 #!/usr/bin/env python3
 """
-Monitor Bridge for Arelorian Engine
-Checks health endpoint every N seconds and logs errors
+Monitor Bridge for Arelorian Engine.
+Checks multiple readiness endpoints and avoids false DOWN alerts while the engine initializes.
 """
 
+import json
+import logging
 import os
 import sys
 import time
-import logging
-from datetime import datetime
-from urllib.request import urlopen, Request
-from urllib.error import URLError, HTTPError
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
-# Configuration
-ENGINE_URL = os.environ.get('ENGINE_URL', 'http://localhost:3000')
-CHECK_INTERVAL = int(os.environ.get('CHECK_INTERVAL', 60))
-FAILURE_THRESHOLD = int(os.environ.get('FAILURE_THRESHOLD', 3))
+ENGINE_URL = os.environ.get("ENGINE_URL", "http://localhost:3001").rstrip("/")
+CHECK_INTERVAL = int(os.environ.get("CHECK_INTERVAL", 60))
+FAILURE_THRESHOLD = int(os.environ.get("FAILURE_THRESHOLD", 3))
+STARTUP_GRACE_SECONDS = int(os.environ.get("STARTUP_GRACE_SECONDS", 360))
+REQUEST_TIMEOUT_SECONDS = int(os.environ.get("REQUEST_TIMEOUT_SECONDS", 10))
+READINESS_PATHS = [path.strip() for path in os.environ.get("READINESS_PATHS", "/health,/client-config.json").split(",") if path.strip()]
 
-# Logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s [MONITOR] %(levelname)s: %(message)s',
-    handlers=[
-        logging.FileHandler('/app/logs/monitor.log'),
-        logging.StreamHandler(sys.stdout)
-    ]
+    format="%(asctime)s [MONITOR] %(levelname)s: %(message)s",
+    handlers=[logging.FileHandler("/app/logs/monitor.log"), logging.StreamHandler(sys.stdout)],
 )
 logger = logging.getLogger(__name__)
 
 consecutive_failures = 0
+started_at = time.time()
 
-def check_health():
-    """Check the /health endpoint"""
+
+def request_path(path: str):
+    url = f"{ENGINE_URL}{path if path.startswith('/') else '/' + path}"
+    req = Request(url)
+    req.add_header("User-Agent", "Monitor-Bridge/1.1")
+    with urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        body = response.read(4096)
+        return response.status, body
+
+
+def is_startup_grace_active() -> bool:
+    return (time.time() - started_at) < STARTUP_GRACE_SECONDS
+
+
+def check_health() -> bool:
     global consecutive_failures
-    
-    try:
-        req = Request(f'{ENGINE_URL}/health')
-        req.add_header('User-Agent', 'Monitor-Bridge/1.0')
-        
-        with urlopen(req, timeout=10) as response:
-            if response.status == 200:
-                if consecutive_failures > 0:
-                    logger.info(f'Engine recovered! ({consecutive_failures} consecutive failures)')
-                    consecutive_failures = 0
-                return True
-            else:
-                logger.warning(f'Unexpected status: {response.status}')
-                consecutive_failures += 1
-                return False
-                
-    except HTTPError as e:
-        logger.error(f'HTTP Error: {e.code} - {e.reason}')
-        consecutive_failures += 1
-        return False
-    except URLError as e:
-        logger.error(f'Connection Error: {e.reason}')
-        consecutive_failures += 1
-        return False
-    except Exception as e:
-        logger.error(f'Unexpected error: {e}')
-        consecutive_failures += 1
-        return False
+    errors = []
 
-def main():
-    """Main loop"""
-    logger.info(f'Starting monitor - checking {ENGINE_URL}/health every {CHECK_INTERVAL}s')
-    logger.info(f'Failure threshold: {FAILURE_THRESHOLD} consecutive failures')
-    
+    for path in READINESS_PATHS:
+        try:
+            status, body = request_path(path)
+            if path == "/health":
+                if status == 200:
+                    if consecutive_failures > 0:
+                        logger.info("Engine recovered after %s consecutive failures", consecutive_failures)
+                    consecutive_failures = 0
+                    return True
+                if status == 503 and is_startup_grace_active():
+                    logger.info("Engine initializing via /health; grace window active")
+                    consecutive_failures = 0
+                    return True
+                errors.append(f"{path}: status {status}")
+                continue
+
+            if status < 500:
+                if consecutive_failures > 0:
+                    logger.info("Engine recovered via %s after %s consecutive failures", path, consecutive_failures)
+                consecutive_failures = 0
+                return True
+            errors.append(f"{path}: status {status}")
+        except HTTPError as exc:
+            if path == "/health" and exc.code == 503 and is_startup_grace_active():
+                logger.info("Engine initializing via /health HTTP 503; grace window active")
+                consecutive_failures = 0
+                return True
+            errors.append(f"{path}: HTTP {exc.code} {exc.reason}")
+        except URLError as exc:
+            errors.append(f"{path}: connection {exc.reason}")
+        except Exception as exc:
+            errors.append(f"{path}: {type(exc).__name__} {exc}")
+
+    consecutive_failures += 1
+    logger.error("Readiness failed: %s", "; ".join(errors))
+    return False
+
+
+def main() -> None:
+    logger.info("Starting monitor - checking %s paths=%s every %ss", ENGINE_URL, json.dumps(READINESS_PATHS), CHECK_INTERVAL)
+    logger.info("Failure threshold: %s consecutive failures", FAILURE_THRESHOLD)
+    logger.info("Startup grace: %ss", STARTUP_GRACE_SECONDS)
+
     while True:
         healthy = check_health()
-        
         if healthy:
-            logger.debug('Engine healthy')
-        else:
-            if consecutive_failures >= FAILURE_THRESHOLD:
-                logger.critical(f'Engine DOWN! {consecutive_failures} consecutive failures')
-                # Could trigger alert here
-        
+            logger.debug("Engine healthy")
+        elif consecutive_failures >= FAILURE_THRESHOLD:
+            logger.critical("Engine DOWN! %s consecutive failures", consecutive_failures)
         time.sleep(CHECK_INTERVAL)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Makes monitor-bridge less brittle during VPS startup.

Changes:
- Default monitor port matches Docker engine port 3001.
- Checks /health and /client-config.json.
- Treats /health HTTP 503 during startup grace as initializing instead of DOWN.
- Adds STARTUP_GRACE_SECONDS, REQUEST_TIMEOUT_SECONDS and READINESS_PATHS.

This prevents false Engine DOWN alerts while Areloria initializes.