### PR TITLE
Add ARE divergence guard

### DIFF
--- a/server/src/core/are/AREDivergenceGuard.ts
+++ b/server/src/core/are/AREDivergenceGuard.ts
@@ -1,0 +1,116 @@
+import type { AREReplayBuffer } from './AREReplayBuffer';
+import { toKappa } from './Kappa';
+
+export type AREDivergenceStatus = 'ok' | 'warn' | 'critical';
+
+export interface AREDivergenceVector {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export interface AREDivergenceSample {
+  readonly tick: number;
+  readonly entityId: string;
+  readonly status: AREDivergenceStatus;
+  readonly drift: AREDivergenceVector;
+  readonly magnitude: number;
+  readonly legacyKappa: AREDivergenceVector;
+  readonly areKappa: AREDivergenceVector;
+  readonly areStateHash: number | null;
+}
+
+export interface AREDivergenceSummary {
+  readonly status: AREDivergenceStatus;
+  readonly samples: number;
+  readonly ok: number;
+  readonly warn: number;
+  readonly critical: number;
+  readonly maxMagnitude: number;
+  readonly latest?: AREDivergenceSample;
+}
+
+export interface AREDivergenceThresholds {
+  readonly warn: number;
+  readonly critical: number;
+}
+
+const DEFAULT_THRESHOLDS: AREDivergenceThresholds = {
+  warn: 1000,
+  critical: 10000,
+};
+
+export class AREDivergenceGuard {
+  private readonly samples: AREDivergenceSample[] = [];
+
+  constructor(private readonly thresholds: AREDivergenceThresholds = DEFAULT_THRESHOLDS, private readonly capacity = 256) {
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new Error('[ARE-Divergence] capacity must be a positive safe integer.');
+    }
+  }
+
+  measure(tick: number, entityId: string, legacyPosition: unknown, buffer: AREReplayBuffer): AREDivergenceSample | null {
+    const entry = buffer.get(tick, entityId) ?? buffer.latest(entityId);
+    if (!entry) return null;
+
+    const legacyKappa = AREDivergenceGuard.toKappaVector(legacyPosition);
+    const areKappa = entry.payload.position;
+    const drift = {
+      x: Math.abs(legacyKappa.x - areKappa.x),
+      y: Math.abs(legacyKappa.y - areKappa.y),
+      z: Math.abs(legacyKappa.z - areKappa.z),
+    };
+    const magnitude = drift.x + drift.y + drift.z;
+    const status = magnitude >= this.thresholds.critical ? 'critical' : magnitude >= this.thresholds.warn ? 'warn' : 'ok';
+
+    const sample: AREDivergenceSample = Object.freeze({
+      tick,
+      entityId,
+      status,
+      drift: Object.freeze(drift),
+      magnitude,
+      legacyKappa: Object.freeze(legacyKappa),
+      areKappa: Object.freeze({ x: areKappa.x, y: areKappa.y, z: areKappa.z }),
+      areStateHash: entry.stateHash ?? null,
+    });
+
+    this.samples.push(sample);
+    while (this.samples.length > this.capacity) this.samples.shift();
+    return sample;
+  }
+
+  summarize(): AREDivergenceSummary {
+    let ok = 0;
+    let warn = 0;
+    let critical = 0;
+    let maxMagnitude = 0;
+
+    for (const sample of this.samples) {
+      if (sample.status === 'critical') critical += 1;
+      else if (sample.status === 'warn') warn += 1;
+      else ok += 1;
+      if (sample.magnitude > maxMagnitude) maxMagnitude = sample.magnitude;
+    }
+
+    const status: AREDivergenceStatus = critical > 0 ? 'critical' : warn > 0 ? 'warn' : 'ok';
+    const latest = this.samples[this.samples.length - 1];
+    return Object.freeze({ status, samples: this.samples.length, ok, warn, critical, maxMagnitude, latest });
+  }
+
+  private static toKappaVector(position: unknown): AREDivergenceVector {
+    const source = (position ?? {}) as Record<string, unknown>;
+    return {
+      x: toKappa(AREDivergenceGuard.toNumber(source.x)),
+      y: toKappa(AREDivergenceGuard.toNumber(source.y)),
+      z: toKappa(AREDivergenceGuard.toNumber(source.z)),
+    };
+  }
+
+  private static toNumber(value: unknown): number {
+    if (value === null || value === undefined) return 0;
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error(`[ARE-Divergence] Invalid legacy position value: ${String(value)}.`);
+    }
+    return value;
+  }
+}

--- a/server/src/core/are/__tests__/AREDivergenceGuard.test.ts
+++ b/server/src/core/are/__tests__/AREDivergenceGuard.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { ARECycle } from '../ARECycle';
+import { AREDivergenceGuard } from '../AREDivergenceGuard';
+import { AREPayloadFactory } from '../AREPayload';
+import { AREReplayBuffer } from '../AREReplayBuffer';
+
+function recordAt(buffer: AREReplayBuffer, tick: number, entityId = 'entity:1') {
+  const genesis = AREPayloadFactory.createNormalized(entityId, { x: 1, y: 2, z: 0 }, { x: 0, y: 0, z: 0 });
+  const next = ARECycle.processCycle(genesis);
+  return buffer.record(tick, next);
+}
+
+describe('ARE-Logic: divergence guard', () => {
+  it('measures zero drift when legacy and ARE kappa positions match', () => {
+    const buffer = new AREReplayBuffer(5);
+    const entry = recordAt(buffer, 10);
+    const guard = new AREDivergenceGuard({ warn: 1000, critical: 10000 });
+
+    const sample = guard.measure(10, 'entity:1', { x: entry.payload.position.x / 1000, y: entry.payload.position.y / 1000, z: 0 }, buffer);
+
+    expect(sample?.status).toBe('ok');
+    expect(sample?.magnitude).toBe(0);
+    expect(guard.summarize().status).toBe('ok');
+  });
+
+  it('reports warn and critical thresholds without throwing', () => {
+    const buffer = new AREReplayBuffer(5);
+    recordAt(buffer, 10);
+    const guard = new AREDivergenceGuard({ warn: 10, critical: 1000 });
+
+    const warn = guard.measure(10, 'entity:1', { x: 2, y: 2, z: 0 }, buffer);
+    const critical = guard.measure(10, 'entity:1', { x: 100, y: 2, z: 0 }, buffer);
+
+    expect(warn?.status).toBe('warn');
+    expect(critical?.status).toBe('critical');
+    expect(guard.summarize().status).toBe('critical');
+    expect(guard.summarize().critical).toBe(1);
+  });
+
+  it('returns null when no matching replay entry exists', () => {
+    const buffer = new AREReplayBuffer(5);
+    const guard = new AREDivergenceGuard();
+    expect(guard.measure(1, 'missing', { x: 0, y: 0, z: 0 }, buffer)).toBeNull();
+  });
+
+  it('keeps bounded telemetry samples', () => {
+    const buffer = new AREReplayBuffer(5);
+    recordAt(buffer, 1);
+    const guard = new AREDivergenceGuard({ warn: 1, critical: 2 }, 2);
+
+    guard.measure(1, 'entity:1', { x: 1, y: 2, z: 0 }, buffer);
+    guard.measure(1, 'entity:1', { x: 2, y: 2, z: 0 }, buffer);
+    guard.measure(1, 'entity:1', { x: 3, y: 2, z: 0 }, buffer);
+
+    expect(guard.summarize().samples).toBe(2);
+  });
+
+  it('rejects invalid legacy positions as measurement errors', () => {
+    const buffer = new AREReplayBuffer(5);
+    recordAt(buffer, 10);
+    const guard = new AREDivergenceGuard();
+
+    expect(() => guard.measure(10, 'entity:1', { x: 'bad' }, buffer)).toThrow('[ARE-Divergence]');
+  });
+});


### PR DESCRIPTION
Adds isolated AREDivergenceGuard and tests only. Measures drift between legacy positions converted through kappa and AREReplayBuffer positions. No WorldTick, dependency, Docker, nginx, workflow, package, lockfile, client, portal, or console changes.