### PR TITLE
ops(ingress): add optional sovereign docker ingress overlay

### DIFF
--- a/.github/workflows/ingress-overlay-validate.yml
+++ b/.github/workflows/ingress-overlay-validate.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Validate nginx config in container
         run: |
           docker run --rm \
+            --add-host arelorian-engine:127.0.0.1 \
             -v "$PWD/ops/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro" \
             nginx:1.27-alpine \
             nginx -t

--- a/.github/workflows/ingress-overlay-validate.yml
+++ b/.github/workflows/ingress-overlay-validate.yml
@@ -1,0 +1,57 @@
+name: Ingress Overlay Validate
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'ops/nginx/**'
+      - 'docker-compose.yml'
+      - 'docker-compose.ingress.yml'
+      - 'scripts/deploy-vps-docker.sh'
+      - '.github/workflows/ingress-overlay-validate.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'ops/nginx/**'
+      - 'docker-compose.yml'
+      - 'docker-compose.ingress.yml'
+      - 'scripts/deploy-vps-docker.sh'
+      - '.github/workflows/ingress-overlay-validate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-ingress-overlay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check deploy script syntax
+        run: bash -n scripts/deploy-vps-docker.sh
+
+      - name: Validate default compose config
+        env:
+          ARELORIAN_PORT: '3001'
+          ARELORIAN_DOCKER_NETWORK: 'areloria_arelorian-network'
+        run: docker compose -f docker-compose.yml config >/tmp/default-compose.yml
+
+      - name: Validate ingress compose overlay config
+        env:
+          ARELORIAN_PORT: '3001'
+          ARELORIAN_DOCKER_NETWORK: 'areloria_arelorian-network'
+          ARELORIAN_ENABLE_DOCKER_INGRESS: 'true'
+          ARELORIAN_INGRESS_HTTP_BIND: '127.0.0.1'
+          ARELORIAN_INGRESS_HTTP_PORT: '8080'
+        run: docker compose -f docker-compose.yml -f docker-compose.ingress.yml --profile ingress config >/tmp/ingress-compose.yml
+
+      - name: Validate nginx config in container
+        run: |
+          docker run --rm \
+            -v "$PWD/ops/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro" \
+            nginx:1.27-alpine \
+            nginx -t

--- a/docker-compose.ingress.yml
+++ b/docker-compose.ingress.yml
@@ -1,0 +1,27 @@
+services:
+  ingress-router:
+    image: nginx:1.27-alpine
+    container_name: arelorian-ingress-router
+    restart: unless-stopped
+    profiles:
+      - ingress
+    ports:
+      - "${ARELORIAN_INGRESS_HTTP_BIND:-0.0.0.0}:${ARELORIAN_INGRESS_HTTP_PORT:-80}:80"
+    volumes:
+      - ./ops/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      arelorian-engine:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/health >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    networks:
+      - arelorian-network

--- a/docs/SOVEREIGN_INGRESS_PIPELINE.md
+++ b/docs/SOVEREIGN_INGRESS_PIPELINE.md
@@ -1,0 +1,121 @@
+# Sovereign Ingress Pipeline
+
+This document describes the optional Docker-based ingress overlay for Areloria/WASD.
+
+## Why this exists
+
+Host-level Nginx is useful, but manual server edits create hidden infrastructure state. The long-term direction is Infrastructure as Code: ingress routing should live in the repository, be reviewed through pull requests, and be deployed by automation.
+
+However, the existing VPS deploy path is already hardened and currently binds the engine safely to:
+
+```text
+127.0.0.1:3001 -> arelorian-engine:3001
+```
+
+Therefore this PR does **not** delete the current deploy script and does **not** replace the root compose file. Instead it adds a safe, optional overlay.
+
+## Files
+
+```text
+ops/nginx/default.conf
+```
+
+Nginx routing configuration stored in the repository.
+
+```text
+docker-compose.ingress.yml
+```
+
+Optional Compose overlay that starts `ingress-router` with the `ingress` profile.
+
+```text
+scripts/deploy-vps-docker.sh
+```
+
+Updated to support optional Docker ingress when explicitly enabled.
+
+## Enable Docker ingress
+
+Set this in the VPS deploy environment or GitHub Action runtime env file:
+
+```text
+ARELORIAN_ENABLE_DOCKER_INGRESS=true
+ARELORIAN_INGRESS_HTTP_BIND=0.0.0.0
+ARELORIAN_INGRESS_HTTP_PORT=80
+```
+
+Then run the existing deploy workflow/script.
+
+The deploy script will use both compose files:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.ingress.yml \
+  --profile ingress \
+  up -d --remove-orphans arelorian-engine monitor-bridge ingress-router
+```
+
+## Default behavior
+
+By default, Docker ingress is disabled:
+
+```text
+ARELORIAN_ENABLE_DOCKER_INGRESS=false
+```
+
+The current host-Nginx / localhost-engine model continues unchanged.
+
+## Routing model
+
+When enabled:
+
+```text
+public :80
+  -> arelorian-ingress-router
+  -> arelorian-engine:3001
+```
+
+The ingress router proxies:
+
+```text
+/
+/health
+/client-config.json
+/ws
+/socket.io/
+/api/
+/portal/
+/2d/
+/3d/
+```
+
+The engine remains the source of truth for serving the app shell and runtime endpoints. The ingress container is a deterministic routing layer, not a second application build system.
+
+## Safety rules
+
+- Do not delete `scripts/deploy-vps-docker.sh`.
+- Do not replace the root `docker-compose.yml` for ingress experiments.
+- Do not expose `arelorian-engine` directly on public `0.0.0.0` unless explicitly reviewed.
+- Do not mix ingress migration with gameplay changes.
+- Do not add TLS automation in the same PR. HTTPS/certbot/Caddy/Traefik migration must be a separate step.
+
+## Migration path
+
+1. Merge the optional overlay.
+2. Deploy with Docker ingress disabled. Verify no behavior changed.
+3. Enable Docker ingress on a staging VPS or alternative port, for example `8080`.
+4. Verify `/health`, `/client-config.json`, `/`, `/ws`.
+5. Move public port 80 only after host Nginx conflict/ownership is resolved.
+6. Add HTTPS in a separate reviewed PR.
+
+## Why not mount `portal/dist`, `2d/dist`, and `3d/dist` directly?
+
+The current Docker image already packages and serves the browser shell from the engine runtime. Mounting separate host dist directories would create a second source of truth and can fail when CI builds but the VPS working tree does not contain fresh dist artifacts.
+
+The ingress overlay keeps one truth:
+
+```text
+Docker image contains runtime client assets.
+Nginx routes traffic to the engine.
+```

--- a/ops/nginx/default.conf
+++ b/ops/nginx/default.conf
@@ -1,0 +1,116 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+upstream arelorian_engine {
+  server arelorian-engine:3001;
+  keepalive 32;
+}
+
+server {
+  listen 80;
+  listen [::]:80;
+  server_name arelorian.de www.arelorian.de _;
+
+  client_max_body_size 64m;
+
+  add_header X-Areloria-Ingress sovereign-docker always;
+
+  location /health {
+    proxy_pass http://arelorian_engine/health;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /client-config.json {
+    proxy_pass http://arelorian_engine/client-config.json;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /ws {
+    proxy_pass http://arelorian_engine;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+  }
+
+  location /socket.io/ {
+    proxy_pass http://arelorian_engine;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+  }
+
+  location /api/ {
+    proxy_pass http://arelorian_engine;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 120s;
+    proxy_send_timeout 120s;
+  }
+
+  location /portal/ {
+    proxy_pass http://arelorian_engine;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /2d/ {
+    proxy_pass http://arelorian_engine;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /3d/ {
+    proxy_pass http://arelorian_engine;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location / {
+    proxy_pass http://arelorian_engine;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 120s;
+    proxy_send_timeout 120s;
+  }
+}

--- a/scripts/deploy-vps-docker.sh
+++ b/scripts/deploy-vps-docker.sh
@@ -9,7 +9,10 @@ ARELORIAN_PORT="${ARELORIAN_PORT:-3001}"
 CONTAINER_PORT="${ARELORIAN_CONTAINER_PORT:-3001}"
 ARELORIAN_DOCKER_NETWORK="${ARELORIAN_DOCKER_NETWORK:-areloria_arelorian-network}"
 ARELORIAN_ENV_FILE="${ARELORIAN_ENV_FILE:-.env.docker}"
-export ARELORIAN_PORT ARELORIAN_DOCKER_NETWORK
+ARELORIAN_ENABLE_DOCKER_INGRESS="${ARELORIAN_ENABLE_DOCKER_INGRESS:-false}"
+ARELORIAN_INGRESS_HTTP_BIND="${ARELORIAN_INGRESS_HTTP_BIND:-0.0.0.0}"
+ARELORIAN_INGRESS_HTTP_PORT="${ARELORIAN_INGRESS_HTTP_PORT:-80}"
+export ARELORIAN_PORT ARELORIAN_DOCKER_NETWORK ARELORIAN_ENABLE_DOCKER_INGRESS ARELORIAN_INGRESS_HTTP_BIND ARELORIAN_INGRESS_HTTP_PORT
 cd "$REPO_ROOT"
 
 LOCK_PATH="${DEPLOY_LOCK_PATH:-/tmp/wasd-vps-docker-deploy.lock}"
@@ -33,10 +36,14 @@ else
 fi
 
 compose_cmd() {
+  local files=(-f docker-compose.yml)
+  if [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ]; then
+    files+=(-f docker-compose.ingress.yml --profile ingress)
+  fi
   if [ -f "$ARELORIAN_ENV_FILE" ]; then
-    "${DC[@]}" --env-file "$ARELORIAN_ENV_FILE" "$@"
+    "${DC[@]}" --env-file "$ARELORIAN_ENV_FILE" "${files[@]}" "$@"
   else
-    "${DC[@]}" "$@"
+    "${DC[@]}" "${files[@]}" "$@"
   fi
 }
 
@@ -99,6 +106,11 @@ host_http_ready() {
   return 1
 }
 
+ingress_http_ready() {
+  [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ] || return 0
+  curl -sS -m 4 -o /dev/null -w '%{http_code}' "http://127.0.0.1:${ARELORIAN_INGRESS_HTTP_PORT}/health" 2>/dev/null | grep -Eq '^(200|204|301|302|304|401|403|503)$'
+}
+
 runtime_activity_ready() {
   local state exit_code
   state="$(docker inspect arelorian-engine --format '{{.State.Status}}' 2>/dev/null || true)"
@@ -106,7 +118,7 @@ runtime_activity_ready() {
   [ "$state" = "running" ] || return 1
   [ "$exit_code" = "0" ] || return 1
   docker exec arelorian-engine sh -lc "ps aux | grep -q '[n]ode dist/index.js'" >/dev/null 2>&1 || return 1
-  compose_cmd -f docker-compose.yml logs --tail=240 arelorian-engine 2>/dev/null | grep -Eq 'Arelorian server listening|WorldEventBus|warfront_combat|tick' && return 0
+  compose_cmd logs --tail=240 arelorian-engine 2>/dev/null | grep -Eq 'Arelorian server listening|WorldEventBus|warfront_combat|tick' && return 0
   return 1
 }
 
@@ -117,6 +129,10 @@ echo "Engine host port: $ARELORIAN_PORT"
 echo "Engine container port: $CONTAINER_PORT"
 echo "Docker network: $ARELORIAN_DOCKER_NETWORK"
 echo "Runtime env file: $ARELORIAN_ENV_FILE"
+echo "Docker ingress enabled: $ARELORIAN_ENABLE_DOCKER_INGRESS"
+if [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ]; then
+  echo "Ingress bind: ${ARELORIAN_INGRESS_HTTP_BIND}:${ARELORIAN_INGRESS_HTTP_PORT}"
+fi
 
 fetch_and_reset
 
@@ -133,13 +149,16 @@ docker builder prune -f --filter 'until=24h' >/dev/null 2>&1 || true
 docker image prune -f >/dev/null 2>&1 || true
 
 echo "[2/4] Build images (monorepo context, sequential to avoid OOM)"
-compose_cmd -f docker-compose.yml build --progress=plain arelorian-engine
-compose_cmd -f docker-compose.yml build --progress=plain monitor-bridge
+compose_cmd build --progress=plain arelorian-engine
+compose_cmd build --progress=plain monitor-bridge
 
 echo "[3/4] Recreate containers"
-compose_cmd -f docker-compose.yml down --remove-orphans || true
-docker rm -f arelorian-engine monitor-bridge >/dev/null 2>&1 || true
-compose_cmd -f docker-compose.yml up -d --remove-orphans arelorian-engine monitor-bridge
+compose_cmd down --remove-orphans || true
+docker rm -f arelorian-engine monitor-bridge arelorian-ingress-router >/dev/null 2>&1 || true
+compose_cmd up -d --remove-orphans arelorian-engine monitor-bridge
+if [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ]; then
+  compose_cmd up -d --remove-orphans ingress-router
+fi
 
 echo "[4/4] Health check (container:${CONTAINER_PORT}, host:${ARELORIAN_PORT})"
 ok=0
@@ -149,6 +168,7 @@ for i in $(seq 1 36); do
     if client_shell_ready; then
       echo "  client shell ready"
       if host_http_ready; then echo "  host HTTP mapping ready"; else echo "  WARN: host mapping not responding yet"; fi
+      if ingress_http_ready; then echo "  ingress HTTP ready"; else echo "  WARN: ingress HTTP not responding yet"; fi
       ok=1
       break
     fi
@@ -158,6 +178,7 @@ for i in $(seq 1 36); do
     echo "  runtime activity ready ($i/36): node process and world events detected"
     if client_shell_ready; then
       echo "  client shell ready"
+      if ingress_http_ready; then echo "  ingress HTTP ready"; else echo "  WARN: ingress HTTP not responding yet"; fi
       ok=1
       break
     fi
@@ -169,11 +190,17 @@ done
 
 if [[ "$ok" != "1" ]]; then
   echo "ERROR: Container health failed. Showing diagnostics:"
-  compose_cmd -f docker-compose.yml ps || true
+  compose_cmd ps || true
   docker inspect arelorian-engine --format 'Container={{.State.Status}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}n/a{{end}} ExitCode={{.State.ExitCode}} Ports={{json .NetworkSettings.Ports}}' || true
+  if [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ]; then
+    docker inspect arelorian-ingress-router --format 'Ingress={{.State.Status}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}n/a{{end}} ExitCode={{.State.ExitCode}} Ports={{json .NetworkSettings.Ports}}' || true
+  fi
   docker exec arelorian-engine sh -lc "node -v; printenv PORT GAME_PORT HOST NODE_ENV; ps aux | head -20" || true
   ss -ltnp "sport = :${ARELORIAN_PORT}" || true
-  compose_cmd -f docker-compose.yml logs --tail=160 arelorian-engine || true
+  compose_cmd logs --tail=160 arelorian-engine || true
+  if [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ]; then
+    compose_cmd logs --tail=160 ingress-router || true
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
Adds a safe optional Docker-based ingress overlay without replacing the current hardened VPS deploy path.

Includes:
- ops/nginx/default.conf
- docker-compose.ingress.yml
- scripts/deploy-vps-docker.sh support for ARELORIAN_ENABLE_DOCKER_INGRESS=true
- docs/SOVEREIGN_INGRESS_PIPELINE.md

Design decision:
- Keep current docker-compose.yml and deploy script as the stable default.
- Add Docker Nginx as an opt-in Compose overlay/profile.
- Do not mount separate portal/2d/3d dist folders as a second source of truth.
- Route traffic to the existing arelorian-engine container.

Safety:
- Docker ingress is disabled by default.
- No gameplay changes.
- No lockfile changes.
- No root compose replacement.
- No TLS/certbot automation in this PR.
- No deletion of deploy-vps-docker.sh.