### PR TITLE
ci(monorepo): add guard against package and lockfile drift

### DIFF
--- a/.github/workflows/monorepo-guard.yml
+++ b/.github/workflows/monorepo-guard.yml
@@ -1,0 +1,25 @@
+name: Monorepo Guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm guard:monorepo
+      - run: pnpm guard:monorepo:frozen

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "dev:3d": "pnpm -r --filter @wasd/client dev",
     "dev:all": "concurrently \"pnpm dev:2d\" \"pnpm dev:3d\" \"pnpm dev:web\"",
     "build:all": "pnpm build:2d && pnpm build:3d && pnpm build:web",
+    "guard:monorepo": "node scripts/monorepo-guard.mjs",
+    "guard:monorepo:frozen": "MONOREPO_GUARD_RUN_PNPM=1 node scripts/monorepo-guard.mjs",
     "clean": "pnpm -r exec rm -rf dist node_modules"
   },
   "engines": {

--- a/scripts/monorepo-guard.mjs
+++ b/scripts/monorepo-guard.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const errors = [];
+const warnings = [];
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function fail(message, hint) {
+  errors.push({ message, hint });
+}
+
+function warn(message, hint) {
+  warnings.push({ message, hint });
+}
+
+function extractPythonOverride(scriptText, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`"${escaped}"\\s*:\\s*"([^"]+)"`);
+  return scriptText.match(re)?.[1] ?? null;
+}
+
+function extractLockRootSpecifier(lockText, dep) {
+  const escaped = dep.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const depRe = new RegExp(`\\n      '${escaped}':\\n        specifier: ([^\\n]+)|\\n      ${escaped}:\\n        specifier: ([^\\n]+)`);
+  const m = lockText.match(depRe);
+  return (m?.[1] ?? m?.[2] ?? null)?.replace(/^['"]|['"]$/g, '') ?? null;
+}
+
+function checkRootOverrideConsistency() {
+  const pkg = readJson('package.json');
+  const lock = readFileSync('pnpm-lock.yaml', 'utf8');
+  const dockerSync = readFileSync('scripts/sync-pnpm-lockfile-for-docker.py', 'utf8');
+
+  const watched = new Set([
+    ...Object.keys(pkg.devDependencies ?? {}),
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.pnpm?.overrides ?? {}),
+    ...Object.keys(pkg.pnpm?.resolutions ?? {}),
+  ]);
+
+  for (const dep of watched) {
+    const pkgSpec = pkg.devDependencies?.[dep] ?? pkg.dependencies?.[dep] ?? null;
+    const overrideSpec = pkg.pnpm?.overrides?.[dep] ?? pkg.pnpm?.resolutions?.[dep] ?? pkgSpec;
+    if (!overrideSpec) continue;
+
+    const lockRootSpecifier = extractLockRootSpecifier(lock, dep);
+    if (lockRootSpecifier && lockRootSpecifier !== overrideSpec) {
+      fail(
+        `Lockfile drift for ${dep}: pnpm-lock.yaml root importer has ${lockRootSpecifier}, package.json/overrides expects ${overrideSpec}.`,
+        `Run pnpm install locally or update pnpm-lock.yaml so ${dep} uses ${overrideSpec}. This is a monorepo; root package.json and lockfile must agree before merge.`
+      );
+    }
+
+    const dockerOverride = extractPythonOverride(dockerSync, dep);
+    if (dockerOverride && dockerOverride !== overrideSpec) {
+      fail(
+        `Docker lockfile sync drift for ${dep}: sync-pnpm-lockfile-for-docker.py has ${dockerOverride}, package.json/overrides expects ${overrideSpec}.`,
+        `Update scripts/sync-pnpm-lockfile-for-docker.py OVERRIDES.${dep} to ${overrideSpec}. Otherwise VPS Docker rewrites the lockfile during build and frozen install fails.`
+      );
+    }
+  }
+}
+
+function checkWorkspacePackageVersions() {
+  const root = readJson('package.json');
+  const rootPackageManager = root.packageManager ?? null;
+  if (rootPackageManager) return;
+  warn(
+    'Root package.json has no packageManager field.',
+    'Consider adding packageManager, e.g. pnpm@9.12.2 or the chosen repo-wide version. This makes agents and CI use one package manager version.'
+  );
+}
+
+function checkVpsBuildTooling() {
+  const dockerfile = existsSync('Dockerfile.vps') ? readFileSync('Dockerfile.vps', 'utf8') : '';
+  const client2dPkg = existsSync('apps/client-2d/package.json') ? readJson('apps/client-2d/package.json') : null;
+  const prebuild = client2dPkg?.scripts?.prebuild ?? '';
+
+  if (prebuild.includes('extract-2d-weapon-pool') && !/apk add[^\n]*unzip/.test(dockerfile)) {
+    fail(
+      'Dockerfile.vps does not install unzip, but @wasd/client-2d prebuild extracts a ZIP asset pack.',
+      'Add unzip to the builder apk line: RUN apk add --no-cache ... unzip. This is required before VPS deploy.'
+    );
+  }
+}
+
+function checkFrozenInstallDryRun() {
+  try {
+    execFileSync('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts'], { stdio: 'pipe' });
+  } catch (error) {
+    fail(
+      'pnpm frozen-lockfile validation failed.',
+      'This repo is a pnpm monorepo. package.json and pnpm-lock.yaml must be updated together. Run pnpm install and commit pnpm-lock.yaml, or align dependency versions manually.'
+    );
+  }
+}
+
+checkRootOverrideConsistency();
+checkWorkspacePackageVersions();
+checkVpsBuildTooling();
+
+if (process.env.MONOREPO_GUARD_RUN_PNPM === '1') {
+  checkFrozenInstallDryRun();
+}
+
+for (const warning of warnings) {
+  console.warn(`MONOREPO GUARD WARNING: ${warning.message}\n  Hint: ${warning.hint}`);
+}
+
+if (errors.length > 0) {
+  console.error('\nMONOREPO GUARD FAILED');
+  console.error('This is a pnpm monorepo. Keep root package.json, workspace package.json files, pnpm-lock.yaml, Docker lockfile sync overrides, and VPS build tooling aligned.');
+  for (const error of errors) {
+    console.error(`\n- ${error.message}\n  Fix: ${error.hint}`);
+  }
+  process.exit(1);
+}
+
+console.log('MONOREPO GUARD OK: package/lockfile/Docker sync checks passed.');


### PR DESCRIPTION
Adds a monorepo guard to catch exactly the class of failures that broke the VPS deploy.

What it checks:
- root package.json dependency/override/resolution versions against pnpm-lock.yaml root importer specifiers
- Docker lockfile sync script overrides against package.json overrides
- VPS Dockerfile build tooling requirements, e.g. unzip when client-2d prebuild extracts ZIP assets
- optional pnpm frozen-lockfile validation

Added scripts:
- `pnpm guard:monorepo`
- `pnpm guard:monorepo:frozen`

Added workflow:
- `.github/workflows/monorepo-guard.yml`

Important follow-up:
To truly block bad merges, enable branch protection for `main` and require the `Monorepo Guard / guard` check before merge.