### PR TITLE
feat(client-2d): validate assets before build

### DIFF
--- a/apps/client-2d/package.json
+++ b/apps/client-2d/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prebuild": "node ../../scripts/extract-2d-weapon-pool.mjs",
+    "prebuild": "pnpm run validate:assets && node ../../scripts/extract-2d-weapon-pool.mjs",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
Implements Issue #1058.

Summary:
- Updates the client-2d prebuild chain.
- Runs `validate:assets` before extracting the weapon pool.
- Keeps the existing Vite build command unchanged.
- No dependencies.

Changed file:
- apps/client-2d/package.json