### PR TITLE
feat(are): migrate loot and combat randomness to ARERng

### DIFF
--- a/server/src/core/systems/CombatSystem.ts
+++ b/server/src/core/systems/CombatSystem.ts
@@ -4,6 +4,7 @@
  * Server-authoritative with deterministic calculations.
  */
 
+import { createARESeed, type ARERng, SeededARERng } from '../determinism/AREDeterminism.js';
 import { type RegionState, KAPPA, OraclePressureTag } from '../state/RegionState.js';
 import { worldStateRegistry, type PendingMutation } from '../state/WorldStateRegistry.js';
 
@@ -111,6 +112,14 @@ const SOFT_SYNC_THRESHOLD = toFP(2); // 2 units - interpolate
 const HARD_SYNC_THRESHOLD = toFP(5); // 5 units - hard correction
 const MAX_INTERPOLATION_DISTANCE = toFP(8); // 8 units max interpolate
 
+function regionSeed(region: RegionState): string {
+  return createARESeed([
+    'region',
+    region.threatLevel,
+    [...region.oraclePressureTags].sort().join(','),
+  ]);
+}
+
 /**
  * CMLS - Combat, Movement & Loot System
  */
@@ -192,7 +201,18 @@ export class CMLS {
     baseDamage: number,
     region: RegionState,
     playerMastery: number,
-    weaponCriticalChance: number = toFP(0.1)
+    weaponCriticalChance: number = toFP(0.1),
+    rng: ARERng = new SeededARERng(createARESeed([
+      'combat',
+      attackerId,
+      targetId,
+      attackerPos,
+      targetPos,
+      baseDamage,
+      playerMastery,
+      weaponCriticalChance,
+      regionSeed(region),
+    ]))
   ): CombatResult {
     // Check range (hitscan logic)
     const range = this.calculateDistance(attackerPos, targetPos);
@@ -203,7 +223,7 @@ export class CMLS {
     }
 
     // Hit confirmed - calculate critical
-    const critical = Math.floor(Math.random() * FP_SCALE) < weaponCriticalChance;
+    const critical = rng.nextInt(FP_SCALE) < weaponCriticalChance;
 
     // Calculate damage: Base_DMG * (1 + Mastery_Bonus / 1000) * (Critical_Mod)
     let masteryBonus = Math.floor(playerMastery * 0.2);
@@ -230,7 +250,16 @@ export class CMLS {
   public resolveLoot(
     combat: CombatResult,
     region: RegionState,
-    victimValue: number
+    victimValue: number,
+    rng: ARERng = new SeededARERng(createARESeed([
+      'combat-loot',
+      combat.attackerId,
+      combat.targetId,
+      combat.damage,
+      combat.critical,
+      victimValue,
+      regionSeed(region),
+    ]))
   ): LootDrop[] {
     if (!combat.hit || combat.damage <= 0) {
       return [];
@@ -246,16 +275,18 @@ export class CMLS {
 
     // Roll for each item in pool
     for (const entry of pool) {
-      const roll = Math.floor(Math.random() * FP_SCALE);
+      const roll = rng.nextInt(FP_SCALE);
       
       // Check if item drops
       if (roll < quality) {
-        const amount = this.rollAmount(entry.rarity);
+        const entryRng = rng.fork(`drop:${entry.itemType}`);
+        const amount = this.rollAmount(entry.rarity, entryRng.fork('amount'));
         const value = this.calculateItemValue(entry.rarity, combat, victimValue);
+        const suffix = entryRng.nextInt(2 ** 31 - 1).toString(36);
 
         drops.push({
           itemType: entry.itemType,
-          itemId: `${entry.itemType}_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+          itemId: `${entry.itemType}_${combat.attackerId}_${combat.targetId}_${suffix}`,
           amount,
           value,
           rarity: entry.rarity,
@@ -315,10 +346,10 @@ export class CMLS {
   /**
    * Roll amount based on rarity
    */
-  private rollAmount(rarity: string): number {
+  private rollAmount(rarity: string, rng: ARERng): number {
     switch (rarity) {
-      case 'common': return 1 + Math.floor(Math.random() * 3);
-      case 'uncommon': return 1 + Math.floor(Math.random() * 2);
+      case 'common': return 1 + rng.nextInt(3);
+      case 'uncommon': return 1 + rng.nextInt(2);
       case 'rare': return 1;
       case 'epic': return 1;
       case 'legendary': return 1;

--- a/server/src/modules/loot/LootSystem.ts
+++ b/server/src/modules/loot/LootSystem.ts
@@ -1,3 +1,4 @@
+import { createARESeed, type ARERng, SeededARERng } from "../../core/determinism/AREDeterminism.js";
 import { ItemRegistry, ItemDefinition } from "../inventory/ItemRegistry.js";
 import fs from "fs";
 import path from "path";
@@ -44,14 +45,20 @@ export class LootSystem {
     }
   }
 
-  rollLoot(dropTable: LootTableEntry[]): { items: ItemDefinition[]; gold: number } {
+  rollLoot(
+    dropTable: LootTableEntry[],
+    rng: ARERng = new SeededARERng(createARESeed([
+      "loot-table-inline",
+      dropTable.map((entry) => `${entry.itemId}:${entry.chance}:${entry.minCount ?? 1}:${entry.maxCount ?? entry.minCount ?? 1}`).join(","),
+    ]))
+  ): { items: ItemDefinition[]; gold: number } {
     const items: ItemDefinition[] = [];
     let gold = 0;
 
     for (const entry of dropTable) {
-      if (Math.random() < entry.chance) {
+      if (rng.nextFloat() < entry.chance) {
         const count = entry.minCount
-          ? Math.floor(Math.random() * ((entry.maxCount || entry.minCount) - entry.minCount + 1)) + entry.minCount
+          ? rng.nextRange(entry.minCount, entry.maxCount || entry.minCount)
           : 1;
         for (let i = 0; i < count; i++) {
           const item = ItemRegistry.createInstance(entry.itemId);
@@ -63,15 +70,15 @@ export class LootSystem {
     return { items, gold };
   }
 
-  rollFromTable(tableId: string): { items: ItemDefinition[]; gold: number } {
+  rollFromTable(tableId: string, rng: ARERng = new SeededARERng(createARESeed(["loot-table", tableId]))): { items: ItemDefinition[]; gold: number } {
     const table = this.lootTables.get(tableId);
     if (!table) return { items: [], gold: 0 };
 
-    const result = this.rollLoot(table.entries);
+    const result = this.rollLoot(table.entries, rng.fork(`${tableId}:entries`));
 
     // Roll gold
     if (table.goldMin !== undefined && table.goldMax !== undefined) {
-      result.gold = Math.floor(Math.random() * (table.goldMax - table.goldMin + 1)) + table.goldMin;
+      result.gold = rng.nextRange(table.goldMin, table.goldMax);
     }
 
     return result;

--- a/server/src/modules/loot/LootSystem.ts
+++ b/server/src/modules/loot/LootSystem.ts
@@ -1,7 +1,6 @@
 import { createARESeed, type ARERng, SeededARERng } from "../../core/determinism/AREDeterminism.js";
 import { ItemRegistry, ItemDefinition } from "../inventory/ItemRegistry.js";
 import fs from "fs";
-import path from "path";
 import { resolveContentFile } from "../content/contentDataRoot.js";
 
 export interface LootTableEntry {

--- a/server/src/modules/loot/diabloItemGen.ts
+++ b/server/src/modules/loot/diabloItemGen.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { createARESeed, type ARERng, SeededARERng } from "../../core/determinism/AREDeterminism.js";
 import { scaleRoll } from "./rollScale.js";
 

--- a/server/src/modules/loot/diabloItemGen.ts
+++ b/server/src/modules/loot/diabloItemGen.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { createARESeed, type ARERng, SeededARERng } from "../../core/determinism/AREDeterminism.js";
 import { scaleRoll } from "./rollScale.js";
 
 export type Rarity = "common" | "magic" | "rare" | "legendary" | "set";
@@ -49,20 +50,20 @@ export type GeneratedItem = {
   legendaryPowerId?: string;
 };
 
-export function randInt(min: number, max: number): number {
+export function randInt(min: number, max: number, rng: ARERng = new SeededARERng(createARESeed(["randInt", min, max]))): number {
   const lo = Math.ceil(min);
   const hi = Math.floor(max);
   if (hi < lo) return lo;
-  return Math.floor(lo + Math.random() * (hi - lo + 1));
+  return rng.nextRange(lo, hi);
 }
 
-export function pickWeighted<T extends { weight: number }>(arr: T[]): T {
+export function pickWeighted<T extends { weight: number }>(arr: T[], rng: ARERng = new SeededARERng(createARESeed(["pickWeighted", arr.length]))): T {
   if (arr.length === 0) {
     throw new Error("pickWeighted: empty array");
   }
   const total = arr.reduce((s, x) => s + Math.max(0, x.weight), 0);
   if (total <= 0) return arr[arr.length - 1]!;
-  let r = Math.random() * total;
+  let r = rng.nextFloat() * total;
   for (const x of arr) {
     r -= Math.max(0, x.weight);
     if (r <= 0) return x;
@@ -70,8 +71,8 @@ export function pickWeighted<T extends { weight: number }>(arr: T[]): T {
   return arr[arr.length - 1]!;
 }
 
-export function rarityRoll(mf = 0): Rarity {
-  const r = Math.random() * (1 + mf * 0.002);
+export function rarityRoll(mf = 0, rng: ARERng = new SeededARERng(createARESeed(["rarityRoll", mf]))): Rarity {
+  const r = rng.nextFloat() * (1 + mf * 0.002);
   if (r > 0.995) return "set";
   if (r > 0.985) return "legendary";
   if (r > 0.92) return "rare";
@@ -87,21 +88,31 @@ export function generateItem(opts: {
   mf?: number;
   setId?: string;
   legendaryPowerId?: string;
+  rng?: ARERng;
 }): GeneratedItem {
-  const rarity = opts.rarity ?? rarityRoll(opts.mf ?? 0);
-  const seed = randInt(1, 2 ** 31 - 1);
+  const rng = opts.rng ?? new SeededARERng(createARESeed([
+    "diablo-item",
+    opts.base.id,
+    opts.ilvl,
+    opts.rarity ?? "auto",
+    opts.mf ?? 0,
+    opts.setId ?? "",
+    opts.legendaryPowerId ?? "",
+  ]));
+  const rarity = opts.rarity ?? rarityRoll(opts.mf ?? 0, rng.fork("rarity"));
+  const seed = randInt(1, 2 ** 31 - 1, rng.fork("seed"));
 
   const affixCount =
     rarity === "common"
       ? 0
       : rarity === "magic"
-        ? randInt(1, 2)
+        ? randInt(1, 2, rng.fork("affix-count"))
         : rarity === "rare"
-          ? randInt(3, 5)
+          ? randInt(3, 5, rng.fork("affix-count"))
           : rarity === "legendary"
-            ? randInt(4, 6)
+            ? randInt(4, 6, rng.fork("affix-count"))
             : rarity === "set"
-              ? randInt(4, 6)
+              ? randInt(4, 6, rng.fork("affix-count"))
               : 0;
 
   const pool = opts.affixes.filter(
@@ -114,7 +125,7 @@ export function generateItem(opts: {
   for (let i = 0; i < affixCount && pool.length; i++) {
     const candidates = pool.filter((a) => !usedGroups.has(a.group));
     if (!candidates.length) break;
-    const a = pickWeighted(candidates);
+    const a = pickWeighted(candidates, rng.fork(`affix:${i}`));
     chosen.push(a);
     usedGroups.add(a.group);
   }
@@ -129,7 +140,7 @@ export function generateItem(opts: {
   for (const a of chosen) {
     for (const rr of a.rolls) {
       const scaled = scaleRoll(rr.min, rr.max, opts.ilvl);
-      const v = randInt(scaled.min, scaled.max);
+      const v = randInt(scaled.min, scaled.max, rng.fork(`stat:${a.id}:${rr.stat}`));
       stats[rr.stat] = (stats[rr.stat] ?? 0) + v;
     }
   }
@@ -147,7 +158,7 @@ export function generateItem(opts: {
   const name = `${prefix}${opts.base.name}${chosen.length ? " " + chosen[0].name : ""}`;
 
   return {
-    uid: randomUUID(),
+    uid: `di_${seed.toString(36)}_${rng.fork("uid").nextInt(2 ** 31 - 1).toString(36)}`,
     baseId: opts.base.id,
     name,
     rarity,

--- a/server/src/modules/loot/diabloTreasure.ts
+++ b/server/src/modules/loot/diabloTreasure.ts
@@ -1,3 +1,4 @@
+import { createARESeed, type ARERng, SeededARERng } from "../../core/determinism/AREDeterminism.js";
 import type { BaseItem, Affix, GeneratedItem } from "./diabloItemGen.js";
 import { generateItem, rarityRoll } from "./diabloItemGen.js";
 
@@ -12,13 +13,13 @@ export type TreasureClass = {
   entries: TreasureEntry[];
 };
 
-function pickWeightedEntry(entries: TreasureEntry[]): TreasureEntry {
+function pickWeightedEntry(entries: TreasureEntry[], rng: ARERng): TreasureEntry {
   if (entries.length === 0) {
     throw new Error("pickWeightedEntry: empty entries");
   }
   const total = entries.reduce((s, x) => s + Math.max(0, x.weight), 0);
   if (total <= 0) return entries[entries.length - 1]!;
-  let r = Math.random() * total;
+  let r = rng.nextFloat() * total;
   for (const e of entries) {
     r -= Math.max(0, e.weight);
     if (r <= 0) return e;
@@ -33,27 +34,37 @@ export function rollTreasure(opts: {
   affixes: Affix[];
   ilvl: number;
   mf?: number;
+  rng?: ARERng;
 }): { gold: number; items: GeneratedItem[] } {
+  const rng = opts.rng ?? new SeededARERng(createARESeed(["treasure", opts.tcId, opts.ilvl, opts.mf ?? 0]));
   const tc = opts.tcs[opts.tcId];
   if (!tc) return { gold: 0, items: [] };
 
   let gold = 0;
   const items: GeneratedItem[] = [];
 
-  const rollFrom = (tcId: string) => {
+  const rollFrom = (tcId: string, depth = 0) => {
     const t = opts.tcs[tcId];
     if (!t) return;
     for (let i = 0; i < t.picks; i++) {
-      const e = pickWeightedEntry(t.entries);
+      const pickRng = rng.fork(`${tcId}:${depth}:${i}`);
+      const e = pickWeightedEntry(t.entries, pickRng.fork("entry"));
       if (e.type === "gold") {
-        gold += Math.floor(e.min + Math.random() * (e.max - e.min + 1));
+        gold += pickRng.nextRange(e.min, e.max);
       } else if (e.type === "tc") {
-        rollFrom(e.tcId);
+        rollFrom(e.tcId, depth + 1);
       } else if (e.type === "base") {
         const base = opts.bases[e.baseId];
         if (!base) continue;
-        const rarity = rarityRoll(opts.mf ?? 0);
-        items.push(generateItem({ base, ilvl: opts.ilvl, rarity, affixes: opts.affixes, mf: opts.mf }));
+        const rarity = rarityRoll(opts.mf ?? 0, pickRng.fork("rarity"));
+        items.push(generateItem({
+          base,
+          ilvl: opts.ilvl,
+          rarity,
+          affixes: opts.affixes,
+          mf: opts.mf,
+          rng: pickRng.fork("item"),
+        }));
       }
     }
   };

--- a/server/src/modules/loot/itemEnchant.ts
+++ b/server/src/modules/loot/itemEnchant.ts
@@ -1,20 +1,26 @@
+import { type ARERng, SeededARERng, createARESeed } from "../../core/determinism/AREDeterminism.js";
 import type { Affix, GeneratedItem, StatKey } from "./diabloItemGen.js";
 import { randInt } from "./diabloItemGen.js";
 
 /**
  * Re-roll one random existing rolled stat key (excluding base weapon dmg lines if you only pass affix stats — caller passes full item).
  */
-export function rerollOneStat(item: GeneratedItem, allowed: StatKey[], affixPool: Affix[]): void {
+export function rerollOneStat(
+  item: GeneratedItem,
+  allowed: StatKey[],
+  affixPool: Affix[],
+  rng: ARERng = new SeededARERng(createARESeed(["item-enchant", item.uid, allowed.join(",")]))
+): void {
   const keys = Object.keys(item.stats) as StatKey[];
   if (!keys.length) throw new Error("no_stats");
-  const victim = keys[Math.floor(Math.random() * keys.length)]!;
+  const victim = keys[rng.nextInt(keys.length)]!;
   delete item.stats[victim];
 
   const pool = affixPool.filter((x) => x.rolls.some((r) => allowed.includes(r.stat)));
   if (!pool.length) throw new Error("no_affix_pool");
-  const a = pool[Math.floor(Math.random() * pool.length)]!;
+  const a = pool[rng.nextInt(pool.length)]!;
   for (const rr of a.rolls) {
     if (!allowed.includes(rr.stat)) continue;
-    item.stats[rr.stat] = (item.stats[rr.stat] ?? 0) + randInt(rr.min, rr.max);
+    item.stats[rr.stat] = (item.stats[rr.stat] ?? 0) + randInt(rr.min, rr.max, rng.fork(`stat:${rr.stat}`));
   }
 }

--- a/server/src/modules/loot/smartLoot.ts
+++ b/server/src/modules/loot/smartLoot.ts
@@ -1,3 +1,5 @@
+import { createARESeed, type ARERng, SeededARERng } from "../../core/determinism/AREDeterminism.js";
+
 export type BadluckState = { noLegendaryStreak: number };
 
 export type BaseWithTags = { tags?: string[] };
@@ -8,7 +10,13 @@ export type BaseWithTags = { tags?: string[] };
 export function smartLootPickBase<T extends BaseWithTags>(
   bases: T[],
   preferredTags: string[],
-  badluck: BadluckState
+  badluck: BadluckState,
+  rng: ARERng = new SeededARERng(createARESeed([
+    "smart-loot",
+    preferredTags.join(","),
+    badluck.noLegendaryStreak,
+    bases.length,
+  ]))
 ): { base: T; mfBoost: number } {
   if (bases.length === 0) {
     throw new Error("smartLootPickBase: empty bases");
@@ -19,7 +27,7 @@ export function smartLootPickBase<T extends BaseWithTags>(
     w: 1 + (b.tags?.some((t: string) => preferredTags.includes(t)) ? 0.75 : 0),
   }));
   const total = tagBoostBases.reduce((s, x) => s + x.w, 0);
-  let r = Math.random() * total;
+  let r = rng.nextFloat() * total;
   for (const x of tagBoostBases) {
     r -= x.w;
     if (r <= 0) return { base: x.b, mfBoost };

--- a/server/src/modules/oracle/OracleEngine.ts
+++ b/server/src/modules/oracle/OracleEngine.ts
@@ -1,10 +1,12 @@
+import { createARESeed, type ARERng, SeededARERng } from "../../core/determinism/AREDeterminism.js";
+
 export class OracleEngine {
-  generateVision() {
+  generateVision(rng: ARERng = new SeededARERng(createARESeed(["oracle", "vision"]))) {
     const visions = [
       "Ich sehe Feuer im Norden.",
       "Unter alten Mauern liegt ein Geheimnis.",
       "Ein Königreich wird fallen."
     ];
-    return visions[Math.floor(Math.random() * visions.length)];
+    return visions[rng.nextInt(visions.length)];
   }
 }


### PR DESCRIPTION
## Summary

First Level-A migration after the determinism classification PR.

This PR replaces direct `Math.random()` / `Date.now()` usage in gameplay-result paths with `ARERng`-based deterministic rolls while keeping backwards-compatible default parameters for existing callers.

Migrated:
- `server/src/core/systems/CombatSystem.ts`
  - critical hit roll
  - loot drop roll
  - loot amount roll
  - item id suffix generation
- `server/src/modules/loot/LootSystem.ts`
  - table drop chance roll
  - item count roll
  - gold roll
- `server/src/modules/loot/diabloItemGen.ts`
  - rarity roll
  - seed roll
  - affix count roll
  - weighted affix selection
  - stat rolls
  - deterministic uid string
- `server/src/modules/loot/diabloTreasure.ts`
  - weighted treasure entries
  - gold rolls
  - nested treasure-class item rolls
- `server/src/modules/loot/itemEnchant.ts`
  - reroll victim selection
  - affix selection
  - replacement stat rolls
- `server/src/modules/loot/smartLoot.ts`
  - weighted base pick
- `server/src/modules/oracle/OracleEngine.ts`
  - vision selection

## Why

PR #765 proved the gate catches nondeterministic calls. PR #767 added the primitives and classification. This PR starts migrating the actual gameplay-output layer instead of allowing or suppressing it.

## Safety

- Existing method signatures remain source-compatible through optional `rng` parameters.
- No Warfront migration in this PR.
- No LiveHeal/API/Logger telemetry changes.
- No Docker/deploy/workflow changes.
- No lockfile changes.

## Notes

Default RNG seeds are stable based on available function inputs. Production call sites should later pass tick/world/region-specific RNGs for stronger replay semantics.