### PR TITLE
fix(core): publish collective gate identity entrypoint

### DIFF
--- a/packages/core-logic/package.json
+++ b/packages/core-logic/package.json
@@ -28,6 +28,11 @@
       "import": "./dist/epoch/SovereignEpochs.js",
       "require": "./dist/epoch/SovereignEpochs.js"
     },
+    "./identity/SovereignIdentity": {
+      "types": "./dist/identity/SovereignIdentity.d.ts",
+      "import": "./dist/identity/SovereignIdentity.js",
+      "require": "./dist/identity/SovereignIdentity.js"
+    },
     "./loot": {
       "types": "./dist/loot/index.d.ts",
       "import": "./dist/loot/index.js",
@@ -44,9 +49,9 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --dts --clean --external react",
-    "build:runtime": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --clean --external react",
-    "dev": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --watch --dts --external react",
+    "build": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/identity/SovereignIdentity.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --dts --clean --external react",
+    "build:runtime": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/identity/SovereignIdentity.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --clean --external react",
+    "dev": "tsup src/index.ts src/are/AREInvariantGuard.ts src/destiny/SovereignDestinyEngine.ts src/epoch/SovereignEpochs.ts src/identity/SovereignIdentity.ts src/loot/index.ts src/react/OuroborosPulseView.tsx --format cjs,esm --watch --dts --external react",
     "test": "vitest run --passWithNoTests",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Fixes the SDK packaging for the restored 10-Hz collective gate identity module.

Problem:
- SovereignIdentity.ts existed and was exported from src/index.ts.
- But package.json did not expose ./identity/SovereignIdentity.
- The tsup build entries also did not include src/identity/SovereignIdentity.ts.

Result:
- @wasd/core-logic/identity/SovereignIdentity is now a proper package export.
- build, build:runtime and dev include the identity module.