### PR TITLE
Run VPS deploy after successful merge to main

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       reason:
@@ -28,6 +33,10 @@ permissions:
 
 jobs:
   deploy:
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## Summary

- Adds `pull_request.closed` trigger for PRs targeting `main`.
- Runs the deploy job only when the PR was actually merged into `main`.
- Keeps existing `push main` and manual `workflow_dispatch` deploy support.

## Why

This makes the VPS Docker deploy workflow explicitly start after a successful PR merge to `main`, even when GitHub does not surface a normal push-triggered run clearly.