### PR TITLE
chore(deploy): disable Vercel and trigger VPS redeploy

### DIFF
--- a/deploy/notes/route-bundle-redeploy.md
+++ b/deploy/notes/route-bundle-redeploy.md
@@ -9,4 +9,4 @@ Expected runtime contents after deployment:
 - /app/client/dist/3d/index.html
 - /app/client/dist/portal/index.html
 
-Timestamp: 2026-05-19T02:45:00+02:00
+Timestamp: 2026-05-19T09:45:00+02:00

--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,9 @@
 {
   "version": 2,
-  "buildCommand": "pnpm build",
-  "installCommand": "pnpm install",
-  "devCommand": "pnpm dev",
-  "outputDirectory": "dist",
-  "framework": null,
-  "cleanUrls": true,
-  "trailingSlash": false,
+  "git": {
+    "deploymentEnabled": false
+  },
   "github": {
-    "silent": false
+    "silent": true
   }
 }


### PR DESCRIPTION
Fixes the deployment noise and kicks the actual production path.

Changes:
- disables unused Vercel Git deployments in vercel.json
- silences Vercel GitHub comments
- updates the existing deploy note under deploy/** so the current deploy-change dispatcher triggers the VPS Docker Deploy workflow after merge

Production target remains the VPS monorepo Docker deploy, not Vercel.