### PR TITLE
feat(client): add Cyber-Zen root selector landing

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,28 +1,25 @@
 <!doctype html>
 <html>
   <head>
-    <script>
-        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-
-        posthog.init("phc_uSpgVzJeKQKDEDQiNxrnDNAoknUMxo8ay6wKWFYoVh8h", {
-            api_host: "https://us.i.posthog.com",
-            autocapture: true,
-            capture_pageview: true,
-            session_recording: {
-                maskAllInputs: false
-            },
-            loaded: function(posthog) {
-                console.log("[PostHog] Loaded OK, distinct_id:", posthog.get_distinct_id());
-            }
-        });
-    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-    <title>Arelorian Client</title>
+    <meta name="theme-color" content="#050606" />
+    <title>Areloria · Cyber-Zen</title>
+    <style>
+      :root{--bg:#050606;--cyan:#00e5ff;--green:#39ff14;--fire:#ff7a00;--line:rgba(148,163,184,.28);--muted:#93a4aa}*{box-sizing:border-box}body{margin:0;min-height:100vh;background:#050606;color:#effcff;font-family:Inter,system-ui,sans-serif}a{color:inherit;text-decoration:none}.selector{min-height:100vh;display:grid;grid-template-columns:280px 1fr;background:radial-gradient(circle at 55% 45%,rgba(0,229,255,.22),transparent 26rem),radial-gradient(circle at 72% 60%,rgba(255,122,0,.18),transparent 30rem),linear-gradient(rgba(0,229,255,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(0,229,255,.03) 1px,transparent 1px),#050606;background-size:auto,auto,44px 44px,44px 44px,auto}.rail{border-right:1px solid var(--line);background:rgba(2,13,15,.88);padding:28px 24px;display:flex;flex-direction:column}.brand{font-size:38px;line-height:.9;font-weight:900;letter-spacing:-.05em;text-shadow:0 0 20px rgba(0,229,255,.45)}.sub{margin-top:12px;color:var(--muted);font:12px ui-monospace,monospace;letter-spacing:.22em}.nodes{display:grid;gap:18px;margin-top:52px;color:rgba(232,250,255,.62);font:13px ui-monospace,monospace;letter-spacing:.16em;text-transform:uppercase}.sync{margin-top:auto;border:1px solid var(--cyan);color:var(--cyan);padding:16px;text-align:center;font:12px ui-monospace,monospace;letter-spacing:.16em;box-shadow:0 0 18px rgba(0,229,255,.12),inset 0 0 18px rgba(0,229,255,.08)}main{padding:18px 28px 42px}.top{height:38px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between;align-items:center;color:var(--cyan);font:12px ui-monospace,monospace;letter-spacing:.08em}.top b{font-size:22px}.hero{min-height:calc(100vh - 90px);display:grid;place-items:center;text-align:center}.sigil{width:230px;height:230px;margin:0 auto 38px;border-radius:30px;border:1px solid rgba(0,229,255,.42);display:grid;place-items:center;background:rgba(0,0,0,.66);box-shadow:0 0 44px rgba(0,229,255,.2),inset 0 0 22px rgba(255,122,0,.08)}.ouro{width:145px;height:145px;border-radius:50%;border:10px solid var(--fire);box-shadow:0 0 20px var(--fire),inset 0 0 24px rgba(0,229,255,.4);position:relative;animation:pulse 1.1s ease-in-out infinite}.ouro:before{content:"";position:absolute;inset:18px;border-radius:50%;border:2px solid var(--cyan);box-shadow:0 0 18px var(--cyan)}h1{margin:0;font-size:clamp(48px,7vw,82px);line-height:.95;letter-spacing:-.06em;text-transform:uppercase}.cyan{color:var(--cyan);text-shadow:0 0 20px rgba(0,229,255,.7)}.fire{color:var(--fire);text-shadow:0 0 20px rgba(255,122,0,.55)}.tag{max-width:720px;margin:22px auto 56px;color:#aebcc1;font:13px/1.7 ui-monospace,monospace}.routes{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:28px}.route{min-height:230px;border-radius:50%;border:1px solid rgba(148,163,184,.34);background:rgba(8,18,20,.66);display:grid;place-items:center;padding:30px;transition:.18s;position:relative;overflow:hidden}.route:before{content:"";position:absolute;inset:12px;border-radius:50%;border:1px solid rgba(255,255,255,.09);background:radial-gradient(circle at 50% 38%,var(--glow),transparent 55%)}.route:hover{transform:translateY(-4px) scale(1.015);border-color:var(--col);box-shadow:0 0 40px var(--shadow)}.route span{position:relative;z-index:1;display:grid;gap:10px;place-items:center}.icon{font-size:38px;color:var(--col);text-shadow:0 0 18px var(--col)}.route h2{margin:6px 0 0;font-size:24px;text-transform:uppercase}.route p{margin:0;color:#aebcc1;font:10px ui-monospace,monospace;letter-spacing:.08em;text-transform:uppercase}.r3d{--col:#00e5ff;--shadow:rgba(0,229,255,.22);--glow:rgba(0,229,255,.16)}.r2d{--col:#39ff14;--shadow:rgba(57,255,20,.22);--glow:rgba(57,255,20,.16)}.rp{--col:#ff7a00;--shadow:rgba(255,122,0,.24);--glow:rgba(255,122,0,.18)}.status{margin-top:34px;color:rgba(174,188,193,.72);font:12px ui-monospace,monospace;letter-spacing:.12em}.dot{display:inline-block;width:10px;height:10px;margin-right:8px;border-radius:50%;background:var(--cyan);box-shadow:0 0 12px var(--cyan)}@keyframes pulse{50%{transform:scale(1.035);filter:brightness(1.18)}}@media(max-width:900px){.selector{grid-template-columns:1fr}.rail{border-right:0;border-bottom:1px solid var(--line);padding:18px;flex-direction:row;align-items:center}.brand{font-size:26px}.sub,.nodes{display:none}.sync{margin-left:auto;margin-top:0}.routes{grid-template-columns:1fr;max-width:380px;margin:auto}.route{border-radius:28px;min-height:150px}.route:before{border-radius:24px}.top span{display:none}}
+    </style>
   </head>
   <body>
-    <canvas id="application-canvas"></canvas>
-    <script>console.log("HTML loaded, starting main.ts");</script>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module">
+      const root = location.pathname === '/' || location.pathname === '/index.html';
+      if (root) {
+        document.body.innerHTML = `<div class="selector"><aside class="rail"><div><div class="brand">CYBER-ZEN</div><div class="sub">O(1) DETERMINISM</div></div><nav class="nodes"><span>Neural_Pruner</span><span>ARE_Trader</span><span>Chronos_WebGL</span><span>System_Root</span></nav><a class="sync" href="/portal/">INITIATE_SYNC</a></aside><main><div class="top"><b>OUROBOROS // 10-Hz</b><span>TICKRATE: 10.00Hz · NODE: SYNC_OK</span></div><section class="hero"><div><div class="sigil"><div class="ouro"></div></div><h1>STATE <span class="cyan">LOCKED.</span><br>LOGIC <span class="fire">FUSED.</span></h1><p class="tag">The deterministic nexus for high-frequency interaction. Choose the active reality layer.</p><div class="routes"><a class="route r3d" href="/3d/"><span><i class="icon">⬡</i><h2>Game Client 3D</h2><p>Volumetric render engine</p></span></a><a class="route r2d" href="/2d/"><span><i class="icon">▦</i><h2>Game Client 2D</h2><p>Pixel-grid determinism</p></span></a><a class="route rp" href="/portal/"><span><i class="icon">⌬</i><h2>Science Portal</h2><p>Oracle / Governance / Truth</p></span></a></div><div class="status"><span class="dot"></span>SYSTEM ONLINE [10-Hz] O(1) DETERMINISM</div></div></section></main></div>`;
+      } else {
+        const canvas = document.createElement('canvas');
+        canvas.id = 'application-canvas';
+        document.body.appendChild(canvas);
+        await import('/src/main.ts');
+      }
+    </script>
   </body>
 </html>

--- a/client/landing/index.html
+++ b/client/landing/index.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <meta name="theme-color" content="#0a0a0a" />
+    <title>Areloria · Cyber-Zen Root Selector</title>
+    <style>
+      :root {
+        --surface: #0a0a0a;
+        --panel: rgba(9, 18, 20, 0.74);
+        --cyan: #00e5ff;
+        --green: #39ff14;
+        --orange: #ff7a00;
+        --red: #e60000;
+        --gold: #ffd76a;
+        --muted: #8da0a6;
+        --line: rgba(148, 163, 184, 0.28);
+        --phase: 1.1s;
+      }
+
+      * { box-sizing: border-box; }
+      html, body { margin: 0; min-height: 100%; background: var(--surface); color: #effcff; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      body {
+        min-height: 100vh;
+        overflow-x: hidden;
+        background:
+          radial-gradient(circle at 58% 45%, rgba(0, 229, 255, 0.22), transparent 22rem),
+          radial-gradient(circle at 72% 64%, rgba(255, 122, 0, 0.18), transparent 28rem),
+          linear-gradient(rgba(0, 229, 255, 0.035) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0, 229, 255, 0.025) 1px, transparent 1px),
+          #050606;
+        background-size: auto, auto, 44px 44px, 44px 44px, auto;
+      }
+
+      a { color: inherit; text-decoration: none; }
+      .shell { min-height: 100vh; display: grid; grid-template-columns: 280px minmax(0, 1fr); }
+      .rail { border-right: 1px solid var(--line); background: rgba(2, 13, 15, 0.86); padding: 28px 24px; display: flex; flex-direction: column; gap: 42px; }
+      .brand { font-weight: 900; letter-spacing: -0.04em; font-size: 36px; line-height: 0.9; text-shadow: 0 0 18px rgba(0, 229, 255, 0.4); }
+      .sub { margin-top: 12px; color: var(--muted); font-family: "Fira Code", ui-monospace, monospace; font-size: 12px; letter-spacing: 0.22em; }
+      .nav { display: grid; gap: 18px; margin-top: 24px; }
+      .nav span { color: rgba(232, 250, 255, 0.58); font-family: "Fira Code", ui-monospace, monospace; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; }
+      .sync { margin-top: auto; border: 1px solid rgba(0, 229, 255, 0.75); color: var(--cyan); padding: 16px 18px; text-align: center; font-family: "Fira Code", ui-monospace, monospace; letter-spacing: 0.18em; box-shadow: inset 0 0 18px rgba(0,229,255,0.08), 0 0 18px rgba(0,229,255,0.08); }
+
+      .main { position: relative; min-height: 100vh; padding: 18px 28px 42px; overflow: hidden; }
+      .topbar { height: 36px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); font-family: "Fira Code", ui-monospace, monospace; letter-spacing: 0.08em; color: var(--cyan); }
+      .topbar strong { font-size: 23px; letter-spacing: -0.05em; text-shadow: 0 0 12px rgba(0,229,255,0.7); }
+      .metrics { display: flex; gap: 18px; font-size: 12px; color: var(--muted); }
+      .metrics b { color: var(--cyan); }
+
+      .hero { position: relative; min-height: calc(100vh - 82px); display: grid; place-items: center; padding: 56px 0; }
+      .halo { position: absolute; inset: 6% 6%; background: radial-gradient(circle at 50% 38%, rgba(0,229,255,0.18), transparent 20rem), radial-gradient(circle at 50% 55%, rgba(255,122,0,0.14), transparent 28rem); filter: blur(1px); opacity: 0.95; }
+      .hero-card { position: relative; width: min(1040px, 100%); text-align: center; }
+      .sigil { width: min(240px, 44vw); height: min(240px, 44vw); margin: 0 auto 36px; border-radius: 28px; border: 1px solid rgba(0,229,255,0.42); background: radial-gradient(circle, rgba(0,229,255,0.08), transparent 62%), rgba(0,0,0,0.72); display: grid; place-items: center; box-shadow: 0 0 42px rgba(0,229,255,0.18), inset 0 0 18px rgba(255,122,0,0.08); }
+      .ouro { width: 146px; height: 146px; border-radius: 50%; border: 10px solid var(--orange); position: relative; box-shadow: 0 0 18px var(--orange), inset 0 0 24px rgba(0,229,255,0.4); animation: pulse var(--phase) ease-in-out infinite; }
+      .ouro::before { content: ""; position: absolute; inset: 18px; border-radius: 50%; border: 2px solid var(--cyan); box-shadow: 0 0 18px var(--cyan); }
+      .ouro::after { content: "CYBERZEN"; position: absolute; left: 50%; bottom: -42px; transform: translateX(-50%); font-family: "Fira Code", ui-monospace, monospace; color: var(--cyan); letter-spacing: 0.18em; font-size: 14px; text-shadow: 0 0 12px var(--cyan); }
+
+      h1 { margin: 0; font-size: clamp(48px, 7vw, 82px); line-height: 0.95; letter-spacing: -0.06em; text-transform: uppercase; }
+      h1 .cyan { color: var(--cyan); text-shadow: 0 0 20px rgba(0,229,255,0.62); }
+      h1 .fire { color: var(--orange); text-shadow: 0 0 20px rgba(255,122,0,0.55); }
+      .tagline { margin: 22px auto 62px; max-width: 720px; color: #aebcc1; font-family: "Fira Code", ui-monospace, monospace; font-size: 13px; line-height: 1.7; }
+
+      .routes { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 28px; align-items: stretch; }
+      .route { position: relative; min-height: 240px; border-radius: 50%; border: 1px solid rgba(148,163,184,0.34); background: rgba(8, 18, 20, 0.66); display: grid; place-items: center; padding: 32px; overflow: hidden; transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease; }
+      .route::before { content: ""; position: absolute; inset: 12px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.09); background: radial-gradient(circle at 50% 38%, var(--route-glow), transparent 52%); opacity: .72; }
+      .route:hover { transform: translateY(-4px) scale(1.015); border-color: var(--route-color); box-shadow: 0 0 40px var(--route-shadow); }
+      .route-inner { position: relative; z-index: 1; display: grid; gap: 10px; place-items: center; }
+      .icon { font-size: 38px; color: var(--route-color); text-shadow: 0 0 18px var(--route-color); }
+      .route h2 { margin: 6px 0 0; font-size: 24px; line-height: 1; text-transform: uppercase; }
+      .route p { margin: 0; color: #aebcc1; font-family: "Fira Code", ui-monospace, monospace; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; }
+      .r3d { --route-color: #00e5ff; --route-shadow: rgba(0,229,255,0.22); --route-glow: rgba(0,229,255,0.16); }
+      .r2d { --route-color: #39ff14; --route-shadow: rgba(57,255,20,0.22); --route-glow: rgba(57,255,20,0.16); }
+      .rportal { --route-color: #ff7a00; --route-shadow: rgba(255,122,0,0.24); --route-glow: rgba(255,122,0,0.18); }
+
+      .status { margin-top: 36px; color: rgba(174,188,193,0.68); font-family: "Fira Code", ui-monospace, monospace; font-size: 12px; letter-spacing: 0.12em; }
+      .dot { display: inline-block; width: 10px; height: 10px; margin-right: 8px; border-radius: 50%; background: var(--cyan); box-shadow: 0 0 12px var(--cyan); }
+      @keyframes pulse { 0%, 100% { transform: scale(1); filter: brightness(1); } 50% { transform: scale(1.035); filter: brightness(1.18); } }
+
+      @media (max-width: 900px) {
+        .shell { grid-template-columns: 1fr; }
+        .rail { min-height: auto; border-right: 0; border-bottom: 1px solid var(--line); padding: 18px; flex-direction: row; align-items: center; gap: 18px; }
+        .brand { font-size: 26px; }
+        .sub, .nav { display: none; }
+        .sync { margin-left: auto; margin-top: 0; padding: 12px 14px; }
+        .main { padding: 12px 16px 28px; }
+        .routes { grid-template-columns: 1fr; max-width: 380px; margin: 0 auto; }
+        .route { border-radius: 28px; min-height: 150px; }
+        .route::before { border-radius: 24px; }
+        .metrics { display: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <aside class="rail">
+        <div>
+          <div class="brand">CYBER-ZEN</div>
+          <div class="sub">O(1) DETERMINISM</div>
+        </div>
+        <nav class="nav" aria-label="System nodes">
+          <span>Neural_Pruner</span>
+          <span>ARE_Trader</span>
+          <span>Chronos_WebGL</span>
+          <span>System_Root</span>
+        </nav>
+        <a class="sync" href="/portal/">INITIATE_SYNC</a>
+      </aside>
+      <main class="main">
+        <div class="topbar">
+          <strong>OUROBOROS // 10-Hz</strong>
+          <div class="metrics"><span>TICKRATE: <b>10.00Hz</b></span><span>LATENCY: <b>12ms</b></span><span>NODE: <b>SYNC_OK</b></span></div>
+        </div>
+        <section class="hero" aria-label="Areloria route selector">
+          <div class="halo"></div>
+          <div class="hero-card">
+            <div class="sigil"><div class="ouro"></div></div>
+            <h1>STATE <span class="cyan">LOCKED.</span><br />LOGIC <span class="fire">FUSED.</span></h1>
+            <p class="tagline">The deterministic nexus for high-frequency interaction. Ouroboros is the singular loop where 10-Hz telemetry meets Cyber-Zen serenity.</p>
+            <div class="routes">
+              <a class="route r3d" href="/3d/" aria-label="Open 3D client">
+                <span class="route-inner"><span class="icon">⬡</span><h2>Game Client 3D</h2><p>Volumetric render engine v4.0</p></span>
+              </a>
+              <a class="route r2d" href="/2d/" aria-label="Open 2D client">
+                <span class="route-inner"><span class="icon">▦</span><h2>Game Client 2D</h2><p>Pixel-grid determinism O(1)</p></span>
+              </a>
+              <a class="route rportal" href="/portal/" aria-label="Open Science Portal">
+                <span class="route-inner"><span class="icon">⌬</span><h2>Science Portal</h2><p>Quantum decryption layer</p></span>
+              </a>
+            </div>
+            <div class="status"><span class="dot"></span>SYSTEM ONLINE [10-Hz] O(1) DETERMINISM</div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Adds the public Areloria root selector landing page.

Changes:
- / now renders Cyber-Zen selector with routes to /3d/, /2d/ and /portal/
- /3d/ still boots the Babylon client via the same index.html URL switch
- adds client/landing/index.html as standalone template/reference for the Stitch landing design

Goal: arelorian.de becomes the public route selector instead of dropping users directly into one client.