### PR TITLE
feat(client-2d): integrate uploaded weapon pool artifact

### DIFF
--- a/apps/client-2d/package.json
+++ b/apps/client-2d/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prebuild": "node ../../scripts/extract-2d-weapon-pool.mjs",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"

--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -11,6 +11,7 @@ export type AssetEntry = {
   frameHeight?: number;
   width?: number;
   height?: number;
+  frame?: { x: number; y: number; w: number; h: number };
   weaponClass?: string;
   rarity?: string;
   tags?: string[];
@@ -33,14 +34,35 @@ export type AssetManifest = {
   fallbacks?: Record<string, string | null>;
 };
 
-export async function loadAssetManifest(): Promise<AssetManifest | null> {
+type WeaponManifestPayload = {
+  weapons?: Record<string, AssetEntry>;
+  sources?: unknown[];
+};
+
+async function loadJson<T>(url: string): Promise<T | null> {
   try {
-    const res = await fetch('/2d-assets/manifest.json', { cache: 'no-store' });
+    const res = await fetch(url, { cache: 'no-store' });
     if (!res.ok) return null;
-    return await res.json() as AssetManifest;
+    return await res.json() as T;
   } catch {
     return null;
   }
+}
+
+export async function loadAssetManifest(): Promise<AssetManifest | null> {
+  const root = await loadJson<AssetManifest>('/2d-assets/manifest.json');
+  const weaponManifest = await loadJson<WeaponManifestPayload>('/2d-assets/weapons/weapon-manifest.json');
+
+  if (!root && !weaponManifest) return null;
+
+  return {
+    ...(root ?? { version: 1, basePath: '/2d-assets' }),
+    sources: [...(root?.sources ?? []), ...(weaponManifest?.sources ?? [])],
+    weapons: {
+      ...(root?.weapons ?? {}),
+      ...(weaponManifest?.weapons ?? {}),
+    },
+  };
 }
 
 export function getEntry(manifest: AssetManifest | null, category: AssetCategory, id?: string | null): AssetEntry | null {

--- a/scripts/extract-2d-weapon-pool.mjs
+++ b/scripts/extract-2d-weapon-pool.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const zipPath = join(repoRoot, 'asset-packs/2d/weapons/wasd-2d-weapon-pool.zip');
+const outDir = repoRoot;
+const expectedAtlas = join(repoRoot, 'apps/client-2d/public/2d-assets/weapons/weapon-atlas.png');
+const expectedManifest = join(repoRoot, 'apps/client-2d/public/2d-assets/weapons/weapon-manifest.json');
+const expectedCredits = join(repoRoot, 'apps/client-2d/public/2d-assets/credits/weapon-packs.md');
+
+function log(message) {
+  console.log(`[2DWeaponPool] ${message}`);
+}
+
+function requireZip() {
+  if (!existsSync(zipPath)) {
+    log(`No weapon pool artifact found at ${zipPath}. Skipping extraction.`);
+    return false;
+  }
+  return true;
+}
+
+function ensureDirs() {
+  mkdirSync(dirname(expectedAtlas), { recursive: true });
+  mkdirSync(dirname(expectedCredits), { recursive: true });
+}
+
+function extract() {
+  ensureDirs();
+  execFileSync('unzip', ['-o', '-q', zipPath, '-d', outDir], { stdio: 'inherit' });
+  const missing = [expectedAtlas, expectedManifest, expectedCredits].filter((p) => !existsSync(p));
+  if (missing.length > 0) {
+    throw new Error(`Weapon pool extraction incomplete. Missing: ${missing.join(', ')}`);
+  }
+  log('Weapon pool extracted into apps/client-2d/public/2d-assets/.');
+}
+
+if (requireZip()) extract();


### PR DESCRIPTION
Integrates the uploaded 270-weapon pool artifact into the 2D client runtime path.

Changes:
- adds `scripts/extract-2d-weapon-pool.mjs`
- `@wasd/client-2d` runs the extractor before build
- extractor unpacks `asset-packs/2d/weapons/wasd-2d-weapon-pool.zip`
- expected runtime files are produced under `apps/client-2d/public/2d-assets/weapons/`
- `loadAssetManifest()` now also loads `/2d-assets/weapons/weapon-manifest.json`
- weapon entries are merged into the root manifest at runtime

Result:
During normal `pnpm build:2d`, the weapon atlas and weapon manifest are extracted before Vite copies public assets. The 2D client can then resolve weapon visuals using `pickWeaponVisual(...)`.