### PR TITLE
feat(portal): bind ARE events to Cyber-Zen theme states

### DIFF
--- a/packages/shared/src/theme/ThemeEngine.ts
+++ b/packages/shared/src/theme/ThemeEngine.ts
@@ -1,9 +1,6 @@
 /**
- * ThemeEngine — visual tokens from live hazard / aggression telemetry.
+ * ThemeEngine — visual tokens from live hazard / aggression / ARE event telemetry.
  * Consumed by GlobalLiveTicker, Science Portal hub, and server-side dashboards.
- *
- * Server runtime uses a aligned copy in `server/src/theme/serverThemeHazard.ts`
- * (same formulas) because of `rootDir` constraints — keep both in sync when tuning.
  */
 
 import { EventEmitter } from "eventemitter3";
@@ -14,8 +11,25 @@ export const THEME_MARINA_AURA = "#00E5FF";
 export const THEME_ORGANIC_FIRE = "#E60000";
 /** Legendary loot aura — deterministic gold resonance */
 export const THEME_LEGENDARY_LOOT = "#FFD76A";
+/** Oracle prophecy aura — gold mixed with Marina resonance */
+export const THEME_ORACLE_GOLD = "#FFE66D";
+/** Governance aura — sovereign violet/silver */
+export const THEME_GOVERNANCE_VIOLET = "#8B5CF6";
+/** Repair aura — surgical deep red / neon green */
+export const THEME_REPAIR_GREEN = "#39FF14";
+/** Observation aura — marina violet for reading the past */
+export const THEME_OBSERVATION_VIOLET = "#3B2CFF";
 
-export type ThemeAuraMode = "marina" | "balanced" | "fire_glitch" | "loot_legendary";
+export type ThemeAuraMode =
+  | "marina"
+  | "balanced"
+  | "fire_glitch"
+  | "loot_legendary"
+  | "oracle_gold"
+  | "governance_sovereign"
+  | "repair_surgery"
+  | "observation_past"
+  | "identity_cyan";
 
 export interface VisualThemeState {
   /** Primary aura / glow color (hex) */
@@ -25,10 +39,7 @@ export interface VisualThemeState {
   mode: ThemeAuraMode;
   /** 0 = stable, 1 = full glitch (hazard > 0.7) */
   glitchIntensity: number;
-  /**
-   * Effective pulse rate for phaseShift-style animations (Hz).
-   * Baseline ~0.85 Hz; `aggressionTrend > 0` increases frequency.
-   */
+  /** Effective pulse rate for phaseShift-style animations (Hz). */
   phaseShiftPulseHz: number;
   hazardIndex: number;
   aggressionTrend: number;
@@ -42,6 +53,25 @@ export interface LootAuraPayload {
   probability?: number;
   rollHash?: string;
   sourceId?: string;
+}
+
+export type AREThemeEventKind =
+  | "tick"
+  | "oracle"
+  | "governance"
+  | "repair"
+  | "violation"
+  | "observation"
+  | "identity";
+
+export interface AREThemeEventPayload {
+  kind: AREThemeEventKind;
+  tick?: number;
+  active?: boolean;
+  severity?: number;
+  phase?: number;
+  hash?: string;
+  label?: string;
 }
 
 const BASE_PHASE_PULSE_HZ = 0.85;
@@ -79,12 +109,13 @@ function stableUnit(input: string): number {
   return (h % 10000) / 10000;
 }
 
+function deterministicPhase(tick: number | undefined, hash = ""): number {
+  const base = Number.isFinite(tick ?? Number.NaN) ? Number(tick) : 0;
+  return stableUnit(`${base}|${hash}|ARE_THEME_PHASE`);
+}
+
 /**
  * Maps hazard + aggression trend into dashboard-ready visual tokens.
- *
- * - hazardIndex < 0.3 → Marina Blue (#00E5FF) aura
- * - hazardIndex > 0.7 → Organic Fire (#E60000) glitch mode
- * - aggressionTrend > 0 → faster phaseShift pulse
  */
 export function getVisualState(hazardIndex: number, aggressionTrend: number): VisualThemeState {
   const h = clamp01(Number.isFinite(hazardIndex) ? hazardIndex : 0);
@@ -144,6 +175,33 @@ export function getLootLegendaryVisualState(payload: LootAuraPayload): VisualThe
   };
 }
 
+export function getAREEventVisualState(payload: AREThemeEventPayload): VisualThemeState {
+  const severity = clamp01(Number.isFinite(payload.severity ?? Number.NaN) ? Number(payload.severity) : payload.active ? 0.72 : 0.18);
+  const phase = Number.isFinite(payload.phase ?? Number.NaN) ? clamp01(Number(payload.phase)) : deterministicPhase(payload.tick, payload.hash ?? payload.label ?? payload.kind);
+  const pulse = 1.0 + phase * 1.25 + severity * 0.9;
+
+  if (payload.kind === "violation") {
+    return { auraHex: THEME_ORGANIC_FIRE, secondaryHex: "#39FF14", mode: "fire_glitch", glitchIntensity: 1, phaseShiftPulseHz: 4.2, hazardIndex: 1, aggressionTrend: 0.012 };
+  }
+  if (payload.kind === "repair") {
+    return { auraHex: lerpHex("#5a0000", THEME_REPAIR_GREEN, 0.42 + phase * 0.16), secondaryHex: THEME_ORGANIC_FIRE, mode: "repair_surgery", glitchIntensity: 0.52 + severity * 0.32, phaseShiftPulseHz: pulse + 0.65, hazardIndex: 0.62 + severity * 0.26, aggressionTrend: 0.004 };
+  }
+  if (payload.kind === "oracle") {
+    return { auraHex: lerpHex(THEME_MARINA_AURA, THEME_ORACLE_GOLD, 0.72 + phase * 0.16), secondaryHex: "#3f2f05", mode: "oracle_gold", glitchIntensity: 0.18 + severity * 0.22, phaseShiftPulseHz: pulse, hazardIndex: 0.22 + severity * 0.18, aggressionTrend: 0.001 };
+  }
+  if (payload.kind === "governance") {
+    return { auraHex: lerpHex("#C0C0C0", THEME_GOVERNANCE_VIOLET, 0.42 + phase * 0.28), secondaryHex: "#E5E7EB", mode: "governance_sovereign", glitchIntensity: 0.12 + severity * 0.18, phaseShiftPulseHz: pulse * 0.72, hazardIndex: 0.18 + severity * 0.22, aggressionTrend: 0.0005 };
+  }
+  if (payload.kind === "observation") {
+    return { auraHex: lerpHex(THEME_MARINA_AURA, THEME_OBSERVATION_VIOLET, 0.66 + phase * 0.22), secondaryHex: "#120a3d", mode: "observation_past", glitchIntensity: 0.18, phaseShiftPulseHz: 0.62 + phase * 0.32, hazardIndex: 0.12, aggressionTrend: -0.002 };
+  }
+  if (payload.kind === "identity") {
+    return { auraHex: lerpHex("#39FF14", THEME_MARINA_AURA, 0.62 + phase * 0.22), secondaryHex: "#032f35", mode: "identity_cyan", glitchIntensity: 0.08 + severity * 0.08, phaseShiftPulseHz: 1.6 + phase, hazardIndex: 0.08 + severity * 0.08, aggressionTrend: 0 };
+  }
+
+  return { auraHex: THEME_MARINA_AURA, secondaryHex: lerpHex("#003844", "#0a1628", phase), mode: "marina", glitchIntensity: 0.04 + phase * 0.08, phaseShiftPulseHz: 0.95 + phase * 0.32, hazardIndex: 0.08 + phase * 0.04, aggressionTrend: 0 };
+}
+
 /** CSS custom properties for root / layout injection */
 export function visualStateToCssVars(state: VisualThemeState): Record<string, string> {
   const periodSec = Math.max(0.12, 1 / Math.max(0.05, state.phaseShiftPulseHz));
@@ -158,10 +216,9 @@ export function visualStateToCssVars(state: VisualThemeState): Record<string, st
   };
 }
 
-// ——— Live ticker hazard bridge (browser + Node) ———
-
 export const THEME_HAZARD_EVENT = "wasd:theme_hazard";
 export const THEME_LOOT_AURA_EVENT = "wasd:loot_aura";
+export const THEME_ARE_EVENT = "wasd:are_event";
 
 export type LiveTickerHazardPayload = {
   hazardIndex?: number;
@@ -187,16 +244,10 @@ function normalizeHazardPayload(p: LiveTickerHazardPayload): { hi: number; at: n
   return { hi: clamp01(hi), at };
 }
 
-/**
- * Push hazard telemetry into the theme pipeline (idempotent for tiny repeats).
- * Call from ScarcityPredictor after `live_ticker_hazard` bus emit and/or from GlobalLiveTicker.
- */
 export function pushLiveTickerHazard(payload: LiveTickerHazardPayload): VisualThemeState {
   const { hi, at } = normalizeHazardPayload(payload);
   const key = `${hi.toFixed(3)}|${at.toFixed(5)}`;
-  if (key === lastDedupeKey && lastVisual) {
-    return lastVisual;
-  }
+  if (key === lastDedupeKey && lastVisual) return lastVisual;
   lastDedupeKey = key;
   const visual = getVisualState(hi, at);
   lastVisual = visual;
@@ -214,13 +265,25 @@ export function pushLootAura(payload: LootAuraPayload): VisualThemeState {
   return visual;
 }
 
-export function subscribeLiveTickerTheme(
-  fn: (detail: { visual: VisualThemeState; payload: LiveTickerHazardPayload }) => void,
-): () => void {
+export function pushAREEventTheme(payload: AREThemeEventPayload): VisualThemeState {
+  const visual = getAREEventVisualState(payload);
+  const key = `are|${payload.kind}|${payload.tick ?? ""}|${payload.active ?? ""}|${payload.severity ?? ""}|${payload.hash ?? ""}|${payload.label ?? ""}`;
+  if (key === lastDedupeKey && lastVisual) return lastVisual;
+  lastDedupeKey = key;
+  lastVisual = visual;
+  themeEmitter.emit(THEME_ARE_EVENT, { visual, payload });
+  themeEmitter.emit("theme_updated", visual);
+  return visual;
+}
+
+export function subscribeLiveTickerTheme(fn: (detail: { visual: VisualThemeState; payload: LiveTickerHazardPayload }) => void): () => void {
   themeEmitter.on(THEME_HAZARD_EVENT, fn);
-  return () => {
-    themeEmitter.off(THEME_HAZARD_EVENT, fn);
-  };
+  return () => themeEmitter.off(THEME_HAZARD_EVENT, fn);
+}
+
+export function subscribeAREEventTheme(fn: (detail: { visual: VisualThemeState; payload: AREThemeEventPayload }) => void): () => void {
+  themeEmitter.on(THEME_ARE_EVENT, fn);
+  return () => themeEmitter.off(THEME_ARE_EVENT, fn);
 }
 
 export function subscribeVisualTheme(fn: (visual: VisualThemeState) => void): () => void {

--- a/portal/src/apps/AREEventThemeBridge.tsx
+++ b/portal/src/apps/AREEventThemeBridge.tsx
@@ -1,0 +1,114 @@
+import { useEffect } from "react";
+import { pushAREEventTheme } from "@wasd/shared";
+
+interface OracleStatusResponse {
+  ok?: boolean;
+  active?: boolean;
+  prophecyCount?: number;
+  generatedAtTick?: number | null;
+}
+
+interface RepairStatusResponse {
+  ok?: boolean;
+  autoRepair?: {
+    active?: boolean;
+    lastPlan?: { severity?: number; sector?: number } | null;
+    totalRepairs?: number;
+    totalRollbacks?: number;
+  } | null;
+}
+
+interface GovernanceStatusResponse {
+  ok?: boolean;
+  activeDirectives?: unknown[];
+  openDirectives?: unknown[];
+  directives?: unknown[];
+  participation?: number;
+}
+
+function safeSeverity(value: unknown, fallback: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, Math.min(1, n));
+}
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function AREEventThemeBridge({ active = true }: { active?: boolean }): null {
+  useEffect(() => {
+    if (!active) return undefined;
+
+    let disposed = false;
+    let tick = 0;
+
+    const tickTimer = window.setInterval(() => {
+      tick += 1;
+      pushAREEventTheme({ kind: "tick", tick, phase: (tick % 10) / 9, severity: 0.08 });
+    }, 100);
+
+    const poll = async () => {
+      const [oracle, repair, governance] = await Promise.all([
+        fetchJson<OracleStatusResponse>("/api/are/replay/oracle/status"),
+        fetchJson<RepairStatusResponse>("/api/are/replay/repair/status"),
+        fetchJson<GovernanceStatusResponse>("/api/are/replay/governance/status"),
+      ]);
+      if (disposed) return;
+
+      if (oracle?.active || Number(oracle?.prophecyCount ?? 0) > 0) {
+        pushAREEventTheme({
+          kind: "oracle",
+          tick: Number(oracle.generatedAtTick ?? tick),
+          active: true,
+          severity: Math.min(1, 0.38 + Number(oracle.prophecyCount ?? 0) * 0.12),
+          label: "oracle-prophecy",
+        });
+      }
+
+      const repairActive = Boolean(repair?.autoRepair?.active || repair?.autoRepair?.lastPlan);
+      if (repairActive) {
+        pushAREEventTheme({
+          kind: "repair",
+          tick,
+          active: true,
+          severity: safeSeverity(repair?.autoRepair?.lastPlan?.severity, 0.82),
+          label: `repair-${repair?.autoRepair?.lastPlan?.sector ?? "grid"}`,
+        });
+      }
+
+      const directiveCount =
+        Number((governance?.activeDirectives as unknown[] | undefined)?.length ?? 0) +
+        Number((governance?.openDirectives as unknown[] | undefined)?.length ?? 0) +
+        Number((governance?.directives as unknown[] | undefined)?.length ?? 0);
+      if (directiveCount > 0) {
+        pushAREEventTheme({
+          kind: "governance",
+          tick,
+          active: true,
+          severity: Math.min(1, 0.22 + directiveCount * 0.08 + Number(governance?.participation ?? 0) * 0.4),
+          label: "sovereign-council",
+        });
+      }
+    };
+
+    void poll();
+    const pollTimer = window.setInterval(poll, 2500);
+
+    return () => {
+      disposed = true;
+      window.clearInterval(tickTimer);
+      window.clearInterval(pollTimer);
+    };
+  }, [active]);
+
+  return null;
+}
+
+export default AREEventThemeBridge;

--- a/portal/src/apps/SciencePortal.tsx
+++ b/portal/src/apps/SciencePortal.tsx
@@ -10,12 +10,12 @@ import EchoTracker from "../community/EchoTracker";
 import EpochChroniclePanel from "../community/EpochChroniclePanel";
 import ForgePanel from "../community/ForgePanel";
 import InventoryRefinementPanel from "../community/InventoryRefinementPanel";
+import AREEventThemeBridge from "./AREEventThemeBridge";
 import ScienceMascotChat from "./ScienceMascotChat";
 import WarfrontCombatHud from "./WarfrontCombatHud";
 
 /**
- * Science Portal hub — reacts to NPC-driven hazard telemetry via ThemeEngine.
- * Listens to `theme_updated` (fed by GlobalLiveTicker / server live_ticker_hazard → pushLiveTickerHazard).
+ * Science Portal hub — reacts to NPC-driven hazard telemetry and ARE runtime events via ThemeEngine.
  */
 export const SciencePortal: React.FC = () => {
   const [active, setActive] = useState(true);
@@ -30,30 +30,48 @@ export const SciencePortal: React.FC = () => {
 
   const isFire = visual.mode === "fire_glitch";
   const isLoot = visual.mode === "loot_legendary";
+  const isOracle = visual.mode === "oracle_gold";
+  const isGovernance = visual.mode === "governance_sovereign";
+  const isRepair = visual.mode === "repair_surgery";
 
   return (
     <div
       className={`relative overflow-hidden rounded-xl border p-4 transition-colors duration-300 ${
-        isLoot
+        isLoot || isOracle
           ? "border-amber-300/70 shadow-[0_0_28px_rgba(255,215,106,0.32)]"
-          : isFire
-            ? "border-red-500/60 shadow-[0_0_24px_rgba(230,0,0,0.35)]"
-            : "border-cyan-500/40 shadow-[0_0_20px_rgba(0,229,255,0.2)]"
+          : isGovernance
+            ? "border-violet-300/70 shadow-[0_0_28px_rgba(139,92,246,0.32)]"
+            : isRepair
+              ? "border-lime-300/70 shadow-[0_0_28px_rgba(57,255,20,0.28)]"
+              : isFire
+                ? "border-red-500/60 shadow-[0_0_24px_rgba(230,0,0,0.35)]"
+                : "border-cyan-500/40 shadow-[0_0_20px_rgba(0,229,255,0.2)]"
       }`}
       style={
         {
           ...cssVars,
           background:
-            visual.mode === "marina"
-              ? "linear-gradient(145deg, #0f172a 0%, #0c4a6e 55%, #0f172a 100%)"
-              : visual.mode === "loot_legendary"
-                ? "linear-gradient(145deg, #140f02 0%, #3f2f05 48%, #0f172a 100%)"
-                : visual.mode === "fire_glitch"
-                  ? "linear-gradient(145deg, #1a0505 0%, #450a0a 50%, #0f172a 100%)"
-                  : "linear-gradient(145deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)",
+            visual.mode === "oracle_gold"
+              ? "linear-gradient(145deg, #061622 0%, #3f2f05 50%, #0f172a 100%)"
+              : visual.mode === "governance_sovereign"
+                ? "linear-gradient(145deg, #0f1020 0%, #31235d 52%, #d8d8e8 140%)"
+                : visual.mode === "repair_surgery"
+                  ? "linear-gradient(145deg, #1a0505 0%, #163d10 52%, #0f172a 100%)"
+                  : visual.mode === "observation_past"
+                    ? "linear-gradient(145deg, #050719 0%, #21155f 55%, #0c4a6e 120%)"
+                    : visual.mode === "identity_cyan"
+                      ? "linear-gradient(145deg, #03191d 0%, #0c4a6e 55%, #062b16 120%)"
+                      : visual.mode === "marina"
+                        ? "linear-gradient(145deg, #0f172a 0%, #0c4a6e 55%, #0f172a 100%)"
+                        : visual.mode === "loot_legendary"
+                          ? "linear-gradient(145deg, #140f02 0%, #3f2f05 48%, #0f172a 100%)"
+                          : visual.mode === "fire_glitch"
+                            ? "linear-gradient(145deg, #1a0505 0%, #450a0a 50%, #0f172a 100%)"
+                            : "linear-gradient(145deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)",
         } as React.CSSProperties
       }
     >
+      <AREEventThemeBridge active={active} />
       <div
         className="pointer-events-none absolute inset-0 opacity-40"
         style={{
@@ -93,7 +111,7 @@ export const SciencePortal: React.FC = () => {
           </div>
 
           <p className="text-sm text-slate-200">
-            Dashboard physisch gekoppelt an NPC-Aggression, Hazard-Index, Loot-Aura und Alchemical Refinement via{" "}
+            Dashboard gekoppelt an 10-Hz Tickphase, Oracle, Governance, Repair, Loot-Aura und Alchemical Refinement via{" "}
             <code className="rounded bg-black/30 px-1">@wasd/shared</code> ThemeEngine.
           </p>
 
@@ -118,7 +136,7 @@ export const SciencePortal: React.FC = () => {
             </div>
           </div>
 
-          <div className="flex items-center gap-2 text-xs text-slate-400">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
             <span
               className="h-3 w-3 rounded-full border border-white/30"
               style={{ backgroundColor: "var(--wasd-aura)", boxShadow: `0 0 10px var(--wasd-aura)` }}
@@ -126,6 +144,9 @@ export const SciencePortal: React.FC = () => {
             Aura <code>{visual.auraHex}</code>
             {isFire && <span className="text-red-400"> · glitch {visual.glitchIntensity.toFixed(2)}</span>}
             {isLoot && <span className="text-amber-200"> · loot aura {visual.glitchIntensity.toFixed(2)}</span>}
+            {isOracle && <span className="text-amber-200"> · oracle active</span>}
+            {isGovernance && <span className="text-violet-200"> · council active</span>}
+            {isRepair && <span className="text-lime-200"> · surgery mode</span>}
           </div>
 
           <WarfrontCombatHud visual={visual} active={active} />


### PR DESCRIPTION
Binds ARE runtime events to the Cyber-Zen design system.

Server-side state already exists:
- WorldTick generates ARE payload, guard, world hash, recorder, oracle, auto-repair, usage at 10 Hz.
- areReplayRoute exposes oracle/governance/repair APIs.

This PR adds the client/theme bridge:
- ThemeEngine modes for oracle_gold, governance_sovereign, repair_surgery, observation_past, identity_cyan
- pushAREEventTheme() and subscribeAREEventTheme()
- AREEventThemeBridge in the Science Portal:
  - pushes a 10-Hz tick phase every 100ms
  - polls /api/are/replay/oracle/status
  - polls /api/are/replay/repair/status
  - polls /api/are/replay/governance/status
  - turns active events into deterministic Cyber-Zen aura states
- SciencePortal background/border/status labels now react to those modes

Result: design colors now react to 10-Hz tick phase and major ARE runtime events, not only static hazard/loot states.