### PR TITLE
feat(client-2d): install depth runtime hook

### DIFF
--- a/apps/client-2d/src/client2dDepthRuntime.ts
+++ b/apps/client-2d/src/client2dDepthRuntime.ts
@@ -1,0 +1,19 @@
+import { Container } from "pixi.js";
+
+let installed = false;
+
+export function installClient2DDepthRuntime(): void {
+  if (installed) return;
+  installed = true;
+
+  const originalAddChild = Container.prototype.addChild;
+
+  Container.prototype.addChild = function patchedAddChild(this: Container, ...children: any[]) {
+    const result = originalAddChild.apply(this, children as any);
+    if (children.some((child) => typeof child?.zIndex === "number")) {
+      this.sortableChildren = true;
+      (this as any).sortDirty = true;
+    }
+    return result;
+  } as typeof Container.prototype.addChild;
+}

--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -4,8 +4,11 @@ import { CyberZenLoginGate } from "./CyberZenLoginGate";
 import { CyberZenIsoApp } from "./CyberZenIsoApp";
 import { LiveRealityBridge } from "./LiveRealityBridge";
 import { MobileMovePad } from "./MobileMovePad";
+import { installClient2DDepthRuntime } from "./client2dDepthRuntime";
 import "./theme.css";
 import "./liveReality.css";
+
+installClient2DDepthRuntime();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
Implements first safe slice of Issue #1049.

Summary:
- Adds a small client-2d depth runtime hook.
- Installs it before the Pixi app starts.
- Keeps the change minimal and dependency-free.

Notes:
- This does not rewrite CyberZenIsoApp yet.
- It prepares Pixi containers for safer zIndex-based sorting when layered/height-aware objects are added.