### PR TITLE
fix(build): install unzip for 2D asset extraction

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -3,6 +3,9 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
+# Build tooling required by asset import/extraction scripts
+RUN apk add --no-cache unzip
+
 # Enable pnpm
 RUN corepack enable && corepack prepare pnpm@9.12.2 --activate
 


### PR DESCRIPTION
Fixes a production build risk introduced by the 2D weapon pool integration.

The client-2d prebuild step extracts `asset-packs/2d/weapons/wasd-2d-weapon-pool.zip` via `unzip`. The production builder image is `node:22-alpine`, which does not guarantee `unzip` is available.

Change:
- installs `unzip` in the Docker builder stage before `pnpm run build`

Why:
Without this, VPS Docker builds can fail before Vite builds the 2D client assets.