### PR TITLE
Add Safe Test Lab workflow

### DIFF
--- a/.github/workflows/safe-test-lab.yml
+++ b/.github/workflows/safe-test-lab.yml
@@ -1,0 +1,62 @@
+name: Safe Test Lab
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: safe-test-lab-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  safe-test:
+    name: Build and test without deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run monorepo guard
+        run: pnpm guard:monorepo:frozen
+
+      - name: Run ARE unit tests
+        run: pnpm exec vitest run server/src/core/are
+
+      - name: Build server
+        run: pnpm -r --filter ./server build
+
+      - name: Build 2D client
+        run: pnpm build:2d
+
+      - name: Build web portal
+        run: pnpm build:web
+
+      - name: Run safe smoke summary
+        if: always()
+        run: node scripts/safe-test-smoke.mjs
+
+      - name: Upload smoke summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: safe-test-summary
+          path: artifacts/safe-test-summary.json
+          if-no-files-found: warn

--- a/docs/CODESPACE_TESTING.md
+++ b/docs/CODESPACE_TESTING.md
@@ -1,0 +1,55 @@
+# Codespace and Safe Test Lab
+
+This repository uses GitHub Actions as a safe test lab before anything is deployed to the VPS.
+
+## Goal
+
+Do not test risky changes directly on production.
+
+Use this flow:
+
+```txt
+branch or pull request
+→ Safe Test Lab workflow
+→ inspect logs/artifact
+→ only then manual VPS deploy
+```
+
+## What the workflow does
+
+The workflow `.github/workflows/safe-test-lab.yml` runs on pull requests to `main` and can also be started manually with `workflow_dispatch`.
+
+It performs:
+
+```txt
+pnpm install --frozen-lockfile
+pnpm guard:monorepo:frozen
+pnpm exec vitest run server/src/core/are
+pnpm -r --filter ./server build
+pnpm build:2d
+pnpm build:web
+node scripts/safe-test-smoke.mjs
+```
+
+It never deploys.
+It never connects to the production VPS.
+It only builds, tests, and uploads a smoke summary artifact.
+
+## Manual Codespace commands
+
+If you open a Codespace manually, use:
+
+```bash
+corepack enable
+pnpm install --frozen-lockfile
+pnpm guard:monorepo:frozen
+pnpm exec vitest run server/src/core/are
+pnpm -r --filter ./server build
+pnpm build:2d
+pnpm build:web
+node scripts/safe-test-smoke.mjs
+```
+
+## Rule
+
+Production deploys remain manual until the alpha is stable.

--- a/scripts/safe-test-smoke.mjs
+++ b/scripts/safe-test-smoke.mjs
@@ -1,0 +1,41 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function run(command) {
+  try {
+    const output = execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return { ok: true, command, output: output.slice(-4000) };
+  } catch (error) {
+    return {
+      ok: false,
+      command,
+      output: String(error?.stdout ?? '').slice(-4000),
+      error: String(error?.stderr ?? error?.message ?? error).slice(-4000),
+    };
+  }
+}
+
+const checks = [
+  { name: 'repo package', ok: existsSync('package.json') },
+  { name: 'pnpm lockfile', ok: existsSync('pnpm-lock.yaml') },
+  { name: 'ARE core directory', ok: existsSync('server/src/core/are') },
+  { name: '2D client package', ok: existsSync('apps/client-2d/package.json') },
+  { name: 'web package', ok: existsSync('apps/web/package.json') },
+];
+
+const commands = [
+  run('node --version'),
+  run('pnpm --version'),
+  run('git rev-parse --short HEAD'),
+];
+
+const summary = {
+  generatedAt: new Date().toISOString(),
+  checks,
+  commands,
+  ok: checks.every((check) => check.ok) && commands.every((command) => command.ok),
+};
+
+mkdirSync('artifacts', { recursive: true });
+writeFileSync('artifacts/safe-test-summary.json', `${JSON.stringify(summary, null, 2)}\n`);
+console.log(JSON.stringify(summary, null, 2));


### PR DESCRIPTION
Adds a no-deploy GitHub Actions test lab for PRs and manual workflow runs. It installs with frozen lockfile, runs monorepo guard, ARE unit tests, server build, 2D build, web build, and uploads a smoke summary artifact. This does not deploy to the VPS and does not change runtime code.