### PR TITLE
feat(are): classify determinism findings and add primitives

### DIFF
--- a/docs/ARE_DETERMINISM_CLASSIFICATION.md
+++ b/docs/ARE_DETERMINISM_CLASSIFICATION.md
@@ -1,0 +1,120 @@
+# ARE Determinism Classification
+
+This document classifies the first findings from PR #765 (`ci(are): add deterministic runtime gate`) and defines the safe migration order.
+
+The goal is not to delete every `Date.now()`, `new Date()`, or `Math.random()` in the repository. The goal is to protect ARE-critical simulation from nondeterministic host time and process-local randomness.
+
+## Classification levels
+
+| Level | Meaning | Required action |
+|---|---|---|
+| A | Simulation-affecting gameplay result | Replace with injected `AREClock` / `ARERng` before gate merge |
+| B | Simulation-adjacent state timestamp | Prefer injected `AREClock`; temporary reviewed marker allowed only if not used for gameplay branching |
+| C | Runtime, observability, health, logging, or local repair telemetry | Keep system time; add reviewed exception marker if scanned |
+| D | UI/demo/test/local-dev only | Exclude from critical gate paths |
+
+## First gate findings
+
+### Level A: migrate first
+
+These directly affect combat, loot, warfront, or oracle output and must become deterministic.
+
+- `server/src/core/systems/CombatSystem.ts`
+  - critical rolls
+  - loot drop rolls
+  - item amount rolls
+  - item id random suffixes
+- `server/src/modules/loot/LootSystem.ts`
+  - drop chance rolls
+  - count rolls
+  - gold rolls
+- `server/src/modules/loot/diabloItemGen.ts`
+  - affix/stat rarity rolls
+- `server/src/modules/loot/diabloTreasure.ts`
+  - treasure table selection and gold rolls
+- `server/src/modules/loot/itemEnchant.ts`
+  - enchant target/affix selection
+- `server/src/modules/loot/smartLoot.ts`
+  - weighted selection
+- `server/src/modules/oracle/OracleEngine.ts`
+  - prophecy/vision selection
+
+### Level B: migrate carefully
+
+These use wall-clock time for world or player state. They should use injected `AREClock`, but some already accept `now` parameters and only need default-source cleanup.
+
+- `server/src/modules/warfront/WarfrontSystem.ts`
+  - default `now = Date.now()` values
+  - cycle ids and season windows
+- `server/src/core/WorldBossDungeonSystem.ts`
+  - current-time helper
+- `server/src/core/state/RegionState.ts`
+  - sync timestamp
+- `server/src/core/state/WorldStateRegistry.ts`
+  - sync timestamp
+- `server/src/core/GameStateManager.ts`
+  - state payload timestamps
+- `server/src/core/PayloadFactory.ts`
+  - payload timestamps
+- `packages/core-logic/src/agent/Orchestrator.ts`
+  - memory ids and timestamps; classify by whether memory affects simulation decisions
+- `server/src/core/AIOrchestrator.ts`
+  - task reset and timeout loops; classify by whether it gates simulation work
+- `server/src/core/systems/EvolutionSystem.ts`
+  - directive ids based on wall-clock time
+
+### Level C: allow or move out of critical scan
+
+These are runtime/ops/self-healing telemetry. They can use wall-clock time because their job is to observe the live process, not to produce deterministic simulation results.
+
+- `server/src/core/api/APIServer.ts`
+  - health/API timestamp
+- `server/src/core/logger/Logger.ts`
+  - log timestamp
+- `server/src/core/integrity/OuroborosAnchor.ts`
+  - integrity event timestamp, unless used as simulation seed
+- `server/src/core/liveheal/**`
+  - anomaly timing
+  - cooldowns
+  - patch ids
+  - learning-store retention
+  - healing durations
+
+## Migration order
+
+1. Add deterministic primitives: `AREClock`, `ARERng`, seeded RNG factory.
+2. Migrate Level A loot/combat/oracle rolls.
+3. Migrate Warfront default wall-clock sources to injected clock or explicit tick time.
+4. Narrow the gate to Level A/B paths, or add explicit `@are-determinism-allow` markers for Level C files.
+5. Re-run PR #765 or replace it with a gate that reflects this classification.
+
+## Default seed guidance
+
+For simulation results, derive seeds from stable game facts, not wall-clock time:
+
+```text
+worldSeed | regionId | chunkId | tick | attackerId | targetId | tableId | cycleId
+```
+
+Good examples:
+
+```text
+combat|region-12|tick-9912|player-a|npc-b
+loot|region-12|tick-9912|npc-b|table-goblin
+warfront|warfront_cycle_20514|sector-combat
+oracle|region-12|cycle-20514|pressure-high_conflict
+```
+
+Bad examples:
+
+```text
+Date.now()
+Math.random()
+process uptime
+hostname
+container id
+```
+
+## Rule
+
+The ARE engine may observe wall-clock time at system boundaries, but deterministic simulation decisions must receive time/randomness as explicit inputs.

--- a/server/src/core/determinism/AREDeterminism.test.ts
+++ b/server/src/core/determinism/AREDeterminism.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { createARESeed, FixedAREClock, SeededARERng } from './AREDeterminism.js';
+
+describe('AREDeterminism primitives', () => {
+  it('returns fixed time from FixedAREClock', () => {
+    const clock = new FixedAREClock(123456);
+    expect(clock.now()).toBe(123456);
+    expect(clock.now()).toBe(123456);
+  });
+
+  it('replays the same RNG sequence for the same seed', () => {
+    const left = new SeededARERng('combat|region-a|tick-10|player|npc');
+    const right = new SeededARERng('combat|region-a|tick-10|player|npc');
+
+    expect(Array.from({ length: 8 }, () => left.nextInt(1000)))
+      .toEqual(Array.from({ length: 8 }, () => right.nextInt(1000)));
+  });
+
+  it('creates different RNG sequences for different seeds', () => {
+    const left = new SeededARERng('loot|region-a|tick-10');
+    const right = new SeededARERng('loot|region-a|tick-11');
+
+    expect(Array.from({ length: 8 }, () => left.nextInt(1000)))
+      .not.toEqual(Array.from({ length: 8 }, () => right.nextInt(1000)));
+  });
+
+  it('forks reproducibly by label', () => {
+    const first = new SeededARERng('oracle|region-a').fork('vision');
+    const second = new SeededARERng('oracle|region-a').fork('vision');
+
+    expect(Array.from({ length: 4 }, () => first.nextFloat()))
+      .toEqual(Array.from({ length: 4 }, () => second.nextFloat()));
+  });
+
+  it('builds stable seed strings from ordered parts', () => {
+    expect(createARESeed(['combat', 'region-a', 10, 'player', 'npc']))
+      .toBe('combat|region-a|10|player|npc');
+  });
+});

--- a/server/src/core/determinism/AREDeterminism.ts
+++ b/server/src/core/determinism/AREDeterminism.ts
@@ -1,0 +1,88 @@
+export interface AREClock {
+  now(): number;
+}
+
+export interface ARERng {
+  nextFloat(): number;
+  nextInt(maxExclusive: number): number;
+  nextRange(minInclusive: number, maxInclusive: number): number;
+  fork(label: string): ARERng;
+}
+
+export class SystemAREClock implements AREClock {
+  now(): number {
+    return Date.now();
+  }
+}
+
+export class FixedAREClock implements AREClock {
+  constructor(private readonly fixedNow: number) {}
+
+  now(): number {
+    return this.fixedNow;
+  }
+}
+
+/**
+ * Small deterministic PRNG for server simulation paths.
+ *
+ * This uses a 32-bit FNV-1a seed and Mulberry32 step. It is intended for
+ * reproducible gameplay decisions, not cryptography or security tokens.
+ */
+export class SeededARERng implements ARERng {
+  private state: number;
+
+  constructor(seed: string | number) {
+    this.state = typeof seed === 'number' ? seed >>> 0 : hashSeed(seed);
+    if (this.state === 0) this.state = 0x6d2b79f5;
+  }
+
+  nextFloat(): number {
+    let next = this.state += 0x6d2b79f5;
+    next = Math.imul(next ^ (next >>> 15), next | 1);
+    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+  }
+
+  nextInt(maxExclusive: number): number {
+    if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) return 0;
+    return Math.floor(this.nextFloat() * Math.floor(maxExclusive));
+  }
+
+  nextRange(minInclusive: number, maxInclusive: number): number {
+    const min = Math.ceil(minInclusive);
+    const max = Math.floor(maxInclusive);
+    if (max <= min) return min;
+    return min + this.nextInt(max - min + 1);
+  }
+
+  fork(label: string): ARERng {
+    return new SeededARERng(`${this.state.toString(36)}:${label}`);
+  }
+}
+
+export function createARESeed(parts: readonly unknown[]): string {
+  return parts.map((part) => stablePart(part)).join('|');
+}
+
+function stablePart(part: unknown): string {
+  if (part === null) return 'null';
+  if (part === undefined) return 'undefined';
+  if (typeof part === 'string' || typeof part === 'number' || typeof part === 'boolean') {
+    return String(part);
+  }
+  try {
+    return JSON.stringify(part, Object.keys(part as Record<string, unknown>).sort());
+  } catch {
+    return String(part);
+  }
+}
+
+function hashSeed(seed: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}


### PR DESCRIPTION
## Summary

Continues from the failing determinism gate in PR #765.

This PR does not attempt a risky mass rewrite. It adds the safe foundation required for the next migration PR:

- `server/src/core/determinism/AREDeterminism.ts`
  - `AREClock`
  - `SystemAREClock`
  - `FixedAREClock`
  - `ARERng`
  - `SeededARERng`
  - `createARESeed`
- `server/src/core/determinism/AREDeterminism.test.ts`
  - documents/replays expected deterministic behavior
- `docs/ARE_DETERMINISM_CLASSIFICATION.md`
  - classifies PR #765 findings into Level A/B/C/D
  - marks Combat/Loot/Oracle as first migration targets
  - separates LiveHeal/API/Logger telemetry from simulation-critical paths

## Why

PR #765 proved the gate works, but current critical paths still contain many `Date.now()` / `Math.random()` calls. Merging that gate before classification would freeze the repo in a failing state.

This PR provides the migration map and primitives so the next PR can safely migrate Level A gameplay outputs instead of blindly replacing everything.

## Safety

- No gameplay behavior changed yet.
- No runtime wiring changed yet.
- No Docker/deploy changes.
- No workflow changes.
- No lockfile changes.

## Recommended next PR

`feat(are): migrate loot and combat randomness to ARERng`

Target files:
- `server/src/core/systems/CombatSystem.ts`
- `server/src/modules/loot/LootSystem.ts`
- `server/src/modules/loot/diabloItemGen.ts`
- `server/src/modules/loot/diabloTreasure.ts`
- `server/src/modules/loot/itemEnchant.ts`
- `server/src/modules/loot/smartLoot.ts`
- `server/src/modules/oracle/OracleEngine.ts`

After that, revisit PR #765 or update the gate to exclude Level C telemetry and enforce Level A/B only.