### PR TITLE
ci(are): add level-aware determinism gate

### DIFF
--- a/.github/workflows/are-determinism-gate.yml
+++ b/.github/workflows/are-determinism-gate.yml
@@ -1,0 +1,44 @@
+name: ARE Determinism Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'server/src/core/systems/**'
+      - 'server/src/modules/loot/**'
+      - 'server/src/modules/warfront/**'
+      - 'server/src/modules/oracle/**'
+      - 'scripts/check-are-determinism.mjs'
+      - 'docs/ARE_TELEMETRY_SIDE_CHANNEL.md'
+      - '.github/workflows/are-determinism-gate.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'server/src/core/systems/**'
+      - 'server/src/modules/loot/**'
+      - 'server/src/modules/warfront/**'
+      - 'server/src/modules/oracle/**'
+      - 'scripts/check-are-determinism.mjs'
+      - 'docs/ARE_TELEMETRY_SIDE_CHANNEL.md'
+      - '.github/workflows/are-determinism-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  determinism-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check ARE deterministic simulation paths
+        run: node scripts/check-are-determinism.mjs

--- a/docs/ARE_TELEMETRY_SIDE_CHANNEL.md
+++ b/docs/ARE_TELEMETRY_SIDE_CHANNEL.md
@@ -1,0 +1,57 @@
+# ARE Telemetry Side-Channel Policy
+
+Deterministic simulation and runtime telemetry have different jobs.
+
+Simulation code must be replayable from explicit inputs. It should use:
+
+- `AREClock` for time
+- `ARERng` for random decisions
+- stable seeds from world facts such as world seed, region, chunk, tick, actor ids, table ids, cycle ids
+
+Telemetry code observes the live runtime. It may use wall-clock time for health checks, logs, anomaly windows, healing cooldowns, and retention policies.
+
+## Decision
+
+Level-C runtime telemetry should not be scattered through simulation files with naked allow comments.
+
+Preferred shape:
+
+```text
+server/src/core/telemetry/**
+server/src/core/liveheal/**
+server/src/core/logger/**
+server/src/core/api/**
+server/src/core/integrity/**
+```
+
+The determinism gate excludes these side-channel paths by policy. This keeps runtime observability from hiding nondeterminism in gameplay code.
+
+## Allowed in telemetry side-channel
+
+- `Date.now()` for process timing
+- `new Date()` for human-readable log timestamps
+- runtime ids for patch logs and health events
+- anomaly windows and cooldowns
+- retention cutoff calculations
+
+## Not allowed in simulation paths
+
+- `Math.random()` for combat, loot, NPC, oracle, warfront, worldgen, economy decisions
+- `Date.now()` for cycle, spawn, loot, cooldown, tick, or replay decisions
+- `randomUUID()` for ids that become gameplay state
+
+## Temporary escape hatch
+
+A reviewed marker exists for rare cases:
+
+```ts
+// @are-determinism-allow reason: explain why this line cannot affect simulation replay
+```
+
+or
+
+```ts
+// @are-telemetry-side-channel reason: runtime observability only
+```
+
+Use markers sparingly. Prefer moving telemetry code into a side-channel path.

--- a/scripts/check-are-determinism.mjs
+++ b/scripts/check-are-determinism.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { readFile, readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const root = process.cwd();
+
+const criticalRoots = [
+  'server/src/core/systems',
+  'server/src/modules/loot',
+  'server/src/modules/warfront',
+  'server/src/modules/oracle',
+];
+
+const excludedPaths = [
+  '/__tests__/',
+  '/tests/',
+  '/test/',
+  '/dist/',
+  '/build/',
+  '/coverage/',
+  '/node_modules/',
+];
+
+const telemetryPaths = [
+  'server/src/core/api/',
+  'server/src/core/logger/',
+  'server/src/core/liveheal/',
+  'server/src/core/integrity/',
+  'server/src/core/telemetry/',
+];
+
+const blockedPatterns = [
+  { name: 'Math.random', regex: /\bMath\.random\s*\(/g },
+  { name: 'Date.now', regex: /\bDate\.now\s*\(/g },
+  { name: 'new Date', regex: /\bnew\s+Date\s*\(/g },
+  { name: 'randomUUID', regex: /\brandomUUID\s*\(/g },
+];
+
+const allowedMarker = '@are-determinism-allow';
+const telemetryMarker = '@are-telemetry-side-channel';
+const sourceExtensions = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs']);
+
+function hasSourceExtension(file) {
+  return [...sourceExtensions].some((extension) => file.endsWith(extension));
+}
+
+function normalize(file) {
+  return file.split('\\').join('/');
+}
+
+function isExcluded(file) {
+  const normalized = normalize(file);
+  return excludedPaths.some((part) => normalized.includes(part))
+    || telemetryPaths.some((part) => normalized.includes(part));
+}
+
+async function walk(dir) {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    const rel = normalize(`/${relative(root, full)}`);
+    if (entry.isDirectory()) {
+      if (isExcluded(rel)) continue;
+      files.push(...await walk(full));
+      continue;
+    }
+    if (entry.isFile() && hasSourceExtension(full) && !isExcluded(rel)) files.push(full);
+  }
+  return files;
+}
+
+function lineNumberForOffset(content, offset) {
+  let line = 1;
+  for (let index = 0; index < offset; index += 1) {
+    if (content.charCodeAt(index) === 10) line += 1;
+  }
+  return line;
+}
+
+function lineAt(content, lineNumber) {
+  return content.split(/\r?\n/)[lineNumber - 1] || '';
+}
+
+function markerAllowed(content, lineNumber) {
+  const lines = content.split(/\r?\n/);
+  const previous = lines[lineNumber - 2] || '';
+  const current = lines[lineNumber - 1] || '';
+  return previous.includes(allowedMarker) || current.includes(allowedMarker)
+    || previous.includes(telemetryMarker) || current.includes(telemetryMarker);
+}
+
+const files = [];
+for (const criticalRoot of criticalRoots) {
+  files.push(...await walk(join(root, criticalRoot)));
+}
+
+const findings = [];
+for (const file of files) {
+  const content = await readFile(file, 'utf8');
+  for (const pattern of blockedPatterns) {
+    pattern.regex.lastIndex = 0;
+    for (const match of content.matchAll(pattern.regex)) {
+      const line = lineNumberForOffset(content, match.index || 0);
+      if (markerAllowed(content, line)) continue;
+      findings.push({
+        file: relative(root, file),
+        line,
+        pattern: pattern.name,
+        code: lineAt(content, line).trim(),
+      });
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error('ARE determinism gate failed. Non-deterministic calls found in simulation-critical paths.');
+  console.error('Use AREClock/ARERng, or move runtime telemetry into a telemetry side-channel path.');
+  console.error('');
+  for (const finding of findings) {
+    console.error(`${finding.file}:${finding.line} ${finding.pattern} :: ${finding.code}`);
+  }
+  process.exit(1);
+}
+
+console.log(`ARE determinism gate passed. Scanned ${files.length} simulation file(s). Telemetry side-channel paths are excluded by policy.`);


### PR DESCRIPTION
Adds ARE determinism gate v2.

Decision:
- Level A/B simulation paths are scanned and must use AREClock/ARERng.
- Level C telemetry is treated as a side-channel, not as scattered allow comments.
- Telemetry paths are excluded by policy and documented.

Includes:
- scripts/check-are-determinism.mjs
- .github/workflows/are-determinism-gate.yml
- docs/ARE_TELEMETRY_SIDE_CHANNEL.md

Note: merge after the Warfront AREClock PR lands.