### PR TITLE
Add ARE emergence and entropy helpers

### DIFF
--- a/server/src/core/are/AREDriftEntropy.ts
+++ b/server/src/core/are/AREDriftEntropy.ts
@@ -1,0 +1,78 @@
+import { AREGuard } from './AREGuard';
+import { AREHash } from './AREHash';
+import type { AREVector3, IAREPayload } from './AREPayload';
+import { assertSafeInteger, kAdd, kSub, toKappa, type KappaInt } from './Kappa';
+
+export type AREDriftAction = 'anchor_support' | 'observe' | 'adaptive_response';
+
+export interface AREDriftResult {
+  readonly playerDrift: KappaInt;
+  readonly status: 'calm' | 'dissonant' | 'chaotic';
+  readonly action: AREDriftAction;
+}
+
+export interface AREEntropyResult {
+  readonly payload: Readonly<IAREPayload> | null;
+  readonly capsule?: Readonly<IAREPayload>;
+  readonly event: 'entropy_decay' | 'capsule_spawn';
+}
+
+const WARN_DRIFT = 5000;
+const CRITICAL_DRIFT = 15000;
+
+function absK(value: KappaInt): KappaInt {
+  return value < 0 ? -value : value;
+}
+
+function manhattan(a: Readonly<AREVector3>, b: Readonly<AREVector3>): KappaInt {
+  return kAdd(kAdd(absK(kSub(a.x, b.x)), absK(kSub(a.y, b.y))), absK(kSub(a.z, b.z)));
+}
+
+function legacyToKappa(pos: Readonly<Partial<Record<'x' | 'y' | 'z', number>>>): AREVector3 {
+  return AREGuard.protectPayload({ x: toKappa(pos.x ?? 0), y: toKappa(pos.y ?? 0), z: toKappa(pos.z ?? 0) });
+}
+
+function readEnergy(payload: Readonly<IAREPayload>): KappaInt {
+  const value = payload.energy;
+  if (typeof value !== 'number') return 0;
+  assertSafeInteger(value, 'energy');
+  return value;
+}
+
+export class AREDriftEntropy {
+  static computeDrift(
+    legacyPosition: Readonly<Partial<Record<'x' | 'y' | 'z', number>>>,
+    kappaPosition: Readonly<AREVector3>,
+    relation: 'ally' | 'neutral' | 'rival' = 'neutral',
+  ): AREDriftResult {
+    return AREGuard.executeProtected(() => {
+      const playerDrift = manhattan(legacyToKappa(legacyPosition), kappaPosition);
+      const status = playerDrift >= CRITICAL_DRIFT ? 'chaotic' : playerDrift >= WARN_DRIFT ? 'dissonant' : 'calm';
+      const action = status === 'calm' ? 'observe' : relation === 'ally' ? 'anchor_support' : relation === 'rival' ? 'adaptive_response' : 'observe';
+      return AREGuard.protectPayload({ playerDrift, status, action });
+    });
+  }
+
+  static applyEntropy(payload: Readonly<IAREPayload>, cost: KappaInt = 1): AREEntropyResult {
+    return AREGuard.executeProtected(() => {
+      AREGuard.assertNoFloats(payload);
+      assertSafeInteger(cost, 'entropy cost');
+      const nextEnergy = kSub(readEnergy(payload), cost);
+      if (nextEnergy <= 0) {
+        const hash = payload.stateHash ?? AREHash.generate(payload);
+        const capsule: IAREPayload = {
+          entityId: `capsule:${payload.entityId}:${hash}`,
+          position: payload.position,
+          velocity: { x: 0, y: 0, z: 0 },
+          stateHash: hash,
+          kind: 'EnergyCapsule',
+          residualEnergy: Math.max(0, nextEnergy),
+          sourceEntityId: payload.entityId,
+        };
+        AREGuard.assertNoFloats(capsule);
+        return AREGuard.protectPayload({ payload: null, capsule: AREGuard.protectPayload(capsule), event: 'capsule_spawn' });
+      }
+      return AREGuard.protectPayload({ payload: AREGuard.protectPayload({ ...payload, energy: nextEnergy }), event: 'entropy_decay' });
+    });
+  }
+}

--- a/server/src/core/are/ARENpcEvolution.ts
+++ b/server/src/core/are/ARENpcEvolution.ts
@@ -1,0 +1,91 @@
+import { AREGuard } from './AREGuard';
+import { AREHash } from './AREHash';
+import type { AREVector3, IAREPayload } from './AREPayload';
+import { assertSafeInteger, kAdd, kSub, type KappaInt } from './Kappa';
+
+export interface AREFusionResult {
+  readonly fused: boolean;
+  readonly apex?: Readonly<IAREPayload>;
+  readonly consumedEntityIds: readonly string[];
+}
+
+export interface ARECapsuleScanResult {
+  readonly capsule: Readonly<IAREPayload> | null;
+  readonly direction: Readonly<AREVector3> | null;
+  readonly movementCost: KappaInt;
+}
+
+const DEFAULT_CHUNK_SIZE = 64000;
+
+function readInt(payload: Readonly<IAREPayload>, key: string): KappaInt {
+  const value = payload[key];
+  if (typeof value !== 'number') return 0;
+  assertSafeInteger(value, key);
+  return value;
+}
+
+function samePosition(a: Readonly<IAREPayload>, b: Readonly<IAREPayload>): boolean {
+  return a.position.x === b.position.x && a.position.y === b.position.y && a.position.z === b.position.z;
+}
+
+function absK(value: KappaInt): KappaInt {
+  return value < 0 ? -value : value;
+}
+
+function distance(a: Readonly<AREVector3>, b: Readonly<AREVector3>): KappaInt {
+  return kAdd(kAdd(absK(kSub(a.x, b.x)), absK(kSub(a.y, b.y))), absK(kSub(a.z, b.z)));
+}
+
+function chunkKey(position: Readonly<AREVector3>, chunkSize: KappaInt): string {
+  assertSafeInteger(chunkSize, 'chunk size');
+  return `${Math.trunc(position.x / chunkSize)}:${Math.trunc(position.y / chunkSize)}:${Math.trunc(position.z / chunkSize)}`;
+}
+
+export class ARENpcEvolution {
+  static fuseOnSameKappaCell(a: Readonly<IAREPayload>, b: Readonly<IAREPayload>): AREFusionResult {
+    return AREGuard.executeProtected(() => {
+      AREGuard.assertNoFloats(a);
+      AREGuard.assertNoFloats(b);
+      if (!samePosition(a, b)) return AREGuard.protectPayload({ fused: false, consumedEntityIds: [] });
+
+      const hash = ((a.stateHash ?? AREHash.generate(a)) ^ (b.stateHash ?? AREHash.generate(b))) >>> 0;
+      const apex: IAREPayload = {
+        entityId: `apex:${hash.toString(16)}`,
+        position: a.position,
+        velocity: { x: 0, y: 0, z: 0 },
+        stateHash: hash,
+        kind: 'ApexNpc',
+        behavior: 'territory_builder',
+        energy: kAdd(readInt(a, 'energy'), readInt(b, 'energy')),
+        health: kAdd(readInt(a, 'health'), readInt(b, 'health')),
+        parents: [a.entityId, b.entityId],
+      };
+      AREGuard.assertNoFloats(apex);
+      return AREGuard.protectPayload({ fused: true, apex: AREGuard.protectPayload(apex), consumedEntityIds: [a.entityId, b.entityId] });
+    });
+  }
+
+  static scanOwnChunkForCapsule(npc: Readonly<IAREPayload>, capsules: readonly Readonly<IAREPayload>[], chunkSize: KappaInt = DEFAULT_CHUNK_SIZE): ARECapsuleScanResult {
+    return AREGuard.executeProtected(() => {
+      AREGuard.assertNoFloats(npc);
+      const own = chunkKey(npc.position, chunkSize);
+      let best: Readonly<IAREPayload> | null = null;
+      let bestDistance: KappaInt | null = null;
+
+      for (const capsule of capsules) {
+        AREGuard.assertNoFloats(capsule);
+        if (capsule.kind !== 'EnergyCapsule') continue;
+        if (chunkKey(capsule.position, chunkSize) !== own) continue;
+        const d = distance(npc.position, capsule.position);
+        if (bestDistance === null || d < bestDistance || (d === bestDistance && capsule.entityId < (best?.entityId ?? ''))) {
+          best = capsule;
+          bestDistance = d;
+        }
+      }
+
+      if (!best) return AREGuard.protectPayload({ capsule: null, direction: null, movementCost: 0 });
+      const direction = AREGuard.protectPayload({ x: kSub(best.position.x, npc.position.x), y: kSub(best.position.y, npc.position.y), z: kSub(best.position.z, npc.position.z) });
+      return AREGuard.protectPayload({ capsule: best, direction, movementCost: bestDistance ?? 0 });
+    });
+  }
+}

--- a/server/src/core/are/__tests__/AREDriftEntropy.test.ts
+++ b/server/src/core/are/__tests__/AREDriftEntropy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { AREDriftEntropy } from '../AREDriftEntropy';
+import { AREPayloadFactory } from '../AREPayload';
+
+function createNpc(energy = 10) {
+  return AREPayloadFactory.createNormalized(
+    'npc:entropy',
+    { x: 1, y: 2, z: 0 },
+    { x: 0, y: 0, z: 0 },
+    { energy, health: 20 },
+  );
+}
+
+describe('ARE-Logic: drift and entropy helpers', () => {
+  it('maps low drift to calm observation', () => {
+    const result = AREDriftEntropy.computeDrift({ x: 1, y: 2, z: 0 }, { x: 1000, y: 2000, z: 0 }, 'neutral');
+    expect(result.playerDrift).toBe(0);
+    expect(result.status).toBe('calm');
+    expect(result.action).toBe('observe');
+  });
+
+  it('maps high ally drift to anchor support', () => {
+    const result = AREDriftEntropy.computeDrift({ x: 20, y: 2, z: 0 }, { x: 1000, y: 2000, z: 0 }, 'ally');
+    expect(result.status).toBe('chaotic');
+    expect(result.action).toBe('anchor_support');
+  });
+
+  it('maps high rival drift to adaptive response', () => {
+    const result = AREDriftEntropy.computeDrift({ x: 20, y: 2, z: 0 }, { x: 1000, y: 2000, z: 0 }, 'rival');
+    expect(result.status).toBe('chaotic');
+    expect(result.action).toBe('adaptive_response');
+  });
+
+  it('decays energy deterministically without mutating input', () => {
+    const npc = createNpc(10);
+    const result = AREDriftEntropy.applyEntropy(npc, 3);
+
+    expect(result.event).toBe('entropy_decay');
+    expect(result.payload?.energy).toBe(7);
+    expect(npc.energy).toBe(10);
+    expect(Object.isFrozen(result.payload)).toBe(true);
+  });
+
+  it('spawns an energy capsule when energy reaches zero', () => {
+    const npc = createNpc(1);
+    const result = AREDriftEntropy.applyEntropy(npc, 1);
+
+    expect(result.event).toBe('capsule_spawn');
+    expect(result.payload).toBeNull();
+    expect(result.capsule?.kind).toBe('EnergyCapsule');
+    expect(result.capsule?.position).toEqual(npc.position);
+    expect(result.capsule?.sourceEntityId).toBe(npc.entityId);
+  });
+});

--- a/server/src/core/are/__tests__/ARENpcEvolution.test.ts
+++ b/server/src/core/are/__tests__/ARENpcEvolution.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { ARENpcEvolution } from '../ARENpcEvolution';
+import { AREPayloadFactory } from '../AREPayload';
+
+function npc(id: string, pos = { x: 4, y: 5, z: 0 }, energy = 10, health = 20) {
+  return AREPayloadFactory.createNormalized(
+    id,
+    pos,
+    { x: 0, y: 0, z: 0 },
+    { energy, health },
+  );
+}
+
+function capsule(id: string, pos = { x: 4.5, y: 5, z: 0 }) {
+  return AREPayloadFactory.createNormalized(
+    id,
+    pos,
+    { x: 0, y: 0, z: 0 },
+    { kind: 'EnergyCapsule', residualEnergy: 3 },
+  );
+}
+
+describe('ARE-Logic: NPC evolution helpers', () => {
+  it('does not fuse NPCs on different kappa positions', () => {
+    const result = ARENpcEvolution.fuseOnSameKappaCell(npc('a'), npc('b', { x: 5, y: 5, z: 0 }));
+    expect(result.fused).toBe(false);
+    expect(result.consumedEntityIds).toEqual([]);
+  });
+
+  it('fuses NPCs on the same kappa position into an apex payload', () => {
+    const a = npc('a', { x: 4, y: 5, z: 0 }, 10, 20);
+    const b = npc('b', { x: 4, y: 5, z: 0 }, 7, 11);
+    const result = ARENpcEvolution.fuseOnSameKappaCell(a, b);
+
+    expect(result.fused).toBe(true);
+    expect(result.consumedEntityIds).toEqual(['a', 'b']);
+    expect(result.apex?.kind).toBe('ApexNpc');
+    expect(result.apex?.energy).toBe(17);
+    expect(result.apex?.health).toBe(31);
+    expect(result.apex?.position).toEqual(a.position);
+    expect(Object.isFrozen(result.apex)).toBe(true);
+  });
+
+  it('scans only the NPC own chunk for energy capsules', () => {
+    const seeker = npc('seeker', { x: 4, y: 5, z: 0 });
+    const local = capsule('capsule:local', { x: 4.5, y: 5, z: 0 });
+    const far = capsule('capsule:far', { x: 100, y: 5, z: 0 });
+
+    const result = ARENpcEvolution.scanOwnChunkForCapsule(seeker, [far, local]);
+
+    expect(result.capsule?.entityId).toBe('capsule:local');
+    expect(result.movementCost).toBe(500);
+    expect(result.direction).toEqual({ x: 500, y: 0, z: 0 });
+  });
+
+  it('returns no target when no capsule is in the same chunk', () => {
+    const seeker = npc('seeker', { x: 4, y: 5, z: 0 });
+    const far = capsule('capsule:far', { x: 100, y: 5, z: 0 });
+
+    const result = ARENpcEvolution.scanOwnChunkForCapsule(seeker, [far]);
+
+    expect(result.capsule).toBeNull();
+    expect(result.direction).toBeNull();
+    expect(result.movementCost).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds isolated ARE emergence/entropy helper modules and tests only.

Included:
- AREDriftEntropy: WakeUpShield-style drift classification and deterministic entropy decay into energy capsules.
- ARENpcEvolution: same-kappa-cell NPC fusion via XOR state hash and own-chunk capsule scanning.
- Unit tests for both modules.

No WorldTick integration, no runtime mutation, no deploy workflow, no package or lockfile changes.