### PR TITLE
Add ARE cycle composition

### DIFF
--- a/server/src/core/are/ARECycle.ts
+++ b/server/src/core/are/ARECycle.ts
@@ -1,0 +1,34 @@
+import { AREBrain, type AREBrainOptions } from './AREBrain';
+import { AREGuard } from './AREGuard';
+import { AREHash } from './AREHash';
+import type { IAREPayload } from './AREPayload';
+import { ARETick } from './ARETick';
+
+export interface ARECycleOptions extends AREBrainOptions {}
+
+/**
+ * ARELORIA CORE: Deterministic Lifecycle Composition
+ * DIRECTIVE: Ouroboros Grand Unification / ARE-Logic
+ *
+ * Isolated composition order:
+ * Payload -> Brain -> Tick -> Hash
+ */
+export class ARECycle {
+  static processCycle(payload: Readonly<IAREPayload>, options: ARECycleOptions = {}): Readonly<IAREPayload> {
+    return AREGuard.executeProtected(() => {
+      AREGuard.assertNoFloats(payload);
+
+      const brainPayload = AREBrain.computeEmergence(payload, options);
+      const tickPayload = ARETick.processEntity(brainPayload);
+      const finalHash = AREHash.generate(tickPayload);
+
+      const finalPayload: IAREPayload = {
+        ...tickPayload,
+        stateHash: finalHash,
+      };
+
+      AREGuard.assertNoFloats(finalPayload);
+      return AREGuard.protectPayload(finalPayload);
+    });
+  }
+}

--- a/server/src/core/are/__tests__/ARECycle.test.ts
+++ b/server/src/core/are/__tests__/ARECycle.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { ARECycle } from '../ARECycle';
+import { AREPayloadFactory } from '../AREPayload';
+
+function createGenesisPayload() {
+  return AREPayloadFactory.createNormalized(
+    'cycle_entity_01',
+    { x: 10, y: 0, z: 0 },
+    { x: 1, y: 0, z: 0 },
+    { generation: 0 },
+  );
+}
+
+describe('ARE-Logic: full lifecycle composition', () => {
+  describe('pipeline execution', () => {
+    it('executes Brain, Tick, and Hash in a seamless pipeline', () => {
+      const genesis = createGenesisPayload();
+      const gen1 = ARECycle.processCycle(genesis);
+
+      expect(gen1.position.x).not.toBe(10000);
+      expect(gen1.stateHash).toBeDefined();
+      expect(typeof gen1.stateHash).toBe('number');
+      expect(Object.isFrozen(gen1)).toBe(true);
+      expect(Object.isFrozen(gen1.position)).toBe(true);
+      expect(Object.isFrozen(gen1.velocity)).toBe(true);
+    });
+
+    it('keeps only the current stateHash on the payload', () => {
+      const gen1 = ARECycle.processCycle(createGenesisPayload());
+      expect(gen1.stateHash).toBeDefined();
+      expect((gen1 as any).stateHashes).toBeUndefined();
+      expect((gen1 as any).replay).toBeUndefined();
+      expect((gen1 as any).history).toBeUndefined();
+    });
+  });
+
+  describe('evolutionary determinism', () => {
+    it('evolves identically across parallel universes', () => {
+      let stateA = createGenesisPayload();
+      let stateB = createGenesisPayload();
+
+      for (let i = 0; i < 5; i += 1) {
+        stateA = ARECycle.processCycle(stateA) as typeof stateA;
+      }
+
+      for (let i = 0; i < 5; i += 1) {
+        stateB = ARECycle.processCycle(stateB) as typeof stateB;
+      }
+
+      expect(stateA).toEqual(stateB);
+      expect(stateA.stateHash).toBe(stateB.stateHash);
+    });
+
+    it('preserves immutability of the genesis state', () => {
+      const genesis = createGenesisPayload();
+      ARECycle.processCycle(genesis);
+
+      expect(genesis.position.x).toBe(10000);
+      expect(genesis.velocity.x).toBe(1000);
+      expect(Object.isFrozen(genesis)).toBe(true);
+    });
+
+    it('supports deterministic plexity options without requiring them', () => {
+      const genesis = createGenesisPayload();
+      const solo = ARECycle.processCycle(genesis);
+      const social = ARECycle.processCycle(genesis, { neighborHashes: [101, 202, 303] });
+      const socialAgain = ARECycle.processCycle(genesis, { neighborHashes: [101, 202, 303] });
+
+      expect(social).toEqual(socialAgain);
+      expect(social.stateHash).not.toBe(solo.stateHash);
+    });
+  });
+});


### PR DESCRIPTION
Adds isolated ARECycle composition and tests only. Pipeline: Payload -> Brain -> Tick -> Hash. Keeps only current stateHash on payload; replay history remains a future external ring buffer. No dependency, Docker, nginx, workflow, package, lockfile, client, portal, console, or WorldTick integration changes.