### PR TITLE
feat(client-2d): prepare Stitch atlas frames

### DIFF
--- a/apps/client-2d/package.json
+++ b/apps/client-2d/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prebuild": "node ../../scripts/validate-client-2d-assets.mjs && node ../../scripts/extract-2d-weapon-pool.mjs",
+    "prebuild": "node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs && node ../../scripts/extract-2d-weapon-pool.mjs",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "validate:assets": "node ../../scripts/validate-client-2d-assets.mjs"
+    "validate:assets": "node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs"
   },
   "dependencies": {
     "pixi.js": "^8.18.1",

--- a/scripts/enrich-stitch-atlas-frames.mjs
+++ b/scripts/enrich-stitch-atlas-frames.mjs
@@ -1,0 +1,69 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const publicRoot = path.join(repoRoot, 'apps/client-2d/public');
+const manifestPath = path.join(publicRoot, '2d-assets/manifest.json');
+
+const GROUPS = ['tilesets', 'characters', 'monsters', 'buildings', 'props', 'fx', 'ui', 'weapons'];
+
+function toPublicPath(assetPath) {
+  if (!assetPath || typeof assetPath !== 'string') return null;
+  const normalized = assetPath.replace(/^\/2d-assets\//, '2d-assets/').replace(/^2d-assets\//, '2d-assets/');
+  return path.join(publicRoot, normalized);
+}
+
+function firstFrameFromAtlas(atlas) {
+  const frames = Object.entries(atlas?.frames ?? {})
+    .filter(([, payload]) => payload?.frame)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return frames[0]?.[1]?.frame ?? null;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function main() {
+  const manifest = await readJson(manifestPath);
+  let enriched = 0;
+
+  for (const groupName of GROUPS) {
+    const group = manifest[groupName];
+    if (!group || typeof group !== 'object') continue;
+
+    for (const [id, entry] of Object.entries(group)) {
+      if (!entry || typeof entry !== 'object' || !entry.atlas) continue;
+      const atlasPath = toPublicPath(entry.atlas);
+      if (!atlasPath) continue;
+
+      try {
+        const atlas = await readJson(atlasPath);
+        const frame = firstFrameFromAtlas(atlas);
+        if (!frame) continue;
+
+        entry.frame = {
+          x: Number(frame.x),
+          y: Number(frame.y),
+          w: Number(frame.w),
+          h: Number(frame.h),
+        };
+        entry.width = entry.width ?? Number(frame.w);
+        entry.height = entry.height ?? Number(frame.h);
+        enriched += 1;
+      } catch (err) {
+        console.warn(`[stitch-frame-enrich] skipped ${id}: ${err.message}`);
+      }
+    }
+  }
+
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`[stitch-frame-enrich] enriched ${enriched} atlas-backed entries in ${path.relative(repoRoot, manifestPath)}`);
+}
+
+main().catch((err) => {
+  console.error('[stitch-frame-enrich] failed', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a small client-2d asset preparation step for Stitch atlas metadata before validation and build.