### PR TITLE
docs: add agent PR policy and overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,140 +1,478 @@
 # Areloria WASD
 
-Areloria WASD is a high-performance 3D RPG and metaverse platform built on modern web technologies and AI-driven agents. The project combines an immersive game world with a 2D fallback client for mobile devices, World Editor tools, and administrative controls.
+**Areloria WASD** is a browser-native deterministic MMORPG engine and living-world simulation platform.
 
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
+It combines a 10Hz authoritative Node.js game server, Three.js/WebGL clients, chunk-streamed world logic, protected player-built civilization systems, deterministic ARE simulation rules, self-healing runtime safeguards, and a long-term design path toward an emergent AI population that can trade, remember, organize, govern, build, revolt, ally, migrate, and reshape the world through explicit rule-bound logic.
+
 ![Node.js](https://img.shields.io/badge/Node.js-22.x-green)
-![License](https://img.shields.io/badge/License-MIT-yellow)
+![Runtime](https://img.shields.io/badge/runtime-deterministic_10Hz-blue)
+![Simulation](https://img.shields.io/badge/simulation-ARE_logic-purple)
+![License](https://img.shields.io/badge/license-proprietary_all_rights_reserved-red)
 
-## 🚀 Quick Start
+> This repository is proprietary. It is not MIT licensed. See [License and Usage Policy](#license-and-usage-policy).
+
+---
+
+## Vision
+
+Areloria is not designed as a simple web game shell. It is an attempt to build a mathematically disciplined, deterministic living-world engine for a browser MMORPG.
+
+The world is meant to feel inhabited rather than scripted. NPCs are not only quest dispensers. They are future citizens, workers, traders, witnesses, political actors, enemies, allies, informants, settlers, rulers, rebels, and memory-bearing participants in a simulated civilization.
+
+The long-term target is an emergent AI population governed by deterministic server logic:
+
+- NPCs remember local events.
+- NPCs react to player history.
+- Villages, towns, cities, kingdoms, and lands can emerge from rules.
+- Trade routes, taxes, elections, wars, scarcity, migration, and resource pressure become systemic forces.
+- Oracle/prophecy systems observe repeated patterns and expose transparent world-thought to players.
+- Simulation remains bounded by tick cadence, chunk observation, and replayable deterministic inputs.
+
+Areloria is therefore both a game project and a simulation architecture project.
+
+---
+
+## Core principles
+
+### 1. Determinism rules the simulation
+
+Gameplay state must be reproducible from explicit inputs.
+
+Simulation code must not depend on process-local randomness or hidden wall-clock state.
+
+Forbidden in simulation paths:
+
+```text
+Math.random()
+Date.now()
+new Date()
+randomUUID()
+process uptime as gameplay input
+host/container identity as gameplay input
+```
+
+Use instead:
+
+```text
+AREClock
+ARERng
+explicit tick time
+stable seeds from world facts
+```
+
+Good seed parts:
+
+```text
+worldSeed | regionId | chunkId | tick | actorId | targetId | tableId | cycleId
+```
+
+The determinism gate currently protects simulation-critical paths including:
+
+```text
+server/src/core/systems/**
+server/src/core/watchdogs/**
+server/src/core/*Watchdog.ts
+server/src/modules/brain/**
+server/src/modules/loot/**
+server/src/modules/warfront/**
+server/src/modules/oracle/**
+```
+
+### 2. ARE logic is the governing model
+
+Areloria is built around the project’s ARE logic model: an axiomatic, deterministic rule system intended to govern simulation flow, replayability, causality, pressure, observation, and bounded emergence.
+
+Within this repository, ARE is treated as the governing logic layer for:
+
+- deterministic time,
+- deterministic randomness,
+- world pressure,
+- causal mutation,
+- replay-safe state transitions,
+- region and chunk rule enforcement,
+- oracle/brain interpretation,
+- protected simulation boundaries.
+
+The current implementation contains practical ARE primitives such as:
+
+```text
+AREClock
+SystemAREClock
+FixedAREClock
+ARERng
+SeededARERng
+createARESeed
+```
+
+These are engineering primitives. The broader ARE theory, formula language, manuscripts, trademarks, research notes, and commercial/political/industrial usage rights are reserved by the rights holder and are not granted by this repository.
+
+### 3. Observation bounds reality
+
+The world should not simulate every possible place at full cost forever.
+
+Areloria follows an observation-driven principle:
+
+```text
+Only observed or relevant regions receive expensive simulation.
+Unobserved regions decay, summarize, or sleep.
+```
+
+This keeps server load proportional to active player observation and relevant world pressure.
+
+### 4. The 10Hz server tick is sacred
+
+The authoritative server loop is designed around deterministic 10Hz logic.
+
+Systems must declare:
+
+- cadence,
+- maximum work per tick,
+- chunk/region scope,
+- deterministic seed/time source,
+- failure behavior,
+- feature flag or registry entry,
+- telemetry side-channel, if any.
+
+No system may dump unbounded scans into the tick.
+
+### 5. Player-built and paid structures are protected
+
+Areloria’s civilization and monetization design includes player-built assets and potentially paid construction energy.
+
+Default rule:
+
+```text
+If uncertain, do not damage the structure.
+```
+
+NPCs, swarms, bosses, decay systems, watchdogs, and world events must not damage or destroy player-built, paid, or protected structures unless an explicit reviewed policy allows it.
+
+Protection concepts include:
+
+```text
+isPlayerBuilt
+paidAsset
+protectedFeature
+damageableByWorldEvent === true
+ownerId
+assetProtectionTier
+```
+
+---
+
+## Game features and world systems
+
+Areloria’s design combines classic MMORPG pleasures with deterministic simulation depth.
+
+### Player progression
+
+- Classless progression inspired by open-skill MMORPG design.
+- Stamina and skill use shape combat capability.
+- No hard conceptual level ceiling in the long-term design.
+- Equipment, loot, region pressure, and mastery shape identity.
+
+### Loot and item systems
+
+- Diablo-like rarity and affix direction.
+- Deterministic loot rolls through `ARERng`.
+- Smart loot and treasure tables must be replay-safe.
+- Item generation cannot use host randomness in simulation.
+
+### Combat
+
+- Server-authoritative combat.
+- Deterministic critical hits and damage calculations.
+- Replay-safe loot drop rolls.
+- Region threat and oracle pressure may affect outcomes through explicit state.
+
+### Warfronts
+
+- Deterministic cycle timing through `AREClock`.
+- Daily/seasonal warfront cycle logic.
+- Front boss readiness, phase changes, and reward history must be reproducible.
+- Warfront combat telemetry is treated as side-channel observability, not gameplay truth.
+
+### Oracle and prophecy
+
+- Oracle systems expose pattern pressure, warnings, visions, and world-thought.
+- Oracle outputs must be deterministic when they affect simulation or player-facing state.
+- Prophecy archive timing is explicit and replay-friendly.
+
+### Brain and watchdog systems
+
+Brain systems perform low-frequency heuristic reasoning.
+
+Watchdog systems perform bounded fast-path checks.
+
+Current and planned examples include:
+
+- Matrix precognition and load projection,
+- chrono swarm density detection,
+- reality fissure/paradox tracking,
+- synaptic load dilation,
+- world-brain cache summaries,
+- future Aetheric Leyline logic,
+- future Chronos Anomaly zones,
+- future Void Swarm incursions.
+
+All Brain/Watchdog simulation code is now expected to pass the ARE determinism gate.
+
+### Emergent AI population
+
+The future population model aims for NPCs that can:
+
+- remember local player actions,
+- share local memory through bounded caches,
+- refuse help to hostile players,
+- trade and price goods according to scarcity,
+- found or join settlements,
+- participate in elections,
+- follow laws or rebel against them,
+- declare war or seek peace,
+- migrate under pressure,
+- form guilds, villages, towns, cities, kingdoms, and lands,
+- generate visible thought/intent channels where appropriate.
+
+This population must remain deterministic, bounded, inspectable, and compatible with server tick constraints.
+
+### Civilization and settlement rules
+
+World-building must respect deterministic layout rules, including concepts such as:
+
+- 64x64 chunk logic,
+- city/village hierarchy,
+- roads between structures,
+- walls connected with valid doors,
+- houses not overlapping houses,
+- spacing rules between buildings,
+- dungeon/world-boss distance constraints,
+- biome or region boundaries for larger political units.
+
+These rules belong in explicit validators, not hidden client-only assumptions.
+
+### GLB and asset safety
+
+Areloria targets GLB-based 3D assets for characters, structures, items, and world objects.
+
+Asset rules:
+
+- validate GLB assets before runtime use,
+- quarantine broken or unsafe assets,
+- do not crash the runtime on malformed content,
+- keep placement deterministic,
+- enforce city layout and protected-asset policies.
+
+---
+
+## Engine architecture
+
+### Monorepo layout
+
+```text
+apps/                 Application surfaces and API shells
+client/               Browser 3D client
+server/               Authoritative game server
+packages/             Shared packages and core logic
+projects/             Additional project modules and experiments
+docs/                 Architecture, deploy, policy, and audit docs
+scripts/              Build, deploy, audit, and validation scripts
+.github/workflows/    CI, deploy, and guardrail automation
+```
+
+### Runtime shape
+
+```text
+Browser Client
+  -> Host Nginx
+  -> 127.0.0.1:3001
+  -> arelorian-engine Docker container
+  -> Node.js authoritative server
+  -> Supabase/PostgreSQL, Redis, Soketi/Pusher-compatible services
+```
+
+Production port policy:
+
+```text
+ARELORIAN_PORT=3001
+ARELORIAN_CONTAINER_PORT=3001
+ENGINE_URL=http://arelorian-engine:3001
+```
+
+Public domain routing:
+
+```text
+arelorian.de -> host Nginx -> 127.0.0.1:3001 -> arelorian-engine:3001
+```
+
+See also:
+
+```text
+docs/DEPLOY_PORT_MAP.md
+docs/NGINX_HOST_GATEWAY.md
+```
+
+---
+
+## Development
+
+### Requirements
+
+```text
+Node.js 22.x
+pnpm 9.x or newer
+Docker for production-style deploy testing
+```
+
+### Common commands
 
 ```bash
-# Install dependencies
 pnpm install
-
-# Build all packages
 pnpm build:all
-
-# Or run in development mode
 pnpm dev:all
 ```
 
-## 🏗 Architecture
-
-### Monorepo Structure
-
-```
-├── apps/
-│   ├── api/          # Node.js API backend
-│   └── web/          # Web application
-├── client/           # 3D client (Three.js/React)
-├── client-2d/       # 2D fallback client (mobile devices)
-├── server/           # Main game server (Node.js/TypeScript)
-├── backend/          # Python services (scoring, analytics)
-├── packages/         # Shared packages
-│   ├── core/        # Core game logic
-│   ├── core-network/# Network system
-│   ├── shared/      # Shared utilities
-│   └── types/       # TypeScript types
-└── admin-tools/     # GM panel, World Editor, rollback tools
-```
-
-### Clients
-
-| Client | Technology | Target |
-|--------|-----------|--------|
-| 3D Client | React + Three.js | Desktop browsers |
-| 2D Client | React + Canvas | Mobile, low-end devices |
-
-The server automatically detects device capabilities and redirects to the appropriate client.
-
-## 📦 Packages
-
-### Core Packages (`packages/`)
-
-- **`@arelorian/core`** - Core game mechanics and logic
-- **`@arelorian/core-network`** - Multiplayer networking
-- **`@arelorian/shared`** - Shared utilities
-- **`@arelorian/types`** - TypeScript definitions
-
-### Applications (`apps/` & `server/`)
-
-- **`@wasd/server`** - Main game server with Express/Genkit
-- **`@wasd/client`** - 3D Three.js client
-- **`@arelorian/client-2d`** - 2D Canvas fallback
-- **`@wasd/api`** - REST API services
-
-## 🛠 Tech Stack
-
-- **Frontend**: React, TypeScript, Three.js, Tailwind CSS
-- **Backend**: Node.js, Python, Express, Genkit AI
-- **Database**: Supabase (PostgreSQL), Redis
-- **Infrastructure**: Docker, Nginx, GitHub Actions
-- **AI**: Custom LLM Agent Logic (Jules Framework)
-
-## 📖 Development
-
-### Prerequisites
-
-- Node.js 22.x
-- pnpm 9.x
-- Python 3.x (for backend services)
-- Docker (optional, for containerized deployment)
-
-### Scripts
+Targeted builds:
 
 ```bash
-# Build all packages
-pnpm build:all
-
-# Build individual packages
-pnpm build:network   # Build core-network
-pnpm build:2d       # Build 2D client
-pnpm build:3d        # Build 3D client
-
-# Development mode
-pnpm dev:all        # Run all dev servers
-pnpm dev:network    # Network server only
-pnpm dev:2d         # 2D client only
-pnpm dev:3d         # 3D client only
+pnpm build:network
+pnpm build:2d
+pnpm build:3d
 ```
 
-## 🌐 Deployment
-
-### Docker Production Build
+Determinism gate:
 
 ```bash
-# Build production Docker image
-docker build -f Dockerfile.prod -t areloria:latest .
-
-# Run container
-docker run -d --name areloria -p 3000:3000 -e NODE_ENV=production areloria:latest
+node scripts/check-are-determinism.mjs
 ```
 
-### GitHub Actions
+Recommended server/client checks:
 
-The project uses GitHub Actions for CI/CD:
-- Auto-deploy to VPS on push to `main`
-- Build and test on PRs
-- Security scanning
+```bash
+pnpm --filter @wasd/server --if-present build
+pnpm --filter @wasd/shared --if-present build
+pnpm --filter @wasd/client --if-present build
+```
 
-## 📁 Documentation
+---
 
-Key documents:
-- `ARCHITECTURE_OVERVIEW.md` - System architecture
-- `DEPLOYMENT.md` - Deployment guide
-- `docs/` - Detailed documentation
+## Deployment
 
-## 🤝 Contributing
+### VPS Docker deploy
 
-1. Fork the repository
-2. Create a feature branch
-3. Submit a PR
+Primary deploy workflow:
 
-## 📄 License
+```text
+GitHub Actions -> VPS Docker Deploy (monorepo)
+```
 
-MIT License - See LICENSE file for details.
-# Deployment test
-# Deployed at Tue May 12 23:57:02 UTC 2026
-# Deploy Wed May 13 00:37:16 UTC 2026
-# Retry Wed May 13 01:23:42 UTC 2026
+Default production values:
+
+```text
+ARELORIAN_PORT=3001
+ARELORIAN_DOCKER_NETWORK=areloria_arelorian-network
+ARELORIAN_ENV_FILE=.env.docker
+```
+
+Runtime secrets are written to a VPS-local `.env.docker` file and loaded by Docker Compose. Do not commit runtime secrets.
+
+After a successful deploy, the verification workflow can validate:
+
+```text
+/health
+/client-config.json
+/
+container state
+host port mapping
+optional nginx config
+recent engine logs
+```
+
+Workflow:
+
+```text
+VPS Final Deploy Verification
+```
+
+### Nginx host gateway
+
+Host-level Nginx can be installed/updated with:
+
+```bash
+sudo ARELORIAN_DOMAIN=arelorian.de \
+  ARELORIAN_WWW_DOMAIN=www.arelorian.de \
+  ARELORIAN_PORT=3001 \
+  bash scripts/install-nginx-host-gateway.sh
+```
+
+---
+
+## Agent and contributor policy
+
+Automated agents must follow:
+
+```text
+docs/AGENT_FEATURE_PR_POLICY.md
+```
+
+Hard rules:
+
+- small PRs only,
+- no unrelated lockfile churn,
+- no hidden nondeterminism,
+- no broad deploy changes inside gameplay PRs,
+- no protected structure damage without explicit policy,
+- every new simulation path must be covered by the determinism gate,
+- every heavy runtime feature must be feature-flagged and cadence-bounded.
+
+---
+
+## Documentation map
+
+Important docs include:
+
+```text
+docs/AGENT_FEATURE_PR_POLICY.md
+docs/ARE_DETERMINISM_CLASSIFICATION.md
+docs/ARE_TELEMETRY_SIDE_CHANNEL.md
+docs/AUDIT_RUNTIME_STABILITY_2026-05-16.md
+docs/DEPLOY_PORT_MAP.md
+docs/NGINX_HOST_GATEWAY.md
+```
+
+---
+
+## License and usage policy
+
+This repository is proprietary and all rights are reserved by Ouroboros Collective / the project rights holder.
+
+The repository is made available, where visible, for inspection, review, controlled development, and authorized collaboration only. No public, private, academic, commercial, industrial, political, organizational, or game-development use is granted unless a separate written license or authorization is issued by the rights holder.
+
+This includes but is not limited to:
+
+- computer games,
+- simulation systems,
+- AI agents,
+- industrial control or planning systems,
+- political or organizational decision systems,
+- commercial tooling,
+- derivative engines,
+- forks, mirrors, clones, or replicas,
+- use of the ARE logic model, formula language, manuscripts, or associated theory.
+
+No license is granted for unauthorized copying, redistribution, training, integration, execution, publication, reverse engineering, derivative works, or commercial exploitation.
+
+Any use of the ARE logic model, axiomatic formula system, deterministic architecture, proprietary terminology, manuscripts, or associated implementation patterns outside this repository requires prior written approval and a separate license from the rights holder.
+
+Nothing in this README should be read as legal advice or as a statement that a patent, trademark, copyright registration, scientific certification, or statutory monopoly has already been granted in every jurisdiction. The project asserts ownership and reserved rights to its code, documentation, terminology, research material, formulas, and implementation architecture to the maximum extent available under applicable law and contract.
+
+See `LICENSE` for the repository license terms.
+
+---
+
+## Status
+
+Areloria WASD is under active development.
+
+The current priority is to keep the engine deterministic, deployable, and safe while expanding toward a living browser MMORPG with an emergent AI population and protected player civilization systems.
+
+The world must be allowed to become strange, but never nondeterministic by accident.

--- a/docs/AGENT_FEATURE_PR_POLICY.md
+++ b/docs/AGENT_FEATURE_PR_POLICY.md
@@ -1,0 +1,265 @@
+# Agent Feature PR Policy
+
+This document is mandatory reading for Jules, Replit, Cursor, Codex-like agents, no-code agents, and any automated contributor that modifies WASD/Areloria.
+
+The repository is not a sandbox for broad rewrites. Every change must preserve the ARE deterministic simulation model, the protected-asset economy, and the deploy/runtime stability guarantees already present in `main`.
+
+## Prime rule
+
+Small, reviewable, deterministic PRs only.
+
+A feature PR must do one thing well. Do not mix gameplay features, lockfile rewrites, React/TypeScript dependency changes, Docker changes, workflow changes, deploy changes, and formatting changes in the same PR.
+
+## Mandatory PR shape
+
+Every feature PR must include:
+
+1. A clear title with a narrow scope.
+2. A body explaining:
+   - what changed,
+   - why it is safe,
+   - which runtime paths are touched,
+   - whether it changes simulation behavior,
+   - whether it touches protected structures or paid assets,
+   - which tests/checks were run.
+3. No unrelated `pnpm-lock.yaml` changes.
+4. No unrelated package dependency changes.
+5. No deploy or Docker changes unless the PR is explicitly a deploy PR.
+6. No broad formatting-only rewrites.
+
+## ARE determinism rules
+
+Simulation code must be replayable from explicit inputs.
+
+Forbidden in simulation paths:
+
+- `Math.random()`
+- `Date.now()`
+- `new Date()`
+- `randomUUID()`
+- process uptime as gameplay input
+- hostname/container id as gameplay input
+
+Use instead:
+
+- `ARERng` for random decisions,
+- `AREClock` or explicit tick/world time for time decisions,
+- stable seeds derived from world facts.
+
+Good seed parts:
+
+```text
+worldSeed | regionId | chunkId | tick | actorId | targetId | tableId | cycleId
+```
+
+Bad seed parts:
+
+```text
+Date.now() | Math.random() | process uptime | host name | container id
+```
+
+## Determinism gate coverage
+
+The ARE determinism gate protects simulation paths, including:
+
+```text
+server/src/core/systems/**
+server/src/core/watchdogs/**
+server/src/core/*Watchdog.ts
+server/src/modules/brain/**
+server/src/modules/loot/**
+server/src/modules/warfront/**
+server/src/modules/oracle/**
+```
+
+If a feature adds simulation elsewhere, the PR must extend the gate.
+
+Telemetry belongs in side-channel paths such as:
+
+```text
+server/src/core/telemetry/**
+server/src/core/liveheal/**
+server/src/core/logger/**
+server/src/core/api/**
+server/src/core/integrity/**
+```
+
+Do not hide gameplay nondeterminism with allow comments. Allow markers are rare exceptions, not a normal development method.
+
+## Protected structures and paid assets
+
+No NPC, swarm, world event, watchdog, decay system, boss system, or automated simulation may damage or destroy protected player assets by default.
+
+Before any structure damage is applied, the code must explicitly check protection policy. Required concepts include one or more of:
+
+```text
+isPlayerBuilt
+paidAsset
+protectedFeature
+damageableByWorldEvent === true
+ownerId
+assetProtectionTier
+```
+
+Default behavior must be protective:
+
+```text
+if uncertain, do not damage the structure.
+```
+
+Paid/player-built structures may only be modified by systems that are explicitly designed and reviewed for that purpose.
+
+## Feature flag requirement
+
+New gameplay systems must be behind a feature flag or registry entry until fully integrated.
+
+Examples:
+
+```text
+features.aethericLeylines
+features.chronosAnomalies
+features.voidSwarmIncursions
+features.emergentNpcSociety
+```
+
+A PR that adds a new system must clearly state whether the system is:
+
+- inactive skeleton,
+- feature-flagged runtime path,
+- production-active runtime path.
+
+## Brain / Watchdog / Plexity pattern
+
+When adding new logical features, use this separation:
+
+### Brain
+
+Low-frequency server heuristic analysis.
+
+Rules:
+
+- deterministic inputs,
+- no direct entity mutation,
+- no random host state,
+- output decisions/directives only.
+
+### Watchdog
+
+Fast-path 10Hz execution or safety enforcement.
+
+Rules:
+
+- deterministic,
+- bounded CPU work,
+- no broad scans without chunk/region limits,
+- no protected-asset damage unless policy allows.
+
+### Plexity
+
+Client/device scaling and visual adaptation.
+
+Rules:
+
+- stateless where possible,
+- may affect rendering quality,
+- must not change authoritative simulation truth.
+
+## WorldTick integration rules
+
+Do not inject heavy logic directly into the 10Hz tick.
+
+Every WorldTick integration must declare:
+
+- tick cadence,
+- max entities/chunks processed per tick,
+- deterministic seed/time source,
+- failure behavior,
+- feature flag,
+- telemetry side-channel, if any.
+
+The server tick must remain bounded and deterministic.
+
+## GLB and asset rules
+
+New GLB/world asset logic must respect:
+
+- asset validation,
+- quarantine for defective assets,
+- no runtime crash on bad GLB,
+- deterministic placement rules,
+- city layout constraints,
+- road/wall/door consistency,
+- protected player structures.
+
+Do not bypass LiveHeal or asset quarantine services.
+
+## Monorepo and dependency rules
+
+Do not modify lockfiles unless the PR explicitly changes dependencies.
+
+Do not add dependencies to solve a local type error if a local type shim or package-local fix is sufficient.
+
+Do not change workspace linking casually. If dependencies are touched, explain:
+
+- which package needs the dependency,
+- whether it is runtime or dev-only,
+- why an existing package cannot provide it,
+- why the lockfile diff is minimal.
+
+## Deploy and workflow rules
+
+Feature PRs must not modify:
+
+- Dockerfiles,
+- docker-compose files,
+- VPS workflows,
+- deployment scripts,
+- Nginx files,
+- secrets handling,
+- env-file behavior.
+
+Unless the PR is specifically a deploy PR.
+
+Deploy PRs must not include gameplay changes.
+
+## Required checks before requesting review
+
+At minimum, run or reason against:
+
+```bash
+node scripts/check-are-determinism.mjs
+pnpm --filter @wasd/server --if-present build
+pnpm --filter @wasd/shared --if-present build
+pnpm --filter @wasd/client --if-present build
+```
+
+If only a subset is relevant, state why.
+
+## Review blockers
+
+A PR must be rejected if it:
+
+- is a draft but asks to be merged,
+- touches unrelated lockfile areas,
+- introduces `Math.random()` or wall-clock time in simulation,
+- bypasses ARE determinism gate paths,
+- damages structures without protection policy,
+- mixes feature work with deploy/CI rewrites,
+- changes licensing or ownership language casually,
+- rewrites README/docs to remove proprietary warnings,
+- activates a heavy runtime system without feature flag or cadence limit.
+
+## Preferred PR sequence for new large features
+
+For major systems, split into stages:
+
+1. Docs and design contract.
+2. Deterministic data types and interfaces.
+3. Inactive skeleton behind feature flag.
+4. Unit/smoke tests.
+5. WorldTick integration with cadence limits.
+6. Client/Plexity visuals.
+7. Telemetry side-channel.
+8. Production activation.
+
+No dragon enters the city without a gate, a name, and a leash.


### PR DESCRIPTION
Adds the requested documentation layer for future agents and project presentation.

Includes:
- docs/AGENT_FEATURE_PR_POLICY.md
- full README.md overhaul
- corrected proprietary/all-rights-reserved positioning instead of the old MIT badge
- ARE determinism and 10Hz engine principles
- emergent AI population vision
- protected player-built / paid structure rules
- current VPS/Nginx/deploy/verification notes
- OSF research/provenance anchor: https://osf.io/cuwtv

Safety:
- Documentation only.
- No runtime behavior changes.
- No deploy changes.
- No lockfile changes.
- Legal/licensing language is framed as repository/project policy and reserved-rights notice, not as legal advice or unsupported statutory claims.