### PR TITLE
ci: run stitch atlas import

### DIFF
--- a/.github/stitch-import-trigger.txt
+++ b/.github/stitch-import-trigger.txt
@@ -1,3 +1,3 @@
 issue_number=1071
 persist=true
-updated=2026-05-23T06:20:00Z
+updated=2026-05-23T06:24:00Z


### PR DESCRIPTION
Refreshes the Stitch import marker so the push-triggered import workflow can run from main.