### PR TITLE
fix(workflow): dispatch VPS Docker deploy for deploy script changes

### DIFF
--- a/.github/workflows/deploy-change-dispatch.yml
+++ b/.github/workflows/deploy-change-dispatch.yml
@@ -1,0 +1,37 @@
+name: Dispatch VPS Docker Deploy for deploy changes
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'deploy/**'
+      - '.github/workflows/deploy-change-dispatch.yml'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: deploy-change-dispatch-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch VPS Docker Deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching VPS Docker Deploy (monorepo) after deploy script change..."
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/actions/workflows/vps-docker-deploy.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"reason":"deploy script changed","arelorian_port":"3001","docker_network":"areloria_arelorian-network"}}'
+          echo "Dispatch requested."


### PR DESCRIPTION
Adds a small dispatcher workflow for deploy script changes.

Why:
- vps-docker-deploy.yml intentionally filters frontend pushes.
- PR #870 changed deploy/update.sh, which is not watched by the Docker deploy workflow.
- This dispatcher watches deploy/** and calls workflow_dispatch on vps-docker-deploy.yml.

This avoids broadening the heavy Docker deploy path filter to all frontend changes while still deploying deploy-script fixes automatically.