### PR TITLE
chore(ci): add runtime version lock and health probes

### DIFF
--- a/.github/workflows/runtime-version-lock.yml
+++ b/.github/workflows/runtime-version-lock.yml
@@ -1,0 +1,30 @@
+name: Runtime Version Lock
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  version-lock:
+    name: Guard critical runtime versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check runtime version locks
+        run: node scripts/check-runtime-version-lock.mjs

--- a/.github/workflows/vps-deploy-check.yml
+++ b/.github/workflows/vps-deploy-check.yml
@@ -70,6 +70,7 @@ jobs:
             DEPLOY_PATH="${DEPLOY_PATH_SECRET:-/opt/areloria}"
             GAME_PORT="${GAME_PORT_INPUT:-3001}"
             CONTAINER='arelorian-engine'
+            HEALTH_PATHS='/health /health/live /health/ready /health/determinism /health/worldhash /client-config.json /'
 
             echo "=== VPS Deploy Truth Check ==="
             echo "deploy_path=$DEPLOY_PATH"
@@ -117,8 +118,8 @@ jobs:
 
             echo "--- internal HTTP ---"
             internal_ok=false
-            for path in /health /client-config.json /; do
-              status="$($DOCKER exec "$CONTAINER" node -e "fetch('http://127.0.0.1:${GAME_PORT}${path}').then(r=>{console.log(r.status); process.exit(r.ok?0:2)}).catch(e=>{console.log('ERR '+e.message); process.exit(3)})" 2>&1 || true)"
+            for path in $HEALTH_PATHS; do
+              status="$($DOCKER exec "$CONTAINER" node -e "fetch('http://127.0.0.1:${GAME_PORT}${path}').then(r=>{console.log(r.status); process.exit(r.status < 500 ? 0 : 2)}).catch(e=>{console.log('ERR '+e.message); process.exit(3)})" 2>&1 || true)"
               echo "container http://127.0.0.1:${GAME_PORT}${path} => $status"
               case "$status" in
                 200*) internal_ok=true ;;
@@ -127,7 +128,7 @@ jobs:
 
             echo "--- host HTTP ---"
             host_ok=false
-            for path in /health /client-config.json /; do
+            for path in $HEALTH_PATHS; do
               code="$(curl -ksS -o /tmp/deploy-check-body -w '%{http_code}' --max-time 5 "http://127.0.0.1:${GAME_PORT}${path}" || true)"
               echo "host http://127.0.0.1:${GAME_PORT}${path} => $code"
               if [ "$code" = 200 ]; then host_ok=true; fi
@@ -159,7 +160,7 @@ jobs:
           fi
           echo "=== Public URL check: $BASE_URL ==="
           ok=false
-          for path in / /2d/ /3d/ /portal/; do
+          for path in / /2d/ /3d/ /portal/ /health/live /health/ready; do
             code="$(curl -ksS -o /tmp/public-check-body -w '%{http_code}' --max-time 15 "${BASE_URL%/}${path}" || true)"
             echo "${BASE_URL%/}${path} => $code"
             if [ "$code" = 200 ]; then ok=true; fi

--- a/scripts/check-runtime-version-lock.mjs
+++ b/scripts/check-runtime-version-lock.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'build', '.turbo', '.cache', 'coverage']);
+
+const exactLocks = new Map([
+  ['vite', '6.4.2'],
+  ['@vitejs/plugin-react', '4.7.0'],
+  ['three', '0.184.0'],
+]);
+
+const blockedMajors = new Map([
+  ['vite', 7],
+  ['@vitejs/plugin-react', 5],
+]);
+
+const advisoryCritical = new Set([
+  '@babylonjs/core',
+  '@babylonjs/loaders',
+  '@babylonjs/materials',
+  '@babylonjs/havok',
+  'typescript',
+  'tsx',
+  'pnpm',
+]);
+
+const findings = [];
+const advisories = [];
+
+function parseMajor(spec) {
+  const match = String(spec).match(/\d+/);
+  return match ? Number(match[0]) : null;
+}
+
+function checkSpecifier(pkgPath, section, name, spec) {
+  if (exactLocks.has(name)) {
+    const expected = exactLocks.get(name);
+    if (spec !== expected) {
+      findings.push(`${pkgPath} ${section}.${name} must be pinned to ${expected}, found ${spec}`);
+    }
+  }
+
+  if (blockedMajors.has(name)) {
+    const major = parseMajor(spec);
+    const blocked = blockedMajors.get(name);
+    if (major !== null && major >= blocked) {
+      findings.push(`${pkgPath} ${section}.${name} uses blocked major ${spec}; stay below ${blocked}.x until the frontend pipeline is migrated.`);
+    }
+  }
+
+  if (advisoryCritical.has(name) && /^[~^*]|latest|next|beta|alpha|rc/i.test(String(spec))) {
+    advisories.push(`${pkgPath} ${section}.${name} is not exact (${spec}). Advisory only for now; pin during the next lockfile maintenance window.`);
+  }
+}
+
+async function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  const entries = await readdir(dir, { withFileTypes: true });
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!ignoredDirs.has(entry.name)) await walk(full, out);
+    } else if (entry.isFile() && entry.name === 'package.json') {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const packageFiles = await walk(repoRoot);
+for (const file of packageFiles) {
+  const rel = path.relative(repoRoot, file);
+  let json;
+  try {
+    json = JSON.parse(await readFile(file, 'utf8'));
+  } catch (err) {
+    findings.push(`${rel} is not valid JSON: ${err.message}`);
+    continue;
+  }
+
+  for (const section of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    const deps = json[section] ?? {};
+    for (const [name, spec] of Object.entries(deps)) checkSpecifier(rel, section, name, spec);
+  }
+
+  const overrides = json.pnpm?.overrides ?? {};
+  for (const [name, spec] of Object.entries(overrides)) checkSpecifier(rel, 'pnpm.overrides', name, spec);
+
+  const resolutions = json.pnpm?.resolutions ?? {};
+  for (const [name, spec] of Object.entries(resolutions)) checkSpecifier(rel, 'pnpm.resolutions', name, spec);
+}
+
+if (advisories.length) {
+  console.log('Runtime Version Lock advisories:');
+  for (const advisory of advisories) console.log(`- ${advisory}`);
+}
+
+if (findings.length) {
+  console.error('Runtime Version Lock failed:');
+  for (const finding of findings) console.error(`- ${finding}`);
+  process.exit(1);
+}
+
+console.log('Runtime Version Lock passed: Vite, React plugin, and Three stay pinned to known-stable versions.');


### PR DESCRIPTION
Phase 3 stability package.

Adds a runtime version lock guard for known-sensitive frontend/runtime packages without changing package.json or pnpm-lock.yaml.

Also extends VPS Deploy Check to probe the split health routes: /health/live, /health/ready, /health/determinism and /health/worldhash.

No dependency upgrades. No lockfile changes. No deploy script changes.