### PR TITLE
ARE Economy Adapter Layer

### DIFF
--- a/server/src/core/are/AREEconomyAdapter.ts
+++ b/server/src/core/are/AREEconomyAdapter.ts
@@ -1,0 +1,39 @@
+import { EconomySimulation } from "../systems/EconomySimulation";
+
+/**
+ * AREEconomyAdapter
+ * Bridges legacy EconomySimulation with ARE deterministic payload model.
+ * Does NOT mutate world directly.
+ */
+export class AREEconomyAdapter {
+  private economy: EconomySimulation;
+
+  constructor(economy: EconomySimulation) {
+    this.economy = economy;
+  }
+
+  /**
+   * Execute one deterministic economy cycle
+   */
+  public tick(): void {
+    // delegate to existing deterministic system
+    this.economy.update();
+  }
+
+  /**
+   * Extract ARE-style payload snapshot
+   */
+  public snapshotARE(): {
+    l: number;
+    k: number;
+    r: number;
+  } {
+    const totalEnergy = this.economy.calculateTotalSystemEnergy();
+
+    return {
+      l: totalEnergy, // local/system energy
+      k: 1000,        // kappa invariant
+      r: totalEnergy % 1000 // simple relational projection
+    };
+  }
+}


### PR DESCRIPTION
Closed during PR cleanup. Useful concept, but this branch is stale/non-mergeable and the economy adapter/shadow telemetry path has already moved forward in later work. Do not merge this old additive adapter as-is.