### PR TITLE
Add Pipoya atlas unpack workflow

### DIFF
--- a/.github/workflows/unpack-pipoya-character-atlas.yml
+++ b/.github/workflows/unpack-pipoya-character-atlas.yml
@@ -1,0 +1,81 @@
+name: Unpack Pipoya Character Atlas
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: unpack-pipoya-character-atlas
+  cancel-in-progress: false
+
+jobs:
+  unpack:
+    name: Unpack prepared 2D character atlas
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create asset branch
+        run: |
+          set -euo pipefail
+          git switch -c pipoya-character-atlas-assets-${{ github.run_id }}
+
+      - name: Unpack asset pack
+        run: |
+          set -euo pipefail
+          python3 scripts/unpack-pipoya-character-atlas.py asset-packs/2d/pipoya-character-atlas-drop.zip
+
+      - name: Verify unpacked files
+        run: |
+          set -euo pipefail
+          test -s apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.png
+          test -s apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.json
+          test -s docs/PIPOYA_CHARACTER_ATLAS_DROP.md
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          data = json.loads(Path('apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.json').read_text())
+          entries = data.get('entries', {})
+          if len(entries) < 300:
+              raise SystemExit(f'Atlas has too few entries: {len(entries)}')
+          print(f"Atlas entries: {len(entries)}")
+          print(f"Groups: {data.get('groups', {})}")
+          PY
+
+      - name: Commit unpacked atlas
+        run: |
+          set -euo pipefail
+          git add apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.png
+          git add apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.json
+          git add docs/PIPOYA_CHARACTER_ATLAS_DROP.md
+          if git diff --cached --quiet; then
+            echo "No asset changes to commit."
+            exit 0
+          fi
+          git commit -m "Add Pipoya 2D character atlas assets"
+          git push origin HEAD
+
+      - name: Open asset PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          BRANCH="pipoya-character-atlas-assets-${{ github.run_id }}"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Add Pipoya 2D character atlas assets" \
+            --body "Cold asset drop generated from asset-packs/2d/pipoya-character-atlas-drop.zip. Adds only the packed PNG atlas, atlas JSON, and documentation. No runtime, package, lockfile, workflow, or deploy changes."

--- a/scripts/unpack-pipoya-character-atlas.py
+++ b/scripts/unpack-pipoya-character-atlas.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Unpack the prepared Pipoya 2D character atlas asset drop.
+
+Source ZIP:
+  asset-packs/2d/pipoya-character-atlas-drop.zip
+
+Expected output:
+  apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.png
+  apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.json
+  docs/PIPOYA_CHARACTER_ATLAS_DROP.md
+
+Standard library only. No package or lockfile changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import zipfile
+from pathlib import Path
+
+DEFAULT_ZIP = Path("asset-packs/2d/pipoya-character-atlas-drop.zip")
+ALLOWED_PREFIXES = (
+    "apps/client-2d/public/2d-assets/characters/pipoya/",
+    "docs/PIPOYA_CHARACTER_ATLAS_DROP.md",
+)
+EXPECTED_FILES = (
+    "apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.png",
+    "apps/client-2d/public/2d-assets/characters/pipoya/pipoya-character-atlas.json",
+    "docs/PIPOYA_CHARACTER_ATLAS_DROP.md",
+)
+
+
+def is_allowed(name: str) -> bool:
+    normalized = name.replace("\\", "/").lstrip("/")
+    if ".." in Path(normalized).parts:
+        return False
+    return any(normalized == prefix or normalized.startswith(prefix) for prefix in ALLOWED_PREFIXES)
+
+
+def unpack(zip_path: Path, repo_root: Path) -> list[str]:
+    if not zip_path.exists():
+        raise SystemExit(f"Asset pack not found: {zip_path}")
+
+    written: list[str] = []
+    with zipfile.ZipFile(zip_path) as archive:
+        names = archive.namelist()
+        blocked = [name for name in names if name and not name.endswith("/") and not is_allowed(name)]
+        if blocked:
+            preview = "\n".join(f"  - {name}" for name in blocked[:20])
+            raise SystemExit(f"Refusing to unpack unexpected paths:\n{preview}")
+
+        for name in names:
+            if not name or name.endswith("/"):
+                continue
+            target = repo_root / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(archive.read(name))
+            written.append(name)
+
+    missing = [path for path in EXPECTED_FILES if not (repo_root / path).exists()]
+    if missing:
+        preview = "\n".join(f"  - {path}" for path in missing)
+        raise SystemExit(f"Unpack incomplete. Missing expected files:\n{preview}")
+
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Unpack the prepared Pipoya character atlas asset pack.")
+    parser.add_argument("zip_path", nargs="?", default=str(DEFAULT_ZIP), help="Path to pipoya-character-atlas-drop.zip")
+    args = parser.parse_args()
+
+    written = unpack(Path(args.zip_path), Path.cwd())
+    print("Pipoya character atlas unpacked")
+    print(f"files: {len(written)}")
+    for path in written:
+        print(f"- {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a manual GitHub Actions workflow to unpack the prepared Pipoya character atlas asset pack that is already in asset-packs/2d.

Scope:
- scripts/unpack-pipoya-character-atlas.py
- .github/workflows/unpack-pipoya-character-atlas.yml

The workflow is manual-only and opens a separate asset PR containing the unpacked atlas PNG, atlas JSON, and docs. No VPS deploy, no package or lockfile changes.