### PR TITLE
fix(ui): apply cyberzen 2.5D visual pass

### DIFF
--- a/apps/client-2d/src/CyberZenIsoApp.tsx
+++ b/apps/client-2d/src/CyberZenIsoApp.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from "react";
+import { Application, Container, Graphics, Text } from "pixi.js";
+import { createClient } from "@wasd/core-network";
+
+const TILE_W = 96;
+const TILE_H = 48;
+
+type Entity = { root: Container; tx: number; tz: number };
+type Msg = { from: string; txt: string };
+
+function iso(x: number, z: number, width: number, height: number) {
+  return { x: width / 2 + (x - z) * TILE_W * 0.5, y: height * 0.45 + (x + z) * TILE_H * 0.5 };
+}
+
+function diamond(color: number, stroke = 0x17361e) {
+  const g = new Graphics();
+  g.moveTo(0, -TILE_H / 2);
+  g.lineTo(TILE_W / 2, 0);
+  g.lineTo(0, TILE_H / 2);
+  g.lineTo(-TILE_W / 2, 0);
+  g.closePath();
+  g.fill(color);
+  g.stroke({ width: 2, color: stroke, alpha: 0.72 });
+  return g;
+}
+
+function propTree() {
+  const c = new Container();
+  c.addChild(new Graphics().ellipse(0, 14, 24, 8).fill({ color: 0x010804, alpha: 0.5 }));
+  c.addChild(new Graphics().roundRect(-5, -22, 10, 34, 4).fill(0x704323));
+  c.addChild(new Graphics().circle(0, -42, 25).fill(0x14572f));
+  c.addChild(new Graphics().circle(-9, -32, 18).fill(0x34a35e).stroke({ width: 1, color: 0xa7ffbf, alpha: 0.22 }));
+  return c;
+}
+
+function propHouse() {
+  const c = new Container();
+  c.addChild(new Graphics().ellipse(0, 18, 48, 12).fill({ color: 0x010804, alpha: 0.44 }));
+  c.addChild(new Graphics().roundRect(-34, -36, 68, 48, 8).fill(0x7d5534).stroke({ width: 2, color: 0xffd890, alpha: 0.32 }));
+  const roof = new Graphics();
+  roof.moveTo(-44, -34); roof.lineTo(0, -70); roof.lineTo(44, -34); roof.lineTo(30, -18); roof.lineTo(-30, -18); roof.closePath();
+  roof.fill(0x8e2c2b); roof.stroke({ width: 2, color: 0xffb568, alpha: 0.5 });
+  c.addChild(roof, new Graphics().roundRect(-8, -16, 16, 28, 4).fill(0x21100a));
+  return c;
+}
+
+function avatar(name: string, player = false) {
+  const c = new Container();
+  const aura = player ? 0x00e5ff : 0x39ff14;
+  c.addChild(new Graphics().ellipse(0, 18, 23, 8).fill({ color: 0x02040a, alpha: 0.56 }));
+  c.addChild(new Graphics().ellipse(0, -8, 14, 21).fill(player ? 0x267dff : 0x249a56).stroke({ width: 2, color: aura, alpha: 0.55 }));
+  c.addChild(new Graphics().circle(0, -34, 11).fill(player ? 0xffd8a9 : 0xd4ffd7).stroke({ width: 2, color: aura, alpha: 0.82 }));
+  const label = new Text({ text: name, style: { fontSize: 11, fill: 0xfff0cf, stroke: { color: 0x02030a, width: 3 }, fontFamily: "monospace" } });
+  label.anchor.set(0.5, 1); label.y = -58;
+  c.addChild(label);
+  return c;
+}
+
+function place(node: Container, x: number, z: number, width: number, height: number) {
+  const p = iso(x, z, width, height);
+  node.x = p.x; node.y = p.y; node.zIndex = p.y;
+}
+
+export function CyberZenIsoApp() {
+  const host = useRef<HTMLDivElement>(null);
+  const appRef = useRef<Application | null>(null);
+  const entities = useRef<Map<string, Entity>>(new Map());
+  const clientRef = useRef<ReturnType<typeof createClient> | null>(null);
+  const keys = useRef(new Set<string>());
+  const moveAt = useRef(0);
+  const [connected, setConnected] = useState(false);
+  const [messages, setMessages] = useState<Msg[]>([{ from: "Oracle", txt: "Cyberzen 2.5D shell online." }]);
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => keys.current.add(e.key.toLowerCase());
+    const up = (e: KeyboardEvent) => keys.current.delete(e.key.toLowerCase());
+    addEventListener("keydown", down); addEventListener("keyup", up);
+    return () => { removeEventListener("keydown", down); removeEventListener("keyup", up); };
+  }, []);
+
+  useEffect(() => {
+    if (!host.current || appRef.current) return;
+    const app = new Application();
+    appRef.current = app;
+    app.init({ backgroundAlpha: 0, resizeTo: host.current, antialias: true, autoDensity: true, resolution: Math.min(devicePixelRatio || 1, 2) }).then(() => {
+      host.current!.appendChild(app.canvas);
+      const terrain = new Container(); const props = new Container(); const actors = new Container(); actors.sortableChildren = true;
+      app.stage.addChild(terrain, props, actors);
+      buildScene(app, terrain, props);
+      addActor(app, actors, "self", 0, 0, localStorage.getItem("wasd:2d:name") || "Architect", true);
+      addActor(app, actors, "elder", 2, 1, "Millbrook Elder", false);
+      startNetwork(app, actors);
+      app.ticker.add(() => tick(app, actors));
+    });
+    return () => { clientRef.current?.disconnect(); app.destroy(true); };
+  }, []);
+
+  function buildScene(app: Application, terrain: Container, props: Container) {
+    for (let z = -7; z <= 7; z++) for (let x = -7; x <= 7; x++) {
+      const tile = diamond((x + z) % 4 === 0 ? 0x3f7f48 : 0x356b40);
+      place(tile, x, z, app.screen.width, app.screen.height); terrain.addChild(tile);
+    }
+    [[-4,-2],[4,-3],[-5,3],[5,2]].forEach(([x,z]) => { const t = propTree(); place(t, x, z, app.screen.width, app.screen.height); props.addChild(t); });
+    [[-2,2],[2,2],[0,-4]].forEach(([x,z]) => { const h = propHouse(); place(h, x, z, app.screen.width, app.screen.height); props.addChild(h); });
+  }
+
+  function addActor(app: Application, layer: Container, id: string, x: number, z: number, name: string, player: boolean) {
+    if (entities.current.has(id)) return;
+    const root = avatar(name, player); place(root, x, z, app.screen.width, app.screen.height);
+    layer.addChild(root); entities.current.set(id, { root, tx: x, tz: z });
+  }
+
+  function startNetwork(app: Application, layer: Container) {
+    const c = createClient({ url: "https://arelorian.de", heartbeatInterval: 30000 });
+    clientRef.current = c;
+    c.on("connect" as any, () => { setConnected(true); setMessages(m => [...m.slice(-12), { from: "Net", txt: "World stream connected." }]); });
+    c.on("disconnect" as any, () => setConnected(false));
+    c.on("WORLD_HEARTBEAT", (e: any) => {
+      Object.entries(e.payload?.players || {}).forEach(([id, p]: any) => addActor(app, layer, id, Number(p.x || 0), Number(p.z || 0), p.name || "Player", true));
+      Object.entries(e.payload?.agents || {}).forEach(([id, a]: any) => addActor(app, layer, id, Number(a.x || 0), Number(a.z || 0), a.name || "NPC", false));
+    });
+    c.on("PLAYER_MOVED", (e: any) => { const ent = entities.current.get(e.payload?.playerId); if (ent) { ent.tx = Number(e.payload.x || ent.tx); ent.tz = Number(e.payload.z || ent.tz); } });
+    c.connect();
+  }
+
+  function tick(app: Application, layer: Container) {
+    let dx = 0, dz = 0; const k = keys.current;
+    if (k.has("w") || k.has("arrowup")) dz += 1; if (k.has("s") || k.has("arrowdown")) dz -= 1; if (k.has("a") || k.has("arrowleft")) dx -= 1; if (k.has("d") || k.has("arrowright")) dx += 1;
+    if ((dx || dz) && clientRef.current?.connected && Date.now() - moveAt.current > 140) { moveAt.current = Date.now(); clientRef.current.sendPlayerAction("MOVE", { dx, dz }); }
+    entities.current.forEach((ent) => { const p = iso(ent.tx, ent.tz, app.screen.width, app.screen.height); ent.root.x += (p.x - ent.root.x) * 0.18; ent.root.y += (p.y - ent.root.y) * 0.18; ent.root.zIndex = ent.root.y; });
+    layer.sortChildren();
+  }
+
+  return <div className="az-shell"><div ref={host} className="az-pixi" /><header className="az-top"><div><small>CYBERZEN 2.5D</small><b>Areloria · Millbrook</b></div><span>{connected ? "ONLINE" : "CONNECTING"}</span></header><nav className="az-skills"><button>⚔️<small>Strike</small></button><button>🛡️<small>Guard</small></button><button>✦<small>Aether</small></button><button>☉<small>Talk</small></button></nav><section className="az-chat">{messages.slice(-4).map((m, i) => <p key={i}><b>{m.from}</b> {m.txt}</p>)}</section><footer className="az-hint">WASD move · isometric terrain · proxy sprites ready for real asset swap</footer></div>;
+}

--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { App } from "./App";
 import { CyberZenLoginGate } from "./CyberZenLoginGate";
+import { CyberZenIsoApp } from "./CyberZenIsoApp";
 import "./theme.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <CyberZenLoginGate>
-      <App />
+      <CyberZenIsoApp />
     </CyberZenLoginGate>
   </React.StrictMode>
 );

--- a/apps/client-2d/src/theme.css
+++ b/apps/client-2d/src/theme.css
@@ -5,6 +5,7 @@
   --cz-line: rgba(103, 92, 255, 0.42);
   --cz-aura: #675cff;
   --cz-cyan: #00e5ff;
+  --cz-green: #39ff14;
   --cz-gold: #ffd76a;
   --cz-text: #f4f7ff;
   --cz-muted: rgba(244, 247, 255, 0.66);
@@ -22,6 +23,10 @@ html, body, #root {
     linear-gradient(145deg, #04050a 0%, #080b12 52%, #05060b 100%);
   color: var(--cz-text);
 }
+
+button, input { font: inherit; }
+button { cursor: pointer; }
+canvas { display: block; filter: saturate(1.16) contrast(1.08); }
 
 .cz-login-root {
   min-height: 100%;
@@ -44,98 +49,38 @@ html, body, #root {
   backdrop-filter: blur(18px);
 }
 
-.cz-eyebrow {
-  color: var(--cz-cyan);
-  font-size: 11px;
-  letter-spacing: 0.24em;
-  font-weight: 800;
-}
+.cz-eyebrow { color: var(--cz-cyan); font-size: 11px; letter-spacing: 0.24em; font-weight: 800; }
+.cz-login-card h1 { margin: 12px 0 10px; font-size: clamp(34px, 8vw, 56px); line-height: 0.94; letter-spacing: -0.06em; }
+.cz-login-card p { margin: 0 0 22px; color: var(--cz-muted); line-height: 1.55; }
+.cz-field { display: grid; gap: 8px; color: var(--cz-muted); font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.12em; }
+.cz-field input { border: 1px solid rgba(255,255,255,0.12); border-radius: 16px; padding: 14px 16px; color: var(--cz-text); background: rgba(0,0,0,0.38); outline: none; font-size: 18px; }
+.cz-field input:focus { border-color: var(--cz-cyan); box-shadow: 0 0 0 3px rgba(0,229,255,0.16); }
+.cz-keybox { margin: 14px 0; display: flex; justify-content: space-between; gap: 12px; padding: 12px 14px; border-radius: 16px; border: 1px solid rgba(255,215,106,0.24); background: rgba(255,215,106,0.08); color: var(--cz-muted); }
+.cz-keybox strong { color: var(--cz-gold); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.cz-enter { width: 100%; border: 0; border-radius: 18px; padding: 15px 18px; color: #05060b; background: linear-gradient(135deg, var(--cz-cyan), var(--cz-gold)); font-weight: 950; letter-spacing: 0.08em; text-transform: uppercase; box-shadow: 0 0 24px rgba(0, 229, 255, 0.22); }
+.cz-hints { margin-top: 14px; display: flex; flex-wrap: wrap; gap: 8px; }
+.cz-hints span { border: 1px solid rgba(255,255,255,0.1); border-radius: 999px; padding: 7px 10px; color: var(--cz-muted); background: rgba(255,255,255,0.04); font-size: 12px; }
 
-.cz-login-card h1 {
-  margin: 12px 0 10px;
-  font-size: clamp(34px, 8vw, 56px);
-  line-height: 0.94;
-  letter-spacing: -0.06em;
-}
+.az-shell { position: relative; width: 100%; height: 100%; overflow: hidden; background: radial-gradient(circle at 50% 18%, rgba(0,229,255,.14), transparent 34%), linear-gradient(180deg, #121426 0%, #142318 58%, #07100b 100%); }
+.az-shell::before { content: ""; position: absolute; inset: 0; pointer-events: none; background-image: linear-gradient(rgba(255,255,255,.035) 1px, transparent 1px), linear-gradient(90deg, rgba(0,229,255,.032) 1px, transparent 1px); background-size: 44px 44px; mask-image: radial-gradient(circle at 50% 48%, black 0%, transparent 78%); }
+.az-world-glow { position: absolute; inset: 8% 0 auto; height: 70%; pointer-events: none; background: radial-gradient(ellipse at center, rgba(57,255,20,.10), transparent 62%); filter: blur(18px); }
+.az-pixi { position: absolute; inset: 0; }
+.az-top { position: absolute; top: 14px; left: 14px; right: 14px; z-index: 10; display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 12px 14px; border: 1px solid rgba(0,229,255,.24); border-radius: 18px; background: linear-gradient(135deg, rgba(5,8,14,.82), rgba(10,18,32,.58)); box-shadow: 0 0 28px rgba(0,229,255,.12), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(14px); }
+.az-top small { display: block; color: var(--cz-cyan); letter-spacing: .22em; font-size: 10px; font-weight: 900; }
+.az-top b { display: block; margin-top: 2px; font-size: 16px; color: #fff6d7; }
+.az-top span { border: 1px solid rgba(57,255,20,.34); border-radius: 999px; padding: 8px 12px; color: #d9ffd2; background: rgba(57,255,20,.07); font-size: 12px; font-weight: 900; }
+.az-skills { position: absolute; left: 50%; bottom: 22px; transform: translateX(-50%); z-index: 10; display: flex; gap: 10px; padding: 10px; border: 1px solid rgba(255,215,106,.2); border-radius: 22px; background: rgba(5,8,14,.68); backdrop-filter: blur(14px); }
+.az-skills button { width: 64px; height: 60px; border: 1px solid rgba(0,229,255,.24); border-radius: 16px; color: white; background: linear-gradient(180deg, rgba(0,229,255,.12), rgba(103,92,255,.12)); box-shadow: inset 0 1px 0 rgba(255,255,255,.1); }
+.az-skills span { display: block; font-size: 21px; }
+.az-skills small { display: block; margin-top: 2px; color: rgba(244,247,255,.72); font-size: 9px; }
+.az-chat { position: absolute; left: 14px; bottom: 18px; z-index: 9; width: min(360px, calc(100vw - 28px)); padding: 12px 14px; border: 1px solid rgba(0,229,255,.18); border-radius: 18px; color: rgba(255,255,255,.72); background: rgba(5,8,14,.46); backdrop-filter: blur(10px); font-size: 12px; }
+.az-chat p { margin: 3px 0; }
+.az-chat b { color: var(--cz-gold); }
+.az-hint { position: absolute; right: 18px; bottom: 22px; z-index: 9; color: rgba(255,255,255,.45); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
 
-.cz-login-card p {
-  margin: 0 0 22px;
-  color: var(--cz-muted);
-  line-height: 1.55;
-}
-
-.cz-field {
-  display: grid;
-  gap: 8px;
-  color: var(--cz-muted);
-  font-size: 12px;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-}
-
-.cz-field input {
-  border: 1px solid rgba(255,255,255,0.12);
-  border-radius: 16px;
-  padding: 14px 16px;
-  color: var(--cz-text);
-  background: rgba(0,0,0,0.38);
-  outline: none;
-  font-size: 18px;
-}
-
-.cz-field input:focus {
-  border-color: var(--cz-cyan);
-  box-shadow: 0 0 0 3px rgba(0,229,255,0.16);
-}
-
-.cz-keybox {
-  margin: 14px 0;
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 16px;
-  border: 1px solid rgba(255,215,106,0.24);
-  background: rgba(255,215,106,0.08);
-  color: var(--cz-muted);
-}
-
-.cz-keybox strong {
-  color: var(--cz-gold);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-.cz-enter {
-  width: 100%;
-  border: 0;
-  border-radius: 18px;
-  padding: 15px 18px;
-  color: #05060b;
-  background: linear-gradient(135deg, var(--cz-cyan), var(--cz-gold));
-  font-weight: 950;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  box-shadow: 0 0 24px rgba(0, 229, 255, 0.22);
-}
-
-.cz-hints {
-  margin-top: 14px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.cz-hints span {
-  border: 1px solid rgba(255,255,255,0.1);
-  border-radius: 999px;
-  padding: 7px 10px;
-  color: var(--cz-muted);
-  background: rgba(255,255,255,0.04);
-  font-size: 12px;
-}
-
-canvas {
-  display: block;
-  filter: saturate(1.08) contrast(1.04);
+@media (max-width: 820px) {
+  .az-top { align-items: flex-start; }
+  .az-skills { bottom: 16px; right: 12px; left: auto; transform: none; flex-direction: column; }
+  .az-chat { bottom: 16px; width: calc(100vw - 116px); }
+  .az-hint { display: none; }
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,1 +1,5 @@
-// Neue Datei
+// The production 3D browser client boots from client/src/main.ts.
+// client/index.html intentionally points to /src/main.ts because the Babylon runtime
+// is an imperative canvas app, not a React root. Keep this file as a guard note so
+// future agents do not patch the wrong entrypoint while chasing Cyberzen UI issues.
+export {};

--- a/portal/src/app/globals.css
+++ b/portal/src/app/globals.css
@@ -2,6 +2,53 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  @apply bg-slate-900 text-white font-sans;
+:root {
+  color-scheme: dark;
+  --cz-bg: #05060b;
+  --cz-panel: rgba(9, 13, 24, 0.72);
+  --cz-cyan: #00e5ff;
+  --cz-violet: #675cff;
+  --cz-gold: #ffd76a;
+  --cz-green: #39ff14;
+}
+
+html, body, #root { min-height: 100%; margin: 0; background: var(--cz-bg); }
+body { @apply text-white font-sans; }
+button { font: inherit; }
+
+.cz-portal-shell {
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  padding: 28px;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(0,229,255,.16), transparent 30%),
+    radial-gradient(circle at 84% 12%, rgba(103,92,255,.22), transparent 34%),
+    radial-gradient(circle at 62% 80%, rgba(255,215,106,.12), transparent 32%),
+    linear-gradient(145deg, #04050a, #07101b 52%, #05060b);
+}
+.cz-portal-grid { position: fixed; inset: 0; pointer-events: none; background-image: linear-gradient(rgba(255,255,255,.035) 1px, transparent 1px), linear-gradient(90deg, rgba(0,229,255,.045) 1px, transparent 1px); background-size: 44px 44px; mask-image: radial-gradient(circle at center, black, transparent 78%); }
+.cz-portal-header { position: relative; z-index: 1; display: flex; justify-content: space-between; align-items: center; gap: 20px; margin-bottom: 28px; padding: 18px 20px; border: 1px solid rgba(0,229,255,.24); border-radius: 28px; background: rgba(5,8,14,.62); box-shadow: 0 0 34px rgba(0,229,255,.13), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(18px); }
+.cz-portal-eyebrow { margin: 0 0 8px; color: var(--cz-cyan); font-size: 11px; font-weight: 900; letter-spacing: .26em; text-transform: uppercase; }
+.cz-portal-header h1 { margin: 0; font-size: clamp(32px, 6vw, 72px); line-height: .9; letter-spacing: -.07em; }
+.cz-live-pill, .cz-back-button { border: 1px solid rgba(57,255,20,.32); border-radius: 999px; padding: 10px 14px; color: #d9ffd2; background: rgba(57,255,20,.07); font-weight: 900; }
+.cz-live-pill span { display: inline-block; width: 9px; height: 9px; margin-right: 8px; border-radius: 50%; background: var(--cz-green); box-shadow: 0 0 14px var(--cz-green); }
+.cz-back-button { border-color: rgba(0,229,255,.34); color: #e7fbff; background: rgba(0,229,255,.08); }
+.cz-portal-main { position: relative; z-index: 1; display: grid; gap: 24px; grid-template-columns: minmax(280px, 420px) 1fr; align-items: start; }
+.cz-hero-card, .cz-module-card, .cz-app-stage { border: 1px solid rgba(0,229,255,.2); border-radius: 28px; background: linear-gradient(135deg, rgba(9,13,24,.82), rgba(9,13,24,.46)); box-shadow: 0 22px 80px rgba(0,0,0,.42), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(18px); }
+.cz-hero-card { padding: 26px; }
+.cz-hero-card h2 { margin: 0 0 14px; font-size: clamp(32px, 5vw, 54px); letter-spacing: -.055em; line-height: .94; }
+.cz-hero-card p:last-child { margin: 0; color: rgba(244,247,255,.68); line-height: 1.65; }
+.cz-module-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 16px; }
+.cz-module-card { min-height: 172px; padding: 20px; text-align: left; color: white; transition: transform .16s ease, border-color .16s ease, box-shadow .16s ease; }
+.cz-module-card:hover { transform: translateY(-3px); border-color: rgba(255,215,106,.48); box-shadow: 0 0 34px rgba(255,215,106,.16), 0 22px 80px rgba(0,0,0,.42); }
+.cz-module-sigil { display: grid; place-items: center; width: 46px; height: 46px; margin-bottom: 18px; border-radius: 16px; background: linear-gradient(135deg, rgba(0,229,255,.14), rgba(103,92,255,.18)); border: 1px solid rgba(0,229,255,.28); color: var(--cz-gold); font-size: 22px; }
+.cz-module-card strong { display: block; font-size: 20px; }
+.cz-module-card small { display: block; margin-top: 8px; color: rgba(244,247,255,.62); line-height: 1.5; }
+.cz-app-stage { position: relative; z-index: 1; padding: 18px; overflow: hidden; }
+
+@media (max-width: 900px) {
+  .cz-portal-shell { padding: 16px; }
+  .cz-portal-header { align-items: flex-start; flex-direction: column; }
+  .cz-portal-main { grid-template-columns: 1fr; }
 }

--- a/portal/src/index.tsx
+++ b/portal/src/index.tsx
@@ -7,20 +7,20 @@ const App = () => {
   const [activeApp, setActiveApp] = useState<string | null>(null);
 
   const appsList = [
-    { id: 'robot-arm', name: 'Robot Arm', component: Apps.RobotArm },
-    { id: 'medical-console', name: 'Medical Console', component: Apps.MedicalConsole },
-    { id: 'logistics', name: 'Logistics Hub', component: Apps.LogisticsHub },
-    { id: 'school-portal', name: 'School Portal', component: Apps.SchoolPortal },
-    { id: 'logic-grid', name: 'Logic Grid', component: Apps.LogicGrid },
-    { id: 'science-portal', name: 'Science Portal', component: Apps.SciencePortal },
-    { id: 'agri-sim', name: 'Agri-Sim', component: Apps.AgriSim },
-    { id: 'urban-flow', name: 'Urban Flow', component: Apps.UrbanFlow },
-    { id: 'fitness', name: 'Fitness', component: Apps.FitnessTracker },
-    { id: 'crypto-pulse', name: 'Crypto Pulse', component: Apps.CryptoPulse },
-    { id: 'eco-trader', name: 'Eco-Trader', component: Apps.EcoTrader },
-    { id: 'social', name: 'Social Hub', component: Apps.SocialHub },
-    { id: 'arena', name: 'Arena', component: Apps.Arena },
-    { id: 'edu-sim', name: 'Edu-Sim', component: Apps.EduSim },
+    { id: 'robot-arm', name: 'Robot Arm', component: Apps.RobotArm, sigil: '⚙️', tone: 'Forge automation and precision motion' },
+    { id: 'medical-console', name: 'Medical Console', component: Apps.MedicalConsole, sigil: '✚', tone: 'Vital signs, triage and recovery loops' },
+    { id: 'logistics', name: 'Logistics Hub', component: Apps.LogisticsHub, sigil: '◇', tone: 'Route pressure and cargo resonance' },
+    { id: 'school-portal', name: 'School Portal', component: Apps.SchoolPortal, sigil: '⌘', tone: 'Learning gates and curriculum flows' },
+    { id: 'logic-grid', name: 'Logic Grid', component: Apps.LogicGrid, sigil: '▦', tone: 'Axiom lattice and deterministic checks' },
+    { id: 'science-portal', name: 'Science Portal', component: Apps.SciencePortal, sigil: '∴', tone: 'Experiment telemetry and ARE probes' },
+    { id: 'agri-sim', name: 'Agri-Sim', component: Apps.AgriSim, sigil: '🌿', tone: 'Biome yields and village supply' },
+    { id: 'urban-flow', name: 'Urban Flow', component: Apps.UrbanFlow, sigil: '▣', tone: 'Town layout, roads and civic rhythm' },
+    { id: 'fitness', name: 'Fitness', component: Apps.FitnessTracker, sigil: '⟁', tone: 'Body metrics and stamina economy' },
+    { id: 'crypto-pulse', name: 'Crypto Pulse', component: Apps.CryptoPulse, sigil: '◈', tone: 'Market signal and treasury pulse' },
+    { id: 'eco-trader', name: 'Eco-Trader', component: Apps.EcoTrader, sigil: '♻', tone: 'Trade pressure and circular goods' },
+    { id: 'social', name: 'Social Hub', component: Apps.SocialHub, sigil: '☉', tone: 'Guild presence and messenger net' },
+    { id: 'arena', name: 'Arena', component: Apps.Arena, sigil: '⚔', tone: 'Combat lobby and challenge board' },
+    { id: 'edu-sim', name: 'Edu-Sim', component: Apps.EduSim, sigil: '✦', tone: 'Scenario trainer and playbook engine' },
   ];
 
   const renderActiveApp = () => {
@@ -31,36 +31,39 @@ const App = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-900 text-white p-8">
-      <header className="mb-8 flex justify-between items-center">
-        <h1 className="text-3xl font-bold text-cyan-400">ARE-Logic Portal</h1>
-        {activeApp && (
-          <button
-            onClick={() => setActiveApp(null)}
-            className="px-4 py-2 bg-slate-800 rounded hover:bg-slate-700 transition-colors"
-          >
-            ← Back to Portal
-          </button>
+    <div className="cz-portal-shell">
+      <div className="cz-portal-grid" />
+      <header className="cz-portal-header">
+        <div>
+          <p className="cz-portal-eyebrow">CYBERZEN COMMAND BRIDGE · ARE-LOGIC</p>
+          <h1>{activeApp ? appsList.find((a) => a.id === activeApp)?.name : 'Areloria Portal'}</h1>
+        </div>
+        {activeApp ? (
+          <button onClick={() => setActiveApp(null)} className="cz-back-button">← Back to Bridge</button>
+        ) : (
+          <div className="cz-live-pill"><span /> 10Hz visual layer online</div>
         )}
       </header>
 
       {!activeApp ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {appsList.map(app => (
-            <div
-              key={app.id}
-              onClick={() => setActiveApp(app.id)}
-              className="bg-slate-800 p-6 rounded-xl cursor-pointer hover:bg-slate-700 hover:ring-2 hover:ring-cyan-500 transition-all"
-            >
-              <h2 className="text-xl font-bold">{app.name}</h2>
-              <p className="text-sm text-slate-400 mt-2">Click to launch module</p>
-            </div>
-          ))}
-        </div>
+        <main className="cz-portal-main">
+          <section className="cz-hero-card">
+            <p className="cz-portal-eyebrow">Visual Contract</p>
+            <h2>No more flat slate grid.</h2>
+            <p>Portal modules now sit in the same Cyberzen art direction as the 2D and 3D clients: glass panels, neon borders, fantasy-tech naming and operational module cards.</p>
+          </section>
+          <section className="cz-module-grid">
+            {appsList.map(app => (
+              <button key={app.id} onClick={() => setActiveApp(app.id)} className="cz-module-card">
+                <span className="cz-module-sigil">{app.sigil}</span>
+                <strong>{app.name}</strong>
+                <small>{app.tone}</small>
+              </button>
+            ))}
+          </section>
+        </main>
       ) : (
-        <div className="mt-8">
-          {renderActiveApp()}
-        </div>
+        <main className="cz-app-stage">{renderActiveApp()}</main>
       )}
     </div>
   );


### PR DESCRIPTION
Applies the missing Cyberzen visual pass across the visible clients.

Changes:
- Adds a new Pixi-based CyberZenIsoApp for the 2D client with isometric terrain, houses, trees, avatar silhouettes, neon HUD, skillbar and chat glass.
- Mounts CyberZenIsoApp behind the existing CyberZen login gate.
- Replaces the old 2D flat rectangle look with an isometric 2.5D fantasy-tech scene.
- Reworks portal layout from plain slate module grid to a Cyberzen command bridge.
- Adds CSS for portal and 2D Cyberzen art direction.
- Documents that the real 3D Babylon entrypoint is client/src/main.ts, not client/src/main.tsx.

This does not add final production sprite/GLB art assets yet, but removes the flat kindergarten placeholder look and gives 2D/portal a coherent Cyberzen 2.5D visual layer.