### PR TITLE
chore(deploy): trigger VPS deploy after Cyberzen UI pass

### DIFF
--- a/server/src/deployTrigger.cyberzen.ts
+++ b/server/src/deployTrigger.cyberzen.ts
@@ -1,0 +1,1 @@
+export const CYBERZEN_UI_DEPLOY_TRIGGER = "2026-05-19-cyberzen-25d";


### PR DESCRIPTION
Forces the existing VPS Docker Deploy workflow to run after the Cyberzen 2.5D UI pass.

Why:
- PR #868 changed UI/frontend paths only.
- The current VPS deploy workflow path filter does not include those UI paths.
- Direct main pushes are blocked by repository rules.

This marker lives under server/**, which is already covered by the current workflow path filter. After merge, the deploy workflow should appear and deploy current main, including the Cyberzen visual changes already merged in #868.

Follow-up recommended: add a dedicated frontend deploy workflow or expand path filters safely so UI changes do not need marker commits.