### PR TITLE
fix(deploy): clean stale VPS git refs before docker deploy

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -117,6 +117,16 @@ jobs:
             uname -a || true
 
             command -v git >/dev/null 2>&1 || { echo "ERROR: git is required on the VPS."; exit 1; }
+
+            if [ -d "$DEPLOY_PATH/.git" ]; then
+              echo "Repairing stale git remote refs in $DEPLOY_PATH before deploy helper runs..."
+              git -C "$DEPLOY_PATH" remote set-url origin "$REPO_URL" || true
+              find "$DEPLOY_PATH/.git/refs/remotes/origin" -name '*.lock' -type f -delete 2>/dev/null || true
+              rm -f "$DEPLOY_PATH/.git/refs/remotes/origin/${DEPLOY_BRANCH}.lock" 2>/dev/null || true
+              git -C "$DEPLOY_PATH" update-ref -d "refs/remotes/origin/${DEPLOY_BRANCH}" 2>/dev/null || true
+              git -C "$DEPLOY_PATH" remote prune origin || true
+            fi
+
             tmp_checkout="$(mktemp -d /tmp/wasd-vps-deploy.XXXXXX)"
             cleanup() { rm -rf "$tmp_checkout" 2>/dev/null || true; }
             trap cleanup EXIT


### PR DESCRIPTION
Fixes the VPS Docker Deploy failure:

cannot lock ref 'refs/remotes/origin/main'

Before the deploy helper runs, the workflow now repairs stale refs in /opt/areloria/.git:
- removes stale origin/*.lock files
- deletes refs/remotes/origin/main through git update-ref
- prunes origin

This keeps the existing deploy helper intact and prevents the local VPS checkout from blocking fresh fetches.