### PR TITLE
chore(ci): add stability determinism gate foundation

### DIFF
--- a/.github/workflows/are-determinism-gate.yml
+++ b/.github/workflows/are-determinism-gate.yml
@@ -5,29 +5,23 @@ on:
     branches:
       - main
     paths:
-      - 'server/src/core/systems/**'
-      - 'server/src/core/watchdogs/**'
-      - 'server/src/core/*Watchdog.ts'
-      - 'server/src/modules/brain/**'
-      - 'server/src/modules/loot/**'
-      - 'server/src/modules/warfront/**'
-      - 'server/src/modules/oracle/**'
+      - 'server/src/core/**'
+      - 'server/src/modules/**'
+      - 'server/src/services/**'
+      - 'packages/shared/src/**'
       - 'scripts/check-are-determinism.mjs'
-      - 'docs/ARE_TELEMETRY_SIDE_CHANNEL.md'
+      - 'scripts/check-determinism-gate.mjs'
       - '.github/workflows/are-determinism-gate.yml'
   push:
     branches:
       - main
     paths:
-      - 'server/src/core/systems/**'
-      - 'server/src/core/watchdogs/**'
-      - 'server/src/core/*Watchdog.ts'
-      - 'server/src/modules/brain/**'
-      - 'server/src/modules/loot/**'
-      - 'server/src/modules/warfront/**'
-      - 'server/src/modules/oracle/**'
+      - 'server/src/core/**'
+      - 'server/src/modules/**'
+      - 'server/src/services/**'
+      - 'packages/shared/src/**'
       - 'scripts/check-are-determinism.mjs'
-      - 'docs/ARE_TELEMETRY_SIDE_CHANNEL.md'
+      - 'scripts/check-determinism-gate.mjs'
       - '.github/workflows/are-determinism-gate.yml'
   workflow_dispatch:
 
@@ -36,7 +30,9 @@ permissions:
 
 jobs:
   determinism-gate:
+    name: Scan runtime logic
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,4 +43,6 @@ jobs:
           node-version: '22'
 
       - name: Check ARE deterministic simulation paths
-        run: node scripts/check-are-determinism.mjs
+        run: |
+          node scripts/check-are-determinism.mjs
+          node scripts/check-determinism-gate.mjs

--- a/scripts/check-determinism-gate.mjs
+++ b/scripts/check-determinism-gate.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const targets = [
+  'server/src/core',
+  'server/src/modules',
+  'server/src/services',
+  'packages/shared/src',
+].map((p) => path.join(repoRoot, p));
+
+const deny = [
+  { pattern: /\bMath\.random\s*\(/, label: 'Math.random()' },
+  { pattern: /\bDate\.now\s*\(/, label: 'Date.now()' },
+  { pattern: /\bnew\s+Date\s*\(/, label: 'new Date()' },
+  { pattern: /\bcrypto\.randomUUID\s*\(/, label: 'crypto.randomUUID()' },
+];
+
+const allowComment = /ARE-DETERMINISM-ALLOW/;
+const extensions = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
+const findings = [];
+
+async function walk(dir) {
+  if (!existsSync(dir)) return;
+  const entries = await readdir(dir, { withFileTypes: true });
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', 'dist', 'build', '.turbo', '.cache'].includes(entry.name)) continue;
+      await walk(full);
+      continue;
+    }
+    if (!entry.isFile() || !extensions.has(path.extname(entry.name))) continue;
+    const content = await readFile(full, 'utf8');
+    const lines = content.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (allowComment.test(line)) return;
+      for (const rule of deny) {
+        if (rule.pattern.test(line)) {
+          findings.push({ file: path.relative(repoRoot, full), line: index + 1, label: rule.label, text: line.trim().slice(0, 180) });
+        }
+      }
+    });
+  }
+}
+
+for (const target of targets) await walk(target);
+
+if (findings.length) {
+  console.error('ARE Determinism Gate failed. Forbidden nondeterministic runtime calls found:');
+  for (const f of findings) console.error(`- ${f.file}:${f.line} ${f.label} :: ${f.text}`);
+  console.error('\nUse a seeded deterministic clock/RNG or add ARE-DETERMINISM-ALLOW only outside runtime logic with a clear reason.');
+  process.exit(1);
+}
+
+console.log(`ARE Determinism Gate passed across ${targets.map((t) => path.relative(repoRoot, t)).join(', ')}`);

--- a/server/src/api/healthRoutes.ts
+++ b/server/src/api/healthRoutes.ts
@@ -1,0 +1,61 @@
+import { Router, type Request, type Response } from 'express';
+import type { WorldTick } from '../core/WorldTick.js';
+
+export type HealthRouteOptions = {
+  getTick: () => WorldTick | undefined;
+  isInitializing: () => boolean;
+  getPort: () => number;
+};
+
+function safe<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+function noStore(res: Response): void {
+  res.setHeader('Cache-Control', 'no-store');
+}
+
+export function healthRoutes(options: HealthRouteOptions): Router {
+  const router = Router();
+
+  router.get('/live', (_req: Request, res: Response) => {
+    noStore(res);
+    res.status(200).json({ ok: true, status: 'live', uptimeSeconds: Math.round(process.uptime()), port: options.getPort() });
+  });
+
+  router.get('/ready', (_req: Request, res: Response) => {
+    noStore(res);
+    const initializing = options.isInitializing();
+    const tick = options.getTick();
+    res.status(initializing ? 503 : 200).json({
+      ok: !initializing,
+      status: initializing ? 'initializing' : 'ready',
+      tickReady: Boolean(tick),
+      uptimeSeconds: Math.round(process.uptime()),
+      port: options.getPort(),
+    });
+  });
+
+  router.get('/determinism', (_req: Request, res: Response) => {
+    noStore(res);
+    const tick = options.getTick();
+    const guard = safe(() => tick?.getAREGuardStatus?.() ?? null, null);
+    const replay = safe(() => tick?.getReplayRecorderStats?.() ?? null, null);
+    const ok = Boolean(tick) && !options.isInitializing();
+    res.status(ok ? 200 : 503).json({ ok, status: ok ? 'deterministic' : 'unready', guard, replay });
+  });
+
+  router.get('/worldhash', (_req: Request, res: Response) => {
+    noStore(res);
+    const tick = options.getTick();
+    const snapshot = safe(() => tick?.getWorldHashSnapshot?.() ?? null, null);
+    const ok = Boolean(snapshot);
+    res.status(ok ? 200 : 503).json({ ok, status: ok ? 'hashed' : 'unavailable', snapshot });
+  });
+
+  return router;
+}


### PR DESCRIPTION
Phase 1 stability package.

Adds a broader ARE determinism gate script and expands the existing workflow to scan runtime logic paths. Also adds a split healthRoutes module for future /health/live, /health/ready, /health/determinism and /health/worldhash wiring.

No deploy files, no lockfile changes, no frontend package changes.