### PR TITLE
fix(runtime): replace real gameplay randomness with ARE seeded determinism

### DIFF
--- a/server/src/modules/combat/CombatSystem.ts
+++ b/server/src/modules/combat/CombatSystem.ts
@@ -1,3 +1,5 @@
+import { createARESeed, SeededARERng, type ARERng } from "../../core/determinism/AREDeterminism.js";
+
 export type FxKind = "hit" | "crit" | "heal" | "miss" | "block" | "xp" | "gold";
 
 export interface CombatResult {
@@ -25,12 +27,13 @@ export class CombatSystem {
 
   /** Spell / skill hit — no stamina cost */
   spellStrike(attacker: any, defender: any, spellPower: number): CombatResult {
+    const rng = this.createCombatRng("spellStrike", attacker, defender, spellPower);
     const hitChance = this.calculateHitChance(attacker, defender);
-    if (Math.random() > hitChance) {
+    if (rng.nextFloat() > hitChance) {
       return { success: true, hit: false, damage: 0, crit: false, fx: { kind: "miss" } };
     }
-    const crit = Math.random() < 0.08;
-    const baseDamage = this.calculateDamage(attacker, defender, spellPower);
+    const crit = rng.nextFloat() < 0.08;
+    const baseDamage = this.calculateDamage(attacker, defender, spellPower, rng.fork("damage"));
     const damage = crit ? Math.floor(baseDamage * 1.75) : baseDamage;
     defender.health = Math.max(0, defender.health - damage);
     const killed = defender.health <= 0;
@@ -50,13 +53,14 @@ export class CombatSystem {
     if (atkStamina <= 0) return { success: false, hit: false, damage: 0, reason: "no_stamina" };
     attacker.stamina = atkStamina - 8;
 
+    const rng = this.createCombatRng("attack", attacker, defender, weaponBonus);
     const hitChance = this.calculateHitChance(attacker, defender);
-    if (Math.random() > hitChance) {
+    if (rng.nextFloat() > hitChance) {
       return { success: true, hit: false, damage: 0, crit: false, fx: { kind: "miss" } };
     }
 
-    const crit = Math.random() < 0.08;
-    const baseDamage = this.calculateDamage(attacker, defender, weaponBonus);
+    const crit = rng.nextFloat() < 0.08;
+    const baseDamage = this.calculateDamage(attacker, defender, weaponBonus, rng.fork("damage"));
     const damage = crit ? Math.floor(baseDamage * 1.75) : baseDamage;
     defender.health = Math.max(0, defender.health - damage);
     const killed = defender.health <= 0;
@@ -85,11 +89,46 @@ export class CombatSystem {
     return Math.min(0.95, Math.max(0.3, base + diff * 0.3));
   }
 
-  calculateDamage(attacker: any, defender: any, weaponBonus = 0) {
+  calculateDamage(attacker: any, defender: any, weaponBonus = 0, rng?: ARERng) {
     const atk = attacker.skills?.combat?.level ?? 1;
     const def = defender.skills?.combat?.level ?? 1;
     const base = 5 + atk + Math.max(0, weaponBonus);
     const mitigation = Math.floor(def * 0.3);
-    return Math.max(1, base - mitigation + Math.floor(Math.random() * 4));
+    const damageRng = rng ?? this.createCombatRng("damage", attacker, defender, weaponBonus);
+    return Math.max(1, base - mitigation + damageRng.nextInt(4));
+  }
+
+  private createCombatRng(kind: string, attacker: any, defender: any, salt: number): SeededARERng {
+    const sequence = this.nextCombatSequence(attacker);
+    return new SeededARERng(createARESeed([
+      "combat",
+      kind,
+      this.stableEntityId(attacker),
+      this.stableEntityId(defender),
+      sequence,
+      salt,
+      attacker?.stamina ?? 0,
+      defender?.health ?? 0,
+    ]));
+  }
+
+  private nextCombatSequence(entity: any): number {
+    if (!entity || typeof entity !== "object") return 0;
+    const previous = Number.isFinite(entity.__areCombatSequence) ? Number(entity.__areCombatSequence) : 0;
+    const next = previous + 1;
+    entity.__areCombatSequence = next;
+    return next;
+  }
+
+  private stableEntityId(entity: any): string {
+    if (typeof entity === "string" || typeof entity === "number") return String(entity);
+    return String(
+      entity?.id ??
+      entity?.playerId ??
+      entity?.npcId ??
+      entity?.identity?.npcId ??
+      entity?.name ??
+      "entity"
+    );
   }
 }

--- a/server/src/modules/dungeon/dungeonInstance.ts
+++ b/server/src/modules/dungeon/dungeonInstance.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createARESeed, SeededARERng } from "../../core/determinism/AREDeterminism.js";
 
 export type DungeonInstance = {
   id: string;
@@ -7,10 +7,16 @@ export type DungeonInstance = {
   partyId?: string;
 };
 
+let dungeonSequence = 0;
+
 export function createDungeon(tier: number, partyId?: string): DungeonInstance {
+  const sequence = dungeonSequence++;
+  const seedKey = createARESeed(["dungeon", tier, partyId ?? "solo", sequence]);
+  const rng = new SeededARERng(seedKey);
+  const seed = rng.nextInt(1_000_000_000);
   return {
-    id: randomUUID(),
-    seed: Math.floor(Math.random() * 1e9),
+    id: `dg_${tier}_${partyId ?? "solo"}_${sequence}_${seed.toString(36)}`,
+    seed,
     tier,
     ...(partyId ? { partyId } : {}),
   };

--- a/server/src/modules/npc/PerceptionLogic.ts
+++ b/server/src/modules/npc/PerceptionLogic.ts
@@ -13,6 +13,7 @@
  * NO RAYCASTING - Pure mathematical distance calculation.
  */
 
+import { createARESeed, SeededARERng } from '../../core/determinism/AREDeterminism.js';
 import type { EntityState } from '../types/index.js';
 
 /**
@@ -178,6 +179,21 @@ export function calculatePhaseShift(npcId: string): number {
   return phaseShift;
 }
 
+function deterministicDetectionRoll(npc: PerceptionState, player: StealthState, currentTick: number): number {
+  const rng = new SeededARERng(createARESeed([
+    'perception',
+    npc.npcId,
+    player.playerId,
+    currentTick,
+    npc.phaseShift,
+    Math.round(npc.position.x * 1000),
+    Math.round(npc.position.z * 1000),
+    Math.round(player.position.x * 1000),
+    Math.round(player.position.z * 1000),
+  ]));
+  return rng.nextFloat() * 100;
+}
+
 /**
  * Tick-based perception updates
  * Called every 10-Hz tick
@@ -231,14 +247,15 @@ export class PerceptionTicker {
 
     this.lastTick = currentTick;
     const detectedBy: string[] = [];
+    const sortedNpcStates = Array.from(this.npcStates.entries()).sort(([a], [b]) => a.localeCompare(b));
 
-    for (const [npcId, npcState] of this.npcStates) {
+    for (const [npcId, npcState] of sortedNpcStates) {
       npcState.lastPerceptionTick = currentTick;
       
       const result = checkStealthDeterministic(npcState, player);
       
-      // Roll for detection based on chance
-      if (result.visible && Math.random() * 100 < result.detectionChance) {
+      // Roll for detection based on deterministic chance
+      if (result.visible && deterministicDetectionRoll(npcState, player, currentTick) < result.detectionChance) {
         detectedBy.push(npcId);
       }
     }


### PR DESCRIPTION
Fixes the first real ARE Guard gameplay hits.

Replaces direct runtime nondeterminism in:
- CombatSystem: Math.random combat rolls -> SeededARERng
- PerceptionLogic: Math.random detection roll -> deterministic tick/entity roll
- dungeonInstance: randomUUID/Math.random seed -> ARE-derived deterministic id/seed

No dependency or lockfile changes.