### PR TITLE
fix(finance): harden PayPal crediting runtime

### DIFF
--- a/server/src/api/financeRoute.ts
+++ b/server/src/api/financeRoute.ts
@@ -1,0 +1,52 @@
+import { Router } from "express";
+import { paypalAdapter } from "../finance/PayPalAdapter.js";
+
+export function financeRouter(): Router {
+  const router = Router();
+
+  router.get("/status", (_req, res) => {
+    res.json({
+      ok: true,
+      paypal: {
+        configured: Boolean(process.env.PAYPAL_CLIENT_ID && process.env.PAYPAL_SECRET),
+        environment: process.env.PAYPAL_ENV || "sandbox",
+        currency: process.env.PAYPAL_CURRENCY || "EUR",
+      },
+    });
+  });
+
+  router.post("/paypal/checkout", async (req, res) => {
+    try {
+      const clientId = String(req.body?.clientId || process.env.ARE_SDK_CLIENT_ID || "local-engine");
+      const displayName = String(req.body?.displayName || clientId);
+      const credits = Number(req.body?.credits ?? 0);
+      const returnUrl = req.body?.returnUrl ? String(req.body.returnUrl) : undefined;
+      const cancelUrl = req.body?.cancelUrl ? String(req.body.cancelUrl) : undefined;
+      const result = await paypalAdapter.createCheckoutLink({ clientId, displayName, credits, returnUrl, cancelUrl });
+      res.json(result);
+    } catch (error) {
+      res.status(400).json({ ok: false, error: error instanceof Error ? error.message : "paypal_checkout_failed" });
+    }
+  });
+
+  router.post("/paypal/verify", async (req, res) => {
+    try {
+      const transactionId = String(req.body?.transactionId || req.body?.orderId || "");
+      const result = await paypalAdapter.creditVerifiedTransaction(transactionId);
+      res.status(result.ok ? 200 : 400).json(result);
+    } catch (error) {
+      res.status(400).json({ ok: false, error: error instanceof Error ? error.message : "paypal_verify_failed" });
+    }
+  });
+
+  router.post("/paypal/webhook", async (req, res) => {
+    try {
+      const result = await paypalAdapter.handleWebhook(req);
+      res.status(result.ok || result.status === "ignored" ? 200 : 400).json(result);
+    } catch (error) {
+      res.status(400).json({ ok: false, error: error instanceof Error ? error.message : "paypal_webhook_failed" });
+    }
+  });
+
+  return router;
+}

--- a/server/src/finance/PayPalAdapter.ts
+++ b/server/src/finance/PayPalAdapter.ts
@@ -1,4 +1,5 @@
 import type { Request } from "express";
+import { createHash } from "node:crypto";
 import { SovereignBillingBridge } from "../market/SovereignBillingBridge.js";
 
 export interface PayPalCheckoutRequest {
@@ -33,6 +34,13 @@ function normalizeCredits(raw: unknown): number {
   return Math.floor(credits * 1000) / 1000;
 }
 
+function stableRequestId(input: PayPalCheckoutRequest, credits: number): string {
+  return createHash("sha256")
+    .update(["ARE_PAYPAL_CHECKOUT", input.clientId, input.displayName || input.clientId, credits, input.returnUrl || "", input.cancelUrl || ""].join("|"))
+    .digest("hex")
+    .slice(0, 24);
+}
+
 async function getPayPalAccessToken(): Promise<string> {
   const clientId = requireEnv("PAYPAL_CLIENT_ID");
   const secret = requireEnv("PAYPAL_SECRET");
@@ -52,6 +60,8 @@ async function getPayPalAccessToken(): Promise<string> {
 }
 
 export class PayPalAdapter {
+  private readonly creditedTransactions = new Set<string>();
+
   async createCheckoutLink(input: PayPalCheckoutRequest): Promise<{ ok: true; orderId: string; approvalUrl: string; credits: number }> {
     const credits = normalizeCredits(input.credits);
     if (!input.clientId || credits <= 0) throw new Error("clientId and positive credits are required.");
@@ -63,7 +73,7 @@ export class PayPalAdapter {
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
-        "PayPal-Request-Id": `are-${input.clientId}-${credits}-${Date.now()}`,
+        "PayPal-Request-Id": `are-${stableRequestId(input, credits)}`,
       },
       body: JSON.stringify({
         intent: "CAPTURE",
@@ -113,22 +123,33 @@ export class PayPalAdapter {
     };
   }
 
-  async handleWebhook(req: Request): Promise<PayPalVerificationResult & { credited?: boolean; account?: unknown }> {
+  async creditVerifiedTransaction(transactionId: string): Promise<PayPalVerificationResult & { credited: boolean; duplicate: boolean; account?: unknown }> {
+    const verified = await this.verifyTransaction(transactionId);
+    if (!verified.ok || !verified.clientId || verified.credits <= 0 || !verified.transactionId) {
+      return { ...verified, credited: false, duplicate: false };
+    }
+    if (this.creditedTransactions.has(verified.transactionId)) {
+      return { ...verified, credited: false, duplicate: true, message: "PayPal transaction already credited." };
+    }
+    this.creditedTransactions.add(verified.transactionId);
+    const account = SovereignBillingBridge.addCredits(verified.clientId, verified.credits, verified.displayName || verified.clientId);
+    return {
+      ...verified,
+      credited: true,
+      duplicate: false,
+      account,
+      message: "Architekt, externe Ressourcen wurden erfolgreich in Kausalitäts-Credits umgewandelt. Systemstatus: Operational.",
+    };
+  }
+
+  async handleWebhook(req: Request): Promise<PayPalVerificationResult & { credited?: boolean; duplicate?: boolean; account?: unknown }> {
     const event = req.body ?? {};
     const eventType = String(event.event_type || "");
     const transactionId = String(event.resource?.supplementary_data?.related_ids?.order_id || event.resource?.id || event.resource?.invoice_id || "");
     if (!eventType.includes("CHECKOUT") && !eventType.includes("PAYMENT")) {
       return { ok: false, transactionId: transactionId || null, clientId: null, displayName: null, credits: 0, status: eventType || "ignored", message: "Webhook event ignored." };
     }
-    const verified = await this.verifyTransaction(transactionId);
-    if (!verified.ok || !verified.clientId || verified.credits <= 0) return verified;
-    const account = SovereignBillingBridge.addCredits(verified.clientId, verified.credits, verified.displayName || verified.clientId);
-    return {
-      ...verified,
-      credited: true,
-      account,
-      message: "Architekt, externe Ressourcen wurden erfolgreich in Kausalitäts-Credits umgewandelt. Systemstatus: Operational.",
-    };
+    return this.creditVerifiedTransaction(transactionId);
   }
 }
 


### PR DESCRIPTION
Hardens the existing PayPal/ARE-Credit runtime path.

Active existing wiring verified:
- areReplayRoute.ts already mounts billing under /api/are/replay/billing/*
- areReplayRoute.ts already calls attachSovereignBillingBridge(tick, ws)
- areReplayRoute.ts already attaches SovereignGovernance to WorldTick
- PayPal checkout/webhook are already reachable under /api/are/replay/billing/paypal/*

Changes in this PR:
- makes PayPal checkout request IDs deterministic instead of time-based
- tracks credited PayPal transaction IDs in PayPalAdapter to prevent duplicate webhook/replay crediting
- returns duplicate=true for already credited transactions
- adds a finance route file for a future direct /api/finance mount, but the current active path remains /api/are/replay/billing/*

Note:
- I intentionally did not rewrite ServerBootstrap because billing/governance are already attached in areReplayRoute and the auth proxy depends on raw body handling.