### PR TITLE
Add ARE shadow state

### DIFF
--- a/server/src/core/are/AREShadowState.ts
+++ b/server/src/core/are/AREShadowState.ts
@@ -1,0 +1,166 @@
+import { AREGuard } from './AREGuard';
+import type { IAREPayload } from './AREPayload';
+import { assertSafeInteger, type KappaInt } from './Kappa';
+
+export type AREShadowStatus = 'observing' | 'active' | 'saturated';
+export type AREShadowEventKind = 'capsule' | 'apex' | 'fusion' | 'scavenger' | 'expired' | 'evicted';
+
+export interface AREShadowStateOptions {
+  readonly maxCapsules?: number;
+  readonly maxApexNpcs?: number;
+  readonly maxEvents?: number;
+  readonly ttlTicks?: number;
+}
+
+export interface AREShadowEvent {
+  readonly tick: number;
+  readonly kind: AREShadowEventKind;
+  readonly summary: string;
+}
+
+export interface AREShadowEcosystemStats {
+  readonly capsules: number;
+  readonly apexNpcs: number;
+  readonly events: readonly string[];
+  readonly latestCapsuleTick: number;
+  readonly latestFusionTick: number;
+  readonly latestScavengerTick: number;
+  readonly status: AREShadowStatus;
+}
+
+interface ShadowEntry {
+  readonly tick: number;
+  readonly expiresAtTick: number;
+  readonly payload: Readonly<IAREPayload>;
+}
+
+const DEFAULT_MAX_CAPSULES = 1000;
+const DEFAULT_MAX_APEX = 500;
+const DEFAULT_MAX_EVENTS = 50;
+const DEFAULT_TTL_TICKS = 72000;
+
+function safePositive(value: number, label: string): number {
+  assertSafeInteger(value, label);
+  if (value <= 0) throw new Error(`[ARE-ShadowState] ${label} must be greater than zero.`);
+  return value;
+}
+
+export class AREShadowState {
+  private readonly capsules = new Map<string, ShadowEntry>();
+  private readonly apexNpcs = new Map<string, ShadowEntry>();
+  private readonly events: AREShadowEvent[] = [];
+  private latestCapsuleTick = 0;
+  private latestFusionTick = 0;
+  private latestScavengerTick = 0;
+
+  private readonly maxCapsules: number;
+  private readonly maxApexNpcs: number;
+  private readonly maxEvents: number;
+  private readonly ttlTicks: number;
+
+  constructor(options: AREShadowStateOptions = {}) {
+    this.maxCapsules = safePositive(options.maxCapsules ?? DEFAULT_MAX_CAPSULES, 'maxCapsules');
+    this.maxApexNpcs = safePositive(options.maxApexNpcs ?? DEFAULT_MAX_APEX, 'maxApexNpcs');
+    this.maxEvents = safePositive(options.maxEvents ?? DEFAULT_MAX_EVENTS, 'maxEvents');
+    this.ttlTicks = safePositive(options.ttlTicks ?? DEFAULT_TTL_TICKS, 'ttlTicks');
+  }
+
+  recordCapsule(tick: number, payload: Readonly<IAREPayload>): void {
+    this.assertTick(tick);
+    AREGuard.assertNoFloats(payload);
+    this.prune(tick);
+    this.capsules.set(payload.entityId, Object.freeze({ tick, expiresAtTick: tick + this.ttlTicks, payload }));
+    this.latestCapsuleTick = tick;
+    this.pushEvent(tick, 'capsule', `capsule:${payload.entityId}`);
+    this.enforceCapsuleCap(tick);
+  }
+
+  recordApex(tick: number, payload: Readonly<IAREPayload>): void {
+    this.assertTick(tick);
+    AREGuard.assertNoFloats(payload);
+    this.prune(tick);
+    this.apexNpcs.set(payload.entityId, Object.freeze({ tick, expiresAtTick: tick + this.ttlTicks, payload }));
+    this.pushEvent(tick, 'apex', `apex:${payload.entityId}`);
+    this.enforceApexCap(tick);
+  }
+
+  recordFusion(tick: number, apex: Readonly<IAREPayload>, consumedEntityIds: readonly string[]): void {
+    this.recordApex(tick, apex);
+    this.latestFusionTick = tick;
+    this.pushEvent(tick, 'fusion', `fusion:${consumedEntityIds.join('+')}=>${apex.entityId}`);
+  }
+
+  recordScavenger(tick: number, npcId: string, capsuleId: string, movementCost: KappaInt): void {
+    this.assertTick(tick);
+    assertSafeInteger(movementCost, 'movementCost');
+    this.latestScavengerTick = tick;
+    this.pushEvent(tick, 'scavenger', `scavenger:${npcId}->${capsuleId}:${movementCost}`);
+  }
+
+  prune(tick: number): void {
+    this.assertTick(tick);
+    for (const [id, entry] of [...this.capsules.entries()]) {
+      if (entry.expiresAtTick <= tick) {
+        this.capsules.delete(id);
+        this.pushEvent(tick, 'expired', `capsule:${id}`);
+      }
+    }
+    for (const [id, entry] of [...this.apexNpcs.entries()]) {
+      if (entry.expiresAtTick <= tick) {
+        this.apexNpcs.delete(id);
+        this.pushEvent(tick, 'expired', `apex:${id}`);
+      }
+    }
+  }
+
+  getCapsules(): readonly Readonly<IAREPayload>[] {
+    return Object.freeze([...this.capsules.values()].map((entry) => entry.payload));
+  }
+
+  getApexNpcs(): readonly Readonly<IAREPayload>[] {
+    return Object.freeze([...this.apexNpcs.values()].map((entry) => entry.payload));
+  }
+
+  getTelemetry(): AREShadowEcosystemStats {
+    const saturated = this.capsules.size >= this.maxCapsules || this.apexNpcs.size >= this.maxApexNpcs || this.events.length >= this.maxEvents;
+    const active = this.capsules.size > 0 || this.apexNpcs.size > 0 || this.events.length > 0;
+    const status: AREShadowStatus = saturated ? 'saturated' : active ? 'active' : 'observing';
+    return Object.freeze({
+      capsules: this.capsules.size,
+      apexNpcs: this.apexNpcs.size,
+      events: Object.freeze(this.events.map((event) => `${event.tick}:${event.kind}:${event.summary}`)),
+      latestCapsuleTick: this.latestCapsuleTick,
+      latestFusionTick: this.latestFusionTick,
+      latestScavengerTick: this.latestScavengerTick,
+      status,
+    });
+  }
+
+  private enforceCapsuleCap(tick: number): void {
+    while (this.capsules.size > this.maxCapsules) {
+      const oldest = this.capsules.keys().next().value as string | undefined;
+      if (!oldest) return;
+      this.capsules.delete(oldest);
+      this.pushEvent(tick, 'evicted', `capsule:${oldest}`);
+    }
+  }
+
+  private enforceApexCap(tick: number): void {
+    while (this.apexNpcs.size > this.maxApexNpcs) {
+      const oldest = this.apexNpcs.keys().next().value as string | undefined;
+      if (!oldest) return;
+      this.apexNpcs.delete(oldest);
+      this.pushEvent(tick, 'evicted', `apex:${oldest}`);
+    }
+  }
+
+  private pushEvent(tick: number, kind: AREShadowEventKind, summary: string): void {
+    this.events.push(Object.freeze({ tick, kind, summary }));
+    while (this.events.length > this.maxEvents) this.events.shift();
+  }
+
+  private assertTick(tick: number): void {
+    assertSafeInteger(tick, 'shadow tick');
+    if (tick < 0) throw new Error('[ARE-ShadowState] tick must be non-negative.');
+  }
+}

--- a/server/src/core/are/__tests__/AREShadowState.test.ts
+++ b/server/src/core/are/__tests__/AREShadowState.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { AREPayloadFactory } from '../AREPayload';
+import { AREShadowState } from '../AREShadowState';
+
+function payload(id: string, kind = 'EnergyCapsule') {
+  return AREPayloadFactory.createNormalized(
+    id,
+    { x: 1, y: 2, z: 0 },
+    { x: 0, y: 0, z: 0 },
+    { kind, energy: 10, health: 20 },
+  );
+}
+
+describe('ARE-Logic: shadow ecosystem state', () => {
+  it('starts in observing status with no phantom state', () => {
+    const state = new AREShadowState();
+    const telemetry = state.getTelemetry();
+
+    expect(telemetry.status).toBe('observing');
+    expect(telemetry.capsules).toBe(0);
+    expect(telemetry.apexNpcs).toBe(0);
+    expect(telemetry.events).toEqual([]);
+  });
+
+  it('records phantom capsules without touching live state', () => {
+    const state = new AREShadowState({ maxCapsules: 3, maxEvents: 10, ttlTicks: 10 });
+    const capsule = payload('capsule:1');
+
+    state.recordCapsule(1, capsule);
+
+    expect(state.getCapsules()).toEqual([capsule]);
+    expect(state.getTelemetry().status).toBe('active');
+    expect(state.getTelemetry().latestCapsuleTick).toBe(1);
+    expect(Object.isFrozen(state.getTelemetry())).toBe(true);
+  });
+
+  it('expires old phantom entries by ttl before hardcap matters', () => {
+    const state = new AREShadowState({ maxCapsules: 10, maxEvents: 20, ttlTicks: 2 });
+    state.recordCapsule(1, payload('capsule:1'));
+    state.recordCapsule(2, payload('capsule:2'));
+
+    state.prune(3);
+
+    expect(state.getCapsules().map((p) => p.entityId)).toEqual(['capsule:2']);
+    expect(state.getTelemetry().events.some((entry) => entry.includes('expired:capsule:capsule:1'))).toBe(true);
+  });
+
+  it('evicts oldest capsules when hard capacity is exceeded', () => {
+    const state = new AREShadowState({ maxCapsules: 2, maxEvents: 20, ttlTicks: 100 });
+    state.recordCapsule(1, payload('capsule:1'));
+    state.recordCapsule(2, payload('capsule:2'));
+    state.recordCapsule(3, payload('capsule:3'));
+
+    expect(state.getCapsules().map((p) => p.entityId)).toEqual(['capsule:2', 'capsule:3']);
+    expect(state.getTelemetry().events.some((entry) => entry.includes('evicted:capsule:capsule:1'))).toBe(true);
+  });
+
+  it('records apex and fusion telemetry without external side effects', () => {
+    const state = new AREShadowState({ maxApexNpcs: 2, maxEvents: 20, ttlTicks: 100 });
+    const apex = payload('apex:abc', 'ApexNpc');
+
+    state.recordFusion(5, apex, ['npc:a', 'npc:b']);
+
+    expect(state.getApexNpcs()).toEqual([apex]);
+    expect(state.getTelemetry().apexNpcs).toBe(1);
+    expect(state.getTelemetry().latestFusionTick).toBe(5);
+    expect(state.getTelemetry().events.some((entry) => entry.includes('fusion:npc:a+npc:b=>apex:abc'))).toBe(true);
+  });
+
+  it('records scavenger observations only as telemetry', () => {
+    const state = new AREShadowState({ maxEvents: 5 });
+
+    state.recordScavenger(7, 'npc:1', 'capsule:1', 500);
+
+    const telemetry = state.getTelemetry();
+    expect(telemetry.latestScavengerTick).toBe(7);
+    expect(telemetry.events[0]).toContain('scavenger:npc:1->capsule:1:500');
+  });
+
+  it('caps event log with FIFO behavior', () => {
+    const state = new AREShadowState({ maxCapsules: 10, maxEvents: 2, ttlTicks: 100 });
+    state.recordCapsule(1, payload('capsule:1'));
+    state.recordCapsule(2, payload('capsule:2'));
+    state.recordCapsule(3, payload('capsule:3'));
+
+    const events = state.getTelemetry().events;
+    expect(events).toHaveLength(2);
+    expect(events[0]).toContain('capsule:capsule:2');
+    expect(events[1]).toContain('capsule:capsule:3');
+  });
+
+  it('reports saturated when any hard limit is reached', () => {
+    const state = new AREShadowState({ maxCapsules: 1, maxEvents: 10, ttlTicks: 100 });
+    state.recordCapsule(1, payload('capsule:1'));
+
+    expect(state.getTelemetry().status).toBe('saturated');
+  });
+
+  it('rejects invalid configuration and invalid ticks', () => {
+    expect(() => new AREShadowState({ maxCapsules: 0 })).toThrow('[ARE-ShadowState]');
+    const state = new AREShadowState();
+    expect(() => state.recordCapsule(-1, payload('capsule:bad'))).toThrow('[ARE-ShadowState]');
+  });
+});


### PR DESCRIPTION
Adds isolated AREShadowState and tests only.

Scope:
- server/src/core/are/AREShadowState.ts
- server/src/core/are/__tests__/AREShadowState.test.ts

The module is capacity-limited, RAM-only, test-covered, and not connected to runtime yet.