### PR TITLE
ci(are): add deterministic runtime gate

### DIFF
--- a/.github/workflows/are-determinism-gate.yml
+++ b/.github/workflows/are-determinism-gate.yml
@@ -1,0 +1,44 @@
+name: ARE Determinism Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'packages/core-logic/src/**'
+      - 'server/src/core/**'
+      - 'server/src/modules/loot/**'
+      - 'server/src/modules/warfront/**'
+      - 'server/src/modules/oracle/**'
+      - 'scripts/check-are-determinism.mjs'
+      - '.github/workflows/are-determinism-gate.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/core-logic/src/**'
+      - 'server/src/core/**'
+      - 'server/src/modules/loot/**'
+      - 'server/src/modules/warfront/**'
+      - 'server/src/modules/oracle/**'
+      - 'scripts/check-are-determinism.mjs'
+      - '.github/workflows/are-determinism-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  determinism-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check ARE-critical deterministic paths
+        run: node scripts/check-are-determinism.mjs

--- a/scripts/check-are-determinism.mjs
+++ b/scripts/check-are-determinism.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { readFile, readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const root = process.cwd();
+const criticalRoots = [
+  'packages/core-logic/src',
+  'server/src/core',
+  'server/src/modules/loot',
+  'server/src/modules/warfront',
+  'server/src/modules/oracle',
+];
+
+const blockedPatterns = [
+  { name: 'Math.random', regex: /\bMath\.random\s*\(/g },
+  { name: 'Date.now', regex: /\bDate\.now\s*\(/g },
+  { name: 'new Date', regex: /\bnew\s+Date\s*\(/g },
+];
+
+const allowedMarker = '@are-determinism-allow';
+const sourceExtensions = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs']);
+
+function hasSourceExtension(file) {
+  return [...sourceExtensions].some((extension) => file.endsWith(extension));
+}
+
+async function walk(dir) {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['dist', 'build', 'coverage', 'node_modules', '__tests__', 'tests', 'test'].includes(entry.name)) continue;
+      files.push(...await walk(full));
+      continue;
+    }
+    if (entry.isFile() && hasSourceExtension(full)) files.push(full);
+  }
+  return files;
+}
+
+function lineNumberForOffset(content, offset) {
+  let line = 1;
+  for (let index = 0; index < offset; index += 1) {
+    if (content.charCodeAt(index) === 10) line += 1;
+  }
+  return line;
+}
+
+function lineAt(content, lineNumber) {
+  return content.split(/\r?\n/)[lineNumber - 1] || '';
+}
+
+function isAllowed(content, lineNumber) {
+  const lines = content.split(/\r?\n/);
+  const previous = lines[lineNumber - 2] || '';
+  const current = lines[lineNumber - 1] || '';
+  return previous.includes(allowedMarker) || current.includes(allowedMarker);
+}
+
+const files = [];
+for (const criticalRoot of criticalRoots) {
+  files.push(...await walk(join(root, criticalRoot)));
+}
+
+const findings = [];
+for (const file of files) {
+  const content = await readFile(file, 'utf8');
+  for (const pattern of blockedPatterns) {
+    pattern.regex.lastIndex = 0;
+    for (const match of content.matchAll(pattern.regex)) {
+      const line = lineNumberForOffset(content, match.index || 0);
+      if (isAllowed(content, line)) continue;
+      findings.push({
+        file: relative(root, file),
+        line,
+        pattern: pattern.name,
+        code: lineAt(content, line).trim(),
+      });
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error('ARE determinism gate failed. Non-deterministic time/random calls found in ARE-critical paths.');
+  console.error('Use injected deterministic clock/RNG, or add a reviewed @are-determinism-allow marker for non-simulation code.');
+  console.error('');
+  for (const finding of findings) {
+    console.error(`${finding.file}:${finding.line} ${finding.pattern} :: ${finding.code}`);
+  }
+  process.exit(1);
+}
+
+console.log(`ARE determinism gate passed. Scanned ${files.length} file(s) across ${criticalRoots.length} critical root(s).`);


### PR DESCRIPTION
## Summary

Continues the runtime stability audit follow-up plan with the guarded `audit/determinism-gate` step.

This PR does **not** rewrite `Math.random`, `Date.now`, or `new Date` usage. Instead it adds a CI gate that blocks new or existing nondeterministic calls only in ARE-critical simulation paths:

- `packages/core-logic/src/**`
- `server/src/core/**`
- `server/src/modules/loot/**`
- `server/src/modules/warfront/**`
- `server/src/modules/oracle/**`

Changes:
- Adds `scripts/check-are-determinism.mjs`.
- Adds `.github/workflows/are-determinism-gate.yml`.
- Reports exact file, line, pattern, and source line when a blocked call is found.
- Allows reviewed exceptions only with `@are-determinism-allow` on the same or previous line.

Why:
- The audit found broad `Math.random` and `Date.now` usage across UI, docs, demos, legacy code, and server logic.
- Blind replacement could corrupt loot, NPC behavior, warfront balancing, and runtime semantics.
- This PR creates the guardrail first, before any deterministic RNG/clock migration.

## Safety

- No behavior rewrites.
- No source logic changes.
- No package install.
- No lockfile changes.
- No Docker changes.
- No deploy workflow changes.

## Verification

```bash
node scripts/check-are-determinism.mjs
```

If this gate fails on current critical paths, the next PR should classify those findings and replace them with injected AREClock/ARERng or add explicit reviewed exception markers where they are not simulation-affecting.