### PR TITLE
feat(client-2d): load imported asset manifest

### DIFF
--- a/apps/client-2d/src/CyberZenIsoApp.tsx
+++ b/apps/client-2d/src/CyberZenIsoApp.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useState } from "react";
-import { Application, Container, Graphics, Text } from "pixi.js";
+import { Application, Assets, Container, Graphics, Sprite, Text, Texture } from "pixi.js";
 import { createClient } from "@wasd/core-network";
+import { fallbackEntry, loadAssetManifest, type AssetEntry, type AssetManifest } from "./assetManifest";
 
 const TILE_W = 96;
 const TILE_H = 48;
 
 type Entity = { root: Container; tx: number; tz: number };
 type Msg = { from: string; txt: string };
+type LoadedAssets = { manifest: AssetManifest | null; textures: Map<string, Texture> };
 
 function iso(x: number, z: number, width: number, height: number) {
   return { x: width / 2 + (x - z) * TILE_W * 0.5, y: height * 0.45 + (x + z) * TILE_H * 0.5 };
@@ -24,8 +26,29 @@ function diamond(color: number, stroke = 0x17361e) {
   return g;
 }
 
-function propTree() {
+function textureFor(assets: LoadedAssets | null, entry: AssetEntry | null): Texture | null {
+  if (!assets || !entry?.src) return null;
+  return assets.textures.get(entry.src) ?? null;
+}
+
+function spriteFromTexture(texture: Texture, width: number, height: number, y = 0) {
+  const s = new Sprite(texture);
+  s.anchor.set(0.5, 1);
+  s.width = width;
+  s.height = height;
+  s.y = y;
+  return s;
+}
+
+function propTree(assets?: LoadedAssets | null) {
   const c = new Container();
+  const entry = fallbackEntry(assets?.manifest ?? null, "props", "tree");
+  const tex = textureFor(assets ?? null, entry);
+  if (tex) {
+    c.addChild(new Graphics().ellipse(0, 18, 30, 10).fill({ color: 0x010804, alpha: 0.42 }));
+    c.addChild(spriteFromTexture(tex, 86, 104));
+    return c;
+  }
   c.addChild(new Graphics().ellipse(0, 14, 24, 8).fill({ color: 0x010804, alpha: 0.5 }));
   c.addChild(new Graphics().roundRect(-5, -22, 10, 34, 4).fill(0x704323));
   c.addChild(new Graphics().circle(0, -42, 25).fill(0x14572f));
@@ -33,8 +56,15 @@ function propTree() {
   return c;
 }
 
-function propHouse() {
+function propHouse(assets?: LoadedAssets | null) {
   const c = new Container();
+  const entry = fallbackEntry(assets?.manifest ?? null, "buildings", "house");
+  const tex = textureFor(assets ?? null, entry);
+  if (tex) {
+    c.addChild(new Graphics().ellipse(0, 20, 52, 14).fill({ color: 0x010804, alpha: 0.44 }));
+    c.addChild(spriteFromTexture(tex, 118, 118));
+    return c;
+  }
   c.addChild(new Graphics().ellipse(0, 18, 48, 12).fill({ color: 0x010804, alpha: 0.44 }));
   c.addChild(new Graphics().roundRect(-34, -36, 68, 48, 8).fill(0x7d5534).stroke({ width: 2, color: 0xffd890, alpha: 0.32 }));
   const roof = new Graphics();
@@ -44,12 +74,17 @@ function propHouse() {
   return c;
 }
 
-function avatar(name: string, player = false) {
+function avatar(name: string, player = false, assets?: LoadedAssets | null) {
   const c = new Container();
   const aura = player ? 0x00e5ff : 0x39ff14;
+  const entry = fallbackEntry(assets?.manifest ?? null, player ? "characters" : "characters", player ? "player" : "npc");
+  const tex = textureFor(assets ?? null, entry);
   c.addChild(new Graphics().ellipse(0, 18, 23, 8).fill({ color: 0x02040a, alpha: 0.56 }));
-  c.addChild(new Graphics().ellipse(0, -8, 14, 21).fill(player ? 0x267dff : 0x249a56).stroke({ width: 2, color: aura, alpha: 0.55 }));
-  c.addChild(new Graphics().circle(0, -34, 11).fill(player ? 0xffd8a9 : 0xd4ffd7).stroke({ width: 2, color: aura, alpha: 0.82 }));
+  if (tex) c.addChild(spriteFromTexture(tex, 58, 74));
+  else {
+    c.addChild(new Graphics().ellipse(0, -8, 14, 21).fill(player ? 0x267dff : 0x249a56).stroke({ width: 2, color: aura, alpha: 0.55 }));
+    c.addChild(new Graphics().circle(0, -34, 11).fill(player ? 0xffd8a9 : 0xd4ffd7).stroke({ width: 2, color: aura, alpha: 0.82 }));
+  }
   const label = new Text({ text: name, style: { fontSize: 11, fill: 0xfff0cf, stroke: { color: 0x02030a, width: 3 }, fontFamily: "monospace" } });
   label.anchor.set(0.5, 1); label.y = -58;
   c.addChild(label);
@@ -61,14 +96,32 @@ function place(node: Container, x: number, z: number, width: number, height: num
   node.x = p.x; node.y = p.y; node.zIndex = p.y;
 }
 
+async function load2DAssets(): Promise<LoadedAssets> {
+  const manifest = await loadAssetManifest();
+  const urls = new Set<string>();
+  if (manifest) {
+    [manifest.tilesets, manifest.characters, manifest.monsters, manifest.buildings, manifest.props, manifest.fx, manifest.ui].forEach((group) => {
+      Object.values(group ?? {}).forEach((entry) => { if (entry.src) urls.add(entry.src); });
+    });
+  }
+  const textures = new Map<string, Texture>();
+  await Promise.all([...urls].map(async (url) => {
+    try { textures.set(url, await Assets.load<Texture>(url)); }
+    catch (err) { console.warn("[2DAssets] Failed to load", url, err); }
+  }));
+  return { manifest, textures };
+}
+
 export function CyberZenIsoApp() {
   const host = useRef<HTMLDivElement>(null);
   const appRef = useRef<Application | null>(null);
+  const assetRef = useRef<LoadedAssets | null>(null);
   const entities = useRef<Map<string, Entity>>(new Map());
   const clientRef = useRef<ReturnType<typeof createClient> | null>(null);
   const keys = useRef(new Set<string>());
   const moveAt = useRef(0);
   const [connected, setConnected] = useState(false);
+  const [assetStatus, setAssetStatus] = useState("ASSETS_LOADING");
   const [messages, setMessages] = useState<Msg[]>([{ from: "Oracle", txt: "Cyberzen 2.5D shell online." }]);
 
   useEffect(() => {
@@ -82,31 +135,37 @@ export function CyberZenIsoApp() {
     if (!host.current || appRef.current) return;
     const app = new Application();
     appRef.current = app;
-    app.init({ backgroundAlpha: 0, resizeTo: host.current, antialias: true, autoDensity: true, resolution: Math.min(devicePixelRatio || 1, 2) }).then(() => {
+    app.init({ backgroundAlpha: 0, resizeTo: host.current, antialias: true, autoDensity: true, resolution: Math.min(devicePixelRatio || 1, 2) }).then(async () => {
       host.current!.appendChild(app.canvas);
+      const loaded = await load2DAssets();
+      assetRef.current = loaded;
+      const textureCount = loaded.textures.size;
+      setAssetStatus(textureCount > 0 ? `ASSETS_${textureCount}_LOADED` : "PROXY_GRAPHICS");
+      setMessages(m => [...m.slice(-12), { from: "AssetRig", txt: textureCount > 0 ? `Loaded ${textureCount} 2D textures from manifest.` : "No manifest textures yet. Using proxy graphics." }]);
       const terrain = new Container(); const props = new Container(); const actors = new Container(); actors.sortableChildren = true;
       app.stage.addChild(terrain, props, actors);
-      buildScene(app, terrain, props);
-      addActor(app, actors, "self", 0, 0, localStorage.getItem("wasd:2d:name") || "Architect", true);
-      addActor(app, actors, "elder", 2, 1, "Millbrook Elder", false);
+      buildScene(app, terrain, props, loaded);
+      addActor(app, actors, "self", 0, 0, localStorage.getItem("wasd:2d:name") || "Architect", true, loaded);
+      addActor(app, actors, "elder", 2, 1, "Millbrook Elder", false, loaded);
       startNetwork(app, actors);
       app.ticker.add(() => tick(app, actors));
     });
     return () => { clientRef.current?.disconnect(); app.destroy(true); };
   }, []);
 
-  function buildScene(app: Application, terrain: Container, props: Container) {
+  function buildScene(app: Application, terrain: Container, props: Container, assets?: LoadedAssets | null) {
+    const terrainTex = textureFor(assets ?? null, fallbackEntry(assets?.manifest ?? null, "tilesets", "terrain"));
     for (let z = -7; z <= 7; z++) for (let x = -7; x <= 7; x++) {
-      const tile = diamond((x + z) % 4 === 0 ? 0x3f7f48 : 0x356b40);
+      const tile = terrainTex ? spriteFromTexture(terrainTex, TILE_W, TILE_H, TILE_H / 2) : diamond((x + z) % 4 === 0 ? 0x3f7f48 : 0x356b40);
       place(tile, x, z, app.screen.width, app.screen.height); terrain.addChild(tile);
     }
-    [[-4,-2],[4,-3],[-5,3],[5,2]].forEach(([x,z]) => { const t = propTree(); place(t, x, z, app.screen.width, app.screen.height); props.addChild(t); });
-    [[-2,2],[2,2],[0,-4]].forEach(([x,z]) => { const h = propHouse(); place(h, x, z, app.screen.width, app.screen.height); props.addChild(h); });
+    [[-4,-2],[4,-3],[-5,3],[5,2]].forEach(([x,z]) => { const t = propTree(assets); place(t, x, z, app.screen.width, app.screen.height); props.addChild(t); });
+    [[-2,2],[2,2],[0,-4]].forEach(([x,z]) => { const h = propHouse(assets); place(h, x, z, app.screen.width, app.screen.height); props.addChild(h); });
   }
 
-  function addActor(app: Application, layer: Container, id: string, x: number, z: number, name: string, player: boolean) {
+  function addActor(app: Application, layer: Container, id: string, x: number, z: number, name: string, player: boolean, assets = assetRef.current) {
     if (entities.current.has(id)) return;
-    const root = avatar(name, player); place(root, x, z, app.screen.width, app.screen.height);
+    const root = avatar(name, player, assets); place(root, x, z, app.screen.width, app.screen.height);
     layer.addChild(root); entities.current.set(id, { root, tx: x, tz: z });
   }
 
@@ -131,5 +190,5 @@ export function CyberZenIsoApp() {
     layer.sortChildren();
   }
 
-  return <div className="az-shell"><div ref={host} className="az-pixi" /><header className="az-top"><div><small>CYBERZEN 2.5D</small><b>Areloria · Millbrook</b></div><span>{connected ? "ONLINE" : "CONNECTING"}</span></header><nav className="az-skills"><button>⚔️<small>Strike</small></button><button>🛡️<small>Guard</small></button><button>✦<small>Aether</small></button><button>☉<small>Talk</small></button></nav><section className="az-chat">{messages.slice(-4).map((m, i) => <p key={i}><b>{m.from}</b> {m.txt}</p>)}</section><footer className="az-hint">WASD move · isometric terrain · proxy sprites ready for real asset swap</footer></div>;
+  return <div className="az-shell"><div ref={host} className="az-pixi" /><header className="az-top"><div><small>CYBERZEN 2.5D · {assetStatus}</small><b>Areloria · Millbrook</b></div><span>{connected ? "ONLINE" : "CONNECTING"}</span></header><nav className="az-skills"><button>⚔️<small>Strike</small></button><button>🛡️<small>Guard</small></button><button>✦<small>Aether</small></button><button>☉<small>Talk</small></button></nav><section className="az-chat">{messages.slice(-4).map((m, i) => <p key={i}><b>{m.from}</b> {m.txt}</p>)}</section><footer className="az-hint">WASD move · isometric terrain · manifest sprites active when /2d-assets/manifest.json exists</footer></div>;
 }

--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -1,0 +1,54 @@
+export type AssetCategory = 'tilesets' | 'characters' | 'monsters' | 'buildings' | 'props' | 'fx' | 'ui';
+
+export type AssetEntry = {
+  src: string;
+  source?: string;
+  license?: string;
+  tileWidth?: number;
+  tileHeight?: number;
+  frameWidth?: number;
+  frameHeight?: number;
+  animations?: Record<string, number[]>;
+};
+
+export type AssetManifest = {
+  version?: number;
+  generatedAt?: string;
+  basePath?: string;
+  sources?: unknown[];
+  tilesets?: Record<string, AssetEntry>;
+  characters?: Record<string, AssetEntry>;
+  monsters?: Record<string, AssetEntry>;
+  buildings?: Record<string, AssetEntry>;
+  props?: Record<string, AssetEntry>;
+  fx?: Record<string, AssetEntry>;
+  ui?: Record<string, AssetEntry>;
+  fallbacks?: Record<string, string | null>;
+};
+
+export async function loadAssetManifest(): Promise<AssetManifest | null> {
+  try {
+    const res = await fetch('/2d-assets/manifest.json', { cache: 'no-store' });
+    if (!res.ok) return null;
+    return await res.json() as AssetManifest;
+  } catch {
+    return null;
+  }
+}
+
+export function getEntry(manifest: AssetManifest | null, category: AssetCategory, id?: string | null): AssetEntry | null {
+  if (!manifest || !id) return null;
+  return manifest[category]?.[id] ?? null;
+}
+
+export function firstEntry(manifest: AssetManifest | null, category: AssetCategory): AssetEntry | null {
+  const group = manifest?.[category];
+  if (!group) return null;
+  const first = Object.keys(group)[0];
+  return first ? group[first] ?? null : null;
+}
+
+export function fallbackEntry(manifest: AssetManifest | null, category: AssetCategory, fallbackKey: string): AssetEntry | null {
+  const id = manifest?.fallbacks?.[fallbackKey] ?? null;
+  return getEntry(manifest, category, id) ?? firstEntry(manifest, category);
+}

--- a/scripts/import-2d-assets-from-issue.mjs
+++ b/scripts/import-2d-assets-from-issue.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readdirSync, copyFileSync, existsSync, writeFileSync, statSync, rmSync } from 'node:fs';
+import { basename, extname, join, relative } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const repo = process.env.GITHUB_REPOSITORY;
+const token = process.env.GITHUB_TOKEN;
+const issueNumber = String(process.env.ISSUE_NUMBER || '893');
+
+if (!repo) throw new Error('GITHUB_REPOSITORY is required');
+if (!token) throw new Error('GITHUB_TOKEN is required');
+
+const root = process.cwd();
+const outRoot = join(root, 'apps/client-2d/public/2d-assets');
+const workRoot = join(tmpdir(), `wasd-2d-assets-${Date.now()}`);
+const extractRoot = join(workRoot, 'extract');
+const zipRoot = join(workRoot, 'zips');
+
+const imageExts = new Set(['.png', '.webp', '.jpg', '.jpeg']);
+const creditExts = new Set(['.txt', '.md', '.rtf', '.html', '.htm', '.pdf']);
+const categories = ['tilesets', 'characters', 'monsters', 'buildings', 'props', 'fx', 'ui'];
+const manifest = {
+  version: 1,
+  generatedAt: new Date().toISOString(),
+  sourceIssue: Number(issueNumber),
+  basePath: '/2d-assets',
+  sources: [],
+  tilesets: {},
+  characters: {},
+  monsters: {},
+  buildings: {},
+  props: {},
+  fx: {},
+  ui: {},
+  fallbacks: {},
+};
+
+function sh(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { stdio: 'pipe', encoding: 'utf8', ...opts });
+}
+
+async function gh(path) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'wasd-2d-asset-importer',
+    },
+  });
+  if (!res.ok) throw new Error(`GitHub API ${path} failed: ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+function slug(input, max = 96) {
+  return String(input || 'asset')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .replace(/_{2,}/g, '_')
+    .slice(0, max) || 'asset';
+}
+
+function listFiles(dir) {
+  const out = [];
+  if (!existsSync(dir)) return out;
+  for (const item of readdirSync(dir)) {
+    const full = join(dir, item);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...listFiles(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+function categoryFor(file, sourceName) {
+  const hay = `${relative(extractRoot, file)} ${sourceName}`.toLowerCase();
+  if (/monster|enemy|slime|wolf|skeleton|beast|creature/.test(hay)) return 'monsters';
+  if (/character|chara|sprite|actor|player|npc|human|people|person|walk/.test(hay)) return 'characters';
+  if (/door|house|building|wall|gate|roof|castle|shop|town/.test(hay)) return 'buildings';
+  if (/effect|fx|magic|slash|hit|fire|heal|spell|animation/.test(hay)) return 'fx';
+  if (/ui|icon|button|hud|window|frame|cursor/.test(hay)) return 'ui';
+  if (/tile|tileset|mapchip|world|terrain|field|grass|road|dungeon|floor/.test(hay)) return 'tilesets';
+  return 'props';
+}
+
+function singular(category) {
+  return ({ tilesets: 'tileset', characters: 'character', monsters: 'monster', buildings: 'building', props: 'prop', fx: 'fx', ui: 'ui' })[category] || 'asset';
+}
+
+function uniqueTarget(category, id, ext) {
+  let candidate = id;
+  let n = 2;
+  while (existsSync(join(outRoot, category, `${candidate}${ext}`))) {
+    candidate = `${id}_${String(n).padStart(2, '0')}`;
+    n++;
+  }
+  return candidate;
+}
+
+function addEntry(category, fileName, sourceName) {
+  const src = `/2d-assets/${category}/${fileName}`;
+  const base = { src, source: sourceName, license: 'See /2d-assets/credits/' };
+  if (category === 'tilesets') return { ...base, tileWidth: 32, tileHeight: 32 };
+  if (category === 'characters' || category === 'monsters') {
+    return {
+      ...base,
+      frameWidth: 32,
+      frameHeight: 32,
+      animations: { idle_south: [0], walk_south: [0, 1, 2, 3], idle_west: [4], walk_west: [4, 5, 6, 7], idle_east: [8], walk_east: [8, 9, 10, 11], idle_north: [12], walk_north: [12, 13, 14, 15] },
+    };
+  }
+  return base;
+}
+
+function chooseFallback(group, pattern) {
+  const entries = Object.keys(group || {});
+  return entries.find((id) => pattern.test(id)) || entries[0] || null;
+}
+
+async function main() {
+  rmSync(workRoot, { recursive: true, force: true });
+  mkdirSync(zipRoot, { recursive: true });
+  mkdirSync(extractRoot, { recursive: true });
+  mkdirSync(outRoot, { recursive: true });
+  for (const c of categories) mkdirSync(join(outRoot, c), { recursive: true });
+  mkdirSync(join(outRoot, 'credits'), { recursive: true });
+
+  const issue = await gh(`/repos/${repo}/issues/${issueNumber}`);
+  const comments = await gh(`/repos/${repo}/issues/${issueNumber}/comments?per_page=100`);
+  const text = [issue.body || '', ...comments.map((c) => c.body || '')].join('\n');
+  const urls = [...new Set([...text.matchAll(/https:\/\/github\.com\/user-attachments\/files\/[^\s)\]]+\.zip/gi)].map((m) => m[0]))];
+  if (!urls.length) throw new Error(`No ZIP attachment URLs found on issue #${issueNumber}`);
+
+  const sourceLines = ['# 2D asset import sources', '', `Generated: ${new Date().toISOString()}`, `Issue: #${issueNumber}`, ''];
+
+  for (const [index, url] of urls.entries()) {
+    const sourceNameRaw = decodeURIComponent(url.split('/').pop() || `asset-pack-${index + 1}.zip`);
+    const sourceName = sourceNameRaw.replace(/\.zip$/i, '');
+    const sourceSlug = slug(sourceName, 60);
+    const zipPath = join(zipRoot, `${String(index + 1).padStart(2, '0')}_${sourceSlug}.zip`);
+    const targetExtract = join(extractRoot, sourceSlug);
+    mkdirSync(targetExtract, { recursive: true });
+
+    console.log(`Downloading ${sourceNameRaw}`);
+    sh('curl', ['-L', '--fail', '--retry', '3', '--retry-delay', '2', '-A', 'wasd-2d-asset-importer', '-o', zipPath, url], { stdio: 'inherit' });
+    console.log(`Extracting ${sourceNameRaw}`);
+    sh('unzip', ['-q', '-o', zipPath, '-d', targetExtract], { stdio: 'inherit' });
+
+    manifest.sources.push({ name: sourceNameRaw, url, importedAs: sourceSlug });
+    sourceLines.push(`- ${sourceNameRaw}: ${url}`);
+
+    for (const file of listFiles(targetExtract)) {
+      const ext = extname(file).toLowerCase();
+      const rel = relative(targetExtract, file);
+      const fileBase = basename(file, ext);
+      const low = `${rel} ${sourceName}`.toLowerCase();
+
+      if (creditExts.has(ext) && /(license|licence|readme|credit|terms|eula|copyright)/i.test(low)) {
+        const creditName = `${sourceSlug}_${slug(basename(file, ext), 60)}${ext}`;
+        copyFileSync(file, join(outRoot, 'credits', creditName));
+        continue;
+      }
+
+      if (!imageExts.has(ext)) continue;
+      const category = categoryFor(file, sourceName);
+      const baseId = uniqueTarget(category, `${singular(category)}_${slug(fileBase, 72)}`, ext);
+      const fileName = `${baseId}${ext}`;
+      copyFileSync(file, join(outRoot, category, fileName));
+      manifest[category][baseId] = addEntry(category, fileName, sourceNameRaw);
+    }
+  }
+
+  manifest.fallbacks.terrain = chooseFallback(manifest.tilesets, /grass|field|world|terrain|outside|base|tile/);
+  manifest.fallbacks.player = chooseFallback(manifest.characters, /player|hero|human|male|adventurer|character|chara/);
+  manifest.fallbacks.npc = Object.keys(manifest.characters).find((id) => id !== manifest.fallbacks.player) || manifest.fallbacks.player || null;
+  manifest.fallbacks.monster = chooseFallback(manifest.monsters, /slime|wolf|monster|enemy/);
+  manifest.fallbacks.house = chooseFallback(manifest.buildings, /house|building|shop|door|gate/);
+  manifest.fallbacks.tree = chooseFallback(manifest.props, /tree|wood|plant|nature/) || chooseFallback(manifest.buildings, /tree|wood|plant|nature/);
+
+  writeFileSync(join(outRoot, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+  writeFileSync(join(outRoot, 'credits', 'source-issue-893.md'), sourceLines.join('\n') + '\n');
+
+  const counts = categories.map((c) => `${c}: ${Object.keys(manifest[c]).length}`).join(', ');
+  console.log(`2D asset import complete: ${counts}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Prepares the Pixi 2D client to actively use imported 2D assets.

Changes:
- adds `scripts/import-2d-assets-from-issue.mjs` to import ZIP links from issue #893 into `apps/client-2d/public/2d-assets/`
- adds `apps/client-2d/src/assetManifest.ts`
- updates CyberZenIsoApp to load `/2d-assets/manifest.json`
- preloads textures through Pixi Assets
- renders terrain, houses, trees and actors from manifest textures when available
- keeps procedural Graphics fallbacks when assets are missing
- shows asset status in the 2D UI

Note:
The GitHub connector could read the ZIP links on issue #893 but could not directly download `github.com/user-attachments` files from this environment. This PR wires the runtime and importer. The actual ZIP import can be run from GitHub Actions/Codespaces/runner where curl can access those links.