### PR TITLE
feat(warfront): wire runtime system and API

### DIFF
--- a/server/src/api/warfrontRoute.ts
+++ b/server/src/api/warfrontRoute.ts
@@ -1,7 +1,26 @@
 import express, { type Request, type Response, type Router } from "express";
+import type { WorldTick } from "../core/WorldTick.js";
 import { WarfrontCombatTelemetry } from "../modules/warfront/WarfrontCombatTelemetry.js";
+import type { WarfrontSectorKind } from "../modules/warfront/warfrontTypes.js";
 
-export function warfrontRouter(): Router {
+function resolvePlayer(tick: WorldTick, req: Request): any | null {
+  const rawId = req.query.playerId ?? req.body?.playerId;
+  const playerId = typeof rawId === "string" && rawId.trim().length > 0 ? rawId.trim() : "dummy_player";
+  return tick.playerSystem.getPlayer(playerId) ?? null;
+}
+
+function resolveNow(req: Request): number | undefined {
+  const raw = req.query.now ?? req.body?.now;
+  const value = typeof raw === "string" || typeof raw === "number" ? Number(raw) : Number.NaN;
+  return Number.isFinite(value) && value >= 0 ? Math.floor(value) : undefined;
+}
+
+function resolveSectorKind(value: unknown): WarfrontSectorKind | null {
+  if (value === "combat" || value === "crafting" || value === "scouting") return value;
+  return null;
+}
+
+export function warfrontRouter(tick?: WorldTick): Router {
   const r = express.Router();
 
   r.options("/feed", (_req: Request, res: Response) => {
@@ -17,6 +36,38 @@ export function warfrontRouter(): Router {
     const sinceSeq = typeof sinceRaw === "string" ? parseInt(sinceRaw, 10) || 0 : 0;
     const data = WarfrontCombatTelemetry.getInstance().getFeedSince(sinceSeq);
     res.json(data);
+  });
+
+  r.get("/cycle", (req: Request, res: Response) => {
+    if (!tick?.warfrontSystem) return res.status(503).json({ ok: false, error: "warfront_runtime_unavailable" });
+    res.json({ ok: true, cycle: tick.warfrontSystem.getCycleSnapshot(resolveNow(req)), rewards: tick.warfrontSystem.getRewardTiers(), frontBossSpawnPoint: tick.warfrontSystem.getFrontBossSpawnPoint() });
+  });
+
+  r.get("/status", (req: Request, res: Response) => {
+    if (!tick?.warfrontSystem) return res.status(503).json({ ok: false, error: "warfront_runtime_unavailable" });
+    const player = resolvePlayer(tick, req);
+    if (!player) return res.status(404).json({ ok: false, error: "player_not_found" });
+    res.json({ ok: true, playerId: player.id, status: tick.warfrontSystem.getStatusForPlayer(player, resolveNow(req)) });
+  });
+
+  r.post("/contribute", express.json({ limit: "64kb" }), (req: Request, res: Response) => {
+    if (!tick?.warfrontSystem) return res.status(503).json({ ok: false, error: "warfront_runtime_unavailable" });
+    const player = resolvePlayer(tick, req);
+    if (!player) return res.status(404).json({ ok: false, error: "player_not_found" });
+    const kind = resolveSectorKind(req.body?.kind);
+    if (!kind) return res.status(400).json({ ok: false, error: "invalid_sector_kind", allowed: ["combat", "crafting", "scouting"] });
+    const amount = Number(req.body?.amount ?? 0);
+    if (!Number.isFinite(amount) || amount <= 0) return res.status(400).json({ ok: false, error: "invalid_amount" });
+    const result = tick.warfrontSystem.registerContribution(player, kind, amount, resolveNow(req));
+    res.status(result.accepted ? 200 : 409).json({ ok: result.accepted, result, status: tick.warfrontSystem.getStatusForPlayer(player, resolveNow(req)) });
+  });
+
+  r.post("/claim", express.json({ limit: "64kb" }), (req: Request, res: Response) => {
+    if (!tick?.warfrontSystem) return res.status(503).json({ ok: false, error: "warfront_runtime_unavailable" });
+    const player = resolvePlayer(tick, req);
+    if (!player) return res.status(404).json({ ok: false, error: "player_not_found" });
+    const result = tick.warfrontSystem.claimSeasonRewards(player, resolveNow(req));
+    res.status(result.ok ? 200 : 409).json({ ok: result.ok, result, status: tick.warfrontSystem.getStatusForPlayer(player, resolveNow(req)) });
   });
 
   return r;

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -114,7 +114,6 @@ export class ServerBootstrap {
     await initRedisClient();
     app.use("/api/mcp", mcpRoute());
     app.use("/api/v1", scienceMascotRouter());
-    app.use("/api/v1/warfront", warfrontRouter());
     app.use("/api/leaderboard", leaderboardRouter());
     app.use("/api/questlines", questlineRouter());
     app.use("/api/lore", loreRouter());
@@ -135,7 +134,7 @@ export class ServerBootstrap {
         supabase: safeHealthValue<HealthSupabaseSummary>(() => getSupabaseSummary(), { status: "unknown" }),
         auth: { useSupabaseWsLogin: envTruthy("USE_SUPABASE_WS_LOGIN"), requireSupabaseAuth: envTruthy("REQUIRE_SUPABASE_AUTH"), allowGuestLogin: !["0", "false", "no"].includes(process.env.ALLOW_GUEST_LOGIN?.trim().toLowerCase() || ""), allowDevLogin: !["0", "false", "no"].includes(process.env.ALLOW_DEV_LOGIN?.trim().toLowerCase() || "") },
         selfHealing: { active: Boolean(selfHealingStatus.active), patchMode: selfHealingStatus.config?.patchMode ?? "disabled", totalErrors: selfHealingStatus.totalErrors ?? 0, totalHealed: selfHealingStatus.totalHealed ?? 0, healingRate: selfHealingStatus.healingRate ?? 0, featuresProtected: selfHealingStatus.featuresProtected ?? 0 },
-        are: { guard: safeHealthValue(() => tick?.getAREGuardStatus?.() ?? null, null), worldHash: safeHealthValue(() => tick?.getWorldHashSnapshot?.()?.worldHash ?? null, null), replay: safeHealthValue(() => tick?.getReplayRecorderStats?.() ?? null, null) }
+        are: { guard: safeHealthValue(() => tick?.getAREGuardStatus?.() ?? null, null), worldHash: safeHealthValue(() => tick?.getWorldHashSnapshot?.()?.worldHash ?? null, null), replay: safeHealthValue(() => tick?.getReplayRecorderStats?.() ?? null, null), warfront: safeHealthValue(() => tick?.warfrontSystem?.getCycleSnapshot?.() ?? null, null) }
       });
     });
     app.get("/", (req, res, next) => { if (req.headers["user-agent"]?.includes("GoogleHC")) return res.status(200).send("OK"); next(); });
@@ -168,6 +167,7 @@ export class ServerBootstrap {
     (this as any)._tick = tick;
     await tick.init();
     this.initializing = false;
+    app.use("/api/v1/warfront", warfrontRouter(tick));
     app.use("/api/are/validation", areValidationRouter(tick));
     app.use("/api/are/replay", areReplayRouter(tick));
     app.use("/api/finance", express.json({ limit: "1mb" }), financeRouter());

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -15,6 +15,7 @@ import { verifyFirebaseToken } from "../config/firebase.js";
 import { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import { WorldHistory } from "../modules/history/WorldHistory.js";
 import { bootstrapWarfrontNpcs, runWarfrontCombatTick } from "../modules/warfront/WarfrontCombatOrchestrator.js";
+import { WarfrontSystem } from "../modules/warfront/WarfrontSystem.js";
 import { AREInvariantGuard, DeterminismViolation, type AREGuardPayload, type AREInvariantGuardStatus } from "../are/AREInvariantGuard.js";
 import { areValidationState } from "../are/AREValidationState.js";
 import { createWorldHashSnapshot, type WorldHashSnapshot } from "../are/WorldHashSnapshot.js";
@@ -50,6 +51,7 @@ export class WorldTick {
   public worldSystem: WorldSystem;
   public persistence: PersistenceManager;
   public glbRegistry: GLBRegistry;
+  public warfrontSystem: WarfrontSystem;
   private lootEntities: Map<string, any> = new Map();
   private socketToPlayer: Map<string, string> = new Map();
   private lastActionTimes: Map<string, any> = new Map();
@@ -96,6 +98,7 @@ export class WorldTick {
     this.persistence = new PersistenceManager();
     this.worldSystem = new WorldSystem(this.persistence);
     this.glbRegistry = new GLBRegistry();
+    this.warfrontSystem = new WarfrontSystem();
     const dummyPlayer = this.playerSystem.createPlayer("dummy_player", "Dummy Player");
     dummyPlayer.position.x = 500;
     dummyPlayer.position.y = 500;
@@ -217,6 +220,7 @@ export class WorldTick {
     this.tickCount += 1;
     const payload = this.buildAREPayload();
     const allPlayers = this.playerSystem.getAllPlayers();
+    this.warfrontSystem.tick(this.tickCount * 100);
     this.npcSystem.tick(allPlayers.filter((p) => !p.isOffline), this.worldSystem.worldTime);
     runWarfrontCombatTick({ tickCount: this.tickCount, npcSystem: this.npcSystem, playerSystem: this.playerSystem, combatService: this.combatService, broadcast: (payload) => this.ws.broadcast(payload) });
     const npcsAgg = this.npcSystem.getAllNPCs();
@@ -235,8 +239,8 @@ export class WorldTick {
     this.updateAREContract(payload, strippedPlayers, strippedNpcs, strippedLoot);
     const autoRepair = areAutoRepairService.getStatus();
     const usage = deterministicUsageTracker.getStats(this.tickCount);
-    if (this.tickCount % 10 === 0) { const npcs = allNpcs.map(n => ({ id: n.id, name: n.name, x: n.position.x, y: n.position.y })); this.ws.broadcast({ type: "WORLD_HEARTBEAT", payload: { players: Object.fromEntries(allPlayers.filter(p => !p.isOffline).map(p => [p.id, { id: p.id, name: p.name, x: p.position.x, y: p.position.y }])), agents: npcs, are: areValidationState.getSnapshot(), replay: deterministicTickRecorder.stats(), oracle: this.lastOracleReport, autoRepair, usage } }); }
+    if (this.tickCount % 10 === 0) { const npcs = allNpcs.map(n => ({ id: n.id, name: n.name, x: n.position.x, y: n.position.y })); this.ws.broadcast({ type: "WORLD_HEARTBEAT", payload: { players: Object.fromEntries(allPlayers.filter(p => !p.isOffline).map(p => [p.id, { id: p.id, name: p.name, x: p.position.x, y: p.position.y }])), agents: npcs, are: areValidationState.getSnapshot(), replay: deterministicTickRecorder.stats(), oracle: this.lastOracleReport, autoRepair, usage, warfront: this.warfrontSystem.getCycleSnapshot(this.tickCount * 100) } }); }
     if (this.tickCount % 600 === 0) this.saveAll().catch(e => console.error(e));
-    this.ws.broadcast({ type: "world_tick", tick: this.tickCount, players: strippedPlayers, npcs: strippedNpcs, loot: strippedLoot, are: { guard: this.lastAREGuardStatus, worldHash: this.lastWorldHashSnapshot?.worldHash ?? null }, replay: { latestTick: this.tickCount }, oracle: this.lastOracleReport, autoRepair, usage });
+    this.ws.broadcast({ type: "world_tick", tick: this.tickCount, players: strippedPlayers, npcs: strippedNpcs, loot: strippedLoot, are: { guard: this.lastAREGuardStatus, worldHash: this.lastWorldHashSnapshot?.worldHash ?? null }, replay: { latestTick: this.tickCount }, oracle: this.lastOracleReport, autoRepair, usage, warfront: this.warfrontSystem.getCycleSnapshot(this.tickCount * 100) });
   }
 }


### PR DESCRIPTION
Wires the existing deterministic WarfrontSystem into the actual runtime path.

Changes:
- WorldTick now owns a live WarfrontSystem instance
- WarfrontSystem ticks at the deterministic 10Hz tick-derived time
- world_tick and WORLD_HEARTBEAT include warfront cycle snapshots
- /api/v1/warfront is mounted with the live WorldTick instance
- Warfront API now exposes cycle, status, contribution and claim endpoints in addition to combat feed
- /health includes the current warfront cycle snapshot under are.warfront

Why:
WarfrontSystem and AREClock already existed, but the public API only exposed WarfrontCombatTelemetry. This connects the deterministic cycle/reward/status system to the server runtime.