### PR TITLE
fix(web): build and serve apps web bundle on VPS

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,11 +33,11 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/three": "0.184.1",
-    "@vitejs/plugin-react": "^6.0.1",
+    "@vitejs/plugin-react": "4.7.0",
     "@vitest/coverage-v8": "^4.1.5",
     "jsdom": "^29.1.1",
     "typescript": "^6.0.3",
-    "vite": "^6.4.2",
+    "vite": "6.4.2",
     "vitest": "^4.1.5"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "main": "index.ts",
   "scripts": {
     "dev": "vite",
-    "build": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc && node --max-old-space-size=4096 ./node_modules/vite/bin/vite.js build --debug --logLevel info || true",
+    "build": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc && node --max-old-space-size=4096 ./node_modules/vite/bin/vite.js build --debug --logLevel info",
     "preview": "vite preview",
     "check-types": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc --noEmit",
     "test": "vitest --passWithNoTests",

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -67,10 +67,11 @@ if command -v pnpm >/dev/null 2>&1; then
   NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/shared --if-present build
   NODE_OPTIONS="$SERVER_BUILD_NODE_OPTIONS" pnpm --filter @wasd/server --if-present build
 
-  echo "Building browser frontends for /, /3d/, /2d/ and /portal/..."
+  echo "Building browser frontends for /, /3d/, /2d/, /portal/ and apps/web..."
   NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/client --if-present build
   NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/client-2d --if-present build
   NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/portal --if-present build
+  NODE_OPTIONS="$BUILD_NODE_OPTIONS" pnpm --filter @wasd/web --if-present build
 else
   echo "ERROR: pnpm is required for this monorepo deploy."
   exit 1
@@ -80,6 +81,7 @@ echo "Assembling browser route folders under client/dist..."
 test -f client/dist/index.html || { echo "ERROR: client/dist/index.html missing after @wasd/client build"; exit 1; }
 test -f apps/client-2d/dist/index.html || { echo "ERROR: apps/client-2d/dist/index.html missing after @wasd/client-2d build"; exit 1; }
 test -f portal/dist/index.html || { echo "ERROR: portal/dist/index.html missing after @wasd/portal build"; exit 1; }
+test -f apps/web/dist/index.html || { echo "ERROR: apps/web/dist/index.html missing after @wasd/web build"; exit 1; }
 
 mkdir -p client/dist/2d client/dist/3d client/dist/portal
 cp -a apps/client-2d/dist/. client/dist/2d/
@@ -91,11 +93,17 @@ if [ -d client/dist/assets ]; then
 fi
 
 echo "Route bundle markers:"
-ls -la client/dist/index.html client/dist/2d/index.html client/dist/3d/index.html client/dist/portal/index.html
+ls -la client/dist/index.html client/dist/2d/index.html client/dist/3d/index.html client/dist/portal/index.html apps/web/dist/index.html
+
+NGINX_WEBROOT="${NGINX_WEBROOT:-$APP_DIR/apps/web/dist}"
+if [ ! -f "$NGINX_WEBROOT/index.html" ]; then
+  echo "WARNING: NGINX_WEBROOT=$NGINX_WEBROOT has no index.html; falling back to $APP_DIR/client/dist"
+  NGINX_WEBROOT="$APP_DIR/client/dist"
+fi
 
 if [ "${SKIP_NGINX_REPAIR:-0}" != "1" ] && [ -f deploy/repair-nginx.sh ] && command -v nginx >/dev/null 2>&1; then
   echo "Repairing nginx document root and reverse proxy if permissions allow..."
-  APP_DIR="$APP_DIR" GAME_PORT="$GAME_PORT" DOMAIN="${DOMAIN:-arelorian.de}" bash deploy/repair-nginx.sh || true
+  APP_DIR="$APP_DIR" WEBROOT="$NGINX_WEBROOT" GAME_PORT="$GAME_PORT" DOMAIN="${DOMAIN:-arelorian.de}" bash deploy/repair-nginx.sh || true
 else
   echo "Skipping nginx repair. Set SKIP_NGINX_REPAIR=0 and ensure nginx is installed to enable it."
 fi

--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r build",
+    "build:web": "pnpm -r --filter @wasd/web build",
     "build:network": "pnpm -r --filter @arelorian/core-network build",
     "build:2d": "pnpm -r --filter @arelorian/client-2d build",
     "build:3d": "pnpm -r --filter @wasd/client build",
+    "dev:web": "pnpm -r --filter @wasd/web dev",
     "dev:network": "pnpm -r --filter @arelorian/core-network dev",
     "dev:2d": "pnpm -r --filter @arelorian/client-2d dev",
     "dev:3d": "pnpm -r --filter @wasd/client dev",
-    "dev:all": "concurrently \"pnpm dev:network\" \"pnpm dev:2d\" \"pnpm dev:3d\"",
-    "build:all": "pnpm build:network && pnpm build:2d && pnpm build:3d",
+    "dev:all": "concurrently \"pnpm dev:network\" \"pnpm dev:2d\" \"pnpm dev:3d\" \"pnpm dev:web\"",
+    "build:all": "pnpm build:network && pnpm build:2d && pnpm build:3d && pnpm build:web",
     "clean": "pnpm -r exec rm -rf dist node_modules"
   },
   "engines": {


### PR DESCRIPTION
Fixes the newly discovered VPS webroot mismatch.

The VPS contains the web app at /opt/areloria/apps/web but no apps/web/dist build output existed. This PR:

- makes @wasd/web build fail loudly instead of swallowing Vite/TS errors with `|| true`
- adds root scripts build:web/dev:web and includes build:web in build:all
- deploy/update.sh now builds @wasd/web
- deploy/update.sh now asserts apps/web/dist/index.html exists
- nginx repair now prefers apps/web/dist as WEBROOT and falls back to client/dist only if needed
- pins apps/web Vite tooling to the stable frontend line expected by the Runtime Version Lock guard

No lockfile changes.