### PR TITLE
Fix VPS final deploy verification path

### DIFF
--- a/.github/workflows/vps-final-deploy-verification.yml
+++ b/.github/workflows/vps-final-deploy-verification.yml
@@ -28,6 +28,7 @@ permissions:
 
 env:
   DEFAULT_ARELORIAN_PORT: '3001'
+  DEPLOY_PATH: /opt/areloria
 
 jobs:
   verify:
@@ -60,6 +61,8 @@ jobs:
 
       - name: Verify deployed VPS runtime
         uses: appleboy/ssh-action@v1.2.0
+        env:
+          DEPLOY_PATH: /opt/areloria
         with:
           host: ${{ secrets.VPS_HOST || secrets.SSH_HOST }}
           username: ${{ secrets.VPS_USER || secrets.SSH_USER }}
@@ -71,9 +74,7 @@ jobs:
           script: |
             set -euo pipefail
 
-            DEPLOY_PRIMARY='${{ secrets.VPS_DEPLOY_PATH }}'
-            DEPLOY_ALT='${{ secrets.DEPLOY_PATH }}'
-            DEPLOY_PATH="${DEPLOY_PRIMARY:-${DEPLOY_ALT:-/opt/areloria}}"
+            DEPLOY_PATH='/opt/areloria'
             SECRET_PORT='${{ secrets.VPS_ARELORIAN_PORT }}'
             INPUT_PORT='${{ github.event.inputs.arelorian_port }}'
             ARELORIAN_PORT="${SECRET_PORT:-${INPUT_PORT:-3001}}"
@@ -86,6 +87,7 @@ jobs:
 
             if [ ! -d "$DEPLOY_PATH" ]; then
               echo "ERROR: deploy path missing: $DEPLOY_PATH"
+              echo "Create it by running the deploy workflow first, or on the VPS: sudo mkdir -p /opt/areloria && sudo chown -R \$USER:\$USER /opt/areloria"
               exit 1
             fi
             cd "$DEPLOY_PATH"


### PR DESCRIPTION
Fixes the VPS Final Deploy Verification workflow so it no longer lets stale DEPLOY_PATH/VPS_DEPLOY_PATH secrets override the expected deploy directory.

Changes:
- Pins DEPLOY_PATH to `/opt/areloria` at workflow/job/script level.
- Removes the secret fallback chain that caused the masked `***` path error.
- Keeps existing SSH secret compatibility and runtime health checks.
- Adds a clearer error hint if `/opt/areloria` does not exist on the VPS.

This directly addresses:

```txt
ERROR: deploy path missing: ***
```