### PR TITLE
chore(deploy): trigger public route diagnostics run

### DIFF
--- a/scripts/vps-public-route-diagnostics.sh
+++ b/scripts/vps-public-route-diagnostics.sh
@@ -6,6 +6,7 @@ PORT="${ARELORIAN_PORT:-3001}"
 NETWORK="${ARELORIAN_DOCKER_NETWORK:-areloria_arelorian-network}"
 
 echo "=== VPS PUBLIC ROUTE DIAGNOSTICS ==="
+echo "Diagnostics revision: trigger-2026-05-19-route-owner"
 echo "Domain: $DOMAIN"
 echo "Engine host port: $PORT"
 echo "Docker network: $NETWORK"


### PR DESCRIPTION
Adds a harmless diagnostics revision marker to `scripts/vps-public-route-diagnostics.sh` so the `VPS Route Diagnostics` workflow auto-runs on main.

Purpose:
- trigger the correct diagnostics workflow
- get the VPS route-owner evidence without relying on manual GitHub UI navigation