### PR TITLE
docs(deploy): clarify production port map

### DIFF
--- a/docs/DEPLOY_PORT_MAP.md
+++ b/docs/DEPLOY_PORT_MAP.md
@@ -1,0 +1,44 @@
+# WASD/Areloria Deploy Port Map
+
+This document prevents old 3000-era deployment references from being mistaken for the current production engine port.
+
+## Current production shape
+
+| Purpose | Host binding | Internal target | Notes |
+|---|---:|---:|---|
+| Areloria engine | `127.0.0.1:3001` | `arelorian-engine:3001` | Active production game/API server |
+| Host Nginx gateway | `:80` / `:443` | `127.0.0.1:3001` | Public edge for `arelorian.de` |
+| Supabase gateway/Kong | stack-owned | `supabase-kong:8000` | Do not replace with engine port |
+| Supabase database | stack-owned | `supabase-db:5432` | Internal database target |
+| Redis | stack-owned | `redis-comn-redis-1:6379` | Internal cache target |
+| Soketi | stack-owned | `soketi-9eoa-soketi-1:6001` | Internal websocket/Pusher-compatible target |
+
+## How to read port 3000 references
+
+Port `3000` may still appear in this repository for legitimate reasons:
+
+- local Vite/dev-server defaults,
+- tests and CORS fixtures,
+- older demo docs,
+- legacy PM2/non-Docker deployment scripts,
+- historical setup scripts.
+
+These references are not automatically wrong. They are only wrong when a production VPS/Docker deploy path claims the Areloria engine should bind publicly or internally to port `3000`.
+
+## Rule for new automation
+
+New production automation should use:
+
+```text
+ARELORIAN_PORT=3001
+ARELORIAN_CONTAINER_PORT=3001
+ENGINE_URL=http://arelorian-engine:3001
+```
+
+Public traffic should go through host Nginx:
+
+```text
+arelorian.de -> Nginx -> 127.0.0.1:3001 -> arelorian-engine:3001
+```
+
+Do not add a Dockerized Nginx service to the WASD compose stack unless the architecture is intentionally changed in a dedicated PR.


### PR DESCRIPTION
## Summary

Completes the last documentation follow-up from `docs/AUDIT_RUNTIME_STABILITY_2026-05-16.md` without mass-editing every old `3000` reference.

Adds `docs/DEPLOY_PORT_MAP.md` to clarify the active production routing shape:

```text
arelorian.de -> host Nginx -> 127.0.0.1:3001 -> arelorian-engine:3001
```

Why:
- The repo still contains legitimate `3000` references in local dev configs, tests, demos, and legacy scripts.
- Blind replacement would risk breaking local dev or historical examples.
- Future agents need a small canonical port map so they do not confuse Supabase/Kong/local dev with the production Areloria engine port.

## Safety

- Documentation only.
- No runtime changes.
- No workflow changes.
- No Docker changes.
- No source code changes.

## Notes

This PR intentionally does not rewrite Vite/test/demo references to port `3000`. It documents when `3000` is acceptable and when production automation must use `3001`.