### PR TITLE
feat(client-2d): add layered render helpers

### DIFF
--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -6,6 +6,13 @@ export type SpriteAnimation = {
   fps?: number;
 };
 
+export type SpriteLayerFrame = {
+  frame: { x: number; y: number; w: number; h: number };
+  offsetX?: number;
+  offsetY?: number;
+  z?: number;
+};
+
 export type AssetEntry = {
   id?: string;
   src: string;
@@ -24,6 +31,10 @@ export type AssetEntry = {
   frame?: { x: number; y: number; w: number; h: number };
   sheetFrame?: { x: number; y: number; w: number; h: number };
   frameSize?: { w: number; h: number };
+  spriteLayers?: SpriteLayerFrame[];
+  zHeight?: number;
+  isoFootprint?: { w: number; h: number };
+  shadow?: { w: number; h: number; alpha?: number };
   weaponClass?: string;
   rarity?: string;
   tags?: string[];

--- a/apps/client-2d/src/isometricProjection.ts
+++ b/apps/client-2d/src/isometricProjection.ts
@@ -1,0 +1,31 @@
+export type IsoPoint = {
+  x: number;
+  y: number;
+  zIndex: number;
+};
+
+export type IsoProjectionInput = {
+  gridX: number;
+  gridZ: number;
+  height?: number;
+  screenWidth: number;
+  screenHeight: number;
+  tileWidth: number;
+  tileHeight: number;
+};
+
+export function iso2(input: Omit<IsoProjectionInput, 'height'>): IsoPoint {
+  const x = input.screenWidth / 2 + (input.gridX - input.gridZ) * input.tileWidth * 0.5;
+  const y = input.screenHeight * 0.45 + (input.gridX + input.gridZ) * input.tileHeight * 0.5;
+  return { x, y, zIndex: y };
+}
+
+export function iso3(input: IsoProjectionInput): IsoPoint {
+  const height = Number.isFinite(input.height) ? Number(input.height) : 0;
+  const base = iso2(input);
+  return {
+    x: base.x,
+    y: base.y - height * input.tileHeight * 0.45,
+    zIndex: base.y + height * 0.1,
+  };
+}

--- a/apps/client-2d/src/stackedProps.ts
+++ b/apps/client-2d/src/stackedProps.ts
@@ -1,0 +1,19 @@
+import { Container, Graphics, Texture } from "pixi.js";
+import { makeStackedSprite, supportsStack } from "./stackedSprite";
+import type { AssetEntry } from "./assetManifest";
+
+export function make2dProp(entry: AssetEntry | null | undefined, texture: Texture | null | undefined, fallback: () => Container, width: number, height: number): Container {
+  if (!entry || !texture) return fallback();
+  if (supportsStack(entry)) return makeStackedSprite(texture, entry, { width, height, layerStep: 3 });
+  const root = new Container();
+  const shadow = entry.shadow;
+  const shadowWidth = shadow?.w ?? entry.isoFootprint?.w ?? width * 0.72;
+  const shadowHeight = shadow?.h ?? entry.isoFootprint?.h ?? Math.max(6, height * 0.12);
+  root.addChild(new Graphics().ellipse(0, 16, shadowWidth * 0.5, shadowHeight * 0.5).fill({ color: 0x010804, alpha: shadow?.alpha ?? 0.42 }));
+  const sprite = new (await import("pixi.js")).Sprite(texture);
+  sprite.anchor.set(0.5, 1);
+  sprite.width = width;
+  sprite.height = height;
+  root.addChild(sprite);
+  return root;
+}

--- a/apps/client-2d/src/stackedProps.ts
+++ b/apps/client-2d/src/stackedProps.ts
@@ -1,4 +1,4 @@
-import { Container, Graphics, Texture } from "pixi.js";
+import { Container, Graphics, Sprite, Texture } from "pixi.js";
 import { makeStackedSprite, supportsStack } from "./stackedSprite";
 import type { AssetEntry } from "./assetManifest";
 
@@ -10,7 +10,7 @@ export function make2dProp(entry: AssetEntry | null | undefined, texture: Textur
   const shadowWidth = shadow?.w ?? entry.isoFootprint?.w ?? width * 0.72;
   const shadowHeight = shadow?.h ?? entry.isoFootprint?.h ?? Math.max(6, height * 0.12);
   root.addChild(new Graphics().ellipse(0, 16, shadowWidth * 0.5, shadowHeight * 0.5).fill({ color: 0x010804, alpha: shadow?.alpha ?? 0.42 }));
-  const sprite = new (await import("pixi.js")).Sprite(texture);
+  const sprite = new Sprite(texture);
   sprite.anchor.set(0.5, 1);
   sprite.width = width;
   sprite.height = height;

--- a/apps/client-2d/src/stackedSprite.ts
+++ b/apps/client-2d/src/stackedSprite.ts
@@ -1,0 +1,53 @@
+import { Container, Graphics, Rectangle, Sprite, Texture } from "pixi.js";
+import type { AssetEntry } from "./assetManifest";
+
+export type StackedSpriteOptions = {
+  width: number;
+  height: number;
+  layerStep?: number;
+  shadow?: boolean;
+};
+
+export function supportsStack(entry: AssetEntry | null | undefined): boolean {
+  return Boolean(entry?.spriteLayers?.length);
+}
+
+function frameTexture(texture: Texture, frame: { x: number; y: number; w: number; h: number }): Texture {
+  return new Texture({ source: texture.source, frame: new Rectangle(frame.x, frame.y, frame.w, frame.h) });
+}
+
+function makeSprite(texture: Texture, width: number, height: number, x = 0, y = 0): Sprite {
+  const sprite = new Sprite(texture);
+  sprite.anchor.set(0.5, 1);
+  sprite.width = width;
+  sprite.height = height;
+  sprite.x = x;
+  sprite.y = y;
+  return sprite;
+}
+
+export function makeStackedSprite(texture: Texture, entry: AssetEntry, options: StackedSpriteOptions): Container {
+  const root = new Container();
+  const layers = [...(entry.spriteLayers ?? [])].sort((a, b) => (a.z ?? 0) - (b.z ?? 0));
+  const step = Number.isFinite(options.layerStep) ? Number(options.layerStep) : 3;
+
+  if (options.shadow !== false) {
+    const shadow = entry.shadow;
+    const sw = shadow?.w ?? entry.isoFootprint?.w ?? options.width * 0.72;
+    const sh = shadow?.h ?? entry.isoFootprint?.h ?? Math.max(6, options.height * 0.12);
+    root.addChild(new Graphics().ellipse(0, 16, sw * 0.5, sh * 0.5).fill({ color: 0x010804, alpha: shadow?.alpha ?? 0.42 }));
+  }
+
+  if (layers.length === 0) {
+    root.addChild(makeSprite(texture, options.width, options.height));
+    return root;
+  }
+
+  for (const layer of layers) {
+    const tex = frameTexture(texture, layer.frame);
+    const z = Number(layer.z ?? 0);
+    root.addChild(makeSprite(tex, options.width, options.height, Number(layer.offsetX ?? 0), Number(layer.offsetY ?? 0) - z * step));
+  }
+
+  return root;
+}


### PR DESCRIPTION
Implements Issue #1047.

Summary:
- Adds iso projection helpers for height-aware 2D rendering.
- Extends client asset metadata with optional layer, height, footprint, and shadow fields.
- Adds Pixi v8-compatible helpers for layered atlas rendering.
- Keeps existing assets compatible and adds no new dependencies.

Follow-up:
- Wire the existing scene props/resources to the new helpers for visible upgrades.