### PR TITLE
Stabilize portal runtime entrypoints

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -49,6 +49,10 @@ COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.ya
 RUN corepack enable && corepack prepare pnpm@9.12.2 --activate && \
     pnpm --filter @wasd/server deploy /app/prod-server
 
+# Copy built client after deploy so static runtime routes are available to ServerBootstrap.
+COPY --from=builder /app/client/dist /app/prod-server/client/dist
+COPY --from=builder /app/client/public /app/prod-server/client/public
+
 WORKDIR /app/prod-server
 
 EXPOSE 3000

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node ../scripts/write-runtime-entrypoints.mjs",
     "build:itch": "tsc && vite build --mode itch",
     "app:build": "vite build && npx cap sync android",
     "cap:sync": "npx cap sync android",


### PR DESCRIPTION
Stabilizes public Portal/Landing runtime routes without touching core simulation.

Scope:
- client build now runs scripts/write-runtime-entrypoints.mjs after Vite build
- Docker production image now copies client/dist and client/public into the server runtime package
- ensures /are-console.html, /sovereign-truth.html, /portal/ and root entrypoints are present for ServerBootstrap static serving

No WorldTick, ARE core, NPC, combat, or world-state logic touched.