### PR TITLE
Add ARE tick prototype

### DIFF
--- a/server/src/core/are/ARETick.ts
+++ b/server/src/core/are/ARETick.ts
@@ -1,0 +1,32 @@
+import { AREGuard } from './AREGuard';
+import type { IAREPayload } from './AREPayload';
+import { kAdd } from './Kappa';
+
+/**
+ * ARELORIA CORE: Deterministic Tick Prototype
+ * DIRECTIVE: Ouroboros Grand Unification / ARE-Logic
+ *
+ * This isolated prototype proves the smallest authoritative transition:
+ * next position = current position + current velocity.
+ */
+export class ARETick {
+  static processEntity(payload: Readonly<IAREPayload>): Readonly<IAREPayload> {
+    return AREGuard.executeProtected(() => {
+      AREGuard.assertNoFloats(payload);
+
+      const nextPosition = {
+        x: kAdd(payload.position.x, payload.velocity.x),
+        y: kAdd(payload.position.y, payload.velocity.y),
+        z: kAdd(payload.position.z, payload.velocity.z),
+      };
+
+      const nextPayload: IAREPayload = {
+        ...payload,
+        position: nextPosition,
+      };
+
+      AREGuard.assertNoFloats(nextPayload);
+      return AREGuard.protectPayload(nextPayload);
+    });
+  }
+}

--- a/server/src/core/are/__tests__/ARETick.test.ts
+++ b/server/src/core/are/__tests__/ARETick.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { AREPayloadFactory } from '../AREPayload';
+import { ARETick } from '../ARETick';
+
+function createTestPayload() {
+  return AREPayloadFactory.createNormalized(
+    'entity_tick_001',
+    { x: 10, y: 5, z: 0 },
+    { x: 1, y: -0.5, z: 0 },
+    { health: 100 },
+  );
+}
+
+describe('ARE-Logic: ARETick isolated execution', () => {
+  describe('fundamental physics', () => {
+    it('calculates the new position using kappa math', () => {
+      const initialState = createTestPayload();
+      const nextState = ARETick.processEntity(initialState);
+
+      expect(nextState.position.x).toBe(11000);
+      expect(nextState.position.y).toBe(4500);
+      expect(nextState.position.z).toBe(0);
+      expect(nextState.health).toBe(100);
+      expect(nextState.entityId).toBe('entity_tick_001');
+    });
+  });
+
+  describe('determinism and immutability', () => {
+    it('produces identical outputs for identical inputs', () => {
+      const outputA = ARETick.processEntity(createTestPayload());
+      const outputB = ARETick.processEntity(createTestPayload());
+      expect(outputA).toEqual(outputB);
+    });
+
+    it('does not mutate the input payload', () => {
+      const initialState = createTestPayload();
+      const nextState = ARETick.processEntity(initialState);
+
+      expect(initialState).not.toBe(nextState);
+      expect(initialState.position).not.toBe(nextState.position);
+      expect(initialState.position.x).toBe(10000);
+      expect(Object.isFrozen(initialState)).toBe(true);
+      expect(Object.isFrozen(nextState)).toBe(true);
+      expect(Object.isFrozen(nextState.position)).toBe(true);
+    });
+  });
+
+  describe('ARE Guard integration', () => {
+    it('blocks non-deterministic APIs inside the protected physics frame', () => {
+      const cleanPayload = createTestPayload();
+      const maliciousPayload = {
+        ...cleanPayload,
+        get velocity() {
+          Math.random();
+          return cleanPayload.velocity;
+        },
+      };
+
+      expect(() => ARETick.processEntity(maliciousPayload as any)).toThrow('[ARE-Guard] Math.random is strictly prohibited');
+    });
+
+    it('rejects dirty payload floats before processing', () => {
+      const cleanPayload = createTestPayload();
+      const dirtyPayload = {
+        ...cleanPayload,
+        position: { x: 10000, y: 5000.25, z: 0 },
+      };
+
+      expect(() => ARETick.processEntity(dirtyPayload as any)).toThrow('[ARE-Guard]');
+    });
+  });
+});


### PR DESCRIPTION
Adds isolated ARETick deterministic transition prototype and tests only. No dependency, Docker, nginx, workflow, package, lockfile, client, portal, console, or WorldTick integration changes.