### PR TITLE
fix(build): repair 2d client package filters and vite aliases

### DIFF
--- a/apps/client-2d/vite.config.mjs
+++ b/apps/client-2d/vite.config.mjs
@@ -1,25 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: {
-      '@wasd/core-network': path.resolve('/workspace/project/Wasd/packages/core-network/src'),
-      'socket.io-client': path.resolve('/workspace/project/Wasd/apps/client-2d/node_modules/socket.io-client')
-    }
-  },
   server: {
     port: 5173,
     host: true
   },
   build: {
     outDir: 'dist',
-    emptyOutDir: true,
-    rollupOptions: {
-      external: ['socket.io-client']
-    }
+    emptyOutDir: true
   },
-  base: '/'
+  base: '/2d/'
 });

--- a/package.json
+++ b/package.json
@@ -6,15 +6,13 @@
   "scripts": {
     "build": "pnpm -r build",
     "build:web": "pnpm -r --filter @wasd/web build",
-    "build:network": "pnpm -r --filter @arelorian/core-network build",
-    "build:2d": "pnpm -r --filter @arelorian/client-2d build",
+    "build:2d": "pnpm -r --filter @wasd/client-2d build",
     "build:3d": "pnpm -r --filter @wasd/client build",
     "dev:web": "pnpm -r --filter @wasd/web dev",
-    "dev:network": "pnpm -r --filter @arelorian/core-network dev",
-    "dev:2d": "pnpm -r --filter @arelorian/client-2d dev",
+    "dev:2d": "pnpm -r --filter @wasd/client-2d dev",
     "dev:3d": "pnpm -r --filter @wasd/client dev",
-    "dev:all": "concurrently \"pnpm dev:network\" \"pnpm dev:2d\" \"pnpm dev:3d\" \"pnpm dev:web\"",
-    "build:all": "pnpm build:network && pnpm build:2d && pnpm build:3d && pnpm build:web",
+    "dev:all": "concurrently \"pnpm dev:2d\" \"pnpm dev:3d\" \"pnpm dev:web\"",
+    "build:all": "pnpm build:2d && pnpm build:3d && pnpm build:web",
     "clean": "pnpm -r exec rm -rf dist node_modules"
   },
   "engines": {


### PR DESCRIPTION
Fixes the current 2D build blocker on the VPS.

Changes:
- removes hardcoded Replit/workspace paths from apps/client-2d/vite.config.mjs
- removes phantom @wasd/core-network alias
- lets socket.io-client resolve normally from pnpm workspace node_modules
- fixes root build/dev scripts to target the existing @wasd/client-2d package instead of missing @arelorian/client-2d
- removes missing @arelorian/core-network scripts from build:all/dev:all

This should allow pnpm --filter @wasd/client-2d build to create apps/client-2d/dist/index.html for /2d/.