### PR TITLE
fix(portal): add loot aura shared theme types

### DIFF
--- a/packages/shared/src/theme/ThemeEngine.ts
+++ b/packages/shared/src/theme/ThemeEngine.ts
@@ -12,8 +12,10 @@ import { EventEmitter } from "eventemitter3";
 export const THEME_MARINA_AURA = "#00E5FF";
 /** Organic Fire — high hazard glitch core */
 export const THEME_ORGANIC_FIRE = "#E60000";
+/** Legendary loot aura — deterministic gold resonance */
+export const THEME_LEGENDARY_LOOT = "#FFD76A";
 
-export type ThemeAuraMode = "marina" | "balanced" | "fire_glitch";
+export type ThemeAuraMode = "marina" | "balanced" | "fire_glitch" | "loot_legendary";
 
 export interface VisualThemeState {
   /** Primary aura / glow color (hex) */
@@ -30,6 +32,16 @@ export interface VisualThemeState {
   phaseShiftPulseHz: number;
   hazardIndex: number;
   aggressionTrend: number;
+}
+
+export interface LootAuraPayload {
+  itemId: string;
+  itemName?: string;
+  quality?: string;
+  sector?: string;
+  probability?: number;
+  rollHash?: string;
+  sourceId?: string;
 }
 
 const BASE_PHASE_PULSE_HZ = 0.85;
@@ -56,6 +68,15 @@ function lerpHex(a: string, b: string, t: number): string {
   const g = Math.round(A.g + (B.g - A.g) * u);
   const bCh = Math.round(A.b + (B.b - A.b) * u);
   return `#${[r, g, bCh].map((x) => x.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function stableUnit(input: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return (h % 10000) / 10000;
 }
 
 /**
@@ -107,6 +128,22 @@ export function getVisualState(hazardIndex: number, aggressionTrend: number): Vi
   };
 }
 
+export function getLootLegendaryVisualState(payload: LootAuraPayload): VisualThemeState {
+  const seed = `${payload.itemId}|${payload.itemName ?? ""}|${payload.sector ?? ""}|${payload.rollHash ?? ""}`;
+  const resonance = stableUnit(seed);
+  const probability = Number.isFinite(payload.probability ?? Number.NaN) ? Number(payload.probability) : 0.000001;
+  const rarityBoost = clamp01(1 - Math.min(1, probability * 100000));
+  return {
+    auraHex: THEME_LEGENDARY_LOOT,
+    secondaryHex: lerpHex("#3f2f05", "#fff0a8", 0.22 + resonance * 0.28),
+    mode: "loot_legendary",
+    glitchIntensity: 0.34 + rarityBoost * 0.32,
+    phaseShiftPulseHz: 1.18 + resonance * 0.64,
+    hazardIndex: 0.12 + rarityBoost * 0.16,
+    aggressionTrend: 0,
+  };
+}
+
 /** CSS custom properties for root / layout injection */
 export function visualStateToCssVars(state: VisualThemeState): Record<string, string> {
   const periodSec = Math.max(0.12, 1 / Math.max(0.05, state.phaseShiftPulseHz));
@@ -124,6 +161,7 @@ export function visualStateToCssVars(state: VisualThemeState): Record<string, st
 // ——— Live ticker hazard bridge (browser + Node) ———
 
 export const THEME_HAZARD_EVENT = "wasd:theme_hazard";
+export const THEME_LOOT_AURA_EVENT = "wasd:loot_aura";
 
 export type LiveTickerHazardPayload = {
   hazardIndex?: number;
@@ -163,6 +201,15 @@ export function pushLiveTickerHazard(payload: LiveTickerHazardPayload): VisualTh
   const visual = getVisualState(hi, at);
   lastVisual = visual;
   themeEmitter.emit(THEME_HAZARD_EVENT, { visual, payload });
+  themeEmitter.emit("theme_updated", visual);
+  return visual;
+}
+
+export function pushLootAura(payload: LootAuraPayload): VisualThemeState {
+  const visual = getLootLegendaryVisualState(payload);
+  lastDedupeKey = `loot|${payload.itemId}|${payload.rollHash ?? ""}|${payload.sector ?? ""}`;
+  lastVisual = visual;
+  themeEmitter.emit(THEME_LOOT_AURA_EVENT, { visual, payload });
   themeEmitter.emit("theme_updated", visual);
   return visual;
 }

--- a/portal/src/community/EpochChroniclePanel.tsx
+++ b/portal/src/community/EpochChroniclePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 type EpochId = 'awakening' | 'strife' | 'synthesis' | 'ascension';
 
@@ -31,7 +31,7 @@ function tinyHash(input: string): string {
   return hash.toString(16).padStart(8, '0');
 }
 
-export function EpochChroniclePanel(): JSX.Element {
+export function EpochChroniclePanel(): React.ReactElement {
   const [epoch, setEpoch] = useState<EpochId>('awakening');
   const [quests, setQuests] = useState(12);
   const [quorum, setQuorum] = useState(0.42);

--- a/portal/src/vite-env.d.ts
+++ b/portal/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="react" />
 
 interface ImportMetaEnv {
   /** e.g. http://localhost:3000 — must expose POST /api/v1/science-mascot (Gemini proxy on Wasd server). */
@@ -7,4 +8,8 @@ interface ImportMetaEnv {
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
+}
+
+declare namespace JSX {
+  type Element = import("react").ReactElement;
 }


### PR DESCRIPTION
Fixes portal TypeScript build errors seen on the VPS.

Changes:
- extends ThemeAuraMode with loot_legendary
- adds getLootLegendaryVisualState() and pushLootAura() to @wasd/shared ThemeEngine
- provides a JSX namespace fallback for portal React typings
- switches EpochChroniclePanel return type to React.ReactElement

This addresses missing @wasd/shared exports and loot_legendary mode comparisons in SciencePortal/EchoTracker.