### PR TITLE
fix(docker): keep pnpm node types override in sync

### DIFF
--- a/scripts/sync-pnpm-lockfile-for-docker.py
+++ b/scripts/sync-pnpm-lockfile-for-docker.py
@@ -18,7 +18,8 @@ SETTINGS_MARKER = "settings:\n  autoInstallPeers: true\n  excludeLinksFromLockfi
 OVERRIDES = {
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.3",
     "zod": "^4.4.3",
     "three": "0.184.0",
     "@babylonjs/core": "^9.6.2",


### PR DESCRIPTION
Hotfix for the production 502 deploy failure. Docker build failed because scripts/sync-pnpm-lockfile-for-docker.py rewrote @types/node to ^25.9.0 while package.json and the committed lockfile use ^25.9.1. This keeps the Docker lockfile sync script aligned with main.