### PR TITLE
Add ARE payload contract

### DIFF
--- a/server/src/core/are/AREPayload.ts
+++ b/server/src/core/are/AREPayload.ts
@@ -1,0 +1,104 @@
+import { AREGuard } from './AREGuard';
+import { assertSafeInteger, toKappa, type KappaInt } from './Kappa';
+
+export interface AREVector3 {
+  x: KappaInt;
+  y: KappaInt;
+  z: KappaInt;
+}
+
+export type AREPayloadValue = string | boolean | null | KappaInt | AREPayloadValue[] | { readonly [key: string]: AREPayloadValue };
+
+export interface IAREPayload {
+  readonly entityId: string;
+  readonly position: Readonly<AREVector3>;
+  readonly velocity: Readonly<AREVector3>;
+  readonly stateHash?: KappaInt;
+  readonly [key: string]: AREPayloadValue | Readonly<AREVector3> | undefined;
+}
+
+export interface AREPayloadNormalizationOptions {
+  /**
+   * Dot-paths in additional state that should be converted through toKappa().
+   * All other additional numeric values must already be safe integers.
+   */
+  readonly kappaFields?: readonly string[];
+}
+
+type RawVector3 = Partial<Record<'x' | 'y' | 'z', unknown>> | null | undefined;
+
+function readNumber(value: unknown, path: string): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value !== 'number') {
+    throw new Error(`[ARE-Payload] Expected numeric value at ${path}, got ${typeof value}.`);
+  }
+  return value;
+}
+
+function normalizeVector3(raw: RawVector3, path: string): AREVector3 {
+  return {
+    x: toKappa(readNumber(raw?.x, `${path}.x`)),
+    y: toKappa(readNumber(raw?.y, `${path}.y`)),
+    z: toKappa(readNumber(raw?.z, `${path}.z`)),
+  };
+}
+
+function normalizeAdditionalState(value: unknown, path: string, kappaFields: Set<string>): AREPayloadValue {
+  if (value === null) return null;
+
+  if (typeof value === 'number') {
+    if (kappaFields.has(path)) return toKappa(value);
+    assertSafeInteger(value, `additional state at '${path}'`);
+    return value;
+  }
+
+  if (typeof value === 'string' || typeof value === 'boolean') return value;
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => normalizeAdditionalState(item, `${path}.${index}`, kappaFields));
+  }
+
+  if (typeof value === 'object' && value !== undefined) {
+    const out: Record<string, AREPayloadValue> = {};
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== 'string') continue;
+      out[key] = normalizeAdditionalState((value as Record<string, unknown>)[key], path ? `${path}.${key}` : key, kappaFields);
+    }
+    return out;
+  }
+
+  if (value === undefined) return null;
+  throw new Error(`[ARE-Payload] Unsupported additional state value at ${path}: ${typeof value}.`);
+}
+
+export class AREPayloadFactory {
+  static createNormalized(
+    rawEntityId: string,
+    rawPosition: RawVector3,
+    rawVelocity: RawVector3,
+    additionalState: Record<string, unknown> = {},
+    options: AREPayloadNormalizationOptions = {},
+  ): Readonly<IAREPayload> {
+    if (!rawEntityId || typeof rawEntityId !== 'string') {
+      throw new Error('[ARE-Payload] entityId must be a non-empty string.');
+    }
+
+    const kappaFields = new Set(options.kappaFields ?? []);
+    const payload: Record<string, AREPayloadValue | Readonly<AREVector3> | undefined> = {
+      entityId: rawEntityId,
+      position: normalizeVector3(rawPosition, 'position'),
+      velocity: normalizeVector3(rawVelocity, 'velocity'),
+    };
+
+    for (const key of Reflect.ownKeys(additionalState)) {
+      if (typeof key !== 'string') continue;
+      if (key === 'entityId' || key === 'position' || key === 'velocity') {
+        throw new Error(`[ARE-Payload] Reserved payload key cannot be overridden: ${key}.`);
+      }
+      payload[key] = normalizeAdditionalState(additionalState[key], key, kappaFields);
+    }
+
+    AREGuard.assertNoFloats(payload);
+    return AREGuard.protectPayload(payload as IAREPayload);
+  }
+}

--- a/server/src/core/are/__tests__/AREPayload.test.ts
+++ b/server/src/core/are/__tests__/AREPayload.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { AREGuard } from '../AREGuard';
+import { AREPayloadFactory } from '../AREPayload';
+
+describe('ARE-Logic: ARE Payload normalization', () => {
+  describe('payload creation and kappa normalization', () => {
+    it('converts raw position and velocity floats into strict kappa integer vectors', () => {
+      const payload = AREPayloadFactory.createNormalized(
+        'entity_001',
+        { x: 1.25, y: -0.5, z: 0 },
+        { x: 10.123, y: 0, z: 2.5 },
+      );
+
+      expect(payload.position.x).toBe(1250);
+      expect(payload.position.y).toBe(-500);
+      expect(payload.position.z).toBe(0);
+      expect(payload.velocity.x).toBe(10123);
+      expect(payload.velocity.z).toBe(2500);
+    });
+
+    it('keeps additional integer state unscaled by default', () => {
+      const payload = AREPayloadFactory.createNormalized(
+        'entity_002',
+        {},
+        {},
+        { health: 100, level: 7, tags: ['player', 'active'] },
+      );
+
+      expect(payload.health).toBe(100);
+      expect(payload.level).toBe(7);
+      expect(payload.tags).toEqual(['player', 'active']);
+    });
+
+    it('scales only whitelisted additional state number paths through kappa', () => {
+      const payload = AREPayloadFactory.createNormalized(
+        'entity_003',
+        {},
+        {},
+        { stats: { manaRegen: 1.5, armor: 25 }, rates: [1, 2.25] },
+        { kappaFields: ['stats.manaRegen', 'rates.1'] },
+      );
+
+      expect((payload.stats as any).manaRegen).toBe(1500);
+      expect((payload.stats as any).armor).toBe(25);
+      expect(payload.rates).toEqual([1, 2250]);
+    });
+  });
+
+  describe('guard integration', () => {
+    it('passes AREGuard float detection after normalization', () => {
+      const payload = AREPayloadFactory.createNormalized('entity_004', { x: 1.25, y: 3.333 }, {});
+      expect(() => AREGuard.assertNoFloats(payload)).not.toThrow();
+    });
+
+    it('returns a deeply frozen payload ready for WorldTick', () => {
+      const payload = AREPayloadFactory.createNormalized('entity_005', { x: 1 }, { y: 2 }, { stats: { hp: 100 } });
+
+      expect(Object.isFrozen(payload)).toBe(true);
+      expect(Object.isFrozen(payload.position)).toBe(true);
+      expect(Object.isFrozen(payload.velocity)).toBe(true);
+      expect(Object.isFrozen(payload.stats)).toBe(true);
+
+      expect(() => {
+        (payload.position as { x: number }).x = 9999;
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('edge cases and contract protection', () => {
+    it('handles null or missing vectors gracefully', () => {
+      const payload = AREPayloadFactory.createNormalized('entity_006', null, undefined);
+      expect(payload.position).toEqual({ x: 0, y: 0, z: 0 });
+      expect(payload.velocity).toEqual({ x: 0, y: 0, z: 0 });
+    });
+
+    it('rejects float values in additional state unless whitelisted', () => {
+      expect(() => AREPayloadFactory.createNormalized('entity_007', {}, {}, { health: 99.5 })).toThrow('[ARE-Guard]');
+    });
+
+    it('rejects invalid entity ids', () => {
+      expect(() => AREPayloadFactory.createNormalized('', {}, {})).toThrow('[ARE-Payload]');
+    });
+
+    it('rejects attempts to override reserved payload keys from additional state', () => {
+      expect(() => AREPayloadFactory.createNormalized('entity_008', {}, {}, { position: { x: 999 } })).toThrow('[ARE-Payload]');
+    });
+  });
+});


### PR DESCRIPTION
Adds the isolated ARE payload data contract and tests. Uses explicit kappa field whitelisting for dynamic additional state. No dependency, Docker, nginx, workflow, package, lockfile, client, portal, or console changes.