### PR TITLE
feat(client-2d): support weapon visual pool

### DIFF
--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -1,13 +1,19 @@
-export type AssetCategory = 'tilesets' | 'characters' | 'monsters' | 'buildings' | 'props' | 'fx' | 'ui';
+export type AssetCategory = 'tilesets' | 'characters' | 'monsters' | 'buildings' | 'props' | 'fx' | 'ui' | 'weapons';
 
 export type AssetEntry = {
   src: string;
   source?: string;
+  sourcePath?: string;
   license?: string;
   tileWidth?: number;
   tileHeight?: number;
   frameWidth?: number;
   frameHeight?: number;
+  width?: number;
+  height?: number;
+  weaponClass?: string;
+  rarity?: string;
+  tags?: string[];
   animations?: Record<string, number[]>;
 };
 
@@ -23,6 +29,7 @@ export type AssetManifest = {
   props?: Record<string, AssetEntry>;
   fx?: Record<string, AssetEntry>;
   ui?: Record<string, AssetEntry>;
+  weapons?: Record<string, AssetEntry>;
   fallbacks?: Record<string, string | null>;
 };
 
@@ -51,4 +58,35 @@ export function firstEntry(manifest: AssetManifest | null, category: AssetCatego
 export function fallbackEntry(manifest: AssetManifest | null, category: AssetCategory, fallbackKey: string): AssetEntry | null {
   const id = manifest?.fallbacks?.[fallbackKey] ?? null;
   return getEntry(manifest, category, id) ?? firstEntry(manifest, category);
+}
+
+export function pickWeaponVisual(
+  manifest: AssetManifest | null,
+  input: { visualId?: string | null; weaponClass?: string | null; rarity?: string | null; seed?: string | number | null },
+): { id: string; entry: AssetEntry } | null {
+  const weapons = manifest?.weapons;
+  if (!weapons) return null;
+
+  if (input.visualId && weapons[input.visualId]) return { id: input.visualId, entry: weapons[input.visualId] };
+
+  const weaponClass = String(input.weaponClass || '').toLowerCase();
+  const rarity = String(input.rarity || '').toLowerCase();
+  const matches = Object.entries(weapons).filter(([, entry]) => {
+    const classOk = !weaponClass || entry.weaponClass === weaponClass || entry.tags?.includes(weaponClass);
+    const rarityOk = !rarity || entry.rarity === rarity || entry.tags?.includes(rarity);
+    return classOk && rarityOk;
+  });
+
+  const pool = matches.length > 0 ? matches : Object.entries(weapons);
+  if (pool.length === 0) return null;
+
+  const seed = String(input.seed ?? `${weaponClass}:${rarity}`);
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  const index = Math.abs(hash) % pool.length;
+  const [id, entry] = pool[index];
+  return { id, entry };
 }

--- a/docs/assets/2d-weapon-pool-integration.md
+++ b/docs/assets/2d-weapon-pool-integration.md
@@ -1,0 +1,76 @@
+# 2D Weapon Visual Pool Integration
+
+This repo now supports weapon visual entries in the 2D asset manifest schema.
+
+## Runtime contract
+
+Generated loot should keep server-side gameplay truth separate from client-side visuals:
+
+```json
+{
+  "id": "item_abc123",
+  "type": "weapon",
+  "weaponClass": "sword",
+  "rarity": "rare",
+  "seed": "loot:orc:12345",
+  "visualId": "weapon_sword_rare_003"
+}
+```
+
+The 2D client resolves visuals through the asset manifest:
+
+```ts
+pickWeaponVisual(manifest, {
+  visualId: item.visualId,
+  weaponClass: item.weaponClass,
+  rarity: item.rarity,
+  seed: item.seed ?? item.id,
+});
+```
+
+## Manifest shape
+
+```json
+{
+  "weapons": {
+    "weapon_sword_rare_003": {
+      "src": "/2d-assets/weapons/weapon-atlas.png",
+      "weaponClass": "sword",
+      "rarity": "rare",
+      "tags": ["sword", "rare"],
+      "frame": { "x": 128, "y": 64, "w": 64, "h": 64 }
+    }
+  }
+}
+```
+
+## Uploaded weapon packs
+
+A normalized full weapon-pool artifact was generated from:
+
+- `FreePixelFantasyWeaponPack.zip`
+- `FreePixelMeleeWeaponPack.zip`
+- `oubliette_weapons _freefree_twg.zip`
+
+The generated artifact contains:
+
+- 270 weapon visuals
+- one compact atlas PNG
+- one weapon manifest with `weaponClass`, `rarity`, source path and atlas frame metadata
+
+## Next implementation step
+
+Copy the generated artifact into the repository root so these files exist:
+
+```text
+apps/client-2d/public/2d-assets/weapons/weapon-atlas.png
+apps/client-2d/public/2d-assets/weapons/weapon-manifest.json
+apps/client-2d/public/2d-assets/credits/weapon-packs.md
+```
+
+Then either:
+
+1. merge the `weapons` object into `/2d-assets/manifest.json`, or
+2. extend the 2D client to load `/2d-assets/weapons/weapon-manifest.json` in addition to the root manifest.
+
+Do not let the client randomly select weapon visuals. Use `visualId` from the server when present, otherwise deterministic selection by `weaponClass`, `rarity` and item seed.


### PR DESCRIPTION
Adds client-side schema support for 2D weapon visuals.

Changes:
- extends AssetCategory with `weapons`
- extends AssetEntry with weapon metadata (`weaponClass`, `rarity`, `tags`, `sourcePath`, dimensions)
- adds deterministic `pickWeaponVisual(...)` helper
- documents the weapon-pool integration contract

Generated artifact:
A normalized 270-weapon atlas + manifest was generated locally from the uploaded weapon ZIPs. It is available as `wasd-2d-weapon-pool.zip` in this ChatGPT session and contains:
- `apps/client-2d/public/2d-assets/weapons/weapon-atlas.png`
- `apps/client-2d/public/2d-assets/weapons/weapon-manifest.json`
- `apps/client-2d/public/2d-assets/credits/weapon-packs.md`

Why not commit the full pool directly here:
The GitHub connector path is safer for schema/code changes. The full binary artifact should be uploaded/imported as a repo file or via a runner/agent so it does not pass through chat text as huge encoded data.