### PR TITLE
Integrate deterministic 2D weapon equipment rendering

### DIFF
--- a/apps/client-2d/src/ArelorianStitchHud.tsx
+++ b/apps/client-2d/src/ArelorianStitchHud.tsx
@@ -7,11 +7,13 @@ export interface ArelorianStitchHudProps {
   connected: boolean;
   assetStatus: string;
   weaponCount: number;
+  equippedWeaponId?: string | null;
   playerName: string;
   messages: Msg[];
   onSkill: (skillId: string) => void;
   onChat: (text: string) => void;
   onInteract: () => void;
+  onCycleWeapon?: () => void;
   onToggleAutoMove?: () => void;
 }
 
@@ -36,11 +38,13 @@ export function ArelorianStitchHud({
   connected,
   assetStatus,
   weaponCount,
+  equippedWeaponId,
   playerName,
   messages,
   onSkill,
   onChat,
   onInteract,
+  onCycleWeapon,
   onToggleAutoMove,
 }: ArelorianStitchHudProps) {
   const [activePanel, setActivePanel] = useState<HudPanel>(null);
@@ -67,21 +71,21 @@ export function ArelorianStitchHud({
 
   return (
     <div className="stitch-hud" aria-label="Arelorian Science MMO HUD">
-      <div className="stitch-scanlines" />
+      <div className="stitch-scanlines" aria-hidden="true" />
 
-      <header className="stitch-topbar">
+      <header className="stitch-topbar" role="banner">
         <div className="stitch-brand">
           <span className="stitch-kicker">ARELORIAN SCIENCE // 2.5D PIXEL CLIENT</span>
           <strong>Millbrook Observer Node</strong>
         </div>
-        <div className="stitch-node-status">
+        <div className="stitch-node-status" role="status" aria-live="polite">
           <span className={connected ? "stitch-live-dot on" : "stitch-live-dot"} />
           <b>{connected ? "WORLD ONLINE" : "SYNCING"}</b>
           <small>{assetStatus} · {weaponCount} WEAPONS</small>
         </div>
       </header>
 
-      <aside className="stitch-vitals">
+      <aside className="stitch-vitals" aria-label="Player Vital Stats">
         <div className="stitch-portrait"><span>Ω</span></div>
         <div className="stitch-nameplate">
           <small>Observer</small>
@@ -93,13 +97,14 @@ export function ArelorianStitchHud({
         <Gauge label="XP" value={xp} tone="gold" />
       </aside>
 
-      <aside className="stitch-side-menu">
+      <aside className="stitch-side-menu" aria-label="Game Menus">
         {panels.map((panel) => (
           <button
             key={panel.id}
             className={activePanel === panel.id ? "active" : ""}
             onClick={() => setActivePanel(activePanel === panel.id ? null : panel.id)}
             title={panel.label}
+            aria-pressed={activePanel === panel.id}
           >
             <span>{panel.icon}</span>
             <small>{panel.label}</small>
@@ -107,7 +112,7 @@ export function ArelorianStitchHud({
         ))}
       </aside>
 
-      <section className="stitch-radar">
+      <section className="stitch-radar" aria-label="Radar Sensor">
         <div className="stitch-radar-ring"><i /><i /><i /></div>
         <div>
           <b>ARE Pulse</b>
@@ -115,23 +120,23 @@ export function ArelorianStitchHud({
         </div>
       </section>
 
-      <section className="stitch-chat">
+      <section className="stitch-chat" aria-label="Chat and Oracle Feed">
         <div className="stitch-panel-title"><b>Local / Oracle Feed</b><span>live</span></div>
-        <div className="stitch-chat-lines">
+        <div className="stitch-chat-lines" role="log" aria-live="polite">
           {visibleMessages.map((message, index) => (
             <p key={`${message.from}-${index}`}><b>{message.from}</b> {message.txt}</p>
           ))}
         </div>
         <form onSubmit={submitChat} className="stitch-chat-input">
-          <input value={chatText} onChange={(event) => setChatText(event.target.value)} placeholder="Send local message…" />
+          <input value={chatText} onChange={(event) => setChatText(event.target.value)} placeholder="Send local message…" aria-label="Chat input" />
           <button type="submit">SEND</button>
         </form>
       </section>
 
-      <nav className="stitch-skillbar">
+      <nav className="stitch-skillbar" aria-label="Skill Bar">
         {skills.map((skill) => (
-          <button key={skill.id} onClick={() => handleSkill(skill.id)}>
-            <kbd>{skill.key}</kbd>
+          <button key={skill.id} onClick={() => handleSkill(skill.id)} aria-label={`${skill.label} skill`}>
+            <kbd aria-hidden="true">{skill.key}</kbd>
             <span>{skill.icon}</span>
             <b>{skill.label}</b>
             <small>{skill.cost}</small>
@@ -139,40 +144,60 @@ export function ArelorianStitchHud({
         ))}
       </nav>
 
-      <section className="stitch-bottom-right">
+      <section className="stitch-bottom-right" aria-label="Quick Actions">
         <button onClick={onToggleAutoMove}>AUTO</button>
         <button onClick={onInteract}>INTERACT</button>
       </section>
 
-      {activePanel && <StitchPanel panel={activePanel} weaponCount={weaponCount} onClose={() => setActivePanel(null)} />}
+      {activePanel && (
+        <StitchPanel
+          panel={activePanel}
+          weaponCount={weaponCount}
+          equippedWeaponId={equippedWeaponId}
+          onCycleWeapon={onCycleWeapon}
+          onClose={() => setActivePanel(null)}
+        />
+      )}
     </div>
   );
 }
 
 function Gauge({ label, value, tone }: { label: string; value: number; tone: string }) {
   return (
-    <div className={`stitch-gauge ${tone}`}>
+    <div className={`stitch-gauge ${tone}`} role="progressbar" aria-valuenow={value} aria-valuemin={0} aria-valuemax={100} aria-label={label}>
       <div><b>{label}</b><span>{value}%</span></div>
       <i style={{ width: `${value}%` }} />
     </div>
   );
 }
 
-function StitchPanel({ panel, weaponCount, onClose }: { panel: Exclude<HudPanel, null>; weaponCount: number; onClose: () => void }) {
+function StitchPanel({
+  panel,
+  weaponCount,
+  equippedWeaponId,
+  onCycleWeapon,
+  onClose,
+}: {
+  panel: Exclude<HudPanel, null>;
+  weaponCount: number;
+  equippedWeaponId?: string | null;
+  onCycleWeapon?: () => void;
+  onClose: () => void;
+}) {
   const title = panelTitle(panel);
   return (
-    <div className="stitch-modal">
+    <div className="stitch-modal" role="dialog" aria-modal="true" aria-labelledby="stitch-modal-title">
       <div className="stitch-modal-card">
         <header>
           <div>
             <small>ARELORIAN SCIENCE MODULE</small>
-            <h2>{title}</h2>
+            <h2 id="stitch-modal-title">{title}</h2>
           </div>
-          <button onClick={onClose}>×</button>
+          <button onClick={onClose} aria-label="Close panel">×</button>
         </header>
-        {panel === "inventory" && <InventoryPreview weaponCount={weaponCount} />}
+        {panel === "inventory" && <InventoryPreview weaponCount={weaponCount} equippedWeaponId={equippedWeaponId} onCycleWeapon={onCycleWeapon} />}
         {panel === "character" && <CharacterPreview />}
-        {panel === "combat" && <CombatPreview />}
+        {panel === "combat" && <CombatPreview equippedWeaponId={equippedWeaponId} />}
         {panel === "map" && <MapPreview />}
         {panel === "guild" && <GuildPreview />}
         {panel === "factions" && <FactionsPreview />}
@@ -194,14 +219,32 @@ function panelTitle(panel: Exclude<HudPanel, null>) {
   } as const)[panel];
 }
 
-function InventoryPreview({ weaponCount }: { weaponCount: number }) {
-  return <div className="stitch-grid-panel"><Info label="Weapon Pool" value={`${weaponCount} visuals`} /><Info label="Drop Logic" value="visualId ready" /><Info label="Atlas" value="weapon-atlas.png" /><Info label="Rarity" value="common → mystic" /></div>;
+function cleanWeaponName(id?: string | null) {
+  return id ? id.replace(/[_-]/g, " ") : "none equipped";
+}
+
+function InventoryPreview({ weaponCount, equippedWeaponId, onCycleWeapon }: { weaponCount: number; equippedWeaponId?: string | null; onCycleWeapon?: () => void }) {
+  return (
+    <div className="stitch-grid-panel">
+      <Info label="Weapon Pool" value={`${weaponCount} visuals`} />
+      <Info label="Equipped" value={cleanWeaponName(equippedWeaponId)} />
+      <Info label="Drop Logic" value="visualId ready" />
+      <Info label="Atlas" value="weapon-atlas.png" />
+      <Info label="Rarity" value="common → mystic" />
+      <article className="stitch-info" style={{ gridColumn: "span 2" }}>
+        <small>Equipment Control</small>
+        <button type="button" onClick={onCycleWeapon} disabled={!onCycleWeapon || weaponCount <= 0}>
+          Cycle equipped visual
+        </button>
+      </article>
+    </div>
+  );
 }
 function CharacterPreview() {
   return <div className="stitch-grid-panel"><Info label="Level" value="1" /><Info label="ARE Sync" value="stable" /><Info label="Class" value="classless" /><Info label="Skill Mode" value="use-based" /></div>;
 }
-function CombatPreview() {
-  return <div className="stitch-grid-panel"><Info label="Tick" value="10Hz" /><Info label="Target" value="nearest" /><Info label="Threat" value="low" /><Info label="Warfront" value="cycle-linked" /></div>;
+function CombatPreview({ equippedWeaponId }: { equippedWeaponId?: string | null }) {
+  return <div className="stitch-grid-panel"><Info label="Tick" value="10Hz" /><Info label="Weapon" value={cleanWeaponName(equippedWeaponId)} /><Info label="Threat" value="low" /><Info label="Warfront" value="cycle-linked" /></div>;
 }
 function MapPreview() {
   return <div className="stitch-map-preview"><span /><span /><span /><span /><b>Millbrook</b></div>;

--- a/apps/client-2d/src/CyberZenIsoApp.tsx
+++ b/apps/client-2d/src/CyberZenIsoApp.tsx
@@ -1,13 +1,27 @@
 import { useEffect, useRef, useState } from "react";
-import { Application, Assets, Container, Graphics, Sprite, Text, Texture } from "pixi.js";
+import { Application, Assets, Container, Graphics, Rectangle, Sprite, Text, Texture } from "pixi.js";
 import { createClient } from "@wasd/core-network";
-import { fallbackEntry, loadAssetManifest, type AssetEntry, type AssetManifest } from "./assetManifest";
+import {
+  fallbackEntry,
+  loadAssetManifest,
+  pickWeaponVisual,
+  type AssetEntry,
+  type AssetManifest,
+} from "./assetManifest";
 import { ArelorianStitchHud } from "./ArelorianStitchHud";
 
 const TILE_W = 96;
 const TILE_H = 48;
+const EQUIPPED_WEAPON_KEY = "wasd:2d:equippedWeaponVisualId";
 
-type Entity = { root: Container; tx: number; tz: number };
+type Entity = {
+  root: Container;
+  tx: number;
+  tz: number;
+  name: string;
+  isPlayer: boolean;
+  weaponVisualId: string | null;
+};
 type Msg = { from: string; txt: string };
 type LoadedAssets = { manifest: AssetManifest | null; textures: Map<string, Texture> };
 
@@ -30,6 +44,18 @@ function diamond(color: number, stroke = 0x17361e) {
 function textureFor(assets: LoadedAssets | null, entry: AssetEntry | null): Texture | null {
   if (!assets || !entry?.src) return null;
   return assets.textures.get(entry.src) ?? null;
+}
+
+function weaponTextureFor(assets: LoadedAssets | null, entry: AssetEntry | null): Texture | null {
+  if (!assets || !entry?.src) return null;
+  const baseTexture = assets.textures.get(entry.src);
+  if (!baseTexture) return null;
+  if (!entry.frame) return baseTexture;
+
+  return new Texture({
+    source: baseTexture.source,
+    frame: new Rectangle(entry.frame.x, entry.frame.y, entry.frame.w, entry.frame.h),
+  });
 }
 
 function spriteFromTexture(texture: Texture, width: number, height: number, y = 0) {
@@ -75,7 +101,20 @@ function propHouse(assets?: LoadedAssets | null) {
   return c;
 }
 
-function avatar(name: string, player = false, assets?: LoadedAssets | null) {
+function addWeaponSprite(c: Container, assets: LoadedAssets | null | undefined, name: string, weaponVisualId?: string | null) {
+  const weapon = pickWeaponVisual(assets?.manifest ?? null, { visualId: weaponVisualId, seed: name });
+  const tex = weaponTextureFor(assets ?? null, weapon?.entry ?? null);
+  if (!tex) return;
+
+  const weaponSprite = spriteFromTexture(tex, 42, 42, 0);
+  weaponSprite.x = 16;
+  weaponSprite.y = -24;
+  weaponSprite.rotation = 0.35;
+  weaponSprite.alpha = 0.96;
+  c.addChild(weaponSprite);
+}
+
+function avatar(name: string, player = false, assets?: LoadedAssets | null, weaponVisualId?: string | null) {
   const c = new Container();
   const aura = player ? 0x00e5ff : 0x39ff14;
   const entry = fallbackEntry(assets?.manifest ?? null, "characters", player ? "player" : "npc");
@@ -86,6 +125,7 @@ function avatar(name: string, player = false, assets?: LoadedAssets | null) {
     c.addChild(new Graphics().ellipse(0, -8, 14, 21).fill(player ? 0x267dff : 0x249a56).stroke({ width: 2, color: aura, alpha: 0.55 }));
     c.addChild(new Graphics().circle(0, -34, 11).fill(player ? 0xffd8a9 : 0xd4ffd7).stroke({ width: 2, color: aura, alpha: 0.82 }));
   }
+  addWeaponSprite(c, assets, name, weaponVisualId);
   const label = new Text({ text: name, style: { fontSize: 11, fill: 0xfff0cf, stroke: { color: 0x02030a, width: 3 }, fontFamily: "monospace" } });
   label.anchor.set(0.5, 1); label.y = -58;
   c.addChild(label);
@@ -95,6 +135,21 @@ function avatar(name: string, player = false, assets?: LoadedAssets | null) {
 function place(node: Container, x: number, z: number, width: number, height: number) {
   const p = iso(x, z, width, height);
   node.x = p.x; node.y = p.y; node.zIndex = p.y;
+}
+
+function weaponIds(manifest: AssetManifest | null | undefined): string[] {
+  return Object.keys(manifest?.weapons ?? {}).sort();
+}
+
+function resolveEquippedWeaponId(manifest: AssetManifest | null, seed: string): string | null {
+  const ids = weaponIds(manifest);
+  if (ids.length === 0) return null;
+  const stored = localStorage.getItem(EQUIPPED_WEAPON_KEY);
+  if (stored && ids.includes(stored)) return stored;
+  const picked = pickWeaponVisual(manifest, { seed });
+  const id = picked?.id ?? ids[0] ?? null;
+  if (id) localStorage.setItem(EQUIPPED_WEAPON_KEY, id);
+  return id;
 }
 
 async function load2DAssets(): Promise<LoadedAssets> {
@@ -116,6 +171,7 @@ async function load2DAssets(): Promise<LoadedAssets> {
 export function CyberZenIsoApp() {
   const host = useRef<HTMLDivElement>(null);
   const appRef = useRef<Application | null>(null);
+  const actorLayerRef = useRef<Container | null>(null);
   const assetRef = useRef<LoadedAssets | null>(null);
   const entities = useRef<Map<string, Entity>>(new Map());
   const clientRef = useRef<ReturnType<typeof createClient> | null>(null);
@@ -125,6 +181,7 @@ export function CyberZenIsoApp() {
   const [connected, setConnected] = useState(false);
   const [assetStatus, setAssetStatus] = useState("ASSETS_LOADING");
   const [weaponCount, setWeaponCount] = useState(0);
+  const [equippedWeaponId, setEquippedWeaponId] = useState<string | null>(() => localStorage.getItem(EQUIPPED_WEAPON_KEY));
   const [messages, setMessages] = useState<Msg[]>([{ from: "Oracle", txt: "Cyberzen 2.5D shell online." }]);
 
   useEffect(() => {
@@ -143,14 +200,17 @@ export function CyberZenIsoApp() {
       const loaded = await load2DAssets();
       assetRef.current = loaded;
       const textureCount = loaded.textures.size;
-      const weapons = Object.keys(loaded.manifest?.weapons ?? {}).length;
+      const weapons = weaponIds(loaded.manifest).length;
+      const initialWeaponId = resolveEquippedWeaponId(loaded.manifest, playerName);
+      setEquippedWeaponId(initialWeaponId);
       setWeaponCount(weapons);
       setAssetStatus(textureCount > 0 ? `ASSETS_${textureCount}_LOADED` : "PROXY_GRAPHICS");
       setMessages(m => [...m.slice(-12), { from: "AssetRig", txt: textureCount > 0 ? `Loaded ${textureCount} textures and ${weapons} weapon visuals.` : "No manifest textures yet. Using proxy graphics." }]);
       const terrain = new Container(); const props = new Container(); const actors = new Container(); actors.sortableChildren = true;
+      actorLayerRef.current = actors;
       app.stage.addChild(terrain, props, actors);
       buildScene(app, terrain, props, loaded);
-      addActor(app, actors, "self", 0, 0, playerName, true, loaded);
+      addActor(app, actors, "self", 0, 0, playerName, true, loaded, initialWeaponId);
       addActor(app, actors, "elder", 2, 1, "Millbrook Elder", false, loaded);
       startNetwork(app, actors);
       app.ticker.add(() => tick(app, actors));
@@ -168,10 +228,46 @@ export function CyberZenIsoApp() {
     [[-2,2],[2,2],[0,-4]].forEach(([x,z]) => { const h = propHouse(assets); place(h, x, z, app.screen.width, app.screen.height); props.addChild(h); });
   }
 
-  function addActor(app: Application, layer: Container, id: string, x: number, z: number, name: string, player: boolean, assets = assetRef.current) {
-    if (entities.current.has(id)) return;
-    const root = avatar(name, player, assets); place(root, x, z, app.screen.width, app.screen.height);
-    layer.addChild(root); entities.current.set(id, { root, tx: x, tz: z });
+  function addActor(app: Application, layer: Container, id: string, x: number, z: number, name: string, player: boolean, assets = assetRef.current, weaponVisualId?: string | null) {
+    const existing = entities.current.get(id);
+    if (existing) {
+      existing.tx = x;
+      existing.tz = z;
+      return;
+    }
+    const resolvedWeaponId = player ? (weaponVisualId ?? equippedWeaponId) : pickWeaponVisual(assets?.manifest ?? null, { seed: name })?.id ?? null;
+    const root = avatar(name, player, assets, resolvedWeaponId); place(root, x, z, app.screen.width, app.screen.height);
+    layer.addChild(root); entities.current.set(id, { root, tx: x, tz: z, name, isPlayer: player, weaponVisualId: resolvedWeaponId });
+  }
+
+  function rebuildActorVisual(id: string, weaponVisualId: string | null) {
+    const app = appRef.current;
+    const layer = actorLayerRef.current;
+    const assets = assetRef.current;
+    const ent = entities.current.get(id);
+    if (!app || !layer || !ent) return;
+
+    const oldRoot = ent.root;
+    const root = avatar(ent.name, ent.isPlayer, assets, weaponVisualId);
+    place(root, ent.tx, ent.tz, app.screen.width, app.screen.height);
+    layer.addChild(root);
+    oldRoot.destroy({ children: true });
+    entities.current.set(id, { ...ent, root, weaponVisualId });
+  }
+
+  function cycleEquippedWeapon() {
+    const ids = weaponIds(assetRef.current?.manifest);
+    if (ids.length === 0) {
+      setMessages(m => [...m.slice(-12), { from: "Inventory", txt: "No weapon visuals loaded yet." }]);
+      return;
+    }
+    const current = equippedWeaponId ?? localStorage.getItem(EQUIPPED_WEAPON_KEY);
+    const currentIndex = current ? ids.indexOf(current) : -1;
+    const next = ids[(currentIndex + 1 + ids.length) % ids.length];
+    localStorage.setItem(EQUIPPED_WEAPON_KEY, next);
+    setEquippedWeaponId(next);
+    rebuildActorVisual("self", next);
+    setMessages(m => [...m.slice(-12), { from: "Inventory", txt: `Equipped weapon visual: ${next}` }]);
   }
 
   function startNetwork(app: Application, layer: Container) {
@@ -196,7 +292,7 @@ export function CyberZenIsoApp() {
   }
 
   function sendSkill(skillId: string) {
-    clientRef.current?.sendPlayerAction("USE_SKILL", { skillId });
+    clientRef.current?.sendPlayerAction("USE_SKILL", { skillId, weaponVisualId: equippedWeaponId });
     setMessages(m => [...m.slice(-12), { from: "Combat", txt: `Skill queued: ${skillId}` }]);
   }
 
@@ -218,11 +314,13 @@ export function CyberZenIsoApp() {
         connected={connected}
         assetStatus={assetStatus}
         weaponCount={weaponCount}
+        equippedWeaponId={equippedWeaponId}
         playerName={playerName}
         messages={messages}
         onSkill={sendSkill}
         onChat={sendChat}
         onInteract={interact}
+        onCycleWeapon={cycleEquippedWeapon}
         onToggleAutoMove={() => setMessages(m => [...m.slice(-12), { from: "Navigator", txt: "Auto-route planner not yet linked." }])}
       />
     </div>


### PR DESCRIPTION
Manual clean integration of the useful 2D weapon/equipment pieces without README, lockfile, dependency, Playwright, Vite, or workflow churn.

Changes:
- Load and render deterministic weapon sprites on 2D avatars using the existing weapon manifest and pickWeaponVisual helper.
- Persist the local equipped weapon visual ID in localStorage.
- Add an inventory HUD control to cycle equipped weapon visuals.
- Show equipped weapon state in Inventory and Combat panels.
- Send the equipped weapon visual ID with USE_SKILL client actions.

Scope is intentionally limited to:
- apps/client-2d/src/CyberZenIsoApp.tsx
- apps/client-2d/src/ArelorianStitchHud.tsx

No production deploy is triggered because VPS deploys are manual-only now.