### PR TITLE
feat(design): add Cyber-Zen Stitch design system

### DIFF
--- a/design/cyberzen/README.md
+++ b/design/cyberzen/README.md
@@ -1,0 +1,55 @@
+# Cyber-Zen Stitch Design System
+
+This folder documents the visual design language supplied through the Stitch screen templates.
+
+## Core DNA
+
+- Matte black cockpit surfaces
+- Marina cyan wireframes and neon strings
+- Organic fire orange/red for hazard, scarcity, glitch and repair crisis
+- Neon green for deterministic recovery and verified causality
+- Gold/yellow for Oracle prophecy and Legendary loot resonance
+- Violet/silver for Governance and Council states
+- 10-Hz deterministic pulse: visual effects derive from tick phase, event severity, or hash-derived phase values.
+
+## Primary UI Archetypes
+
+| Template | Purpose | Runtime use |
+|---|---|---|
+| `screen-03-auth-root.png` / `screen-04-fire-ouroboros.png` | AUTH_ROOT deterministic gateway | Login / identity gate |
+| `screen-10-science-hub.png` | SCIENCE_PORTAL_HUB | Portal root dashboard |
+| `screen-01-chain-validator.png` / `screen-02-chain-validator-alt.png` / `screen-00-chain-validator.png` | CHAIN_STRING_VALIDATOR | Hash bridge / transfer panel |
+| `screen-05-cyber-globe.png` | GLOBAL ASSET REPOSITORY / cyber globe | Right rail, asset/world status |
+| `screen-06-fire-ouroboros.png` | Organic fire ouroboros | Crisis / repair / hazard state |
+| `screen-07-are-logik.png` | ARE-LOGIK ouroboros | ARE logic / SDK / root state |
+| `screen-08-mobile-system-dash.png` | Mobile System Dash | Responsive mobile status panels |
+
+## Implementation Files
+
+- `packages/shared/src/theme/ThemeEngine.ts` contains event-driven color state.
+- `server/src/theme/serverThemeHazard.ts` mirrors server-side theme modes.
+- `portal/public/cyberzen/stitch/*` stores the Stitch template images.
+- `portal/src/design/cyberzenStitch.ts` maps theme states to Stitch-inspired templates.
+- `portal/src/design/CyberZenStitchPanel.tsx` renders the live visual rail.
+- `apps/client-2d/src/theme.css` holds the 2D Cyber-Zen CSS base.
+
+## Planned Route Selector
+
+After login the next visual layer should become:
+
+```text
+AUTH_ROOT → Route Selector → 3D Client / 2D Client / Science Portal
+```
+
+Future Stitch images for this selector should be added under `portal/public/cyberzen/stitch/selector-*` and registered in `portal/src/design/cyberzenStitch.ts`.
+
+## Runtime Rule
+
+Every dynamic glow must be deterministic:
+
+```ts
+phase = (tick % 10) / 9
+pulse = Math.sin(tick * frequency + hashPhase)
+```
+
+No raw `Math.random()` or wall-clock-only animation may be used in core ARE logic. UI may animate, but state selection must come from 10-Hz tick phase, hash phase, or ThemeEngine event severity.

--- a/portal/src/design/CyberZenStitchPanel.tsx
+++ b/portal/src/design/CyberZenStitchPanel.tsx
@@ -1,0 +1,114 @@
+import React, { useMemo } from "react";
+import type { VisualThemeState } from "@wasd/shared";
+import { cyberZenTemplateCssVars, selectCyberZenTemplate } from "./cyberzenStitch";
+
+interface Props {
+  visual: VisualThemeState;
+}
+
+function hexRows(seed: string): string[] {
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i += 1) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return Array.from({ length: 6 }, (_, row) => {
+    const addr = `0x${(row * 16).toString(16).padStart(4, "0")}`;
+    const cells = Array.from({ length: 8 }, (_, col) => {
+      h ^= row * 31 + col * 17;
+      h = Math.imul(h, 16777619) >>> 0;
+      return (h & 0xff).toString(16).padStart(2, "0").toUpperCase();
+    }).join(" ");
+    return `${addr}: ${cells}`;
+  });
+}
+
+export const CyberZenStitchPanel: React.FC<Props> = ({ visual }) => {
+  const template = selectCyberZenTemplate(visual);
+  const rows = useMemo(() => hexRows(`${template.id}|${visual.mode}|${visual.auraHex}`), [template.id, visual.mode, visual.auraHex]);
+  const cssVars = cyberZenTemplateCssVars(template);
+  const active = visual.mode !== "marina" && visual.mode !== "balanced";
+
+  return (
+    <section
+      className="relative overflow-hidden rounded-xl border bg-black/35 p-4 text-slate-100 shadow-[0_0_22px_rgba(0,229,255,0.14)]"
+      style={{
+        ...cssVars,
+        borderColor: "color-mix(in srgb, var(--stitch-a) 45%, transparent)",
+      }}
+    >
+      <div className="pointer-events-none absolute inset-0 opacity-30">
+        <div className="absolute inset-0 bg-[linear-gradient(rgba(0,229,255,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(0,229,255,0.06)_1px,transparent_1px)] bg-[size:22px_22px]" />
+        <div className="absolute -right-24 top-8 h-64 w-64 rounded-full border border-[var(--stitch-a)] shadow-[0_0_42px_var(--stitch-a)]" />
+        <div className="absolute -right-10 top-24 h-36 w-36 rounded-full border border-[var(--stitch-c)] shadow-[0_0_28px_var(--stitch-c)]" />
+      </div>
+
+      <div className="relative z-10 grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
+        <div>
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.28em] text-[var(--stitch-a)]">STITCH_TEMPLATE</div>
+              <h3 className="mt-1 text-lg font-black uppercase tracking-wide text-white">{template.title}</h3>
+            </div>
+            <span className="rounded border border-[var(--stitch-a)] px-2 py-1 font-mono text-[10px] uppercase text-[var(--stitch-a)]">
+              {active ? "AI_ACTIVE" : "SYNC_IDLE"}
+            </span>
+          </div>
+
+          <div className="rounded-lg border border-white/10 bg-black/45 p-3 font-mono text-xs text-slate-300">
+            <div className="mb-2 flex items-center justify-between border-b border-white/10 pb-2 text-[10px] uppercase tracking-[0.18em] text-slate-400">
+              <span>CHAIN_STRING_HASH_VALIDATOR</span>
+              <span style={{ color: "var(--stitch-b)" }}>10-Hz</span>
+            </div>
+            {rows.map((row) => (
+              <div key={row} className="leading-6">
+                {row.slice(0, 7)} <span className="text-slate-500">{row.slice(7, 17)}</span>{" "}
+                <span style={{ color: "var(--stitch-a)" }}>{row.slice(17, 34)}</span>{" "}
+                <span style={{ color: "var(--stitch-b)" }}>{row.slice(34)}</span>
+              </div>
+            ))}
+            <div className="mt-3 h-1 overflow-hidden rounded bg-white/10">
+              <div
+                className="h-full rounded"
+                style={{
+                  width: `${Math.round(18 + visual.hazardIndex * 72)}%`,
+                  background: "linear-gradient(90deg, var(--stitch-a), var(--stitch-b), var(--stitch-c))",
+                  boxShadow: "0 0 14px var(--stitch-a)",
+                }}
+              />
+            </div>
+          </div>
+
+          <div className="mt-3 grid gap-2 text-xs md:grid-cols-3">
+            <div className="rounded border border-white/10 bg-black/30 p-2">
+              <div className="text-slate-500">role</div>
+              <div>{template.role}</div>
+            </div>
+            <div className="rounded border border-white/10 bg-black/30 p-2">
+              <div className="text-slate-500">mode</div>
+              <div>{visual.mode}</div>
+            </div>
+            <div className="rounded border border-white/10 bg-black/30 p-2">
+              <div className="text-slate-500">pulse</div>
+              <div>{visual.phaseShiftPulseHz.toFixed(2)} Hz</div>
+            </div>
+          </div>
+        </div>
+
+        <aside className="rounded-xl border border-white/10 bg-black/40 p-3">
+          <div className="mx-auto mb-3 grid h-36 w-36 place-items-center rounded-full border border-[var(--stitch-a)] bg-black/40 shadow-[0_0_30px_var(--stitch-a)]">
+            <div className="grid h-24 w-24 place-items-center rounded-full border border-[var(--stitch-c)] shadow-[0_0_24px_var(--stitch-c)]">
+              <div className="h-10 w-10 rounded-full border-4 border-[var(--stitch-b)] shadow-[0_0_18px_var(--stitch-b)]" />
+            </div>
+          </div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">runtime_use</div>
+          <p className="mt-1 text-xs text-slate-200">{template.runtimeUse}</p>
+          <div className="mt-3 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">source</div>
+          <p className="mt-1 text-xs text-slate-300">{template.sourceScreens.join(" · ")}</p>
+        </aside>
+      </div>
+    </section>
+  );
+};
+
+export default CyberZenStitchPanel;

--- a/portal/src/design/cyberzenStitch.ts
+++ b/portal/src/design/cyberzenStitch.ts
@@ -1,0 +1,111 @@
+import type { ThemeAuraMode, VisualThemeState } from "@wasd/shared";
+
+export type CyberZenStitchArchetype =
+  | "auth_root"
+  | "science_hub"
+  | "chain_validator"
+  | "cyber_globe"
+  | "fire_ouroboros"
+  | "are_logik"
+  | "mobile_dash"
+  | "route_selector";
+
+export interface CyberZenStitchTemplate {
+  id: CyberZenStitchArchetype;
+  title: string;
+  role: string;
+  palette: string[];
+  sourceScreens: string[];
+  runtimeUse: string;
+}
+
+export const CYBERZEN_STITCH_TEMPLATES: CyberZenStitchTemplate[] = [
+  {
+    id: "auth_root",
+    title: "AUTH_ROOT",
+    role: "Deterministic Gateway",
+    palette: ["#0a0a0a", "#00E5FF", "#FF7A00", "#39FF14"],
+    sourceScreens: ["screen (3).png", "screen (4).png"],
+    runtimeUse: "Login, kappaPos hash, identity bootstrap",
+  },
+  {
+    id: "science_hub",
+    title: "SCIENCE_PORTAL_HUB",
+    role: "Main Dashboard",
+    palette: ["#0a0a0a", "#00E5FF", "#FF7A00", "#E60000"],
+    sourceScreens: ["screen (10).png"],
+    runtimeUse: "Portal overview, telemetry, heatmaps, Emily status",
+  },
+  {
+    id: "chain_validator",
+    title: "CHAIN_STRING_VALIDATOR",
+    role: "Security Bridge",
+    palette: ["#0a0a0a", "#00E5FF", "#39FF14"],
+    sourceScreens: ["screen.png", "screen (1).png", "screen (2).png"],
+    runtimeUse: "Hash bridge, vault transfer, route validation",
+  },
+  {
+    id: "cyber_globe",
+    title: "CYBER_GLOBE",
+    role: "World/Asset Repository",
+    palette: ["#0a0a0a", "#00E5FF", "#FF7A00"],
+    sourceScreens: ["screen (5).png"],
+    runtimeUse: "Right rail, global asset status, world mesh",
+  },
+  {
+    id: "fire_ouroboros",
+    title: "ORGANIC_FIRE_OUROBOROS",
+    role: "Crisis / Repair / Hazard",
+    palette: ["#0a0a0a", "#FF7A00", "#E60000", "#39FF14"],
+    sourceScreens: ["screen (6).png"],
+    runtimeUse: "AutoRepair, Fire Glitch, scarcity crisis",
+  },
+  {
+    id: "are_logik",
+    title: "ARE_LOGIK",
+    role: "Core Logic Emblem",
+    palette: ["#0a0a0a", "#00E5FF", "#39FF14", "#FF7A00"],
+    sourceScreens: ["screen (7).png"],
+    runtimeUse: "ARE kernel, SDK, root logic state",
+  },
+  {
+    id: "mobile_dash",
+    title: "SYSTEM_DASH_MOBILE",
+    role: "Mobile Cockpit",
+    palette: ["#0a0a0a", "#00E5FF", "#FF7A00"],
+    sourceScreens: ["screen (8).png"],
+    runtimeUse: "Android status layout and bottom nav",
+  },
+  {
+    id: "route_selector",
+    title: "ROUTE_SELECTOR",
+    role: "Post-login Branching",
+    palette: ["#0a0a0a", "#00E5FF", "#FFD76A", "#39FF14"],
+    sourceScreens: ["planned"],
+    runtimeUse: "After AUTH_ROOT choose 3D Client, 2D Client or Science Portal",
+  },
+];
+
+export function selectCyberZenTemplate(visual: VisualThemeState): CyberZenStitchTemplate {
+  const mode: ThemeAuraMode = visual.mode;
+  if (mode === "fire_glitch" || mode === "repair_surgery") return byId("fire_ouroboros");
+  if (mode === "oracle_gold") return byId("are_logik");
+  if (mode === "governance_sovereign") return byId("science_hub");
+  if (mode === "observation_past") return byId("chain_validator");
+  if (mode === "identity_cyan") return byId("auth_root");
+  if (mode === "loot_legendary") return byId("cyber_globe");
+  return byId("science_hub");
+}
+
+export function byId(id: CyberZenStitchArchetype): CyberZenStitchTemplate {
+  return CYBERZEN_STITCH_TEMPLATES.find((template) => template.id === id) ?? CYBERZEN_STITCH_TEMPLATES[0];
+}
+
+export function cyberZenTemplateCssVars(template: CyberZenStitchTemplate): React.CSSProperties {
+  const [a = "#00E5FF", b = "#39FF14", c = "#FF7A00"] = template.palette;
+  return {
+    "--stitch-a": a,
+    "--stitch-b": b,
+    "--stitch-c": c,
+  } as React.CSSProperties;
+}


### PR DESCRIPTION
Adds the Stitch-derived Cyber-Zen design foundation to the repo.

Included:
- design/cyberzen/README.md
  - documents all supplied Stitch templates
  - records the planned post-login route selector: AUTH_ROOT -> 3D / 2D / Portal
  - defines runtime 10-Hz deterministic visual rules
- portal/src/design/cyberzenStitch.ts
  - maps Stitch archetypes to runtime uses and theme states
  - includes future route_selector slot for additional images
- portal/src/design/CyberZenStitchPanel.tsx
  - renders a live Cyber-Zen panel using the Stitch archetypes
  - adapts colors to ThemeEngine VisualThemeState

Next PR will mount this panel into SciencePortal and can add the binary Stitch template files once the image asset upload path is stable.