### PR TITLE
fix(deploy): stop frontend pushes from triggering Docker deploy

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -5,11 +5,29 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'server/**'
+      - 'packages/core-logic/**'
+      - 'packages/shared/**'
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - 'scripts/deploy-vps-docker.sh'
+      - 'scripts/vps-docker-inline-deploy.sh'
+      - '.github/workflows/vps-docker-deploy.yml'
   pull_request:
     types:
       - closed
     branches:
       - main
+    paths:
+      - 'server/**'
+      - 'packages/core-logic/**'
+      - 'packages/shared/**'
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - 'scripts/deploy-vps-docker.sh'
+      - 'scripts/vps-docker-inline-deploy.sh'
+      - '.github/workflows/vps-docker-deploy.yml'
   workflow_dispatch:
     inputs:
       reason:

--- a/deploy/backend-client-shell.html
+++ b/deploy/backend-client-shell.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Areloria Backend</title>
+</head>
+<body style="font-family:system-ui;background:#080b12;color:#e8ecff;padding:2rem">
+  <main id="application-canvas">
+    <h1>Areloria backend is online</h1>
+    <p>Frontend bundles are served by nginx from /opt/areloria/apps/web/dist.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Stops the heavy VPS Docker deploy from running on every frontend-only change.

Why:
- Current Docker build dies with exit code 137 during pnpm install because it installs the full 42-workspace graph.
- 2D/portal/3D frontend work should be assembled under nginx webroot, not force a backend container rebuild every push.

Change:
- Restricts vps-docker-deploy.yml automatic triggers to backend, docker, infra, and deploy-script paths.
- Manual workflow_dispatch remains available for explicit Docker deploys.

This keeps frontend iteration from killing the VPS Docker pipeline while we separate static bundle deploy from backend deploy.