### PR TITLE
ci: harden wiki sync automation

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -6,12 +6,24 @@ on:
       - main
     paths:
       - 'docs/wiki/**'
+      - 'scripts/sync-wiki.mjs'
+      - '.github/workflows/sync-wiki.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: sync-wiki
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
   sync-wiki:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -22,4 +34,8 @@ jobs:
           node-version: 22
 
       - name: Sync Wiki Content
+        env:
+          GITHUB_TOKEN: ${{ secrets.WIKI_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
         run: node scripts/sync-wiki.mjs

--- a/scripts/sync-wiki.mjs
+++ b/scripts/sync-wiki.mjs
@@ -1,0 +1,66 @@
+import { cpSync, existsSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const repo = process.env.GITHUB_REPOSITORY;
+const token = process.env.GITHUB_TOKEN;
+const sha = process.env.GITHUB_SHA ?? 'unknown';
+
+if (!repo) {
+  throw new Error('GITHUB_REPOSITORY is missing.');
+}
+
+if (!token) {
+  throw new Error('GITHUB_TOKEN is missing.');
+}
+
+const sourceDir = path.resolve('docs/wiki');
+const wikiDir = path.resolve('.wiki-sync');
+
+if (!existsSync(sourceDir)) {
+  throw new Error(`Wiki source directory not found: ${sourceDir}`);
+}
+
+function run(command, args, options = {}) {
+  console.log(`> ${command} ${args.join(' ')}`);
+  execFileSync(command, args, {
+    stdio: 'inherit',
+    ...options,
+  });
+}
+
+function output(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  }).trim();
+}
+
+rmSync(wikiDir, { recursive: true, force: true });
+
+const remoteUrl = `https://x-access-token:${token}@github.com/${repo}.wiki.git`;
+
+run('git', ['clone', remoteUrl, wikiDir]);
+run('bash', ['-lc', `find "${wikiDir}" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +`]);
+
+cpSync(sourceDir, wikiDir, {
+  recursive: true,
+  force: true,
+});
+
+run('git', ['config', 'user.name', 'github-actions[bot]'], { cwd: wikiDir });
+run('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com'], { cwd: wikiDir });
+run('git', ['add', '--all'], { cwd: wikiDir });
+
+const status = output('git', ['status', '--porcelain'], { cwd: wikiDir });
+
+if (!status) {
+  console.log('Wiki already up to date. Nothing to commit.');
+  process.exit(0);
+}
+
+run('git', ['commit', '-m', `docs: sync wiki from ${sha.slice(0, 7)}`], { cwd: wikiDir });
+run('git', ['push', 'origin', 'master'], { cwd: wikiDir });
+
+console.log('Wiki sync complete.');


### PR DESCRIPTION
## Summary
- harden the Sync Wiki workflow with manual dispatch, concurrency, timeout, and write permissions
- include workflow/script path triggers
- add `scripts/sync-wiki.mjs` to mirror `docs/wiki` into the repository wiki

## Notes
- The workflow uses `secrets.WIKI_TOKEN` when present and falls back to `secrets.GITHUB_TOKEN`.
- The GitHub Wiki repository must exist before syncing.
