### PR TITLE
feat(are): remove residual wall-clock simulation sources

### DIFF
--- a/server/src/core/systems/EvolutionSystem.ts
+++ b/server/src/core/systems/EvolutionSystem.ts
@@ -105,6 +105,10 @@ const VISUAL_CORRUPTION_VALUES: Record<StabilityLevel, number> = {
   [StabilityLevel.TOTAL_COLLAPSE]: toFP(1.0),
 };
 
+function directiveId(prefix: string, ...parts: unknown[]): string {
+  return [prefix, ...parts.map((part) => String(part).replace(/[^a-zA-Z0-9_.:-]/g, '_'))].join('_');
+}
+
 /**
  * EvolutionSystem - World Flow and Regional Evolution
  */
@@ -195,7 +199,7 @@ export class EvolutionSystem {
       if (corridor.intensity > this.SOG_THRESHOLD) {
         // This is a "pull" effect - too many players going to same place
         this.flowDirectives.push({
-          directiveId: `flow_${key}_${Date.now()}`,
+          directiveId: directiveId('flow', key, corridor.fromChunk, corridor.toChunk),
           fromChunk: corridor.fromChunk,
           toChunk: corridor.toChunk,
           type: 'PULL',
@@ -211,7 +215,7 @@ export class EvolutionSystem {
         for (const corridor of this.travelHeat.values()) {
           if (corridor.toChunk === chunk && corridor.intensity < toFP(0.1)) {
             this.flowDirectives.push({
-              directiveId: `disperse_${chunk}_${Date.now()}`,
+              directiveId: directiveId('disperse', chunk, corridor.fromChunk, corridor.toChunk),
               fromChunk: corridor.fromChunk,
               toChunk: chunk,
               type: 'DISPERSE',

--- a/server/src/modules/loot/ItemGenerator.ts
+++ b/server/src/modules/loot/ItemGenerator.ts
@@ -1,10 +1,10 @@
 export class ItemGenerator {
-  generate(baseId: string, rarity: string, affixes: string[] = []) {
+  generate(baseId: string, rarity: string, affixes: string[] = [], generatedAt = 0) {
     return {
       id: baseId,
       rarity,
       affixes,
-      generatedAt: Date.now()
+      generatedAt
     };
   }
 }

--- a/server/src/modules/loot/lootBag.ts
+++ b/server/src/modules/loot/lootBag.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import type { GearItem, StackItem } from "../items/dualInventoryTypes.js";
 
 export type LootBag = {
@@ -12,6 +11,10 @@ export type LootBag = {
   despawnAt: number;
 };
 
+function lootBagId(p: { x: number; y: number; ownerId?: string; gold?: number; now: number }): string {
+  return `lootbag_${p.ownerId ?? 'world'}_${Math.floor(p.x)}_${Math.floor(p.y)}_${p.gold ?? 0}_${Math.floor(p.now)}`;
+}
+
 export function spawnLootBag(p: {
   x: number;
   y: number;
@@ -20,21 +23,24 @@ export function spawnLootBag(p: {
   gear?: GearItem[];
   ownerId?: string;
   ttlMs?: number;
+  now?: number;
+  id?: string;
 }): LootBag {
+  const now = p.now ?? 0;
   return {
-    id: randomUUID(),
+    id: p.id ?? lootBagId({ x: p.x, y: p.y, ownerId: p.ownerId, gold: p.gold, now }),
     x: p.x,
     y: p.y,
     gold: p.gold ?? 0,
     stack: p.stack ?? [],
     gear: p.gear ?? [],
     ownerId: p.ownerId,
-    despawnAt: Date.now() + (p.ttlMs ?? 2 * 60_000),
+    despawnAt: now + (p.ttlMs ?? 2 * 60_000),
   };
 }
 
 /** Runtime bag shape used by WorldTick (position + legacy timing). */
-export function lootBagToRuntimeBag(bag: LootBag, ownerExclusiveMs: number): any {
+export function lootBagToRuntimeBag(bag: LootBag, ownerExclusiveMs: number, now = 0): any {
   return {
     id: bag.id,
     position: { x: bag.x, y: bag.y },
@@ -44,7 +50,7 @@ export function lootBagToRuntimeBag(bag: LootBag, ownerExclusiveMs: number): any
     items: bag.stack.map((s) => ({ id: s.id, quantity: s.quantity })),
     gear: bag.gear,
     ownerId: bag.ownerId,
-    ownerExclusiveUntil: Date.now() + ownerExclusiveMs,
+    ownerExclusiveUntil: now + ownerExclusiveMs,
     despawnAt: bag.despawnAt,
   };
 }

--- a/server/src/modules/oracle/ProphecyArchive.ts
+++ b/server/src/modules/oracle/ProphecyArchive.ts
@@ -1,5 +1,5 @@
 export class ProphecyArchive {
   private entries: any[] = [];
-  add(entry: any) { this.entries.push({ timestamp: Date.now(), ...entry }); }
+  add(entry: any, timestamp = 0) { this.entries.push({ timestamp, ...entry }); }
   all() { return this.entries; }
 }


### PR DESCRIPTION
Migrates remaining simulation-adjacent determinism gate findings before enabling the gate.

Changes:
- EvolutionSystem directive ids no longer use Date.now.
- ItemGenerator generatedAt is explicit.
- lootBag ids/timing use explicit now/id inputs.
- ProphecyArchive timestamps are explicit.

Not changed:
- WarfrontCombatTelemetry remains telemetry side-channel.
- No LiveHeal changes.
- No deploy changes.