### PR TITLE
feat(core): restore 10hz collective gate identity

### DIFF
--- a/apps/client-2d/src/CyberZenLoginGate.tsx
+++ b/apps/client-2d/src/CyberZenLoginGate.tsx
@@ -2,25 +2,88 @@ import React, { useMemo, useState } from "react";
 
 interface Props { children: React.ReactNode }
 
-function makePublicKey(seed: string): string {
-  let h = 2166136261;
-  for (let i = 0; i < seed.length; i += 1) {
-    h ^= seed.charCodeAt(i);
-    h = Math.imul(h, 16777619) >>> 0;
+type Role = "Scavenger" | "Trader" | "Guardian" | "Oracle" | "Builder" | "Warden";
+
+interface GateIdentity {
+  handle: string;
+  publicKey: string;
+  role: Role;
+  tick: number;
+  phase: number;
+  spawn: { chunkX: number; chunkY: number; x: number; y: number };
+  loadout: string[];
+  identityHash: string;
+}
+
+const ROLES: Role[] = ["Scavenger", "Trader", "Guardian", "Oracle", "Builder", "Warden"];
+const LOADOUTS: Record<Role, string[]> = {
+  Scavenger: ["rusted_blade", "scrap_satchel", "echo_ration"],
+  Trader: ["ledger_tablet", "trade_token", "travel_cloak"],
+  Guardian: ["training_spear", "ward_shield", "iron_ration"],
+  Oracle: ["signal_lens", "echo_charm", "night_ink"],
+  Builder: ["layout_compass", "stone_marker", "road_string"],
+  Warden: ["sentinel_key", "ward_torch", "civic_badge"],
+};
+
+function stableHash(parts: Array<string | number>): string {
+  let h1 = 0x811c9dc5;
+  let h2 = 0x9e3779b9;
+  const payload = parts.join("|");
+  for (let i = 0; i < payload.length; i += 1) {
+    const code = payload.charCodeAt(i);
+    h1 ^= code;
+    h1 = Math.imul(h1, 0x01000193) >>> 0;
+    h2 ^= code + i;
+    h2 = Math.imul(h2, 0x85ebca6b) >>> 0;
   }
-  return `are-${h.toString(16).padStart(8, "0")}`;
+  const a = h1.toString(16).padStart(8, "0");
+  const b = h2.toString(16).padStart(8, "0");
+  return `${a}${b}${b}${a}${a}${b}${b}${a}`.slice(0, 64);
+}
+
+function hashInt(hash: string, offset: number, modulo: number): number {
+  return Number.parseInt(hash.slice(offset, offset + 8).padEnd(8, "0"), 16) % modulo;
+}
+
+function deriveIdentity(handleRaw: string): GateIdentity {
+  const handle = (handleRaw || "architect").trim().replace(/\s+/g, "-").toLowerCase().slice(0, 48) || "architect";
+  const tick = Math.floor(performance.now() / 100);
+  const phase = tick % 10;
+  const kappa = 1000;
+  const worldSeed = "ARELORIA|COLLECTIVE|ALPHA";
+  const identityHash = stableHash(["ARE_COLLECTIVE_GATE", worldSeed, handle, tick, phase, kappa]);
+  const role = ROLES[hashInt(identityHash, 0, ROLES.length)];
+  return {
+    handle,
+    publicKey: `are-${identityHash.slice(0, 8)}-${identityHash.slice(8, 16)}-${phase}`,
+    role,
+    tick,
+    phase,
+    spawn: {
+      chunkX: hashInt(identityHash, 8, 32) - 16,
+      chunkY: hashInt(identityHash, 16, 32) - 16,
+      x: hashInt(identityHash, 24, 64),
+      y: hashInt(identityHash, 32, 64),
+    },
+    loadout: LOADOUTS[role],
+    identityHash,
+  };
 }
 
 export function CyberZenLoginGate({ children }: Props): React.ReactElement {
   const [name, setName] = useState(() => localStorage.getItem("wasd:2d:name") ?? "Thomas");
   const [entered, setEntered] = useState(() => localStorage.getItem("wasd:2d:entered") === "1");
-  const publicKey = useMemo(() => makePublicKey(name.trim() || "architect"), [name]);
+  const identity = useMemo(() => deriveIdentity(name), [name]);
 
   if (entered) return <>{children}</>;
 
   function enter(): void {
-    localStorage.setItem("wasd:2d:name", name.trim() || "Architect");
-    localStorage.setItem("wasd:2d:publicKey", publicKey);
+    localStorage.setItem("wasd:2d:name", identity.handle);
+    localStorage.setItem("wasd:2d:publicKey", identity.publicKey);
+    localStorage.setItem("wasd:2d:role", identity.role);
+    localStorage.setItem("wasd:2d:identityHash", identity.identityHash);
+    localStorage.setItem("wasd:2d:spawn", JSON.stringify(identity.spawn));
+    localStorage.setItem("wasd:2d:loadout", JSON.stringify(identity.loadout));
     localStorage.setItem("wasd:2d:entered", "1");
     setEntered(true);
   }
@@ -28,16 +91,22 @@ export function CyberZenLoginGate({ children }: Props): React.ReactElement {
   return (
     <main className="cz-login-root">
       <section className="cz-login-card">
-        <div className="cz-eyebrow">ARELORIA WASD · 2D PIXI CLIENT</div>
+        <div className="cz-eyebrow">ARELORIA WASD · SOVEREIGN 10HZ GATE</div>
         <h1>Cyber-Zen Gateway</h1>
-        <p>Deterministischer Einstieg fuer den Browser-Client. Public-Key, Rolle und UI-Aura werden lokal stabil erzeugt.</p>
+        <p>
+          Deterministischer Einstieg ohne klassische Nutzerdaten. Dein Public-Key, deine Rolle, Spawn-Position und
+          Startausrüstung entstehen aus Handle, Kappa=1000 und der aktuellen 10-Hz-Tickphase.
+        </p>
         <label className="cz-field">
           <span>Architect Handle</span>
           <input value={name} onChange={(event) => setName(event.target.value)} autoComplete="nickname" />
         </label>
-        <div className="cz-keybox"><span>Public-Key</span><strong>{publicKey}</strong></div>
+        <div className="cz-keybox"><span>Public-Key</span><strong>{identity.publicKey}</strong></div>
+        <div className="cz-keybox"><span>Role</span><strong>{identity.role}</strong></div>
+        <div className="cz-keybox"><span>10-Hz Tick</span><strong>{identity.tick} · phase {identity.phase}/9</strong></div>
+        <div className="cz-keybox"><span>Spawn</span><strong>{identity.spawn.chunkX}:{identity.spawn.chunkY} · {identity.spawn.x},{identity.spawn.y}</strong></div>
         <button className="cz-enter" type="button" onClick={enter}>Collective betreten</button>
-        <div className="cz-hints"><span>Mobile Joystick</span><span>Chat Panel</span><span>10-Hz UI Pulse</span></div>
+        <div className="cz-hints"><span>Kappa 1000</span><span>Hash Identity</span><span>10-Hz Seed</span></div>
       </section>
     </main>
   );

--- a/packages/core-logic/src/identity/SovereignIdentity.ts
+++ b/packages/core-logic/src/identity/SovereignIdentity.ts
@@ -1,0 +1,90 @@
+export type CollectiveRole = 'Scavenger' | 'Trader' | 'Guardian' | 'Oracle' | 'Builder' | 'Warden';
+
+export interface CollectiveGateInput {
+  handle: string;
+  worldSeed?: string;
+  tick: number;
+  kappa?: number;
+}
+
+export interface CollectiveIdentity {
+  handle: string;
+  publicKey: string;
+  role: CollectiveRole;
+  deterministicSeed: string;
+  tick: number;
+  kappa: 1000;
+  spawn: {
+    chunkX: number;
+    chunkY: number;
+    x: number;
+    y: number;
+  };
+  starterLoadout: string[];
+  identityHash: string;
+}
+
+const ROLES: CollectiveRole[] = ['Scavenger', 'Trader', 'Guardian', 'Oracle', 'Builder', 'Warden'];
+const LOADOUTS: Record<CollectiveRole, string[]> = {
+  Scavenger: ['rusted_blade', 'scrap_satchel', 'echo_ration'],
+  Trader: ['ledger_tablet', 'trade_token', 'travel_cloak'],
+  Guardian: ['training_spear', 'ward_shield', 'iron_ration'],
+  Oracle: ['signal_lens', 'echo_charm', 'night_ink'],
+  Builder: ['layout_compass', 'stone_marker', 'road_string'],
+  Warden: ['sentinel_key', 'ward_torch', 'civic_badge'],
+};
+
+export function stableIdentityHash(parts: Array<string | number | boolean | null | undefined>): string {
+  let h1 = 0x811c9dc5;
+  let h2 = 0x9e3779b9;
+  const payload = parts.map((part) => String(part ?? '')).join('|');
+  for (let i = 0; i < payload.length; i += 1) {
+    const code = payload.charCodeAt(i);
+    h1 ^= code;
+    h1 = Math.imul(h1, 0x01000193) >>> 0;
+    h2 ^= code + i;
+    h2 = Math.imul(h2, 0x85ebca6b) >>> 0;
+  }
+  const a = h1.toString(16).padStart(8, '0');
+  const b = h2.toString(16).padStart(8, '0');
+  return `${a}${b}${b}${a}${a}${b}${b}${a}`.slice(0, 64);
+}
+
+function hashInt(hash: string, offset: number, modulo: number): number {
+  const value = Number.parseInt(hash.slice(offset, offset + 8).padEnd(8, '0'), 16);
+  return modulo <= 0 ? value : value % modulo;
+}
+
+export function normalizeCollectiveHandle(handle: string): string {
+  return (handle || 'architect').trim().replace(/\s+/g, '-').toLowerCase().slice(0, 48) || 'architect';
+}
+
+export function deriveCollectiveIdentity(input: CollectiveGateInput): CollectiveIdentity {
+  const handle = normalizeCollectiveHandle(input.handle);
+  const kappa = input.kappa ?? 1000;
+  if (kappa !== 1000) throw new Error(`Collective identity requires kappa === 1000, got ${kappa}`);
+
+  const tick = Math.max(0, Math.trunc(input.tick));
+  const worldSeed = input.worldSeed ?? 'ARELORIA|COLLECTIVE|ALPHA';
+  const tickPhase10Hz = tick % 10;
+  const identityHash = stableIdentityHash(['ARE_COLLECTIVE_GATE', worldSeed, handle, tick, tickPhase10Hz, kappa]);
+  const role = ROLES[hashInt(identityHash, 0, ROLES.length)];
+  const chunkX = hashInt(identityHash, 8, 32) - 16;
+  const chunkY = hashInt(identityHash, 16, 32) - 16;
+  const x = hashInt(identityHash, 24, 64);
+  const y = hashInt(identityHash, 32, 64);
+  const publicKey = `are-${identityHash.slice(0, 8)}-${identityHash.slice(8, 16)}-${tickPhase10Hz}`;
+  const deterministicSeed = stableIdentityHash(['ARE_IDENTITY_SEED', identityHash, role, chunkX, chunkY]);
+
+  return {
+    handle,
+    publicKey,
+    role,
+    deterministicSeed,
+    tick,
+    kappa: 1000,
+    spawn: { chunkX, chunkY, x, y },
+    starterLoadout: LOADOUTS[role],
+    identityHash,
+  };
+}

--- a/packages/core-logic/src/index.ts
+++ b/packages/core-logic/src/index.ts
@@ -2,5 +2,6 @@ export * from './agent/Orchestrator';
 export * from './are/AREInvariantGuard';
 export * from './destiny/SovereignDestinyEngine';
 export * from './epoch/SovereignEpochs';
+export * from './identity/SovereignIdentity';
 export * from './loot';
 export * from './react/OuroborosPulseView';


### PR DESCRIPTION
Restores the deterministic collective gate identity layer.

Changes:
- adds packages/core-logic/src/identity/SovereignIdentity.ts
- exports the identity module from @wasd/core-logic root
- upgrades apps/client-2d CyberZenLoginGate from name-only FNV key to a 10-Hz collective gate:
  - kappa fixed at 1000
  - publicKey derived from handle + worldSeed + tick phase
  - deterministic role
  - deterministic spawn chunk/tile
  - deterministic starter loadout
  - identityHash persisted to localStorage

This does not use user accounts or passwords; it restores the hash/key-based entrance concept.