### PR TITLE
fix(deploy): route public domain to WASD container and verify UI deploys

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -7,12 +7,19 @@ on:
       - main
     paths:
       - 'server/**'
+      - 'client/**'
+      - 'portal/**'
+      - 'apps/client-2d/**'
+      - 'asset-packs/**'
       - 'packages/core-logic/**'
       - 'packages/shared/**'
       - 'Dockerfile*'
       - 'docker-compose*.yml'
+      - '.dockerignore'
       - 'scripts/deploy-vps-docker.sh'
       - 'scripts/vps-docker-inline-deploy.sh'
+      - 'scripts/write-runtime-entrypoints.mjs'
+      - 'scripts/extract-2d-weapon-pool.mjs'
       - '.github/workflows/vps-docker-deploy.yml'
   pull_request:
     types:
@@ -21,12 +28,19 @@ on:
       - main
     paths:
       - 'server/**'
+      - 'client/**'
+      - 'portal/**'
+      - 'apps/client-2d/**'
+      - 'asset-packs/**'
       - 'packages/core-logic/**'
       - 'packages/shared/**'
       - 'Dockerfile*'
       - 'docker-compose*.yml'
+      - '.dockerignore'
       - 'scripts/deploy-vps-docker.sh'
       - 'scripts/vps-docker-inline-deploy.sh'
+      - 'scripts/write-runtime-entrypoints.mjs'
+      - 'scripts/extract-2d-weapon-pool.mjs'
       - '.github/workflows/vps-docker-deploy.yml'
   workflow_dispatch:
     inputs:
@@ -155,3 +169,14 @@ jobs:
             test -f scripts/vps-docker-inline-deploy.sh || { echo "ERROR: missing scripts/vps-docker-inline-deploy.sh"; exit 1; }
             chmod +x scripts/vps-docker-inline-deploy.sh
             bash scripts/vps-docker-inline-deploy.sh
+
+      - name: Verify public runtime route
+        run: |
+          set -euo pipefail
+          echo "Checking public runtime marker..."
+          body="$(curl -fsSL --max-time 20 https://arelorian.de/runtime-build-info.json || true)"
+          echo "$body"
+          echo "$body" | grep -q 'entrypoints' || {
+            echo "::error::Public domain does not serve runtime-build-info.json from the new WASD container. Check Traefik/nginx route for arelorian.de -> arelorian-engine:3001."
+            exit 1
+          }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,21 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:${ARELORIAN_PORT:-3001}:3001"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${ARELORIAN_DOCKER_NETWORK:-areloria_arelorian-network}"
+      - "traefik.http.services.arelorian-engine.loadbalancer.server.port=3001"
+      - "traefik.http.routers.arelorian-engine.rule=Host(`arelorian.de`) || Host(`www.arelorian.de`)"
+      - "traefik.http.routers.arelorian-engine.entrypoints=websecure"
+      - "traefik.http.routers.arelorian-engine.tls=true"
+      - "traefik.http.routers.arelorian-engine.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.arelorian-engine.priority=10000"
+      - "traefik.http.routers.arelorian-engine.service=arelorian-engine"
+      - "traefik.http.routers.arelorian-engine-http.rule=Host(`arelorian.de`) || Host(`www.arelorian.de`)"
+      - "traefik.http.routers.arelorian-engine-http.entrypoints=web"
+      - "traefik.http.routers.arelorian-engine-http.middlewares=arelorian-engine-https-redirect"
+      - "traefik.http.routers.arelorian-engine-http.priority=10000"
+      - "traefik.http.middlewares.arelorian-engine-https-redirect.redirectscheme.scheme=https"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs


### PR DESCRIPTION
Addresses the situation where the VPS deploy succeeds internally but https://arelorian.de still shows stale/old content.

Root cause likely observed:
- `arelorian-engine` is published only on `127.0.0.1:3001`.
- Public `arelorian.de` appears to be served by an external reverse proxy/static route that is not pointing at the new container.
- The deploy workflow did not trigger for many UI/client changes and did not verify the public route.

Changes:
- adds Traefik labels to `arelorian-engine` for `arelorian.de` and `www.arelorian.de`
- routes Traefik service to container port `3001`
- gives the route high priority so it can override stale domain routers
- expands VPS deploy trigger paths to include:
  - `client/**`
  - `portal/**`
  - `apps/client-2d/**`
  - `asset-packs/**`
  - runtime entrypoint/asset scripts
- adds post-deploy public verification:
  - fetches `https://arelorian.de/runtime-build-info.json`
  - fails workflow if it does not contain the runtime `entrypoints` marker

Expected outcome:
- Deploy no longer passes while the public domain still serves stale content.
- If the public route is still wrong, the workflow fails with an explicit routing error instead of pretending success.