### PR TITLE
Add Kappa fixed point kernel

### DIFF
--- a/server/src/core/are/Kappa.ts
+++ b/server/src/core/are/Kappa.ts
@@ -1,0 +1,91 @@
+/**
+ * ARELORIA CORE: Kappa Math Kernel
+ * DIRECTIVE: Ouroboros Grand Unification / ARE-Logic
+ *
+ * Authoritative core math uses fixed-point integer values only.
+ * Rendering and display layers may convert values back for presentation,
+ * but simulation truth must stay integer-safe and deterministic.
+ */
+
+export const KAPPA = 1000 as const;
+export type KappaInt = number;
+
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
+const KAPPA_BIG = BigInt(KAPPA);
+
+export function assertSafeInteger(value: number, operation: string): void {
+  if (!Number.isInteger(value)) {
+    throw new Error(`[ARE-Guard] Float detected in ${operation}: ${value}. Only integers allowed.`);
+  }
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`[ARE-Guard] Unsafe integer in ${operation}: ${value}.`);
+  }
+}
+
+function assertFiniteInput(value: number, operation: string): void {
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    throw new Error(`[ARE-Guard] Invalid number input in ${operation}: ${value}.`);
+  }
+}
+
+function fromBigInt(value: bigint, operation: string): KappaInt {
+  if (value > MAX_SAFE || value < MIN_SAFE) {
+    throw new Error(`[ARE-Guard] Unsafe integer overflow in ${operation}: ${value.toString()}.`);
+  }
+  return Number(value);
+}
+
+/**
+ * Converts external decimal input into the authoritative kappa integer scale.
+ * Decimal input is allowed only at this boundary.
+ */
+export function toKappa(value: number): KappaInt {
+  assertFiniteInput(value, 'toKappa');
+  const scaled = Math.round(value * KAPPA);
+  assertSafeInteger(scaled, 'toKappa');
+  return scaled;
+}
+
+/**
+ * Converts kappa integer values back to decimal values for display/debug only.
+ */
+export function fromKappaInt(value: KappaInt): number {
+  assertSafeInteger(value, 'fromKappaInt');
+  return value / KAPPA;
+}
+
+export function kAdd(a: KappaInt, b: KappaInt): KappaInt {
+  assertSafeInteger(a, 'kAdd arg a');
+  assertSafeInteger(b, 'kAdd arg b');
+  return fromBigInt(BigInt(a) + BigInt(b), 'kAdd result');
+}
+
+export function kSub(a: KappaInt, b: KappaInt): KappaInt {
+  assertSafeInteger(a, 'kSub arg a');
+  assertSafeInteger(b, 'kSub arg b');
+  return fromBigInt(BigInt(a) - BigInt(b), 'kSub result');
+}
+
+/**
+ * Multiplies two fixed-point values using integer arithmetic.
+ * BigInt division truncates toward zero, avoiding value creation by rounding up.
+ */
+export function kMul(a: KappaInt, b: KappaInt): KappaInt {
+  assertSafeInteger(a, 'kMul arg a');
+  assertSafeInteger(b, 'kMul arg b');
+  return fromBigInt((BigInt(a) * BigInt(b)) / KAPPA_BIG, 'kMul result');
+}
+
+/**
+ * Divides two fixed-point values using integer arithmetic.
+ * BigInt division truncates toward zero, avoiding value creation by rounding up.
+ */
+export function kDiv(a: KappaInt, b: KappaInt): KappaInt {
+  assertSafeInteger(a, 'kDiv arg a');
+  assertSafeInteger(b, 'kDiv arg b');
+  if (b === 0) {
+    throw new Error('[ARE-Guard] Division by zero is strictly prohibited.');
+  }
+  return fromBigInt((BigInt(a) * KAPPA_BIG) / BigInt(b), 'kDiv result');
+}

--- a/server/src/core/are/__tests__/Kappa.test.ts
+++ b/server/src/core/are/__tests__/Kappa.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { KAPPA, assertSafeInteger, fromKappaInt, kAdd, kDiv, kMul, kSub, toKappa } from '../Kappa';
+
+describe('ARE-Logic: Kappa fixed-point math kernel', () => {
+  describe('constants and conversions', () => {
+    it('keeps KAPPA strictly fixed at 1000', () => {
+      expect(KAPPA).toBe(1000);
+    });
+
+    it('converts decimal boundary input into kappa integers', () => {
+      expect(toKappa(1.25)).toBe(1250);
+      expect(toKappa(-2.5)).toBe(-2500);
+      expect(toKappa(0)).toBe(0);
+    });
+
+    it('converts kappa integers back only for display/debug values', () => {
+      expect(fromKappaInt(1250)).toBe(1.25);
+      expect(fromKappaInt(-2500)).toBe(-2.5);
+    });
+  });
+
+  describe('deterministic operations', () => {
+    it('adds fixed-point integers without scale changes', () => {
+      expect(kAdd(1000, 250)).toBe(1250);
+    });
+
+    it('subtracts fixed-point integers without scale changes', () => {
+      expect(kSub(1250, 250)).toBe(1000);
+    });
+
+    it('multiplies fixed-point integers and rescales by kappa', () => {
+      expect(kMul(1250, 2000)).toBe(2500);
+    });
+
+    it('divides fixed-point integers and rescales by kappa', () => {
+      expect(kDiv(2500, 2000)).toBe(1250);
+    });
+
+    it('truncates multiplication toward zero instead of creating value by rounding up', () => {
+      expect(kMul(1001, 1001)).toBe(1002);
+      expect(kMul(-1001, 1001)).toBe(-1002);
+    });
+
+    it('truncates division toward zero instead of flooring negative values', () => {
+      expect(kDiv(1000, 3000)).toBe(333);
+      expect(kDiv(-1000, 3000)).toBe(-333);
+    });
+  });
+
+  describe('ARE Guard protections', () => {
+    it('rejects float inputs in core math operations', () => {
+      expect(() => kAdd(1000.5, 250)).toThrow('[ARE-Guard]');
+      expect(() => kMul(1250, 1.5)).toThrow('[ARE-Guard]');
+    });
+
+    it('rejects NaN and Infinity boundary inputs', () => {
+      expect(() => toKappa(Number.NaN)).toThrow('[ARE-Guard]');
+      expect(() => toKappa(Number.POSITIVE_INFINITY)).toThrow('[ARE-Guard]');
+    });
+
+    it('rejects division by zero', () => {
+      expect(() => kDiv(1000, 0)).toThrow('[ARE-Guard]');
+    });
+
+    it('rejects unsafe integer inputs', () => {
+      expect(() => assertSafeInteger(Number.MAX_SAFE_INTEGER + 1, 'test')).toThrow('[ARE-Guard]');
+    });
+
+    it('rejects unsafe integer overflow results', () => {
+      expect(() => kAdd(Number.MAX_SAFE_INTEGER, 1)).toThrow('[ARE-Guard]');
+      expect(() => kMul(Number.MAX_SAFE_INTEGER, 2000)).toThrow('[ARE-Guard]');
+    });
+  });
+});


### PR DESCRIPTION
Adds the ARE Kappa fixed-point math kernel and focused Vitest coverage. No dependency, Docker, nginx, workflow, package, lockfile, or client changes.