### PR TITLE
Keep VPS backend deployable when client build fails

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -47,7 +47,21 @@ RUN pnpm --filter @wasd/core-logic --if-present run build:runtime && \
 
 RUN node scripts/sync-world-assets.mjs || true
 
-RUN pnpm --filter @wasd/client --if-present build
+# The VPS runtime must remain deployable even when the browser client build is temporarily broken.
+# The server image still needs /app/client/dist because the runner stage copies that path.
+# When the Vite client build fails, create a tiny fallback page and keep the backend alive.
+RUN pnpm --filter @wasd/client --if-present build || \
+    (echo "WARN: @wasd/client build failed during VPS image build; creating fallback client/dist so backend can start." && \
+     mkdir -p client/dist && \
+     printf '%s\n' \
+       '<!doctype html>' \
+       '<html lang="en">' \
+       '<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Areloria</title></head>' \
+       '<body style="font-family:system-ui;background:#080b12;color:#e8ecff;padding:2rem">' \
+       '<h1>Areloria backend is online</h1>' \
+       '<p>The browser client build failed during Docker image creation. The backend image was kept deployable so health checks and APIs can start.</p>' \
+       '</body></html>' \
+       > client/dist/index.html)
 
 FROM node:22-alpine AS runner
 


### PR DESCRIPTION
Keeps the VPS Docker image build deployable even if the browser client build currently fails.

Why:
- Kodee reports the Docker project fails during `pnpm --filter @wasd/client --if-present build`.
- The backend/server image should still come up so the VPS project can be active and health/API checks can run.

Change:
- `Dockerfile.vps` now tries the client build.
- If it fails, it creates a tiny fallback `client/dist/index.html` instead of failing the whole image build.
- This preserves the server/core/shared build as mandatory while allowing the runtime container to start.

Next step after deploy: inspect the real Vite client build error separately and fix it without blocking backend deployment.