### PR TITLE
fix(deploy): remove unsupported pnpm install option

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -13,7 +13,6 @@ ENV npm_config_jobs=1
 ENV NODE_OPTIONS=--max-old-space-size=1024
 ENV PNPM_CONFIG_NETWORK_CONCURRENCY=1
 ENV PNPM_CONFIG_CHILD_CONCURRENCY=1
-ENV PNPM_CONFIG_WORKSPACE_CONCURRENCY=1
 ENV PNPM_CONFIG_SIDE_EFFECTS_CACHE=false
 ENV PNPM_CONFIG_VERIFY_STORE_INTEGRITY=false
 
@@ -21,7 +20,6 @@ RUN corepack enable && corepack prepare pnpm@9.12.2 --activate && \
     pnpm config set store-dir /pnpm/store && \
     pnpm config set network-concurrency 1 && \
     pnpm config set child-concurrency 1 && \
-    pnpm config set workspace-concurrency 1 && \
     pnpm config set verify-store-integrity false && \
     pnpm config set side-effects-cache false
 
@@ -49,7 +47,7 @@ RUN --mount=type=cache,id=wasd-vps-pnpm-store,target=/pnpm/store \
       '  - packages/shared' \
       > pnpm-workspace.yaml && \
     python3 scripts/sync-pnpm-lockfile-for-docker.py && \
-    pnpm --filter @wasd/server... --filter @wasd/client... --filter @wasd/portal... --filter @wasd/client-2d... --filter @wasd/core-logic... --filter @wasd/shared... install --frozen-lockfile --prefer-offline --ignore-scripts --workspace-concurrency=1 --network-concurrency=1 --child-concurrency=1 --reporter=append-only
+    pnpm --filter @wasd/server... --filter @wasd/client... --filter @wasd/portal... --filter @wasd/client-2d... --filter @wasd/core-logic... --filter @wasd/shared... install --frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
 
 COPY . .
 RUN rm -rf packages/sdk-examples || true && \


### PR DESCRIPTION
## Fix

Behebt den aktuellen VPS-Docker-Build-Fehler:

```text
ERROR Unknown option: 'workspace-concurrency'
```

## Änderungen

- Entfernt `PNPM_CONFIG_WORKSPACE_CONCURRENCY`.
- Entfernt `pnpm config set workspace-concurrency 1`.
- Entfernt `--workspace-concurrency=1` aus `pnpm install`.
- Behält die echten Speicherbremsen bei:
  - `NODE_OPTIONS=--max-old-space-size=1024`
  - `network-concurrency=1`
  - `child-concurrency=1`
  - BuildKit cache mount für `/pnpm/store`

## Warum

`pnpm install` in der verwendeten pnpm-Version akzeptiert `workspace-concurrency` nicht als Install-CLI-Option. Der vorherige OOM-Fix bleibt ansonsten erhalten.