### PR TITLE
Add ARE emergence core

### DIFF
--- a/server/src/core/are/AREBrain.ts
+++ b/server/src/core/are/AREBrain.ts
@@ -1,0 +1,39 @@
+import { AREGuard } from './AREGuard';
+import { AREHash } from './AREHash';
+import type { IAREPayload } from './AREPayload';
+import { kAdd, kSub } from './Kappa';
+
+export interface AREBrainOptions {
+  /** Optional neighbor or sector hashes for future plexity mixing. */
+  readonly neighborHashes?: readonly number[];
+}
+
+export class AREBrain {
+  static computeEmergence(payload: Readonly<IAREPayload>, options: AREBrainOptions = {}): Readonly<IAREPayload> {
+    return AREGuard.executeProtected(() => {
+      AREGuard.assertNoFloats(payload);
+
+      const selfDNA = AREHash.generate(payload);
+      const currentDNA = AREHash.mix(selfDNA, options.neighborHashes ?? []);
+      const actionGene = currentDNA & 3;
+      const nextVelocity = { ...payload.velocity };
+
+      if (actionGene === 0) {
+        nextVelocity.x = kAdd(nextVelocity.x, 100);
+      } else if (actionGene === 1) {
+        nextVelocity.x = kSub(nextVelocity.x, 50);
+      } else if (actionGene === 2) {
+        nextVelocity.y = kAdd(nextVelocity.y, 200);
+      }
+
+      const nextPayload: IAREPayload = {
+        ...payload,
+        velocity: nextVelocity,
+        stateHash: currentDNA,
+      };
+
+      AREGuard.assertNoFloats(nextPayload);
+      return AREGuard.protectPayload(nextPayload);
+    });
+  }
+}

--- a/server/src/core/are/AREHash.ts
+++ b/server/src/core/are/AREHash.ts
@@ -1,0 +1,38 @@
+import type { IAREPayload } from './AREPayload';
+
+export class AREHash {
+  private static readonly FNV_PRIME = 16777619;
+  private static readonly OFFSET_BASIS = 2166136261;
+
+  static generate(payload: Readonly<IAREPayload>): number {
+    const stateString = AREHash.stateString(payload);
+    let hash = AREHash.OFFSET_BASIS;
+
+    for (let index = 0; index < stateString.length; index += 1) {
+      hash ^= stateString.charCodeAt(index);
+      hash = Math.imul(hash, AREHash.FNV_PRIME);
+    }
+
+    return hash >>> 0;
+  }
+
+  static mix(baseHash: number, hashes: readonly number[] = []): number {
+    let hash = baseHash >>> 0;
+
+    for (const next of hashes) {
+      hash ^= next >>> 0;
+      hash = Math.imul(hash, AREHash.FNV_PRIME) >>> 0;
+    }
+
+    return hash >>> 0;
+  }
+
+  private static stateString(payload: Readonly<IAREPayload>): string {
+    return [
+      payload.entityId,
+      `${payload.position.x},${payload.position.y},${payload.position.z}`,
+      `${payload.velocity.x},${payload.velocity.y},${payload.velocity.z}`,
+      payload.stateHash ?? 0,
+    ].join('|');
+  }
+}

--- a/server/src/core/are/__tests__/AREEmergence.test.ts
+++ b/server/src/core/are/__tests__/AREEmergence.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { AREBrain } from '../AREBrain';
+import { AREHash } from '../AREHash';
+import { AREPayloadFactory } from '../AREPayload';
+
+describe('ARE-Logic: emergent brain and deterministic hashing', () => {
+  describe('AREHash generator', () => {
+    it('generates identical hashes for identical states', () => {
+      const stateA = AREPayloadFactory.createNormalized('brain_01', { x: 10, y: 5 }, { x: 1, y: 0 });
+      const stateB = AREPayloadFactory.createNormalized('brain_01', { x: 10, y: 5 }, { x: 1, y: 0 });
+
+      expect(AREHash.generate(stateA)).toBe(AREHash.generate(stateB));
+    });
+
+    it('changes hashes for tiny positional drifts', () => {
+      const stateA = AREPayloadFactory.createNormalized('brain_01', { x: 10 }, {});
+      const stateB = AREPayloadFactory.createNormalized('brain_01', { x: 10.001 }, {});
+
+      expect(AREHash.generate(stateA)).not.toBe(AREHash.generate(stateB));
+    });
+
+    it('mixes neighbor hashes deterministically for future plexity', () => {
+      const base = 123456;
+      expect(AREHash.mix(base, [1, 2, 3])).toBe(AREHash.mix(base, [1, 2, 3]));
+      expect(AREHash.mix(base, [1, 2, 3])).not.toBe(AREHash.mix(base, [3, 2, 1]));
+    });
+  });
+
+  describe('AREBrain emergence', () => {
+    it('evolves deterministic behavior without Math.random', () => {
+      const genesisState = AREPayloadFactory.createNormalized('organism_01', { x: 0, y: 0 }, { x: 0, y: 0 });
+
+      const gen1 = AREBrain.computeEmergence(genesisState);
+      const gen2 = AREBrain.computeEmergence(gen1);
+      const gen3 = AREBrain.computeEmergence(gen2);
+
+      expect(gen1.stateHash).toBeDefined();
+
+      const altGen1 = AREBrain.computeEmergence(genesisState);
+      const altGen2 = AREBrain.computeEmergence(altGen1);
+      const altGen3 = AREBrain.computeEmergence(altGen2);
+
+      expect(gen3).toEqual(altGen3);
+    });
+
+    it('allows deterministic plexity mixing without making it mandatory', () => {
+      const genesisState = AREPayloadFactory.createNormalized('organism_plex', { x: 0, y: 0 }, { x: 0, y: 0 });
+
+      const solo = AREBrain.computeEmergence(genesisState);
+      const social = AREBrain.computeEmergence(genesisState, { neighborHashes: [11, 22, 33] });
+      const socialAgain = AREBrain.computeEmergence(genesisState, { neighborHashes: [11, 22, 33] });
+
+      expect(social).toEqual(socialAgain);
+      expect(social.stateHash).not.toBe(solo.stateHash);
+    });
+
+    it('does not mutate the original organism', () => {
+      const genesisState = AREPayloadFactory.createNormalized('organism_02', { x: 100 }, {});
+      const next = AREBrain.computeEmergence(genesisState);
+
+      expect(Object.isFrozen(genesisState)).toBe(true);
+      expect(genesisState).not.toBe(next);
+      expect(genesisState.velocity).not.toBe(next.velocity);
+    });
+
+    it('blocks non-deterministic APIs during emergence through protected execution', () => {
+      const cleanPayload = AREPayloadFactory.createNormalized('organism_03', { x: 0 }, { x: 0 });
+      const maliciousPayload = {
+        ...cleanPayload,
+        get position() {
+          Date.now();
+          return cleanPayload.position;
+        },
+      };
+
+      expect(() => AREBrain.computeEmergence(maliciousPayload as any)).toThrow('[ARE-Guard] Date.now is strictly prohibited');
+    });
+  });
+});


### PR DESCRIPTION
Adds isolated AREHash and AREBrain emergence core with tests only. Default behavior uses self DNA; optional neighbor hash mixing is supported for later plexity experiments. No dependency, Docker, nginx, workflow, package, lockfile, client, portal, console, or WorldTick integration changes.