### PR TITLE
chore(deploy): request route bundle redeploy

### DIFF
--- a/deploy/notes/route-bundle-redeploy.md
+++ b/deploy/notes/route-bundle-redeploy.md
@@ -1,0 +1,12 @@
+# Route Bundle Redeploy
+
+Purpose: request a fresh VPS Docker deployment after the Docker runtime image was updated to include the 2D, 3D, and Portal route bundles.
+
+Expected runtime contents after deployment:
+
+- /app/client/dist/index.html
+- /app/client/dist/2d/index.html
+- /app/client/dist/3d/index.html
+- /app/client/dist/portal/index.html
+
+Timestamp: 2026-05-19T02:45:00+02:00


### PR DESCRIPTION
Small deploy-note change under deploy/** to trigger the deploy-change dispatcher.

Purpose:
- force a fresh VPS Docker Deploy after Dockerfile.vps was fixed to package /2d/, /3d/, and /portal/ bundles into the runtime image.

No runtime code changes.