### PR TITLE
fix(deploy): avoid relative nginx configs and repair public nginx

### DIFF
--- a/scripts/vps-nginx-route-areloria.sh
+++ b/scripts/vps-nginx-route-areloria.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 DOMAIN="${ARELORIAN_PUBLIC_DOMAIN:-arelorian.de}"
 UPSTREAM="${ARELORIAN_UPSTREAM:-http://127.0.0.1:${ARELORIAN_PORT:-3001}}"
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+PUBLIC_NGINX_BIN="${PUBLIC_NGINX_BIN:-/usr/sbin/nginx}"
+PUBLIC_NGINX_CONF="${PUBLIC_NGINX_CONF:-/etc/nginx/nginx.conf}"
+PUBLIC_NGINX_ROOT="$(dirname "$PUBLIC_NGINX_CONF")"
+INCLUDE_DIR="${PUBLIC_NGINX_ROOT}/conf.d"
+MANAGED_FILE="${INCLUDE_DIR}/99-wasd-areloria.conf"
+BACKUP_DIR="${PUBLIC_NGINX_ROOT}/wasd-backups/${STAMP}"
 
 run_root() {
   if [ "$(id -u)" = "0" ]; then
@@ -28,25 +34,14 @@ write_root() {
   fi
 }
 
-read_root() {
+file_exists() {
   local path="$1"
   if [ "$(id -u)" = "0" ]; then
-    cat "$path"
+    [ -f "$path" ]
   elif command -v sudo >/dev/null 2>&1; then
-    sudo cat "$path"
+    sudo test -f "$path"
   else
-    cat "$path"
-  fi
-}
-
-path_exists() {
-  local path="$1"
-  if [ "$(id -u)" = "0" ]; then
-    [ -e "$path" ]
-  elif command -v sudo >/dev/null 2>&1; then
-    sudo test -e "$path"
-  else
-    [ -e "$path" ]
+    [ -f "$path" ]
   fi
 }
 
@@ -61,194 +56,98 @@ dir_exists() {
   fi
 }
 
-file_exists() {
-  local path="$1"
-  if [ "$(id -u)" = "0" ]; then
-    [ -f "$path" ]
-  elif command -v sudo >/dev/null 2>&1; then
-    sudo test -f "$path"
+safe_backup_public_nginx() {
+  run_root mkdir -p "$BACKUP_DIR"
+  if dir_exists "$PUBLIC_NGINX_ROOT"; then
+    run_root cp -a "$PUBLIC_NGINX_ROOT" "$BACKUP_DIR/nginx-root" 2>/dev/null || true
+  fi
+  if dir_exists "$BACKUP_DIR/nginx-root"; then
+    echo "Backed up public nginx root to $BACKUP_DIR/nginx-root"
   else
-    [ -f "$path" ]
+    echo "WARN: No full public nginx root backup was created. Continuing with nginx -t validation."
   fi
 }
 
-nginx_main_config() {
-  local from_proc from_v from_known
-  from_proc="$(ps -eo args | awk '/[n]ginx: master process/ {for(i=1;i<=NF;i++){if($i=="-c"){print $(i+1); exit}}}')"
-  if [ -n "$from_proc" ] && file_exists "$from_proc"; then
-    echo "$from_proc"
-    return 0
+restore_public_nginx_if_possible() {
+  if dir_exists "$BACKUP_DIR/nginx-root"; then
+    echo "Restoring public nginx root from $BACKUP_DIR/nginx-root"
+    run_root rm -rf "$PUBLIC_NGINX_ROOT"
+    run_root cp -a "$BACKUP_DIR/nginx-root" "$PUBLIC_NGINX_ROOT"
+  else
+    echo "WARN: No backup exists to restore. Removing managed file only."
+    run_root rm -f "$MANAGED_FILE" 2>/dev/null || true
   fi
-
-  from_v="$(nginx -V 2>&1 | sed -n 's/.*--conf-path=\([^ ]*\).*/\1/p' | tail -n 1)"
-  if [ -n "$from_v" ] && file_exists "$from_v"; then
-    echo "$from_v"
-    return 0
-  fi
-
-  for from_known in \
-    /etc/nginx/nginx.conf \
-    /usr/local/nginx/conf/nginx.conf \
-    /usr/local/lsws/conf/nginx.conf \
-    /etc/openresty/nginx.conf \
-    /usr/local/openresty/nginx/conf/nginx.conf \
-    /var/lib/nginx/conf/nginx.conf \
-    /etc/hpanel/nginx/nginx.conf \
-    /opt/hostinger/nginx/conf/nginx.conf; do
-    if file_exists "$from_known"; then
-      echo "$from_known"
-      return 0
-    fi
-  done
-
-  return 1
 }
 
-choose_include_dir() {
-  local main_conf="$1"
-  local base_dir conf_text candidate
-  base_dir="$(dirname "$main_conf")"
-  conf_text="$(read_root "$main_conf" 2>/dev/null || true)"
+write_minimal_public_nginx_conf_if_missing() {
+  if file_exists "$PUBLIC_NGINX_CONF"; then
+    return 0
+  fi
 
-  for candidate in \
-    "$(echo "$conf_text" | sed -n 's/^[[:space:]]*include[[:space:]]\+\([^;]*conf\.d\/\*\.conf\)[[:space:]]*;.*/\1/p' | head -n 1)" \
-    "$(echo "$conf_text" | sed -n 's/^[[:space:]]*include[[:space:]]\+\([^;]*sites-enabled\/\*\)[[:space:]]*;.*/\1/p' | head -n 1)" \
-    "$base_dir/conf.d/*.conf" \
-    "$base_dir/sites-enabled/*" \
-    /etc/nginx/conf.d/*.conf \
-    /etc/nginx/sites-enabled/*; do
-    [ -n "$candidate" ] || continue
-    case "$candidate" in
-      /*) ;;
-      *) candidate="$base_dir/$candidate" ;;
-    esac
-    candidate="${candidate%/*}"
-    if dir_exists "$candidate"; then
-      echo "$candidate"
-      return 0
-    fi
-  done
+  echo "WARN: $PUBLIC_NGINX_CONF is missing, but public nginx owns 80/443. Creating minimal WASD public nginx.conf."
+  run_root mkdir -p "$PUBLIC_NGINX_ROOT" "$INCLUDE_DIR" /var/log/nginx /var/lib/nginx/body /var/lib/nginx/proxy /run
+  cat <<'EOF' | write_root "$PUBLIC_NGINX_CONF"
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
-  # Last resort: create conf.d beside the active config. This only works when
-  # the main config already includes it, so caller must inject include if needed.
-  echo "$base_dir/conf.d"
+events {
+    worker_connections 1024;
 }
 
-ensure_include_present() {
-  local main_conf="$1"
-  local include_dir="$2"
-  local include_pattern="$include_dir/*.conf"
-  local conf_text tmp
-  conf_text="$(read_root "$main_conf" 2>/dev/null || true)"
+http {
+    sendfile on;
+    tcp_nopush on;
+    types_hash_max_size 2048;
+    server_tokens off;
 
-  if echo "$conf_text" | grep -Fq "$include_pattern"; then
-    return 0
-  fi
-  if echo "$conf_text" | grep -Eq '^[[:space:]]*include[[:space:]]+[^;]*conf\.d/\*\.conf[[:space:]]*;'; then
-    return 0
-  fi
-  if echo "$conf_text" | grep -Eq '^[[:space:]]*include[[:space:]]+[^;]*sites-enabled/\*[[:space:]]*;'; then
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    gzip on;
+    include /etc/nginx/conf.d/*.conf;
+}
+EOF
+}
+
+ensure_public_nginx_conf_includes_conf_d() {
+  local tmp
+  if ! file_exists "$PUBLIC_NGINX_CONF"; then
+    write_minimal_public_nginx_conf_if_missing
     return 0
   fi
 
-  echo "WARN: Could not prove active nginx config includes $include_pattern. Injecting include into http{} block."
+  if run_root sh -c "grep -Eq '^[[:space:]]*include[[:space:]]+/etc/nginx/conf\.d/\*\.conf[[:space:]]*;' '$PUBLIC_NGINX_CONF'"; then
+    return 0
+  fi
+
+  echo "WARN: $PUBLIC_NGINX_CONF does not include /etc/nginx/conf.d/*.conf. Injecting include into http{} block."
   tmp="$(mktemp)"
-  awk -v inc="    include ${include_pattern};" '
-    BEGIN { inserted=0; in_http=0 }
-    /^[[:space:]]*http[[:space:]]*\{/ && inserted==0 { print; print inc; inserted=1; next }
+  run_root cat "$PUBLIC_NGINX_CONF" | awk '
+    BEGIN { inserted=0 }
+    /^[[:space:]]*http[[:space:]]*\{/ && inserted==0 { print; print "    include /etc/nginx/conf.d/*.conf;"; inserted=1; next }
     { print }
     END { if (inserted==0) exit 42 }
-  ' <<< "$conf_text" > "$tmp" || {
-    echo "ERROR: active nginx config has no editable http{} block; cannot install route safely." >&2
+  ' > "$tmp" || {
     rm -f "$tmp"
+    echo "ERROR: Could not inject include because $PUBLIC_NGINX_CONF has no http{} block." >&2
     return 1
   }
-  cat "$tmp" | write_root "$main_conf"
+  cat "$tmp" | write_root "$PUBLIC_NGINX_CONF"
   rm -f "$tmp"
 }
 
-nginx_test() {
-  local main_conf="$1"
-  if [ -n "$main_conf" ]; then
-    run_root nginx -t -c "$main_conf"
-  else
-    run_root nginx -t
-  fi
-}
+write_route_conf() {
+  local cert_file="/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
+  local cert_key="/etc/letsencrypt/live/${DOMAIN}/privkey.pem"
+  run_root mkdir -p "$INCLUDE_DIR"
 
-nginx_reload() {
-  local main_conf="$1"
-  run_root nginx -s reload -c "$main_conf" || run_root systemctl reload nginx || run_root service nginx reload
-}
-
-echo "=== WASD nginx public route installer ==="
-echo "Domain: ${DOMAIN} www.${DOMAIN}"
-echo "Upstream: ${UPSTREAM}"
-
-if ! command -v nginx >/dev/null 2>&1; then
-  echo "nginx binary not found. Skipping nginx route install."
-  exit 0
-fi
-
-if ! pgrep -x nginx >/dev/null 2>&1; then
-  echo "nginx is installed but not running. Skipping nginx route install."
-  exit 0
-fi
-
-echo "nginx version/configure:"
-nginx -V 2>&1 | head -c 2000 || true
-echo
-
-echo "nginx master process:"
-ps -eo pid,args | grep '[n]ginx: master process' || true
-
-MAIN_CONF="$(nginx_main_config || true)"
-if [ -z "$MAIN_CONF" ]; then
-  echo "ERROR: Could not discover active nginx.conf. Refusing to edit unknown nginx layout." >&2
-  exit 1
-fi
-
-NGINX_ROOT="$(dirname "$MAIN_CONF")"
-BACKUP_DIR="${NGINX_ROOT}/wasd-backups/${STAMP}"
-INCLUDE_DIR="$(choose_include_dir "$MAIN_CONF")"
-MANAGED_FILE="${INCLUDE_DIR}/99-wasd-areloria.conf"
-
-echo "Active nginx.conf: $MAIN_CONF"
-echo "Nginx config root: $NGINX_ROOT"
-echo "Managed include dir: $INCLUDE_DIR"
-echo "Managed route file: $MANAGED_FILE"
-
-run_root mkdir -p "$BACKUP_DIR" "$INCLUDE_DIR"
-if path_exists "$NGINX_ROOT"; then
-  run_root cp -a "$NGINX_ROOT" "$BACKUP_DIR/nginx-root" 2>/dev/null || true
-fi
-if ! path_exists "$BACKUP_DIR/nginx-root"; then
-  echo "WARN: Could not create full nginx backup at $BACKUP_DIR/nginx-root; continuing with validation/rollback guarded by nginx -t."
-else
-  echo "Backed up nginx config root to $BACKUP_DIR/nginx-root"
-fi
-
-echo "Existing server_name references for ${DOMAIN}:"
-run_root sh -c "grep -RIn --include='*.conf' --include='*' 'server_name .*${DOMAIN}' '$(dirname "$NGINX_ROOT")' '$NGINX_ROOT' 2>/dev/null || true"
-
-# Disable older WASD-managed files if they exist to avoid duplicate server_name conflicts.
-run_root rm -f \
-  /etc/nginx/conf.d/99-wasd-areloria.conf \
-  /etc/nginx/sites-enabled/99-wasd-areloria.conf \
-  /etc/nginx/sites-available/99-wasd-areloria.conf \
-  "$MANAGED_FILE" 2>/dev/null || true
-
-ensure_include_present "$MAIN_CONF" "$INCLUDE_DIR"
-
-CERT_FILE="/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
-CERT_KEY="/etc/letsencrypt/live/${DOMAIN}/privkey.pem"
-HAS_CERT=false
-if file_exists "$CERT_FILE" && file_exists "$CERT_KEY"; then
-  HAS_CERT=true
-fi
-
-if [ "$HAS_CERT" = true ]; then
-  cat <<EOF | write_root "$MANAGED_FILE"
+  if file_exists "$cert_file" && file_exists "$cert_key"; then
+    cat <<EOF | write_root "$MANAGED_FILE"
 # Managed by WASD deploy. Do not edit manually; update scripts/vps-nginx-route-areloria.sh instead.
 # Generated: ${STAMP}
 # Domain: ${DOMAIN}
@@ -272,8 +171,8 @@ server {
     http2 on;
     server_name ${DOMAIN} www.${DOMAIN};
 
-    ssl_certificate ${CERT_FILE};
-    ssl_certificate_key ${CERT_KEY};
+    ssl_certificate ${cert_file};
+    ssl_certificate_key ${cert_key};
 
     location / {
         proxy_pass ${UPSTREAM};
@@ -290,9 +189,9 @@ server {
     }
 }
 EOF
-else
-  echo "WARN: TLS certificate files for ${DOMAIN} were not found. Installing HTTP-only nginx route."
-  cat <<EOF | write_root "$MANAGED_FILE"
+  else
+    echo "WARN: TLS cert files for ${DOMAIN} were not found. Installing HTTP route and leaving existing HTTPS listener untouched if any."
+    cat <<EOF | write_root "$MANAGED_FILE"
 # Managed by WASD deploy. HTTP-only fallback because Let's Encrypt certs were not found.
 # Generated: ${STAMP}
 # Domain: ${DOMAIN}
@@ -323,28 +222,67 @@ server {
     }
 }
 EOF
-fi
-
-echo "Testing nginx config with active config path..."
-if ! nginx_test "$MAIN_CONF"; then
-  echo "ERROR: nginx config test failed. Removing managed file and attempting restore."
-  run_root rm -f "$MANAGED_FILE" 2>/dev/null || true
-  if path_exists "$BACKUP_DIR/nginx-root"; then
-    echo "Restoring nginx config root from backup."
-    run_root rm -rf "$NGINX_ROOT"
-    run_root cp -a "$BACKUP_DIR/nginx-root" "$NGINX_ROOT"
   fi
-  nginx_test "$MAIN_CONF" || true
+}
+
+public_nginx_test() {
+  run_root "$PUBLIC_NGINX_BIN" -t -c "$PUBLIC_NGINX_CONF"
+}
+
+public_nginx_reload_or_restart() {
+  if run_root "$PUBLIC_NGINX_BIN" -s reload -c "$PUBLIC_NGINX_CONF"; then
+    return 0
+  fi
+  echo "WARN: nginx reload failed; trying systemctl/service restart for public nginx."
+  run_root systemctl restart nginx || run_root service nginx restart || run_root "$PUBLIC_NGINX_BIN" -c "$PUBLIC_NGINX_CONF"
+}
+
+echo "=== WASD nginx public route installer ==="
+echo "Domain: ${DOMAIN} www.${DOMAIN}"
+echo "Upstream: ${UPSTREAM}"
+echo "Public nginx binary: ${PUBLIC_NGINX_BIN}"
+echo "Public nginx config: ${PUBLIC_NGINX_CONF}"
+
+if [ ! -x "$PUBLIC_NGINX_BIN" ]; then
+  echo "ERROR: public nginx binary $PUBLIC_NGINX_BIN not found/executable." >&2
   exit 1
 fi
 
-echo "Reloading nginx with active config path..."
-nginx_reload "$MAIN_CONF"
+echo "nginx version/configure:"
+"$PUBLIC_NGINX_BIN" -V 2>&1 | head -c 2000 || true
+echo
 
-echo "Testing local nginx Host route..."
+echo "nginx master processes, for diagnostics only; Kong/OpenResty relative configs are ignored:"
+ps -eo pid,args | grep '[n]ginx: master process' || true
+
+echo "Public socket owners before route install:"
+ss -ltnp 2>/dev/null | grep -E ':(80|443|3001)\b' || true
+
+safe_backup_public_nginx
+write_minimal_public_nginx_conf_if_missing
+ensure_public_nginx_conf_includes_conf_d
+
+run_root rm -f "$MANAGED_FILE" 2>/dev/null || true
+write_route_conf
+
+echo "Testing public nginx config..."
+if ! public_nginx_test; then
+  echo "ERROR: public nginx config test failed. Rolling back WASD-managed route."
+  restore_public_nginx_if_possible
+  public_nginx_test || true
+  exit 1
+fi
+
+echo "Reloading/restarting public nginx..."
+public_nginx_reload_or_restart
+
+echo "Testing local nginx Host route after install..."
 curl -ksSL --max-time 10 -H "Host: ${DOMAIN}" "https://127.0.0.1/runtime-build-info.json" | head -c 800 || true
 echo
 curl -sSL --max-time 10 -H "Host: ${DOMAIN}" "http://127.0.0.1/runtime-build-info.json" | head -c 800 || true
 echo
+
+echo "Public socket owners after route install:"
+ss -ltnp 2>/dev/null | grep -E ':(80|443|3001)\b' || true
 
 echo "=== WASD nginx route installer done ==="


### PR DESCRIPTION
Fixes the route installer selecting Kong/OpenResty relative `nginx.conf` instead of the public nginx instance.

Observed from deploy log:
- public ports are owned by nginx
- multiple nginx masters exist:
  - Kong/OpenResty with relative `-c nginx.conf`
  - another base nginx
  - public `/usr/sbin/nginx`
- previous installer selected `nginx.conf`, treated `.` as config root, then restore attempted to remove `.`

Changes:
- stop discovering arbitrary nginx configs
- explicitly target public nginx binary `/usr/sbin/nginx`
- explicitly target public config `/etc/nginx/nginx.conf`
- if `/etc/nginx/nginx.conf` is missing, create a minimal safe public nginx config
- ignore Kong/OpenResty/Supabase nginx processes for route install
- never accept relative config paths
- never restore/delete `.`
- write only `/etc/nginx/conf.d/99-wasd-areloria.conf`
- test with `/usr/sbin/nginx -t -c /etc/nginx/nginx.conf`
- reload/restart public nginx only after test passes

Expected result:
The deploy should stop failing on relative `nginx.conf` and should route `arelorian.de` to `127.0.0.1:3001`.