### PR TITLE
feat(client-2d): integrate Arelorian Stitch HUD

### DIFF
--- a/apps/client-2d/src/ArelorianStitchHud.tsx
+++ b/apps/client-2d/src/ArelorianStitchHud.tsx
@@ -1,0 +1,220 @@
+import { FormEvent, useMemo, useState } from "react";
+
+type Msg = { from: string; txt: string };
+type HudPanel = "inventory" | "character" | "map" | "combat" | "guild" | "factions" | "quests" | null;
+
+export interface ArelorianStitchHudProps {
+  connected: boolean;
+  assetStatus: string;
+  weaponCount: number;
+  playerName: string;
+  messages: Msg[];
+  onSkill: (skillId: string) => void;
+  onChat: (text: string) => void;
+  onInteract: () => void;
+  onToggleAutoMove?: () => void;
+}
+
+const skills = [
+  { id: "atk", key: "1", icon: "⚔", label: "Strike", cost: "STA 4" },
+  { id: "def", key: "2", icon: "🛡", label: "Guard", cost: "MANA +" },
+  { id: "mag", key: "3", icon: "✦", label: "Aether", cost: "MANA 12" },
+  { id: "talk", key: "E", icon: "☉", label: "Talk", cost: "SYNC" },
+];
+
+const panels: { id: Exclude<HudPanel, null>; label: string; icon: string }[] = [
+  { id: "inventory", label: "Inventory", icon: "◇" },
+  { id: "character", label: "Skills", icon: "⬢" },
+  { id: "combat", label: "Matrix", icon: "✕" },
+  { id: "map", label: "Map", icon: "◌" },
+  { id: "guild", label: "Guild", icon: "♜" },
+  { id: "factions", label: "Factions", icon: "⚖" },
+  { id: "quests", label: "Quests", icon: "!" },
+];
+
+export function ArelorianStitchHud({
+  connected,
+  assetStatus,
+  weaponCount,
+  playerName,
+  messages,
+  onSkill,
+  onChat,
+  onInteract,
+  onToggleAutoMove,
+}: ArelorianStitchHudProps) {
+  const [activePanel, setActivePanel] = useState<HudPanel>(null);
+  const [chatText, setChatText] = useState("");
+  const hp = 86;
+  const mana = 64;
+  const stamina = 78;
+  const xp = 31;
+
+  const visibleMessages = useMemo(() => messages.slice(-6), [messages]);
+
+  function submitChat(event: FormEvent) {
+    event.preventDefault();
+    const text = chatText.trim();
+    if (!text) return;
+    onChat(text);
+    setChatText("");
+  }
+
+  function handleSkill(id: string) {
+    if (id === "talk") onInteract();
+    else onSkill(id);
+  }
+
+  return (
+    <div className="stitch-hud" aria-label="Arelorian Science MMO HUD">
+      <div className="stitch-scanlines" />
+
+      <header className="stitch-topbar">
+        <div className="stitch-brand">
+          <span className="stitch-kicker">ARELORIAN SCIENCE // 2.5D PIXEL CLIENT</span>
+          <strong>Millbrook Observer Node</strong>
+        </div>
+        <div className="stitch-node-status">
+          <span className={connected ? "stitch-live-dot on" : "stitch-live-dot"} />
+          <b>{connected ? "WORLD ONLINE" : "SYNCING"}</b>
+          <small>{assetStatus} · {weaponCount} WEAPONS</small>
+        </div>
+      </header>
+
+      <aside className="stitch-vitals">
+        <div className="stitch-portrait"><span>Ω</span></div>
+        <div className="stitch-nameplate">
+          <small>Observer</small>
+          <strong>{playerName}</strong>
+        </div>
+        <Gauge label="HP" value={hp} tone="ruby" />
+        <Gauge label="MP" value={mana} tone="aether" />
+        <Gauge label="STA" value={stamina} tone="emerald" />
+        <Gauge label="XP" value={xp} tone="gold" />
+      </aside>
+
+      <aside className="stitch-side-menu">
+        {panels.map((panel) => (
+          <button
+            key={panel.id}
+            className={activePanel === panel.id ? "active" : ""}
+            onClick={() => setActivePanel(activePanel === panel.id ? null : panel.id)}
+            title={panel.label}
+          >
+            <span>{panel.icon}</span>
+            <small>{panel.label}</small>
+          </button>
+        ))}
+      </aside>
+
+      <section className="stitch-radar">
+        <div className="stitch-radar-ring"><i /><i /><i /></div>
+        <div>
+          <b>ARE Pulse</b>
+          <small>10Hz deterministic mesh</small>
+        </div>
+      </section>
+
+      <section className="stitch-chat">
+        <div className="stitch-panel-title"><b>Local / Oracle Feed</b><span>live</span></div>
+        <div className="stitch-chat-lines">
+          {visibleMessages.map((message, index) => (
+            <p key={`${message.from}-${index}`}><b>{message.from}</b> {message.txt}</p>
+          ))}
+        </div>
+        <form onSubmit={submitChat} className="stitch-chat-input">
+          <input value={chatText} onChange={(event) => setChatText(event.target.value)} placeholder="Send local message…" />
+          <button type="submit">SEND</button>
+        </form>
+      </section>
+
+      <nav className="stitch-skillbar">
+        {skills.map((skill) => (
+          <button key={skill.id} onClick={() => handleSkill(skill.id)}>
+            <kbd>{skill.key}</kbd>
+            <span>{skill.icon}</span>
+            <b>{skill.label}</b>
+            <small>{skill.cost}</small>
+          </button>
+        ))}
+      </nav>
+
+      <section className="stitch-bottom-right">
+        <button onClick={onToggleAutoMove}>AUTO</button>
+        <button onClick={onInteract}>INTERACT</button>
+      </section>
+
+      {activePanel && <StitchPanel panel={activePanel} weaponCount={weaponCount} onClose={() => setActivePanel(null)} />}
+    </div>
+  );
+}
+
+function Gauge({ label, value, tone }: { label: string; value: number; tone: string }) {
+  return (
+    <div className={`stitch-gauge ${tone}`}>
+      <div><b>{label}</b><span>{value}%</span></div>
+      <i style={{ width: `${value}%` }} />
+    </div>
+  );
+}
+
+function StitchPanel({ panel, weaponCount, onClose }: { panel: Exclude<HudPanel, null>; weaponCount: number; onClose: () => void }) {
+  const title = panelTitle(panel);
+  return (
+    <div className="stitch-modal">
+      <div className="stitch-modal-card">
+        <header>
+          <div>
+            <small>ARELORIAN SCIENCE MODULE</small>
+            <h2>{title}</h2>
+          </div>
+          <button onClick={onClose}>×</button>
+        </header>
+        {panel === "inventory" && <InventoryPreview weaponCount={weaponCount} />}
+        {panel === "character" && <CharacterPreview />}
+        {panel === "combat" && <CombatPreview />}
+        {panel === "map" && <MapPreview />}
+        {panel === "guild" && <GuildPreview />}
+        {panel === "factions" && <FactionsPreview />}
+        {panel === "quests" && <QuestPreview />}
+      </div>
+    </div>
+  );
+}
+
+function panelTitle(panel: Exclude<HudPanel, null>) {
+  return ({
+    inventory: "Inventory Matrix",
+    character: "Character & Skills",
+    combat: "Combat Matrix",
+    map: "Arelorian Highlands",
+    guild: "Guild Console",
+    factions: "Faction Reputation",
+    quests: "Quest Log",
+  } as const)[panel];
+}
+
+function InventoryPreview({ weaponCount }: { weaponCount: number }) {
+  return <div className="stitch-grid-panel"><Info label="Weapon Pool" value={`${weaponCount} visuals`} /><Info label="Drop Logic" value="visualId ready" /><Info label="Atlas" value="weapon-atlas.png" /><Info label="Rarity" value="common → mystic" /></div>;
+}
+function CharacterPreview() {
+  return <div className="stitch-grid-panel"><Info label="Level" value="1" /><Info label="ARE Sync" value="stable" /><Info label="Class" value="classless" /><Info label="Skill Mode" value="use-based" /></div>;
+}
+function CombatPreview() {
+  return <div className="stitch-grid-panel"><Info label="Tick" value="10Hz" /><Info label="Target" value="nearest" /><Info label="Threat" value="low" /><Info label="Warfront" value="cycle-linked" /></div>;
+}
+function MapPreview() {
+  return <div className="stitch-map-preview"><span /><span /><span /><span /><b>Millbrook</b></div>;
+}
+function GuildPreview() {
+  return <div className="stitch-grid-panel"><Info label="Guild" value="unclaimed" /><Info label="Village Rights" value="50 members" /><Info label="Treasury" value="offline" /><Info label="Rank" value="observer" /></div>;
+}
+function FactionsPreview() {
+  return <div className="stitch-grid-panel"><Info label="Millbrook" value="neutral" /><Info label="Oracle Circle" value="trusted" /><Info label="Warfront" value="contested" /><Info label="Merchants" value="open" /></div>;
+}
+function QuestPreview() {
+  return <div className="stitch-grid-panel"><Info label="First Steps" value="available" /><Info label="Oracle Echo" value="hidden" /><Info label="Warfront Aid" value="locked" /><Info label="Crafting" value="pending" /></div>;
+}
+function Info({ label, value }: { label: string; value: string }) {
+  return <article className="stitch-info"><small>{label}</small><b>{value}</b></article>;
+}

--- a/apps/client-2d/src/CyberZenIsoApp.tsx
+++ b/apps/client-2d/src/CyberZenIsoApp.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Application, Assets, Container, Graphics, Sprite, Text, Texture } from "pixi.js";
 import { createClient } from "@wasd/core-network";
 import { fallbackEntry, loadAssetManifest, type AssetEntry, type AssetManifest } from "./assetManifest";
+import { ArelorianStitchHud } from "./ArelorianStitchHud";
 
 const TILE_W = 96;
 const TILE_H = 48;
@@ -77,7 +78,7 @@ function propHouse(assets?: LoadedAssets | null) {
 function avatar(name: string, player = false, assets?: LoadedAssets | null) {
   const c = new Container();
   const aura = player ? 0x00e5ff : 0x39ff14;
-  const entry = fallbackEntry(assets?.manifest ?? null, player ? "characters" : "characters", player ? "player" : "npc");
+  const entry = fallbackEntry(assets?.manifest ?? null, "characters", player ? "player" : "npc");
   const tex = textureFor(assets ?? null, entry);
   c.addChild(new Graphics().ellipse(0, 18, 23, 8).fill({ color: 0x02040a, alpha: 0.56 }));
   if (tex) c.addChild(spriteFromTexture(tex, 58, 74));
@@ -100,7 +101,7 @@ async function load2DAssets(): Promise<LoadedAssets> {
   const manifest = await loadAssetManifest();
   const urls = new Set<string>();
   if (manifest) {
-    [manifest.tilesets, manifest.characters, manifest.monsters, manifest.buildings, manifest.props, manifest.fx, manifest.ui].forEach((group) => {
+    [manifest.tilesets, manifest.characters, manifest.monsters, manifest.buildings, manifest.props, manifest.fx, manifest.ui, manifest.weapons].forEach((group) => {
       Object.values(group ?? {}).forEach((entry) => { if (entry.src) urls.add(entry.src); });
     });
   }
@@ -120,8 +121,10 @@ export function CyberZenIsoApp() {
   const clientRef = useRef<ReturnType<typeof createClient> | null>(null);
   const keys = useRef(new Set<string>());
   const moveAt = useRef(0);
+  const playerName = localStorage.getItem("wasd:2d:name") || "Architect";
   const [connected, setConnected] = useState(false);
   const [assetStatus, setAssetStatus] = useState("ASSETS_LOADING");
+  const [weaponCount, setWeaponCount] = useState(0);
   const [messages, setMessages] = useState<Msg[]>([{ from: "Oracle", txt: "Cyberzen 2.5D shell online." }]);
 
   useEffect(() => {
@@ -140,12 +143,14 @@ export function CyberZenIsoApp() {
       const loaded = await load2DAssets();
       assetRef.current = loaded;
       const textureCount = loaded.textures.size;
+      const weapons = Object.keys(loaded.manifest?.weapons ?? {}).length;
+      setWeaponCount(weapons);
       setAssetStatus(textureCount > 0 ? `ASSETS_${textureCount}_LOADED` : "PROXY_GRAPHICS");
-      setMessages(m => [...m.slice(-12), { from: "AssetRig", txt: textureCount > 0 ? `Loaded ${textureCount} 2D textures from manifest.` : "No manifest textures yet. Using proxy graphics." }]);
+      setMessages(m => [...m.slice(-12), { from: "AssetRig", txt: textureCount > 0 ? `Loaded ${textureCount} textures and ${weapons} weapon visuals.` : "No manifest textures yet. Using proxy graphics." }]);
       const terrain = new Container(); const props = new Container(); const actors = new Container(); actors.sortableChildren = true;
       app.stage.addChild(terrain, props, actors);
       buildScene(app, terrain, props, loaded);
-      addActor(app, actors, "self", 0, 0, localStorage.getItem("wasd:2d:name") || "Architect", true, loaded);
+      addActor(app, actors, "self", 0, 0, playerName, true, loaded);
       addActor(app, actors, "elder", 2, 1, "Millbrook Elder", false, loaded);
       startNetwork(app, actors);
       app.ticker.add(() => tick(app, actors));
@@ -190,5 +195,36 @@ export function CyberZenIsoApp() {
     layer.sortChildren();
   }
 
-  return <div className="az-shell"><div ref={host} className="az-pixi" /><header className="az-top"><div><small>CYBERZEN 2.5D · {assetStatus}</small><b>Areloria · Millbrook</b></div><span>{connected ? "ONLINE" : "CONNECTING"}</span></header><nav className="az-skills"><button>⚔️<small>Strike</small></button><button>🛡️<small>Guard</small></button><button>✦<small>Aether</small></button><button>☉<small>Talk</small></button></nav><section className="az-chat">{messages.slice(-4).map((m, i) => <p key={i}><b>{m.from}</b> {m.txt}</p>)}</section><footer className="az-hint">WASD move · isometric terrain · manifest sprites active when /2d-assets/manifest.json exists</footer></div>;
+  function sendSkill(skillId: string) {
+    clientRef.current?.sendPlayerAction("USE_SKILL", { skillId });
+    setMessages(m => [...m.slice(-12), { from: "Combat", txt: `Skill queued: ${skillId}` }]);
+  }
+
+  function sendChat(text: string) {
+    clientRef.current?.sendPlayerAction("chat", { text, channel: "local" });
+    setMessages(m => [...m.slice(-12), { from: playerName, txt: text }]);
+  }
+
+  function interact() {
+    clientRef.current?.sendPlayerAction("interact", { targetId: "elder" });
+    setMessages(m => [...m.slice(-12), { from: "System", txt: "Interaction ping sent." }]);
+  }
+
+  return (
+    <div className="az-shell">
+      <div className="az-world-glow" />
+      <div ref={host} className="az-pixi" />
+      <ArelorianStitchHud
+        connected={connected}
+        assetStatus={assetStatus}
+        weaponCount={weaponCount}
+        playerName={playerName}
+        messages={messages}
+        onSkill={sendSkill}
+        onChat={sendChat}
+        onInteract={interact}
+        onToggleAutoMove={() => setMessages(m => [...m.slice(-12), { from: "Navigator", txt: "Auto-route planner not yet linked." }])}
+      />
+    </div>
+  );
 }

--- a/apps/client-2d/src/theme.css
+++ b/apps/client-2d/src/theme.css
@@ -9,6 +9,12 @@
   --cz-gold: #ffd76a;
   --cz-text: #f4f7ff;
   --cz-muted: rgba(244, 247, 255, 0.66);
+  --st-ruby: #ff3f6f;
+  --st-emerald: #39ff14;
+  --st-aether: #00e5ff;
+  --st-gold: #ffd76a;
+  --st-violet: #8b5cf6;
+  --st-dark: rgba(4, 8, 14, 0.78);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -65,22 +71,108 @@ canvas { display: block; filter: saturate(1.16) contrast(1.08); }
 .az-shell::before { content: ""; position: absolute; inset: 0; pointer-events: none; background-image: linear-gradient(rgba(255,255,255,.035) 1px, transparent 1px), linear-gradient(90deg, rgba(0,229,255,.032) 1px, transparent 1px); background-size: 44px 44px; mask-image: radial-gradient(circle at 50% 48%, black 0%, transparent 78%); }
 .az-world-glow { position: absolute; inset: 8% 0 auto; height: 70%; pointer-events: none; background: radial-gradient(ellipse at center, rgba(57,255,20,.10), transparent 62%); filter: blur(18px); }
 .az-pixi { position: absolute; inset: 0; }
-.az-top { position: absolute; top: 14px; left: 14px; right: 14px; z-index: 10; display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 12px 14px; border: 1px solid rgba(0,229,255,.24); border-radius: 18px; background: linear-gradient(135deg, rgba(5,8,14,.82), rgba(10,18,32,.58)); box-shadow: 0 0 28px rgba(0,229,255,.12), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(14px); }
-.az-top small { display: block; color: var(--cz-cyan); letter-spacing: .22em; font-size: 10px; font-weight: 900; }
-.az-top b { display: block; margin-top: 2px; font-size: 16px; color: #fff6d7; }
-.az-top span { border: 1px solid rgba(57,255,20,.34); border-radius: 999px; padding: 8px 12px; color: #d9ffd2; background: rgba(57,255,20,.07); font-size: 12px; font-weight: 900; }
-.az-skills { position: absolute; left: 50%; bottom: 22px; transform: translateX(-50%); z-index: 10; display: flex; gap: 10px; padding: 10px; border: 1px solid rgba(255,215,106,.2); border-radius: 22px; background: rgba(5,8,14,.68); backdrop-filter: blur(14px); }
-.az-skills button { width: 64px; height: 60px; border: 1px solid rgba(0,229,255,.24); border-radius: 16px; color: white; background: linear-gradient(180deg, rgba(0,229,255,.12), rgba(103,92,255,.12)); box-shadow: inset 0 1px 0 rgba(255,255,255,.1); }
-.az-skills span { display: block; font-size: 21px; }
-.az-skills small { display: block; margin-top: 2px; color: rgba(244,247,255,.72); font-size: 9px; }
-.az-chat { position: absolute; left: 14px; bottom: 18px; z-index: 9; width: min(360px, calc(100vw - 28px)); padding: 12px 14px; border: 1px solid rgba(0,229,255,.18); border-radius: 18px; color: rgba(255,255,255,.72); background: rgba(5,8,14,.46); backdrop-filter: blur(10px); font-size: 12px; }
-.az-chat p { margin: 3px 0; }
-.az-chat b { color: var(--cz-gold); }
-.az-hint { position: absolute; right: 18px; bottom: 22px; z-index: 9; color: rgba(255,255,255,.45); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
 
-@media (max-width: 820px) {
-  .az-top { align-items: flex-start; }
-  .az-skills { bottom: 16px; right: 12px; left: auto; transform: none; flex-direction: column; }
-  .az-chat { bottom: 16px; width: calc(100vw - 116px); }
-  .az-hint { display: none; }
+.stitch-hud { position: absolute; inset: 0; z-index: 20; pointer-events: none; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+.stitch-hud button, .stitch-hud input { pointer-events: auto; }
+.stitch-scanlines { position: absolute; inset: 0; pointer-events: none; opacity: .22; background: repeating-linear-gradient(0deg, rgba(255,255,255,.05) 0 1px, transparent 1px 4px); mix-blend-mode: overlay; }
+.stitch-topbar { position: absolute; top: 14px; left: 14px; right: 14px; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 14px; border: 1px solid rgba(0,229,255,.28); border-radius: 20px; background: linear-gradient(135deg, rgba(3,8,16,.82), rgba(13,18,33,.58)); box-shadow: 0 0 30px rgba(0,229,255,.14), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(15px); pointer-events: auto; }
+.stitch-kicker { display: block; color: var(--st-aether); font-size: 10px; font-weight: 950; letter-spacing: .22em; }
+.stitch-brand strong { display: block; margin-top: 2px; color: #fff6d7; font-size: 16px; letter-spacing: .02em; }
+.stitch-node-status { display: grid; justify-items: end; gap: 2px; color: rgba(244,247,255,.75); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.stitch-node-status b { color: #d9ffd2; font-size: 12px; }
+.stitch-live-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; background: #ff3f6f; box-shadow: 0 0 14px #ff3f6f; justify-self: end; }
+.stitch-live-dot.on { background: var(--st-emerald); box-shadow: 0 0 14px var(--st-emerald); }
+
+.stitch-vitals { position: absolute; top: 94px; left: 14px; width: 246px; padding: 14px; border: 1px solid rgba(255,215,106,.22); border-radius: 24px; background: rgba(4,8,14,.66); box-shadow: 0 0 34px rgba(255,215,106,.08), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(12px); pointer-events: auto; }
+.stitch-portrait { width: 74px; height: 74px; border-radius: 22px; display: grid; place-items: center; color: var(--st-aether); font-weight: 950; font-size: 38px; background: radial-gradient(circle, rgba(0,229,255,.24), rgba(139,92,246,.08)); border: 1px solid rgba(0,229,255,.32); box-shadow: inset 0 0 22px rgba(0,229,255,.15); float: left; margin-right: 12px; }
+.stitch-nameplate { min-height: 74px; display: grid; align-content: center; }
+.stitch-nameplate small { color: rgba(244,247,255,.55); text-transform: uppercase; letter-spacing: .14em; font-size: 10px; }
+.stitch-nameplate strong { color: white; font-size: 18px; }
+.stitch-gauge { clear: both; margin-top: 10px; }
+.stitch-gauge div { display: flex; justify-content: space-between; color: rgba(244,247,255,.72); font-size: 10px; letter-spacing: .12em; font-weight: 900; }
+.stitch-gauge { height: 24px; position: relative; border-radius: 999px; background: rgba(255,255,255,.055); border: 1px solid rgba(255,255,255,.08); overflow: hidden; }
+.stitch-gauge div { position: relative; z-index: 1; padding: 5px 9px; }
+.stitch-gauge i { position: absolute; inset: 0 auto 0 0; display: block; border-radius: inherit; transition: width .2s ease; }
+.stitch-gauge.ruby i { background: linear-gradient(90deg, #7f1028, var(--st-ruby)); }
+.stitch-gauge.aether i { background: linear-gradient(90deg, #0d4e66, var(--st-aether)); }
+.stitch-gauge.emerald i { background: linear-gradient(90deg, #156b22, var(--st-emerald)); }
+.stitch-gauge.gold i { background: linear-gradient(90deg, #725310, var(--st-gold)); }
+
+.stitch-side-menu { position: absolute; top: 94px; right: 14px; display: grid; gap: 8px; pointer-events: auto; }
+.stitch-side-menu button { width: 96px; min-height: 56px; border: 1px solid rgba(0,229,255,.2); border-radius: 18px; color: rgba(244,247,255,.82); background: rgba(4,8,14,.62); box-shadow: inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(10px); }
+.stitch-side-menu button.active, .stitch-side-menu button:hover { border-color: var(--st-gold); color: white; background: rgba(255,215,106,.12); }
+.stitch-side-menu span { display: block; font-size: 20px; }
+.stitch-side-menu small { display: block; margin-top: 2px; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+
+.stitch-radar { position: absolute; right: 126px; top: 94px; width: 188px; min-height: 96px; display: flex; align-items: center; gap: 14px; padding: 12px; border: 1px solid rgba(57,255,20,.2); border-radius: 22px; background: rgba(4,8,14,.48); backdrop-filter: blur(10px); color: rgba(244,247,255,.7); pointer-events: auto; }
+.stitch-radar b { display: block; color: var(--st-emerald); }
+.stitch-radar small { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+.stitch-radar-ring { width: 66px; height: 66px; border-radius: 50%; position: relative; border: 1px solid rgba(57,255,20,.38); box-shadow: 0 0 18px rgba(57,255,20,.12), inset 0 0 18px rgba(57,255,20,.08); }
+.stitch-radar-ring i { position: absolute; width: 7px; height: 7px; border-radius: 50%; background: var(--st-emerald); box-shadow: 0 0 12px var(--st-emerald); }
+.stitch-radar-ring i:nth-child(1) { left: 18px; top: 17px; }
+.stitch-radar-ring i:nth-child(2) { right: 17px; top: 30px; }
+.stitch-radar-ring i:nth-child(3) { left: 30px; bottom: 13px; }
+
+.stitch-chat { position: absolute; left: 14px; bottom: 18px; width: min(390px, calc(100vw - 28px)); padding: 12px; border: 1px solid rgba(0,229,255,.18); border-radius: 22px; background: rgba(4,8,14,.58); backdrop-filter: blur(12px); pointer-events: auto; }
+.stitch-panel-title { display: flex; justify-content: space-between; color: rgba(244,247,255,.58); font-size: 10px; text-transform: uppercase; letter-spacing: .12em; }
+.stitch-panel-title b { color: var(--st-aether); }
+.stitch-panel-title span { color: var(--st-emerald); }
+.stitch-chat-lines { min-height: 104px; max-height: 104px; overflow: hidden; margin: 8px 0; }
+.stitch-chat-lines p { margin: 4px 0; color: rgba(244,247,255,.76); font-size: 12px; }
+.stitch-chat-lines b { color: var(--st-gold); }
+.stitch-chat-input { display: flex; gap: 8px; }
+.stitch-chat-input input { min-width: 0; flex: 1; border: 1px solid rgba(255,255,255,.1); border-radius: 14px; padding: 10px 12px; color: white; background: rgba(0,0,0,.32); outline: none; }
+.stitch-chat-input button, .stitch-bottom-right button { border: 1px solid rgba(0,229,255,.26); border-radius: 14px; padding: 10px 12px; color: #061018; font-weight: 950; background: linear-gradient(135deg, var(--st-aether), var(--st-gold)); }
+
+.stitch-skillbar { position: absolute; left: 50%; bottom: 20px; transform: translateX(-50%); display: flex; gap: 10px; padding: 10px; border: 1px solid rgba(255,215,106,.22); border-radius: 24px; background: rgba(4,8,14,.64); backdrop-filter: blur(12px); pointer-events: auto; }
+.stitch-skillbar button { position: relative; width: 76px; height: 72px; border: 1px solid rgba(0,229,255,.2); border-radius: 18px; color: white; background: linear-gradient(180deg, rgba(0,229,255,.12), rgba(139,92,246,.13)); }
+.stitch-skillbar button:hover { border-color: var(--st-gold); transform: translateY(-2px); }
+.stitch-skillbar kbd { position: absolute; top: 6px; left: 7px; color: rgba(244,247,255,.5); font-size: 10px; }
+.stitch-skillbar span { display: block; font-size: 23px; }
+.stitch-skillbar b { display: block; font-size: 11px; }
+.stitch-skillbar small { display: block; color: rgba(244,247,255,.58); font-size: 8px; margin-top: 1px; }
+.stitch-bottom-right { position: absolute; right: 14px; bottom: 20px; display: flex; gap: 8px; pointer-events: auto; }
+
+.stitch-modal { position: absolute; inset: 0; display: grid; place-items: center; background: rgba(0,0,0,.18); pointer-events: auto; }
+.stitch-modal-card { width: min(720px, calc(100vw - 28px)); max-height: min(620px, calc(100vh - 42px)); overflow: auto; border: 1px solid rgba(0,229,255,.28); border-radius: 30px; background: linear-gradient(135deg, rgba(4,8,14,.92), rgba(19,25,45,.86)); box-shadow: 0 28px 100px rgba(0,0,0,.48), 0 0 34px rgba(0,229,255,.13); backdrop-filter: blur(18px); padding: 20px; }
+.stitch-modal-card header { display: flex; justify-content: space-between; align-items: start; gap: 14px; margin-bottom: 18px; }
+.stitch-modal-card small { color: var(--st-aether); font-size: 10px; letter-spacing: .18em; font-weight: 950; }
+.stitch-modal-card h2 { margin: 4px 0 0; font-size: clamp(28px, 5vw, 48px); letter-spacing: -.05em; }
+.stitch-modal-card header button { width: 38px; height: 38px; border-radius: 13px; border: 1px solid rgba(255,255,255,.12); background: rgba(255,255,255,.06); color: white; font-size: 24px; }
+.stitch-grid-panel { display: grid; grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); gap: 12px; }
+.stitch-info { min-height: 108px; border: 1px solid rgba(255,255,255,.1); border-radius: 22px; padding: 15px; background: rgba(255,255,255,.045); display: grid; align-content: center; gap: 8px; }
+.stitch-info small { color: rgba(244,247,255,.54); }
+.stitch-info b { color: #fff6d7; font-size: 18px; }
+.stitch-map-preview { height: 260px; position: relative; border: 1px solid rgba(57,255,20,.18); border-radius: 24px; overflow: hidden; background: radial-gradient(circle at 45% 45%, rgba(57,255,20,.18), transparent 20%), linear-gradient(135deg, rgba(0,229,255,.1), rgba(255,215,106,.06)); }
+.stitch-map-preview span { position: absolute; width: 15px; height: 15px; border-radius: 50%; background: var(--st-gold); box-shadow: 0 0 18px var(--st-gold); }
+.stitch-map-preview span:nth-child(1) { left: 18%; top: 32%; }
+.stitch-map-preview span:nth-child(2) { left: 62%; top: 45%; }
+.stitch-map-preview span:nth-child(3) { left: 42%; top: 70%; }
+.stitch-map-preview span:nth-child(4) { left: 78%; top: 22%; }
+.stitch-map-preview b { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); color: white; font-size: 24px; text-shadow: 0 0 18px black; }
+
+@media (max-width: 920px) {
+  .stitch-topbar { left: 10px; right: 10px; top: 10px; padding: 10px; }
+  .stitch-brand strong { font-size: 14px; }
+  .stitch-node-status small { display: none; }
+  .stitch-vitals { top: 78px; left: 10px; width: 210px; padding: 10px; }
+  .stitch-portrait { width: 54px; height: 54px; font-size: 28px; border-radius: 17px; }
+  .stitch-nameplate { min-height: 54px; }
+  .stitch-radar { display: none; }
+  .stitch-side-menu { top: auto; bottom: 102px; right: 10px; grid-template-columns: repeat(2, 52px); }
+  .stitch-side-menu button { width: 52px; min-height: 48px; border-radius: 16px; }
+  .stitch-side-menu small { display: none; }
+  .stitch-chat { width: calc(100vw - 116px); left: 10px; bottom: 10px; padding: 10px; }
+  .stitch-chat-lines { min-height: 70px; max-height: 70px; }
+  .stitch-skillbar { left: auto; right: 10px; bottom: 10px; transform: none; flex-direction: column; gap: 7px; padding: 7px; border-radius: 20px; }
+  .stitch-skillbar button { width: 74px; height: 54px; }
+  .stitch-skillbar small { display: none; }
+  .stitch-bottom-right { display: none; }
+}
+
+@media (max-width: 520px) {
+  .stitch-vitals { width: calc(100vw - 20px); display: grid; grid-template-columns: 54px 1fr; gap: 8px; }
+  .stitch-vitals .stitch-gauge { grid-column: span 2; margin-top: 0; }
+  .stitch-chat { width: calc(100vw - 104px); }
+  .stitch-kicker { letter-spacing: .12em; }
 }


### PR DESCRIPTION
Integrates the uploaded Arelorian Science / Stitch pixel MMORPG interface kit into the existing Pixi 2D client as a functional React HUD layer.

Changes:
- adds `ArelorianStitchHud.tsx`
- replaces the old minimal overlay in `CyberZenIsoApp` with the new HUD
- keeps Pixi as the world renderer and React as the HUD layer
- adds functional panels for:
  - Inventory Matrix
  - Character & Skills
  - Combat Matrix
  - Map
  - Guild
  - Factions
  - Quests
- wires HUD buttons to existing callbacks:
  - skill buttons send `USE_SKILL`
  - chat form sends local chat
  - interact button sends interaction ping
- shows runtime state:
  - connection status
  - asset loading status
  - weapon visual pool count
  - local/oracle chat feed
- adds responsive mobile/tablet/desktop styling in `theme.css`

The uploaded kit is HTML/Tailwind prototype material, so this PR ports the design language into native React/CSS without relying on external CDN/Tailwind runtime dependencies.