### PR TITLE
fix(deploy): reduce VPS pnpm install pressure

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -10,12 +10,19 @@ ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 ENV CI=true
 ENV npm_config_jobs=1
-ENV NODE_OPTIONS=--max-old-space-size=2048
+ENV NODE_OPTIONS=--max-old-space-size=1024
+ENV PNPM_CONFIG_NETWORK_CONCURRENCY=1
+ENV PNPM_CONFIG_CHILD_CONCURRENCY=1
+ENV PNPM_CONFIG_WORKSPACE_CONCURRENCY=1
+ENV PNPM_CONFIG_SIDE_EFFECTS_CACHE=false
+ENV PNPM_CONFIG_VERIFY_STORE_INTEGRITY=false
 
 RUN corepack enable && corepack prepare pnpm@9.12.2 --activate && \
     pnpm config set store-dir /pnpm/store && \
-    pnpm config set network-concurrency 2 && \
+    pnpm config set network-concurrency 1 && \
     pnpm config set child-concurrency 1 && \
+    pnpm config set workspace-concurrency 1 && \
+    pnpm config set verify-store-integrity false && \
     pnpm config set side-effects-cache false
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
@@ -28,7 +35,8 @@ COPY engine/package.json engine/package.json
 COPY portal/package.json portal/package.json
 COPY scripts/sync-pnpm-lockfile-for-docker.py scripts/sync-pnpm-lockfile-for-docker.py
 
-RUN find packages apps projects -type f ! -name package.json -delete || true && \
+RUN --mount=type=cache,id=wasd-vps-pnpm-store,target=/pnpm/store \
+    find packages apps projects -type f ! -name package.json -delete || true && \
     rm -rf packages/sdk-examples || true && \
     find packages apps projects -type d -empty -delete || true && \
     printf '%s\n' \
@@ -41,7 +49,7 @@ RUN find packages apps projects -type f ! -name package.json -delete || true && 
       '  - packages/shared' \
       > pnpm-workspace.yaml && \
     python3 scripts/sync-pnpm-lockfile-for-docker.py && \
-    pnpm --filter @wasd/server... --filter @wasd/client... --filter @wasd/portal... --filter @wasd/client-2d... --filter @wasd/core-logic... --filter @wasd/shared... install --frozen-lockfile --prefer-offline --ignore-scripts
+    pnpm --filter @wasd/server... --filter @wasd/client... --filter @wasd/portal... --filter @wasd/client-2d... --filter @wasd/core-logic... --filter @wasd/shared... install --frozen-lockfile --prefer-offline --ignore-scripts --workspace-concurrency=1 --network-concurrency=1 --child-concurrency=1 --reporter=append-only
 
 COPY . .
 RUN rm -rf packages/sdk-examples || true && \


### PR DESCRIPTION
## Fix

Behebt den neuen VPS-Docker-Build-Abbruch:

```text
exit code: 137
```

Der Fehler tritt während `pnpm install` im Docker-Build auf und ist ein typischer OOM/Kill im Builder.

## Änderungen

- Reduziert Node-Heap während der pnpm-Install-Phase von 2048 MB auf 1024 MB.
- Setzt pnpm network/child/workspace concurrency auf 1.
- Deaktiviert Store-Integrity-Checks für weniger Install-Druck.
- Nutzt BuildKit Cache-Mount für `/pnpm/store`.
- Lässt den späteren Build-Heap weiterhin hoch, damit TypeScript/Vite danach genug Luft haben.

## Erwartetes Ergebnis

Der Build sollte beim Install-Schritt weniger RAM-Spitzen erzeugen und nicht mehr mit 137 sterben.