### PR TITLE
ci: trigger VPS deploy check on pushes

### DIFF
--- a/.github/workflows/vps-deploy-check.yml
+++ b/.github/workflows/vps-deploy-check.yml
@@ -2,6 +2,9 @@ name: VPS Deploy Check
 run-name: VPS Deploy Check • ${{ github.event_name }} • ${{ github.ref_name }}
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       base_url:


### PR DESCRIPTION
Adds a push trigger for main to the VPS Deploy Check workflow so the runtime truth check starts immediately after merges, while keeping manual and scheduled runs.