### PR TITLE
fix(core-logic): enable JSX typecheck for React export

### DIFF
--- a/packages/core-logic/tsconfig.json
+++ b/packages/core-logic/tsconfig.json
@@ -6,8 +6,9 @@
     "composite": false,
     "incremental": false,
     "skipLibCheck": true,
+    "jsx": "react-jsx",
     "lib": ["ESNext", "DOM"],
-    "types": ["node"]
+    "types": ["node", "react"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Fixes the CI blocker currently affecting PR #768 and other unrelated PRs.

`@wasd/core-logic` exports `src/react/OuroborosPulseView.tsx`, but its package `tsconfig.json` did not enable JSX or React types. The shared CI typecheck therefore fails before reaching server checks.

Changes:
- Enables `jsx: react-jsx` in `packages/core-logic/tsconfig.json`.
- Adds `react` to the package type list alongside `node`.

## Safety

- Typecheck config only.
- No runtime behavior changes.
- No lockfile changes.
- No package dependency changes; React already exists in this package devDependencies and peerDependencies.

## Observed CI failure

```text
src/index.ts(6,15): error TS6142: Module './react/OuroborosPulseView' was resolved to ...OuroborosPulseView.tsx, but '--jsx' is not set.
src/react/OuroborosPulseView.tsx: Cannot use JSX unless the '--jsx' flag is provided.
Cannot find namespace 'React'.
```