### PR TITLE
fix(runtime): make payload and world generation deterministic

### DIFF
--- a/server/src/core/PayloadFactory.ts
+++ b/server/src/core/PayloadFactory.ts
@@ -9,6 +9,8 @@ export interface AREPayload {
 
 export class PayloadFactory {
     private weatherResonance: WeatherResonance;
+    private tick = 0;
+    private readonly tickRate = 10;
 
     constructor(weatherResonance: WeatherResonance) {
         this.weatherResonance = weatherResonance;
@@ -22,10 +24,11 @@ export class PayloadFactory {
      * @returns Das vollständige AREPayload-Objekt für den Client-Versand.
      */
     public createAREPayload(entities: any[]): AREPayload {
+        this.tick += 1;
         return {
-            timestamp: Date.now(),
+            timestamp: this.tick * 100,
             resonance: this.weatherResonance.calculateCurrentResonance(),
-            tickRate: 10,
+            tickRate: this.tickRate,
             entities: entities
         };
     }

--- a/server/src/core/WorldBossDungeonSystem.ts
+++ b/server/src/core/WorldBossDungeonSystem.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-
 const WORLD_BOSS_DUNGEON_ID = "obsidian_fracture";
 const WORLD_BOSS_SCENE_ID = "worldboss_obsidian_fracture";
 const HUB_SCENE_ID = "didis_hub";
@@ -102,7 +100,7 @@ function ensureRecord(value: unknown): Record<string, unknown> {
 }
 
 function nowMs(): number {
-  return Date.now();
+  return Date.now(); // ARE-DETERMINISM-ALLOW wall-clock cooldown and audit metadata, not world-hash input.
 }
 
 export class WorldBossDungeonSystem {
@@ -114,6 +112,8 @@ export class WorldBossDungeonSystem {
   private openDungeonInstanceId = "";
   private currentBossNpcId = WORLD_BOSS_NPC_ID;
   private encounterAnnouncementSent = false;
+  private instanceSequence = 0;
+  private encounterSequence = 0;
 
   constructor() {
     this.definitions = {
@@ -246,7 +246,7 @@ export class WorldBossDungeonSystem {
     if (!bossNpc || (Number(bossNpc.health) || 0) <= 0) return;
     if (this.activeEncounter?.completed === false && this.activeEncounter.bossNpcId === bossNpc.id) return;
     this.activeEncounter = {
-      encounterId: randomUUID(),
+      encounterId: this.newEncounterId(),
       dungeonId: WORLD_BOSS_DUNGEON_ID,
       bossNpcId: bossNpc.id,
       startedAt: nowMs(),
@@ -447,7 +447,13 @@ export class WorldBossDungeonSystem {
   }
 
   private newInstanceId(): string {
-    return randomUUID().slice(0, 8);
+    this.instanceSequence += 1;
+    return `wb_${this.instanceSequence.toString(36).padStart(4, "0")}`;
+  }
+
+  private newEncounterId(): string {
+    this.encounterSequence += 1;
+    return `wbe_${this.encounterSequence.toString(36).padStart(4, "0")}`;
   }
 }
 

--- a/server/src/modules/network/AREPayloadManager.ts
+++ b/server/src/modules/network/AREPayloadManager.ts
@@ -11,11 +11,12 @@ export class AREPayloadManager {
     private payload: AREPayload;
     private updateInterval: NodeJS.Timeout | null = null;
     private readonly TICK_RATE_MS = 100;
+    private tick = 0;
 
     private constructor() {
         this.payload = {
             id: "are_broadcast_node_01",
-            timestamp: Date.now(),
+            timestamp: 0,
             resonance: 0
         };
         this.startPayloadTick();
@@ -35,10 +36,11 @@ export class AREPayloadManager {
     }
 
     private refreshPayload(): void {
+        this.tick += 1;
         this.payload = {
             ...this.payload,
             resonance: WeatherResonance.calculate(),
-            timestamp: Date.now()
+            timestamp: this.tick * this.TICK_RATE_MS
         };
     }
 

--- a/server/src/modules/world/ResourceSystem.ts
+++ b/server/src/modules/world/ResourceSystem.ts
@@ -1,5 +1,6 @@
 import { ResourceScatter } from "./ResourceScatter.js";
 import { ItemRegistry } from "../inventory/ItemRegistry.js";
+import { SeededARERng } from "../../core/determinism/AREDeterminism.js";
 
 export interface ResourceNode {
   id: string;
@@ -26,15 +27,16 @@ export class ResourceSystem {
   initializeNodes() {
     // Generate some default nodes across the map
     const biomes = ["forest", "mountain", "desert"];
+    const rng = new SeededARERng("resource-system:v1");
     let idCounter = 0;
 
     for (let i = 0; i < 50; i++) {
-      const biome = biomes[Math.floor(Math.random() * biomes.length)];
+      const biome = biomes[rng.nextInt(biomes.length)];
       const resources = this.scatter.generateForBiome(biome);
 
       if (resources.length === 0) continue;
 
-      const resourceType = resources[Math.floor(Math.random() * resources.length)];
+      const resourceType = resources[rng.nextInt(resources.length)];
 
       // Determine node properties based on type
       let typeName = "node";
@@ -56,8 +58,8 @@ export class ResourceSystem {
         id,
         type: typeName,
         position: {
-          x: (Math.random() - 0.5) * 400, // spread across -200 to 200
-          y: (Math.random() - 0.5) * 400
+          x: (rng.nextFloat() - 0.5) * 400, // spread across -200 to 200
+          y: (rng.nextFloat() - 0.5) * 400
         },
         amount: maxAmount,
         maxAmount,
@@ -71,7 +73,7 @@ export class ResourceSystem {
   }
 
   private updateCache() {
-    this.cachedNodes = Array.from(this.nodes.values());
+    this.cachedNodes = Array.from(this.nodes.values()).sort((a, b) => a.id.localeCompare(b.id));
   }
 
   gatherNode(id: string): { success: boolean, item?: any, reason?: string } {


### PR DESCRIPTION
Second ARE Guard real-hit repair batch.

Changes:
- PayloadFactory timestamps now derive from 10-Hz tick count instead of Date.now
- AREPayloadManager payload timestamps now derive from tick count instead of Date.now
- ResourceSystem initialization now uses SeededARERng and sorted cache output
- WorldBossDungeonSystem no longer uses randomUUID for instance/encounter ids

Wall-clock worldboss cooldown timing remains explicitly marked as ARE-DETERMINISM-ALLOW because it is cooldown/audit metadata, not world-hash input.

No dependency or lockfile changes.