### PR TITLE
Preserve VPS Docker runtime env during deploy

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -165,14 +165,28 @@ jobs:
 
             cd "$DEPLOY_PATH"
             umask 077
-            {
-              echo "ARELORIAN_PORT=$ARELORIAN_PORT"
-              echo "ARELORIAN_DOCKER_NETWORK=$ARELORIAN_DOCKER_NETWORK"
-              echo "ARELORIAN_ENABLE_DOCKER_INGRESS=$ARELORIAN_ENABLE_DOCKER_INGRESS"
-              echo "ARELORIAN_INGRESS_HTTP_BIND=$ARELORIAN_INGRESS_HTTP_BIND"
-              echo "ARELORIAN_INGRESS_HTTP_PORT=$ARELORIAN_INGRESS_HTTP_PORT"
-            } > "$ARELORIAN_ENV_FILE"
+            if [ -f "$ARELORIAN_ENV_FILE" ]; then
+              cp "$ARELORIAN_ENV_FILE" "${ARELORIAN_ENV_FILE}.backup.$(date +%Y%m%d%H%M%S)" || true
+            fi
+            touch "$ARELORIAN_ENV_FILE"
             chmod 600 "$ARELORIAN_ENV_FILE"
+            update_env_key() {
+              key="$1"
+              value="$2"
+              tmp_file="${ARELORIAN_ENV_FILE}.tmp"
+              grep -v "^${key}=" "$ARELORIAN_ENV_FILE" > "$tmp_file" || true
+              printf '%s=%s\n' "$key" "$value" >> "$tmp_file"
+              mv "$tmp_file" "$ARELORIAN_ENV_FILE"
+              chmod 600 "$ARELORIAN_ENV_FILE"
+            }
+            update_env_key ARELORIAN_PORT "$ARELORIAN_PORT"
+            update_env_key ARELORIAN_DOCKER_NETWORK "$ARELORIAN_DOCKER_NETWORK"
+            update_env_key ARELORIAN_ENABLE_DOCKER_INGRESS "$ARELORIAN_ENABLE_DOCKER_INGRESS"
+            update_env_key ARELORIAN_INGRESS_HTTP_BIND "$ARELORIAN_INGRESS_HTTP_BIND"
+            update_env_key ARELORIAN_INGRESS_HTTP_PORT "$ARELORIAN_INGRESS_HTTP_PORT"
+            echo "Runtime env file preserved/refreshed: $DEPLOY_PATH/$ARELORIAN_ENV_FILE"
+            echo "Runtime env keys present:"
+            grep -E '^[A-Z0-9_]+=' "$ARELORIAN_ENV_FILE" | cut -d= -f1 | sed 's/^/  - /'
             chmod +x scripts/deploy-vps-docker.sh 2>/dev/null || true
 
             if [ "$DOCKER" = 'sudo docker' ]; then


### PR DESCRIPTION
## Summary

- Stops the VPS Docker deploy workflow from overwriting `.env.docker` with only Areloria control values.
- Preserves existing runtime keys already present on the VPS.
- Updates only Areloria deploy control values such as port, Docker network, and ingress flags.
- Prints present env key names without values for safer diagnostics.

## Why

The previous workflow simplified `.env.docker` generation and could remove runtime values needed by the Docker stack. This can explain a previously green continuous deploy suddenly causing the full VPS Docker stack to fail.