### PR TITLE
Add ARE shadow adapter

### DIFF
--- a/server/src/core/are/AREConfig.ts
+++ b/server/src/core/are/AREConfig.ts
@@ -1,0 +1,7 @@
+export const ARE_CONFIG = {
+  /**
+   * Shadow execution is disabled by default.
+   * When enabled later, ARE can run beside the legacy tick without controlling live state.
+   */
+  ENABLE_SHADOW_TICK: false,
+};

--- a/server/src/core/are/AREShadowAdapter.ts
+++ b/server/src/core/are/AREShadowAdapter.ts
@@ -1,0 +1,49 @@
+import { ARE_CONFIG } from './AREConfig';
+import { ARECycle } from './ARECycle';
+import { AREGuard } from './AREGuard';
+import { AREPayloadFactory, type AREPayloadNormalizationOptions } from './AREPayload';
+import type { AREReplayBuffer } from './AREReplayBuffer';
+
+export interface AREShadowTickInput {
+  readonly entityId: string;
+  readonly position: unknown;
+  readonly velocity: unknown;
+  readonly tick: number;
+  readonly buffer: AREReplayBuffer;
+  readonly additionalState?: Record<string, unknown>;
+  readonly normalization?: AREPayloadNormalizationOptions;
+}
+
+export interface AREShadowTickResult {
+  readonly skipped: boolean;
+  readonly recorded: boolean;
+  readonly stateHash?: number;
+  readonly error?: unknown;
+}
+
+export class AREShadowAdapter {
+  static executeShadowTick(input: AREShadowTickInput): AREShadowTickResult {
+    if (!ARE_CONFIG.ENABLE_SHADOW_TICK) {
+      return { skipped: true, recorded: false };
+    }
+
+    try {
+      const entry = AREGuard.executeProtected(() => {
+        const genesisPayload = AREPayloadFactory.createNormalized(
+          input.entityId,
+          input.position as any,
+          input.velocity as any,
+          input.additionalState ?? {},
+          input.normalization ?? {},
+        );
+
+        const nextPayload = ARECycle.processCycle(genesisPayload);
+        return input.buffer.record(input.tick, nextPayload);
+      });
+
+      return { skipped: false, recorded: true, stateHash: entry.stateHash };
+    } catch (error) {
+      return { skipped: false, recorded: false, error };
+    }
+  }
+}

--- a/server/src/core/are/__tests__/AREShadowAdapter.test.ts
+++ b/server/src/core/are/__tests__/AREShadowAdapter.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ARE_CONFIG } from '../AREConfig';
+import { AREReplayBuffer } from '../AREReplayBuffer';
+import { AREShadowAdapter } from '../AREShadowAdapter';
+
+describe('ARE-Logic: WorldTick shadow adapter', () => {
+  let buffer: AREReplayBuffer;
+
+  beforeEach(() => {
+    buffer = new AREReplayBuffer(10);
+    ARE_CONFIG.ENABLE_SHADOW_TICK = false;
+  });
+
+  it('does nothing when ENABLE_SHADOW_TICK is false', () => {
+    const result = AREShadowAdapter.executeShadowTick({
+      entityId: 'shadow_01',
+      position: { x: 1.5 },
+      velocity: { y: 2.0 },
+      tick: 1,
+      buffer,
+    });
+
+    expect(result).toEqual({ skipped: true, recorded: false });
+    expect(buffer.latest('shadow_01')).toBeUndefined();
+    expect(buffer.size).toBe(0);
+  });
+
+  it('processes the full ARE cycle and stores it in the buffer when enabled', () => {
+    ARE_CONFIG.ENABLE_SHADOW_TICK = true;
+
+    const result = AREShadowAdapter.executeShadowTick({
+      entityId: 'shadow_02',
+      position: { x: 1.25, y: 0 },
+      velocity: { x: 1, y: 0 },
+      tick: 100,
+      buffer,
+    });
+
+    const entry = buffer.get(100, 'shadow_02');
+    expect(result.skipped).toBe(false);
+    expect(result.recorded).toBe(true);
+    expect(result.stateHash).toBe(entry?.stateHash);
+    expect(entry).toBeDefined();
+    expect(entry?.tick).toBe(100);
+    expect(Number.isInteger(entry?.payload.position.x)).toBe(true);
+    expect(Number.isInteger(entry?.payload.velocity.x)).toBe(true);
+  });
+
+  it('accepts kappa field whitelisting for additional state', () => {
+    ARE_CONFIG.ENABLE_SHADOW_TICK = true;
+
+    AREShadowAdapter.executeShadowTick({
+      entityId: 'shadow_03',
+      position: { x: 0 },
+      velocity: { x: 0 },
+      tick: 101,
+      buffer,
+      additionalState: { stats: { manaRegen: 1.5, hp: 100 } },
+      normalization: { kappaFields: ['stats.manaRegen'] },
+    });
+
+    const entry = buffer.get(101, 'shadow_03');
+    expect((entry?.payload.stats as any).manaRegen).toBe(1500);
+    expect((entry?.payload.stats as any).hp).toBe(100);
+  });
+
+  it('catches ARE errors and does not crash legacy execution', () => {
+    ARE_CONFIG.ENABLE_SHADOW_TICK = true;
+
+    expect(() => {
+      AREShadowAdapter.executeShadowTick({
+        entityId: 'shadow_04',
+        position: { x: 'corrupt' },
+        velocity: {},
+        tick: 102,
+        buffer,
+      });
+    }).not.toThrow();
+
+    const result = AREShadowAdapter.executeShadowTick({
+      entityId: 'shadow_04',
+      position: { x: 'corrupt' },
+      velocity: {},
+      tick: 102,
+      buffer,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.recorded).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(buffer.latest('shadow_04')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds isolated shadow execution adapter and config only. Shadow tick is disabled by default and records into AREReplayBuffer only when explicitly enabled. No dependency, Docker, nginx, workflow, package, lockfile, client, portal, console, or WorldTick integration changes.