### PR TITLE
fix(client-2d): preserve depth slice dimensions

### DIFF
--- a/apps/client-2d/src/client2dDepthRuntime.ts
+++ b/apps/client-2d/src/client2dDepthRuntime.ts
@@ -15,7 +15,6 @@ function cloneDepthSlice(source: Sprite, offset: number, alpha: number): Sprite 
   slice.x = source.x;
   slice.y = source.y + offset;
   slice.rotation = source.rotation;
-  slice.scale.x = source.scale.x;
   slice.skew.copyFrom(source.skew);
   slice.alpha = alpha;
   slice.tint = source.tint;


### PR DESCRIPTION
Small follow-up after PR #1051.

Summary:
- Removes the extra scale copy from automatic depth slices.
- Keeps slice width/height controlled by the explicitly assigned dimensions.
- Reduces the chance of visual distortion or doubled scaling on large sprites.

Changed files:
- apps/client-2d/src/client2dDepthRuntime.ts