### PR TITLE
fix(vps): sync Docker lockfile override and unzip

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-RUN apk add --no-cache libc6-compat dumb-init python3 make g++
+RUN apk add --no-cache libc6-compat dumb-init python3 make g++ unzip
 
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH

--- a/scripts/sync-pnpm-lockfile-for-docker.py
+++ b/scripts/sync-pnpm-lockfile-for-docker.py
@@ -18,7 +18,7 @@ SETTINGS_MARKER = "settings:\n  autoInstallPeers: true\n  excludeLinksFromLockfi
 OVERRIDES = {
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@types/node": "^25.7.0",
+    "@types/node": "^25.9.0",
     "zod": "^4.4.3",
     "three": "0.184.0",
     "@babylonjs/core": "^9.6.2",


### PR DESCRIPTION
Fixes the VPS deploy failure seen on commit c21a6c49.

Root cause:
- `scripts/sync-pnpm-lockfile-for-docker.py` still hardcoded `@types/node: ^25.7.0`
- root `package.json` and `pnpm-lock.yaml` now use `@types/node: ^25.9.0`
- during Docker build, the script rewrote the lockfile importer specifier back to ^25.7.0
- `pnpm install --frozen-lockfile` then correctly failed because package.json and lockfile disagreed

Also fixes:
- `Dockerfile.vps` now installs `unzip`, required by the 2D weapon pool prebuild extractor.

This targets the actual VPS Docker path, not only Dockerfile.prod.