### PR TITLE
Add ARE guard tests

### DIFF
--- a/server/src/core/are/AREGuard.ts
+++ b/server/src/core/are/AREGuard.ts
@@ -1,0 +1,61 @@
+import { KAPPA, assertSafeInteger } from './Kappa';
+
+export class AREGuard {
+  static verifyKappaIntegrity(): void {
+    if (KAPPA !== 1000) {
+      throw new Error(`[ARE-Guard] FATAL: KAPPA has been compromised. Expected 1000, got ${KAPPA}.`);
+    }
+  }
+
+  static assertNoFloats(payload: unknown, path = 'root', seen = new WeakSet<object>()): void {
+    if (payload === null || payload === undefined) return;
+
+    if (typeof payload === 'number') {
+      assertSafeInteger(payload, `payload at '${path}'`);
+      return;
+    }
+
+    if (typeof payload !== 'object') return;
+    if (seen.has(payload)) return;
+    seen.add(payload);
+
+    for (const key of Reflect.ownKeys(payload)) {
+      const value = (payload as Record<PropertyKey, unknown>)[key];
+      AREGuard.assertNoFloats(value, `${path}.${String(key)}`, seen);
+    }
+  }
+
+  static protectPayload<T>(payload: T, seen = new WeakSet<object>()): T {
+    if (payload === null || typeof payload !== 'object') return payload;
+    if (seen.has(payload)) return payload;
+    seen.add(payload);
+
+    for (const key of Reflect.ownKeys(payload)) {
+      const value = (payload as Record<PropertyKey, unknown>)[key];
+      if (value !== null && typeof value === 'object') {
+        AREGuard.protectPayload(value, seen);
+      }
+    }
+
+    return Object.freeze(payload);
+  }
+
+  static executeProtected<T>(tickFn: () => T): T {
+    const originalRandom = Math.random;
+    const originalDateNow = Date.now;
+
+    try {
+      Math.random = () => {
+        throw new Error('[ARE-Guard] Math.random is strictly prohibited in authoritative core.');
+      };
+      Date.now = () => {
+        throw new Error('[ARE-Guard] Date.now is strictly prohibited. Use deterministic tick time.');
+      };
+
+      return tickFn();
+    } finally {
+      Math.random = originalRandom;
+      Date.now = originalDateNow;
+    }
+  }
+}

--- a/server/src/core/are/__tests__/AREGuard.test.ts
+++ b/server/src/core/are/__tests__/AREGuard.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { AREGuard } from '../AREGuard';
+
+describe('ARE-Logic: ARE Guard protections', () => {
+  describe('system integrity', () => {
+    it('verifies KAPPA remains exactly 1000', () => {
+      expect(() => AREGuard.verifyKappaIntegrity()).not.toThrow();
+    });
+  });
+
+  describe('execution isolation', () => {
+    it('blocks Math.random inside a protected execution frame', () => {
+      expect(() => {
+        AREGuard.executeProtected(() => Math.random());
+      }).toThrow('[ARE-Guard] Math.random is strictly prohibited');
+    });
+
+    it('blocks Date.now inside a protected execution frame', () => {
+      expect(() => {
+        AREGuard.executeProtected(() => Date.now());
+      }).toThrow('[ARE-Guard] Date.now is strictly prohibited');
+    });
+
+    it('restores Math.random and Date.now after successful execution', () => {
+      const result = AREGuard.executeProtected(() => 42);
+      expect(result).toBe(42);
+      expect(() => Math.random()).not.toThrow();
+      expect(() => Date.now()).not.toThrow();
+    });
+
+    it('restores Math.random and Date.now after failed execution', () => {
+      expect(() => AREGuard.executeProtected(() => { throw new Error('tick failed'); })).toThrow('tick failed');
+      expect(() => Math.random()).not.toThrow();
+      expect(() => Date.now()).not.toThrow();
+    });
+  });
+
+  describe('payload protections', () => {
+    it('accepts integer-only nested payloads', () => {
+      const cleanPayload = { position: { x: 1250, y: 3000 }, health: 100, tags: ['npc', 'observer'] };
+      expect(() => AREGuard.assertNoFloats(cleanPayload)).not.toThrow();
+    });
+
+    it('blocks float values deep inside nested payloads', () => {
+      const dirtyPayload = { position: { x: 1250, y: 3000.5 }, health: 100 };
+      expect(() => AREGuard.assertNoFloats(dirtyPayload)).toThrow("[ARE-Guard] Float detected in payload at 'root.position.y'");
+    });
+
+    it('handles cyclic payloads without recursive overflow', () => {
+      const cyclic: { value: number; self?: unknown } = { value: 1000 };
+      cyclic.self = cyclic;
+      expect(() => AREGuard.assertNoFloats(cyclic)).not.toThrow();
+      const protectedPayload = AREGuard.protectPayload(cyclic);
+      expect(Object.isFrozen(protectedPayload)).toBe(true);
+    });
+
+    it('deeply freezes payloads to prevent direct mutation', () => {
+      const state = { entity: { id: 1, velocity: 500 } };
+      const protectedState = AREGuard.protectPayload(state);
+
+      expect(Object.isFrozen(protectedState)).toBe(true);
+      expect(Object.isFrozen(protectedState.entity)).toBe(true);
+
+      expect(() => {
+        (protectedState.entity as { velocity: number }).velocity = 1000;
+      }).toThrow(TypeError);
+    });
+  });
+});


### PR DESCRIPTION
Adds isolated ARE Guard runtime protections and tests only. No dependency, Docker, nginx, workflow, package, lockfile, client, portal, or console changes.