### PR TITLE
Force local builds for VPS compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vps
-    image: arelorian-engine:latest
+    pull_policy: build
     container_name: arelorian-engine
     restart: unless-stopped
     ports:
@@ -72,7 +72,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.monitor
-    image: monitor-bridge:latest
+    pull_policy: build
     container_name: monitor-bridge
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Fixes Hostinger/Kodee Docker Manager trying to pull local image names from Docker Hub.

Observed error:
- `pull access denied for arelorian-engine`
- `pull access denied for monitor-bridge`
- Compose warned that services must be built from source.

Change:
- Removes local-only `image: arelorian-engine:latest` and `image: monitor-bridge:latest` tags.
- Adds `pull_policy: build` to both services.
- Keeps build contexts and Dockerfiles unchanged so services are built from the repository source.