### PR TITLE
fix(docker): align pg override with server dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
       "@babylonjs/loaders": "^9.6.2",
       "react": "^19.2.6",
       "socket.io-client": "^4.8.3",
-      "pg": "^8.20.0"
+      "pg": "^8.21.0"
     },
     "resolutions": {
       "typescript": "^6.0.3",

--- a/scripts/sync-pnpm-lockfile-for-docker.py
+++ b/scripts/sync-pnpm-lockfile-for-docker.py
@@ -27,7 +27,7 @@ OVERRIDES = {
     "@babylonjs/loaders": "^9.6.2",
     "react": "^19.2.6",
     "socket.io-client": "^4.8.3",
-    "pg": "^8.20.0",
+    "pg": "^8.21.0",
 }
 OVERRIDES_BLOCK = "overrides:\n" + "".join(
     f"  '{name}': {version}\n" if name.startswith("@") else f"  {name}: {version}\n"


### PR DESCRIPTION
Fixes another Docker frozen-lockfile drift: server/package.json uses pg ^8.21.0 while root pnpm overrides and the Docker lockfile sync script still forced pg ^8.20.0.