### PR TITLE
ops(nginx): add host gateway installer

### DIFF
--- a/docs/NGINX_HOST_GATEWAY.md
+++ b/docs/NGINX_HOST_GATEWAY.md
@@ -1,0 +1,47 @@
+# Areloria Host Nginx Gateway
+
+The production Docker stack keeps the Areloria engine bound to the host loopback port:
+
+```text
+127.0.0.1:3001 -> arelorian-engine:3001
+```
+
+Nginx is intentionally treated as the host edge service, not as a Docker service in the WASD compose stack. This keeps Supabase/Kong free to use its own ports and prevents the game stack from taking over unrelated host routing.
+
+## Install or update
+
+Run on the VPS as root or through sudo from the repository root:
+
+```bash
+sudo ARELORIAN_DOMAIN=arelorian.de \
+  ARELORIAN_WWW_DOMAIN=www.arelorian.de \
+  ARELORIAN_PORT=3001 \
+  bash scripts/install-nginx-host-gateway.sh
+```
+
+The script:
+
+- installs Nginx on apt-based hosts when missing,
+- writes `/etc/nginx/conf.d/arelorian-websocket-map.conf`,
+- writes `/etc/nginx/sites-available/arelorian-game`,
+- links it into `/etc/nginx/sites-enabled/arelorian-game`,
+- backs up previous managed files,
+- validates with `nginx -t`,
+- reloads Nginx only after validation succeeds.
+
+## Supported routes
+
+The generated host gateway sends these routes to `127.0.0.1:3001`:
+
+- `/`
+- `/ws`
+- `/socket.io/`
+- `/2d/`
+- `/3d/`
+- `/portal/`
+
+## Notes
+
+- TLS/certbot is intentionally not automated in this script because certificate state is host-specific.
+- The script does not change Docker Compose.
+- The script does not expose the engine directly to the public network; Docker still binds the engine host port to `127.0.0.1`.

--- a/scripts/install-nginx-host-gateway.sh
+++ b/scripts/install-nginx-host-gateway.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Install or update the host-level Nginx gateway for Areloria.
+# This script is intended to run on the VPS, not inside Docker.
+set -euo pipefail
+
+DOMAIN="${ARELORIAN_DOMAIN:-arelorian.de}"
+WWW_DOMAIN="${ARELORIAN_WWW_DOMAIN:-www.arelorian.de}"
+ENGINE_HOST="${ARELORIAN_ENGINE_HOST:-127.0.0.1}"
+ENGINE_PORT="${ARELORIAN_PORT:-3001}"
+SITE_NAME="${ARELORIAN_NGINX_SITE_NAME:-arelorian-game}"
+AVAILABLE_DIR="${NGINX_AVAILABLE_DIR:-/etc/nginx/sites-available}"
+ENABLED_DIR="${NGINX_ENABLED_DIR:-/etc/nginx/sites-enabled}"
+CONF_PATH="$AVAILABLE_DIR/$SITE_NAME"
+ENABLED_PATH="$ENABLED_DIR/$SITE_NAME"
+MAP_CONF_PATH="${NGINX_MAP_CONF_PATH:-/etc/nginx/conf.d/arelorian-websocket-map.conf}"
+BACKUP_SUFFIX="$(date +%Y%m%d-%H%M%S)"
+
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+  echo "ERROR: run as root or with sudo."
+  exit 1
+fi
+
+if ! command -v nginx >/dev/null 2>&1; then
+  echo "Installing nginx ..."
+  if command -v apt-get >/dev/null 2>&1; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
+  else
+    echo "ERROR: nginx is missing and this script currently supports apt-based hosts only."
+    exit 1
+  fi
+fi
+
+mkdir -p "$AVAILABLE_DIR" "$ENABLED_DIR" "$(dirname "$MAP_CONF_PATH")"
+
+if [ -f "$CONF_PATH" ]; then
+  cp "$CONF_PATH" "$CONF_PATH.bak-$BACKUP_SUFFIX"
+fi
+if [ -f "$MAP_CONF_PATH" ]; then
+  cp "$MAP_CONF_PATH" "$MAP_CONF_PATH.bak-$BACKUP_SUFFIX"
+fi
+
+cat > "$MAP_CONF_PATH" <<'EOF_MAP'
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+EOF_MAP
+
+cat > "$CONF_PATH" <<EOF_SITE
+server {
+  listen 80;
+  listen [::]:80;
+  server_name $DOMAIN $WWW_DOMAIN;
+
+  client_max_body_size 64m;
+
+  location / {
+    proxy_pass http://$ENGINE_HOST:$ENGINE_PORT;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_read_timeout 120s;
+    proxy_send_timeout 120s;
+  }
+
+  location /ws {
+    proxy_pass http://$ENGINE_HOST:$ENGINE_PORT;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection \$connection_upgrade;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+  }
+
+  location /socket.io/ {
+    proxy_pass http://$ENGINE_HOST:$ENGINE_PORT;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection \$connection_upgrade;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+  }
+
+  location /2d/ {
+    proxy_pass http://$ENGINE_HOST:$ENGINE_PORT/2d/;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+  }
+
+  location /3d/ {
+    proxy_pass http://$ENGINE_HOST:$ENGINE_PORT/3d/;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+  }
+
+  location /portal/ {
+    proxy_pass http://$ENGINE_HOST:$ENGINE_PORT/portal/;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+  }
+}
+EOF_SITE
+
+ln -sfn "$CONF_PATH" "$ENABLED_PATH"
+
+if [ -L "$ENABLED_DIR/default" ]; then
+  rm -f "$ENABLED_DIR/default"
+fi
+
+nginx -t
+systemctl reload nginx 2>/dev/null || service nginx reload
+
+echo "Nginx host gateway installed: $DOMAIN -> http://$ENGINE_HOST:$ENGINE_PORT"


### PR DESCRIPTION
## Summary

Continues the runtime stability follow-up plan from `docs/AUDIT_RUNTIME_STABILITY_2026-05-16.md`.

Adds a small host-level Nginx gateway installer for the current production shape:

```text
arelorian.de -> host Nginx -> 127.0.0.1:3001 -> arelorian-engine:3001
```

Changes:
- Adds `scripts/install-nginx-host-gateway.sh`.
- Adds `docs/NGINX_HOST_GATEWAY.md`.
- Keeps Nginx as a host service, not a Docker Compose service.
- Preserves Supabase/Kong and other service routing by only proxying Areloria domain routes to the engine port.

The script:
- installs Nginx on apt-based hosts if missing,
- writes the WebSocket upgrade map under `/etc/nginx/conf.d/`,
- writes the managed site under `/etc/nginx/sites-available/`,
- links it into `/etc/nginx/sites-enabled/`,
- backs up previous managed files,
- validates with `nginx -t`,
- reloads Nginx only after validation succeeds.

## Safety

- No Docker Compose changes.
- No deploy workflow changes.
- No server code changes.
- No lockfile changes.
- No TLS/certbot automation in this PR.
- No determinism changes.

## Manual verification on VPS

```bash
sudo ARELORIAN_DOMAIN=arelorian.de \
  ARELORIAN_WWW_DOMAIN=www.arelorian.de \
  ARELORIAN_PORT=3001 \
  bash scripts/install-nginx-host-gateway.sh
```

Next after this PR:
1. Run VPS Docker Deploy.
2. Run the host Nginx gateway installer on the VPS if domain routing still needs repair.
3. Add `audit/determinism-gate` as the next guarded CI PR.