### PR TITLE
ops(deploy): make legacy PM2 deploy manual only

### DIFF
--- a/.github/workflows/vps-production-deploy.yml
+++ b/.github/workflows/vps-production-deploy.yml
@@ -1,4 +1,9 @@
-# Full VPS deploy: SSH to host, sync `main`, run `deploy/update.sh` (pnpm build + PM2).
+# Legacy VPS deploy: SSH to host, sync `main`, run `deploy/update.sh` (pnpm build + PM2).
+#
+# Manual-only by design.
+# The automatic production path is now `VPS Docker Deploy (monorepo)`.
+# This legacy workflow builds browser frontends directly on the VPS and can OOM
+# during Vite builds on small hosts with exit 137.
 #
 # Accepts either naming convention:
 #   VPS_HOST / VPS_USER / VPS_SSH_KEY / VPS_DEPLOY_PATH
@@ -9,12 +14,6 @@
 name: VPS production deploy
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The failed run was not the new Docker deploy. It was the legacy `VPS production deploy` workflow calling `deploy/update.sh`, which builds Vite frontends directly on the VPS and was killed with exit 137 during `@wasd/client` build.

This PR removes the automatic push trigger from the legacy PM2 workflow so it is manual-only.

Production should use:
- `VPS Docker Deploy (monorepo)`

Why:
- Avoid VPS OOM during direct Vite builds.
- Prevent duplicate deploy paths from racing.
- Keep the Docker/IaC path as the automatic deploy source of truth.

Safety:
- Workflow trigger change only.
- No runtime code changes.
- No lockfile changes.
- Legacy workflow remains available via manual dispatch if needed.