### PR TITLE
Deploy VPS Docker stack after merged PRs

### DIFF
--- a/.github/workflows/vps-docker-deploy-on-merge.yml
+++ b/.github/workflows/vps-docker-deploy-on-merge.yml
@@ -1,0 +1,162 @@
+name: VPS Docker Deploy on Merge
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+concurrency:
+  group: vps-docker-deploy-main
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Verify VPS secrets are set
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+        run: |
+          set -euo pipefail
+          ok=true
+          HOST="${VPS_HOST:-${SSH_HOST:-}}"
+          USER="${VPS_USER:-${SSH_USER:-}}"
+          KEY="${VPS_SSH_KEY:-${SSH_PRIVATE_KEY:-}}"
+          if [ -z "${HOST:-}" ]; then echo "::error::Set VPS_HOST or SSH_HOST."; ok=false; fi
+          if [ -z "${USER:-}" ]; then echo "::error::Set VPS_USER or SSH_USER."; ok=false; fi
+          if [ -z "${KEY:-}" ] && [ -z "${SSH_PASSWORD:-}" ]; then
+            echo "::error::Set VPS_SSH_KEY / SSH_PRIVATE_KEY, or SSH_PASSWORD for Docker deploy."
+            ok=false
+          fi
+          if [ "$ok" != true ]; then exit 1; fi
+
+      - name: Deploy merged main to VPS
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST || secrets.SSH_HOST }}
+          username: ${{ secrets.VPS_USER || secrets.SSH_USER }}
+          key: ${{ secrets.VPS_SSH_KEY || secrets.SSH_PRIVATE_KEY }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          port: ${{ secrets.SSH_PORT || 22 }}
+          timeout: 2m
+          command_timeout: 55m
+          script_stop: true
+          script: |
+            set -euo pipefail
+
+            DEPLOY_PATH='/opt/areloria'
+            REPO_URL='https://github.com/OuroborosCollective/Wasd.git'
+            DEPLOY_BRANCH='main'
+            ARELORIAN_ENV_FILE='.env.docker'
+
+            SECRET_PORT='${{ secrets.VPS_ARELORIAN_PORT }}'
+            SECRET_NETWORK='${{ secrets.VPS_ARELORIAN_DOCKER_NETWORK }}'
+            export ARELORIAN_PORT="${SECRET_PORT:-3001}"
+            export ARELORIAN_DOCKER_NETWORK="${SECRET_NETWORK:-areloria_arelorian-network}"
+            export ARELORIAN_ENABLE_DOCKER_INGRESS='false'
+            export ARELORIAN_INGRESS_HTTP_BIND='127.0.0.1'
+            export ARELORIAN_INGRESS_HTTP_PORT='8080'
+            export ARELORIAN_ENV_FILE
+            export DEPLOY_BRANCH
+
+            echo "=== WASD automatic deploy after merged PR ==="
+            echo "PR: #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}"
+            echo "Deploy path: $DEPLOY_PATH"
+            echo "Engine port: $ARELORIAN_PORT"
+
+            command -v git >/dev/null 2>&1 || { echo "ERROR: git is required on the VPS."; exit 1; }
+            command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required on the VPS."; exit 1; }
+            docker info >/dev/null 2>&1 || { echo "ERROR: Docker daemon is not reachable by this SSH user."; exit 1; }
+            if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then
+              echo "ERROR: Docker Compose is required on the VPS."
+              exit 1
+            fi
+
+            if [ ! -d "$DEPLOY_PATH" ]; then
+              mkdir -p "$DEPLOY_PATH" 2>/dev/null || sudo mkdir -p "$DEPLOY_PATH"
+              sudo chown -R "$(id -un):$(id -gn)" "$DEPLOY_PATH" 2>/dev/null || true
+            fi
+
+            if [ -e "$DEPLOY_PATH" ] && [ ! -d "$DEPLOY_PATH/.git" ] && [ -n "$(ls -A "$DEPLOY_PATH" 2>/dev/null || true)" ]; then
+              backup="${DEPLOY_PATH}.backup.$(date +%Y%m%d%H%M%S)"
+              echo "Existing non-git deploy dir found. Moving to $backup"
+              mv "$DEPLOY_PATH" "$backup" 2>/dev/null || sudo mv "$DEPLOY_PATH" "$backup"
+              mkdir -p "$DEPLOY_PATH" 2>/dev/null || sudo mkdir -p "$DEPLOY_PATH"
+              sudo chown -R "$(id -un):$(id -gn)" "$DEPLOY_PATH" 2>/dev/null || true
+            fi
+
+            if [ ! -d "$DEPLOY_PATH/.git" ]; then
+              git clone --branch "$DEPLOY_BRANCH" --depth 1 "$REPO_URL" "$DEPLOY_PATH"
+            else
+              cd "$DEPLOY_PATH"
+              git remote set-url origin "$REPO_URL" || true
+              git fetch --no-tags origin "$DEPLOY_BRANCH"
+              git reset --hard "origin/$DEPLOY_BRANCH"
+              git clean -fd -e .env -e .env.local -e .env.docker -e data/ -e logs/ || true
+            fi
+
+            cd "$DEPLOY_PATH"
+
+            umask 077
+            tmp_env="${ARELORIAN_ENV_FILE}.tmp"
+            cat > "$tmp_env" <<'EOF_RUNTIME_ENV'
+ARELORIAN_PORT=${{ secrets.VPS_ARELORIAN_PORT || '3001' }}
+ARELORIAN_DOCKER_NETWORK=${{ secrets.VPS_ARELORIAN_DOCKER_NETWORK || 'areloria_arelorian-network' }}
+ARELORIAN_ENABLE_DOCKER_INGRESS=false
+ARELORIAN_INGRESS_HTTP_BIND=127.0.0.1
+ARELORIAN_INGRESS_HTTP_PORT=8080
+SUPABASE_URL=${{ secrets.SUPABASE_URL }}
+SUPABASE_PUBLIC_URL=${{ secrets.SUPABASE_PUBLIC_URL }}
+SUPABASE_PROXY_URL=${{ secrets.SUPABASE_PROXY_URL }}
+SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
+ANON_KEY=${{ secrets.ANON_KEY }}
+SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+SERVICE_ROLE_KEY=${{ secrets.SERVICE_ROLE_KEY }}
+JWT_SECRET=${{ secrets.JWT_SECRET }}
+DATABASE_URL=${{ secrets.DATABASE_URL }}
+DIRECT_URL=${{ secrets.DIRECT_URL }}
+POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+REDIS_URL=${{ secrets.REDIS_URL }}
+REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
+SOKETI_APP_ID=${{ secrets.SOKETI_APP_ID }}
+SOKETI_APP_KEY=${{ secrets.SOKETI_APP_KEY }}
+SOKETI_APP_SECRET=${{ secrets.SOKETI_APP_SECRET }}
+PUSHER_APP_ID=${{ secrets.PUSHER_APP_ID }}
+PUSHER_APP_KEY=${{ secrets.PUSHER_APP_KEY }}
+PUSHER_APP_SECRET=${{ secrets.PUSHER_APP_SECRET }}
+EOF_RUNTIME_ENV
+            chmod 600 "$tmp_env"
+            mv "$tmp_env" "$ARELORIAN_ENV_FILE"
+
+            pm2 stop areloria >/dev/null 2>&1 || true
+            pm2 delete areloria >/dev/null 2>&1 || true
+            docker rm -f arelorian-engine monitor-bridge arelorian-ingress-router >/dev/null 2>&1 || true
+
+            if command -v fuser >/dev/null 2>&1; then
+              PIDS="$(fuser -n tcp "$ARELORIAN_PORT" 2>/dev/null || true)"
+              if [ -n "${PIDS// }" ]; then kill $PIDS >/dev/null 2>&1 || true; sleep 2; kill -9 $PIDS >/dev/null 2>&1 || true; fi
+            fi
+
+            chmod +x scripts/deploy-vps-docker.sh 2>/dev/null || true
+            ARELORIAN_PORT="$ARELORIAN_PORT" \
+              ARELORIAN_DOCKER_NETWORK="$ARELORIAN_DOCKER_NETWORK" \
+              ARELORIAN_ENABLE_DOCKER_INGRESS="$ARELORIAN_ENABLE_DOCKER_INGRESS" \
+              ARELORIAN_INGRESS_HTTP_BIND="$ARELORIAN_INGRESS_HTTP_BIND" \
+              ARELORIAN_INGRESS_HTTP_PORT="$ARELORIAN_INGRESS_HTTP_PORT" \
+              ARELORIAN_ENV_FILE="$ARELORIAN_ENV_FILE" \
+              DEPLOY_BRANCH="$DEPLOY_BRANCH" \
+              bash scripts/deploy-vps-docker.sh


### PR DESCRIPTION
Adds a dedicated automatic deploy trigger for merged pull requests into main.

Why:
- `push` deploy remains in the existing workflow.
- GitHub App or bot-created merge commits may not reliably trigger follow-up workflows in every setup.
- This adds a clean `pull_request.closed` trigger with `github.event.pull_request.merged == true`.

What it does:
- Runs only when a PR into `main` is merged.
- Uses `/opt/areloria`.
- Clones or heals the VPS repo checkout.
- Writes `.env.docker` from GitHub secrets.
- Frees old containers and engine port.
- Runs `scripts/deploy-vps-docker.sh` for Docker build, compose up and health checks.