### PR TITLE
fix(vps): package and verify client shell

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -45,6 +45,10 @@ RUN pnpm --filter @wasd/core-logic --if-present run build:runtime && \
     pnpm --filter @wasd/shared --if-present build && \
     pnpm --filter @wasd/server --if-present build
 
+RUN node scripts/sync-world-assets.mjs || true
+
+RUN pnpm --filter @wasd/client --if-present build
+
 FROM node:22-alpine AS runner
 
 WORKDIR /app
@@ -65,6 +69,7 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/server ./server
 COPY --from=builder /app/packages/core-logic ./packages/core-logic
 COPY --from=builder /app/packages/shared ./packages/shared
+COPY --from=builder /app/client/dist ./client/dist
 
 RUN rm -rf \
     /app/server/src \

--- a/packages/shared/scripts/transpile-build.mjs
+++ b/packages/shared/scripts/transpile-build.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { existsSync } from 'node:fs';
 import { copyFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { dirname, extname, join, relative } from 'node:path';
 import ts from 'typescript';
@@ -52,23 +53,32 @@ function shouldRewriteSpecifier(specifier) {
   return extname(clean) === '';
 }
 
-function withJsExtension(specifier) {
+function resolveExtensionlessSpecifier(specifier, fromFile) {
   if (!shouldRewriteSpecifier(specifier)) return specifier;
   const suffixIndex = specifier.search(/[?#]/);
-  if (suffixIndex === -1) return `${specifier}.js`;
-  return `${specifier.slice(0, suffixIndex)}.js${specifier.slice(suffixIndex)}`;
+  const bareSpecifier = suffixIndex === -1 ? specifier : specifier.slice(0, suffixIndex);
+  const suffix = suffixIndex === -1 ? '' : specifier.slice(suffixIndex);
+  const sourceTarget = join(dirname(fromFile), bareSpecifier);
+
+  for (const extension of ['.ts', '.tsx', '.mts', '.cts']) {
+    if (existsSync(`${sourceTarget}${extension}`)) return `${bareSpecifier}.js${suffix}`;
+  }
+  for (const extension of ['.ts', '.tsx', '.mts', '.cts']) {
+    if (existsSync(join(sourceTarget, `index${extension}`))) return `${bareSpecifier}/index.js${suffix}`;
+  }
+  return `${bareSpecifier}.js${suffix}`;
 }
 
-function rewriteRelativeEsmSpecifiers(output) {
+function rewriteRelativeEsmSpecifiers(output, fromFile) {
   return output
     .replace(/(from\s*['"])(\.\.?\/[^'"]+)(['"])/g, (_match, prefix, specifier, suffix) => {
-      return `${prefix}${withJsExtension(specifier)}${suffix}`;
+      return `${prefix}${resolveExtensionlessSpecifier(specifier, fromFile)}${suffix}`;
     })
     .replace(/(import\s*['"])(\.\.?\/[^'"]+)(['"])/g, (_match, prefix, specifier, suffix) => {
-      return `${prefix}${withJsExtension(specifier)}${suffix}`;
+      return `${prefix}${resolveExtensionlessSpecifier(specifier, fromFile)}${suffix}`;
     })
     .replace(/(import\(\s*['"])(\.\.?\/[^'"]+)(['"]\s*\))/g, (_match, prefix, specifier, suffix) => {
-      return `${prefix}${withJsExtension(specifier)}${suffix}`;
+      return `${prefix}${resolveExtensionlessSpecifier(specifier, fromFile)}${suffix}`;
     });
 }
 
@@ -103,7 +113,7 @@ async function transpile(file) {
 
   const jsFile = toOutFile(file, '.js');
   await ensureParent(jsFile);
-  await writeFile(jsFile, rewriteRelativeEsmSpecifiers(result.outputText || ''));
+  await writeFile(jsFile, rewriteRelativeEsmSpecifiers(result.outputText || '', file));
 }
 
 async function copyAsset(file) {

--- a/scripts/deploy-vps-docker.sh
+++ b/scripts/deploy-vps-docker.sh
@@ -89,6 +89,10 @@ container_http_ready() {
   return 1
 }
 
+client_shell_ready() {
+  docker exec arelorian-engine node -e "fetch('http://127.0.0.1:${CONTAINER_PORT}/').then(async r=>{const body=await r.text();process.exit(r.ok&&body.includes('application-canvas')?0:1)}).catch(()=>process.exit(1))" >/dev/null 2>&1
+}
+
 host_http_ready() {
   curl -sS -m 4 -o /dev/null -w '%{http_code}' "http://127.0.0.1:${ARELORIAN_PORT}/health" 2>/dev/null | grep -Eq '^(200|204|301|302|304|401|403|503)$' && return 0
   curl -sS -m 4 -o /dev/null -w '%{http_code}' "http://127.0.0.1:${ARELORIAN_PORT}/client-config.json" 2>/dev/null | grep -Eq '^(200|204|301|302|304|401|403|503)$' && return 0
@@ -142,14 +146,22 @@ ok=0
 for i in $(seq 1 36); do
   if container_http_ready; then
     echo "  container HTTP ready ($i/36)"
-    if host_http_ready; then echo "  host HTTP mapping ready"; else echo "  WARN: host mapping not responding yet"; fi
-    ok=1
-    break
+    if client_shell_ready; then
+      echo "  client shell ready"
+      if host_http_ready; then echo "  host HTTP mapping ready"; else echo "  WARN: host mapping not responding yet"; fi
+      ok=1
+      break
+    fi
+    echo "  waiting for client shell... ($i/36)"
   fi
   if [ "$i" -ge 12 ] && runtime_activity_ready; then
     echo "  runtime activity ready ($i/36): node process and world events detected"
-    ok=1
-    break
+    if client_shell_ready; then
+      echo "  client shell ready"
+      ok=1
+      break
+    fi
+    echo "  waiting for client shell... ($i/36)"
   fi
   echo "  waiting... ($i/36)"
   sleep 5


### PR DESCRIPTION
## Summary

Continues from `docs/AUDIT_RUNTIME_STABILITY_2026-05-16.md` and carries forward the safe, deploy-relevant part of draft PR #759 on top of the current `main` after #758/#760.

Changes:
- Build the production client bundle in `Dockerfile.vps` after server/shared builds.
- Copy `client/dist` into the runner image so the server can actually serve the browser shell.
- Update the shared transpile helper so extensionless relative ESM imports resolve directory exports like `./math` to `./math/index.js` when the source target is an index module.
- Strengthen `scripts/deploy-vps-docker.sh` so deploy readiness requires the served client shell, not only `/health` or runtime log activity.

Why:
- A Docker deploy can otherwise pass while the Node process is alive but the public game UI is missing from the runtime image.
- Shared package directory exports can produce broken runtime ESM references after transpile.

## Verification intended by CI / agent

```bash
bash -n scripts/deploy-vps-docker.sh
pnpm --filter @wasd/shared --if-present build
pnpm --filter @wasd/client --if-present build
pnpm --filter @wasd/server --if-present build
```

## Safety

- No broad workflow rewrite.
- No lockfile rewrite.
- No ServerBootstrap rewrite.
- No determinism changes yet.

Next after this PR:
1. Run VPS Docker Deploy again.
2. If green, proceed with `audit/workflow-env-file`.
3. Then `audit/nginx-host-gateway`.
4. Then `audit/determinism-gate` as a separate guarded PR.