### PR TITLE
ci: trigger stitch import by push

### DIFF
--- a/.github/stitch-import-trigger.txt
+++ b/.github/stitch-import-trigger.txt
@@ -1,0 +1,3 @@
+issue_number=1071
+persist=true
+updated=2026-05-23T06:20:00Z

--- a/.github/workflows/import-stitch-atlases.yml
+++ b/.github/workflows/import-stitch-atlases.yml
@@ -11,6 +11,12 @@ on:
         description: 'Commit imported assets to a PR branch after validation'
         required: false
         default: 'true'
+  push:
+    branches: [main]
+    paths:
+      - '.github/stitch-import-trigger.txt'
+      - '.github/workflows/import-stitch-atlases.yml'
+      - 'scripts/import-stitch-generated-atlases.mjs'
 
 permissions:
   contents: write
@@ -79,7 +85,7 @@ jobs:
           retention-days: 3
 
       - name: Create import pull request
-        if: success() && (github.event.inputs.persist == '' || github.event.inputs.persist == 'true')
+        if: success() && (github.event_name == 'push' || github.event.inputs.persist == '' || github.event.inputs.persist == 'true')
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a push trigger marker for the Stitch atlas import workflow so imports can run without the manual workflow button.