### PR TITLE
Use target PR event for VPS workflow

### DIFF
--- a/.github/workflows/vps-docker-deploy-on-merge.yml
+++ b/.github/workflows/vps-docker-deploy-on-merge.yml
@@ -2,7 +2,7 @@
 name: VPS Docker Deploy on Merge
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:


### PR DESCRIPTION
Switches the automatic VPS deploy workflow from pull_request to pull_request_target for merged PR events into main. This avoids the previous case where a normal merged PR did not start the deploy workflow.