### PR TITLE
Add ARE logic blueprint

### DIFF
--- a/docs/research/ouroboros-grand-unification-are-logic.md
+++ b/docs/research/ouroboros-grand-unification-are-logic.md
@@ -1,0 +1,345 @@
+# Ouroboros Grand Unification — ARE Logic
+
+**Classification:** Master blueprint for deterministic state evolution  
+**Targets:** GitHub GitOps → OSF Science Portal → Areloria MMORPG Engine  
+**Status:** Research and architecture directive. This document is not a one-shot implementation patch.
+
+---
+
+## 1. Mission and Vision
+
+The Ouroboros Collective does not treat randomness as a foundation. The long-term goal is a stateless, deterministic system where every relevant world state can be derived, replayed, verified, and explained.
+
+State bloat is considered architectural debt. Floating-point drift is considered a determinism risk. Every module, engine routine, and research note should be evaluated against ARE Logic: **Authentic Reality Emergence**.
+
+Areloria is not only a browser MMORPG. It is intended to become a deterministic world machine: a game-facing expression of replayable, integer-safe, observer-bound state evolution.
+
+---
+
+## 2. Mathematical Foundation
+
+### 2.1 Kappa Standardization
+
+The canonical kappa invariant is:
+
+```txt
+kappa = 1000
+```
+
+All core simulation values should be represented as fixed-point integer values wherever determinism matters.
+
+Examples:
+
+```txt
+1.25  → 1250
+0.10  → 100
+64.00 → 64000
+```
+
+The preferred internal representation for core runtime math is signed 64-bit integer compatible logic. JavaScript and TypeScript implementations must avoid unsafe integer overflow and must explicitly guard conversions.
+
+### 2.2 Fixed-Point Rule
+
+Floating-point values may exist in client rendering, animation interpolation, CSS, WebGL, or visual-only effects.
+
+Floating-point values must not decide authoritative simulation truth.
+
+Authoritative logic includes:
+
+```txt
+- world tick evolution
+- player position truth
+- resource accounting
+- combat resolution
+- replay hashes
+- sovereign truth hashes
+- oracle prediction seeds
+- billing metering
+- governance directives
+```
+
+### 2.3 Trinitarian Psi Evolution
+
+For the deterministic 10Hz Areloria engine, the conceptual state transition is:
+
+```txt
+Psi[n + 1] = kappa * (Psi[n] odot A_ARE)^3 + 3 * P(Psi[n])
+```
+
+Where:
+
+```txt
+Psi[n]      current state vector at tick n
+A_ARE       axiomatic ARE coupling operator
+P(Psi[n])   plexity function of the current state
+kappa       fixed invariant scale factor, fixed at 1000
+```
+
+This formula is a research-level directive. Engine implementation must translate it into bounded, testable fixed-point routines rather than arbitrary floating-point math.
+
+---
+
+## 3. Runtime Principles
+
+### 3.1 10Hz World Tick
+
+The authoritative engine tick is:
+
+```txt
+10 Hz = 1 tick every 100ms
+```
+
+Every authoritative state transition must be traceable to a tick.
+
+### 3.2 Stateless Preference
+
+The system should store minimal durable state. It should prefer reconstructable state over accumulating opaque mutable state.
+
+Acceptable persistent records:
+
+```txt
+- account identity
+- ownership claims
+- purchases and protected paid construction data
+- replay seeds and compact checkpoints
+- audit logs
+- world directives
+```
+
+Avoid persistent bloat:
+
+```txt
+- unbounded NPC memory dumps
+- raw per-frame positions
+- floating mutable world snapshots without replay seed
+- duplicate state that can be derived from tick + seed + inputs
+```
+
+### 3.3 Replayable Truth
+
+Every meaningful world state should be reproducible from:
+
+```txt
+- tick
+- seed
+- input stream
+- kappa invariant
+- ARE logic version
+- deterministic engine version
+```
+
+Replay is not a debug accessory. Replay is the proof layer of the world.
+
+---
+
+## 4. Implementation Pipeline
+
+### Phase I — Code Origin: Sovereign Studio and GitHub
+
+Code is authored and reviewed in the repository. GitHub is the source of static truth.
+
+Before implementation of ARE runtime logic, every change must be classified:
+
+```txt
+SAFE:
+- documentation
+- markdown research notes
+- isolated CSS or client-only UI copy
+
+RISKY:
+- client gameplay code
+- world rendering
+- asset manifests
+- ARE console logic
+
+CRITICAL:
+- package.json
+- pnpm-lock.yaml
+- Dockerfile
+- nginx
+- GitHub Actions
+- server startup
+- authoritative WorldTick
+- fixed-point math kernel
+```
+
+No critical ARE runtime change should be merged without a rollback path.
+
+### Phase II — Verification: OSF Science Portal
+
+The underlying algorithms should be documented in an OSF-compatible scientific structure.
+
+Suggested OSF structure:
+
+```txt
+1. Abstract
+2. Definitions
+3. Kappa fixed-point standard
+4. Observer axiom
+5. Replay determinism
+6. Psi evolution model
+7. MMORPG application layer
+8. Limitations
+9. Reproducibility protocol
+10. Citations
+```
+
+The purpose is not to overclaim. The purpose is to make the research traceable, reproducible, and properly separated from implementation hype.
+
+### Phase III — Execution: Areloria MMORPG on VPS
+
+The deployed container serves:
+
+```txt
+/portal
+/2d
+/3d
+/are-console.html
+/sovereign-truth.html
+/api/...
+```
+
+The server runtime must protect:
+
+```txt
+- 10Hz tick rhythm
+- deterministic replay
+- kappa invariant
+- hashable world truth
+- clear separation between visual client effects and authoritative state
+```
+
+---
+
+## 5. Engine Directives
+
+### 5.1 Kappa Kernel
+
+Create and preserve a small deterministic math layer before spreading ARE math through the codebase.
+
+Target concept:
+
+```txt
+server/src/core/are/Kappa.ts
+```
+
+Required behavior:
+
+```txt
+- KAPPA = 1000
+- toKappa(value)
+- fromKappa(value)
+- add/sub/mul/div helpers
+- overflow guards
+- deterministic integer rounding policy
+```
+
+### 5.2 ARE Guard
+
+The runtime guard must reject accidental drift.
+
+It should check:
+
+```txt
+- kappa remains 1000
+- no direct mutation of protected simulation objects
+- no Math.random in authoritative simulation paths
+- no Date.now as authoritative state input
+- no floating-point decision in core world truth
+```
+
+### 5.3 WorldTick Integration
+
+WorldTick must remain the heart of the authoritative simulation.
+
+Target behavior:
+
+```txt
+- tick at 10Hz
+- ingest input events
+- normalize into deterministic input vector
+- apply ARE state transition
+- update replay buffer
+- emit visual/client events
+- update sovereign truth hash
+```
+
+### 5.4 Client Separation
+
+Clients may interpolate, animate, and beautify.
+
+Clients must not become authoritative.
+
+2D and 3D clients should display derived truth. They may predict locally, but server truth wins.
+
+---
+
+## 6. Areloria Gameplay Meaning
+
+ARE Logic should become visible to players as gameplay, not only as mathematics.
+
+Examples:
+
+```txt
+Oracle:
+- reads replay pattern windows
+- converts deterministic evidence into prophecy text
+- never invents non-replayable truth
+
+Sovereign Truth:
+- shows hash, tick, branch, guard status
+- proves the world is coherent
+
+NPC Memory:
+- stores compact, derived reputation vectors
+- avoids unbounded narrative memory bloat
+
+Warfront:
+- evolves by deterministic contribution and tick rules
+- exposes phase, sectors, reward thresholds, boss spawn truth
+```
+
+---
+
+## 7. Current Safety Rule After Recovery
+
+Because recent production crashes were caused by small changes touching build/runtime paths, this blueprint must not be implemented as one monolithic patch.
+
+Implementation order:
+
+```txt
+1. Documentation only
+2. Kappa math tests only
+3. ARE guard tests only
+4. Server core integration behind feature flag
+5. Replay hash validation
+6. 2D client visualization
+7. 3D client visualization
+8. OSF publication package
+```
+
+Forbidden first steps:
+
+```txt
+- no Docker changes
+- no nginx changes
+- no package upgrades
+- no lockfile drift
+- no HTML postprocessor changes
+- no normalizer changes touching are-console.html
+```
+
+---
+
+## 8. Execution Command
+
+The axioms stand, but implementation must be staged.
+
+```txt
+Document first.
+Test second.
+Integrate third.
+Deploy last.
+```
+
+The Ouroboros does not rush into its own tail. It closes the loop deterministically.


### PR DESCRIPTION
Adds the Ouroboros Grand Unification ARE Logic blueprint as research documentation only. No runtime, dependency, workflow, Docker, nginx, or client code changes.