### PR TITLE
feat(client-2d): render forged Stitch prop frames

### DIFF
--- a/apps/client-2d/src/stackedProps.ts
+++ b/apps/client-2d/src/stackedProps.ts
@@ -1,16 +1,29 @@
-import { Container, Graphics, Sprite, Texture } from "pixi.js";
+import { Container, Graphics, Rectangle, Sprite, Texture } from "pixi.js";
 import { makeStackedSprite, supportsStack } from "./stackedSprite";
 import type { AssetEntry } from "./assetManifest";
 
+function propTextureFor(entry: AssetEntry, texture: Texture): Texture {
+  const frame = entry.frame;
+  if (!frame) return texture;
+  if (![frame.x, frame.y, frame.w, frame.h].every(Number.isFinite)) return texture;
+  if (frame.w <= 0 || frame.h <= 0) return texture;
+
+  return new Texture({
+    source: texture.source,
+    frame: new Rectangle(frame.x, frame.y, frame.w, frame.h),
+  });
+}
+
 export function make2dProp(entry: AssetEntry | null | undefined, texture: Texture | null | undefined, fallback: () => Container, width: number, height: number): Container {
   if (!entry || !texture) return fallback();
-  if (supportsStack(entry)) return makeStackedSprite(texture, entry, { width, height, layerStep: 3 });
+  const propTexture = propTextureFor(entry, texture);
+  if (supportsStack(entry)) return makeStackedSprite(propTexture, entry, { width, height, layerStep: 3 });
   const root = new Container();
   const shadow = entry.shadow;
   const shadowWidth = shadow?.w ?? entry.isoFootprint?.w ?? width * 0.72;
   const shadowHeight = shadow?.h ?? entry.isoFootprint?.h ?? Math.max(6, height * 0.12);
   root.addChild(new Graphics().ellipse(0, 16, shadowWidth * 0.5, shadowHeight * 0.5).fill({ color: 0x010804, alpha: shadow?.alpha ?? 0.42 }));
-  const sprite = new Sprite(texture);
+  const sprite = new Sprite(propTexture);
   sprite.anchor.set(0.5, 1);
   sprite.width = width;
   sprite.height = height;


### PR DESCRIPTION
Makes make2dProp crop atlas-backed prop/building textures through entry.frame before rendering. This turns the existing scene houses and trees into real visual smoke markers for the forged Stitch frame pipeline instead of showing whole atlas sheets.