### PR TITLE
fix(deploy): dispatch VPS deploy for visible app changes

### DIFF
--- a/.github/workflows/deploy-change-dispatch.yml
+++ b/.github/workflows/deploy-change-dispatch.yml
@@ -1,4 +1,4 @@
-name: Dispatch VPS Docker Deploy for deploy changes
+name: Dispatch VPS Docker Deploy for visible app changes
 
 on:
   push:
@@ -6,6 +6,21 @@ on:
       - main
     paths:
       - 'deploy/**'
+      - 'client/**'
+      - 'portal/**'
+      - 'apps/client-2d/**'
+      - 'apps/web/**'
+      - 'design/**'
+      - 'public/**'
+      - 'assets/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '**/package.json'
+      - '**/vite.config.*'
+      - '**/tsconfig*.json'
+      - 'scripts/sync-world-assets.mjs'
+      - 'scripts/sync-pnpm-lockfile-for-docker.py'
       - '.github/workflows/deploy-change-dispatch.yml'
   workflow_dispatch:
 
@@ -27,11 +42,11 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          echo "Dispatching VPS Docker Deploy (monorepo) after deploy script change..."
+          echo "Dispatching VPS Docker Deploy after visible app or build graph change..."
           curl -fsS -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${REPO}/actions/workflows/vps-docker-deploy.yml/dispatches" \
-            -d '{"ref":"main","inputs":{"reason":"deploy script changed","arelorian_port":"3001","docker_network":"areloria_arelorian-network"}}'
+            -d '{"ref":"main","inputs":{"reason":"visible app changed","arelorian_port":"3001","docker_network":"areloria_arelorian-network"}}'
           echo "Dispatch requested."


### PR DESCRIPTION
Makes the existing VPS deploy dispatcher watch player-visible frontend and build graph changes.

Why:
- production is the VPS monorepo deploy
- UI/design changes were not reliably triggering the VPS deploy
- this avoids marker PRs for client, portal, 2D, web, design, assets, and package/build config changes

The dispatcher still calls the existing VPS Docker Deploy workflow.