### PR TITLE
docs(wiki): professionalize ARE wiki crosslinks

### DIFF
--- a/docs/wiki/ARE-Erdos-Attractor-Model.md
+++ b/docs/wiki/ARE-Erdos-Attractor-Model.md
@@ -1,0 +1,89 @@
+# ARE-Erdos Attractor Model
+
+Tags: `are`, `erdos`, `kappa`, `topology`, `determinism`, `self-healing`
+Status: `research-blueprint`
+
+The **ARE-Erdos Attractor Model** maps graph distance and deterministic propagation into the ARE runtime. It is the mathematical bridge between [[ARE Logic Core|ARE-Logic-Core]], [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]] and future self-healing simulation logic.
+
+---
+
+## Kappa standardization
+
+`kappa = 1000` is the canonical integer scaling constant.
+
+Continuous-looking values are projected into an integer grid before simulation logic evaluates them. This protects the runtime from floating-point drift and platform-dependent rounding.
+
+Related terms:
+
+- [[Kappa|Glossary#kappa]]
+- [[Determinism]]
+- [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]]
+
+---
+
+## 10Hz simulation tick
+
+The model assumes a fixed simulation interval of `100ms`, also described as a **10Hz tick**.
+
+Dynamic delta-time is avoided for core simulation decisions. Rendering may interpolate, but authoritative simulation stays tick-bound.
+
+See [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]].
+
+---
+
+## Erdos distance
+
+`E` describes topological distance from a core node, creator node, apex node or system singularity.
+
+Practical interpretation:
+
+- low `E` means close to trusted structure,
+- high `E` means isolated or weakly connected,
+- unreachable or stale nodes become pruning candidates.
+
+---
+
+## Attractor coefficient
+
+The attractor coefficient translates distance into stabilizing force:
+
+```txt
+Omega_E = floor(kappa / (E + 1))
+```
+
+High trust/low distance produces stronger structural integrity. Isolated nodes converge toward zero influence.
+
+---
+
+## Pruning interpretation
+
+The model supports deterministic pruning:
+
+1. a node becomes isolated,
+2. its effective graph distance no longer improves,
+3. its stabilizing coefficient decays,
+4. the runtime can convert it into passive residue, cache, loot, energy or removal.
+
+This idea should be implemented cautiously and always behind tests.
+
+---
+
+## Implementation anchors
+
+| Concept | Current / planned anchor | Status |
+| --- | --- | --- |
+| 10Hz tick | `server/src/core/WorldTick.ts` | implemented/active |
+| Kappa integer grid | future `server/src/core/AREKernel.ts` | planned |
+| Erdos network | future `server/src/core/AREErdosNetwork.ts` | planned |
+| Self-pruning | future SelfHeal / energy capsule layer | planned |
+| Asset metadata integrity | `scripts/are-asset-forge.mjs` | implemented for assets |
+
+---
+
+## See also
+
+- [[Home]]
+- [[Glossary]]
+- [[ARE Logic Core|ARE-Logic-Core]]
+- [[Implementation Map|Implementation-Map]]
+- [[Determinism]]

--- a/docs/wiki/ARE-Logic-Core.md
+++ b/docs/wiki/ARE-Logic-Core.md
@@ -1,0 +1,65 @@
+# ARE Logic Core
+
+Tags: `are`, `determinism`, `axioms`, `world-model`, `research`
+Status: `research-backed-design`
+
+The **ARE Logic Core** is the conceptual foundation of Areloria. ARE means **Authentic Reality Emancipation**: a deterministic reality model where the world is not stored as uncontrolled bloat, but derived from axioms, seeds, ticks and observable interactions.
+
+---
+
+## Authentic Reality Emancipation ARE
+
+ARE defines reality as a field of information that becomes concrete inside deterministic simulation windows. In practical engine terms, this means:
+
+- stable tick boundaries,
+- integer-scaled coordinates through [[Kappa Coordinate System|ARE-Erdos-Attractor-Model#kappa-standardization]],
+- replayable outcomes,
+- no hidden random mutation,
+- clear links from design theory to implementation files.
+
+---
+
+## The five axioms
+
+| Axiom | Keyword | Meaning |
+| --- | --- | --- |
+| I | Information Field | Every entity is a node in the world information field. |
+| II | Emergence | Complexity grows from simple deterministic rules. |
+| III | Persistence | Truth is preserved through replayable seeds and hashes. |
+| IV | Ouroboros Cycle | Input, simulation, memory and future decision form a closed loop. |
+| V | Observer | The player or agent collapses potential into observed world state. |
+
+---
+
+## Implementation interpretation
+
+| Theory term | Engine interpretation | See |
+| --- | --- | --- |
+| Field | World state projection per tick | [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]] |
+| Persistence | Replayable events and seeds | [[Determinism]] |
+| Observer | Player/NPC/action focus | [[NPC Core|NPC_Core]] |
+| Self-correction | Guard rails and validators | [[Guard and Ops|Guard_and_Ops]] |
+| Kappa | Integer coordinate scaling | [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]] |
+
+---
+
+## Research boundary
+
+ARE pages may describe research goals that are not fully implemented yet. Whenever a claim is not implemented, mark it as:
+
+- `planned`,
+- `prototype`,
+- `research`,
+- or `implemented`.
+
+Use [[Implementation Map|Implementation-Map]] to prevent confusion between vision and shipped code.
+
+---
+
+## See also
+
+- [[Home]]
+- [[Glossary]]
+- [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]]
+- [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]]
+- [[Implementation Map|Implementation-Map]]

--- a/docs/wiki/Agent-Index.md
+++ b/docs/wiki/Agent-Index.md
@@ -1,0 +1,86 @@
+# Agent Index
+
+Tags: `agents`, `copilot`, `cursor`, `jules`, `chatgpt`, `automation`
+Status: `operational-guide`
+
+This page tells AI agents and human maintainers how to work inside the Areloria / WASD repository without damaging deterministic systems.
+
+---
+
+## Prime directive
+
+Do not make broad mixed changes shortly before or during a stability test.
+
+Prefer small PRs that touch one concept and one implementation anchor.
+
+---
+
+## Required context pages
+
+Before editing, read:
+
+1. [[Home]]
+2. [[Implementation Map|Implementation-Map]]
+3. [[Glossary]]
+4. the concept page related to your task
+
+Examples:
+
+| Task | Read first |
+| --- | --- |
+| Asset import | [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]] |
+| Tick logic | [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]] |
+| ARE math | [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]] |
+| NPC behavior | [[NPC Core|NPC_Core]] |
+| Deployment | [[Guard and Ops|Guard_and_Ops]] |
+
+---
+
+## PR shape rules
+
+Good PR:
+
+```txt
+one subsystem
+one reason
+clear test path
+wiki update if behavior changed
+```
+
+Bad PR:
+
+```txt
+NPC + Economy + CI + Date.now + asset rewrite + build config
+```
+
+---
+
+## Stability window rule
+
+During a 72h stability test:
+
+- no large feature merges,
+- no broad bot drafts,
+- no mass refactors,
+- only hard bug hotfixes,
+- document postponed ideas as issues.
+
+---
+
+## Commit message examples
+
+```txt
+feat(client-2d): add ARE asset forge pipeline
+fix(client-2d): render Stitch prop frames
+ci(client-2d): assert asset forge smoke output
+docs(wiki): add implementation map
+```
+
+---
+
+## See also
+
+- [[Home]]
+- [[Glossary]]
+- [[Implementation Map|Implementation-Map]]
+- [[Guard and Ops|Guard_and_Ops]]

--- a/docs/wiki/Areloria-Vision.md
+++ b/docs/wiki/Areloria-Vision.md
@@ -1,0 +1,48 @@
+# Areloria Vision
+
+Tags: `vision`, `mmorpg`, `world-simulation`, `arelorian`, `ouroboros`
+Status: `living-design`
+
+Areloria is a browser-first MMORPG and simulation research platform. It combines a playable fantasy world with deterministic systems research under the umbrella of [[ARE Logic Core|ARE-Logic-Core]].
+
+---
+
+## Design intent
+
+Areloria is built around three promises:
+
+1. **A living world** — villages, cities, guilds, kingdoms, NPCs, economy and terrain are allowed to emerge from rules.
+2. **A deterministic runtime** — every important state transition should be reproducible through [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]].
+3. **A research engine** — the game is also a testbed for [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]], [[Stateless Simulation|Determinism#stateless-simulation]] and self-healing logic.
+
+---
+
+## Product pillars
+
+| Pillar | Meaning | Linked system |
+| --- | --- | --- |
+| World | Procedural terrain, cities, dungeons, biomes | [[Systems Architecture|Systems_Architecture]] |
+| Life | NPC memory, quests, economy, politics | [[NPC Core|NPC_Core]] |
+| Determinism | 10Hz tick, kappa grid, replayability | [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]] |
+| Assets | 2.5D/3D asset ingestion, Forge metadata | [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]] |
+| Ops | CI, VPS deploy, wiki sync, guard rails | [[Guard and Ops|Guard_and_Ops]] |
+
+---
+
+## Non-goals
+
+Areloria should not become a random collection of features. Every feature must connect to at least one of:
+
+- [[ARE Logic Core|ARE-Logic-Core]]
+- [[Implementation Map|Implementation-Map]]
+- [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]]
+- [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]]
+
+---
+
+## See also
+
+- [[Home]]
+- [[Glossary]]
+- [[ARE Logic Core|ARE-Logic-Core]]
+- [[Implementation Map|Implementation-Map]]

--- a/docs/wiki/Asset-Forge-and-2D-Pipeline.md
+++ b/docs/wiki/Asset-Forge-and-2D-Pipeline.md
@@ -1,0 +1,105 @@
+# Asset Forge and 2D Pipeline
+
+Tags: `assets`, `pixi`, `stitch`, `atlas`, `forge`, `2d-client`
+Status: `implemented-and-evolving`
+
+The **Asset Forge** converts imported sprite and atlas material into deterministic runtime metadata for the Areloria 2D client.
+
+It protects the client from broken paths, missing frames, atlas-sheet rendering mistakes and inconsistent pickable metadata.
+
+---
+
+## Pipeline order
+
+The client 2D build path should run in this order:
+
+```txt
+are-asset-forge.mjs
+→ enrich-stitch-atlas-frames.mjs
+→ validate-client-2d-assets.mjs
+→ extract-2d-weapon-pool.mjs
+→ vite build
+```
+
+---
+
+## ARE Asset Forge
+
+Repository anchor:
+
+```txt
+scripts/are-asset-forge.mjs
+```
+
+Responsibilities:
+
+- scan `apps/client-2d/public/2d-assets/manifest.json`,
+- infer deterministic roles such as `house`, `tree`, `terrain`, `npc`, `prop`, `fx`,
+- mark pickable objects,
+- add stable `assetHash`,
+- read PNG signature dimensions without extra dependencies,
+- add depth hints such as `zHeight`, `isoFootprint`, and `shadow`,
+- write a Forge report,
+- quarantine obviously broken entries.
+
+---
+
+## Stitch atlas frame enrichment
+
+Repository anchor:
+
+```txt
+scripts/enrich-stitch-atlas-frames.mjs
+```
+
+Responsibilities:
+
+- read Stitch JSON atlases,
+- choose a valid frame,
+- write `entry.frame`,
+- normalize width and height,
+- prepare atlases for Pixi cropping.
+
+---
+
+## Runtime cropping
+
+Repository anchor:
+
+```txt
+apps/client-2d/src/stackedProps.ts
+```
+
+`make2dProp()` must respect `entry.frame`. Without this, the runtime may show the entire atlas sheet instead of a single building or tree.
+
+---
+
+## Manifest anchors
+
+| File | Purpose |
+| --- | --- |
+| `apps/client-2d/public/2d-assets/manifest.json` | canonical runtime manifest |
+| `apps/client-2d/public/2d-assets/stitch/stitch-atlas-manifest.json` | imported Stitch source index |
+| `apps/client-2d/public/2d-assets/credits/are-asset-forge-report.json` | generated Forge report |
+
+---
+
+## Quality gates
+
+Every asset PR should answer:
+
+1. Does the asset appear as a single frame?
+2. Does it have `role`?
+3. Does it have `pickable` when expected?
+4. Does it have stable `assetHash`?
+5. Does the validator pass?
+6. Does the smoke build include the Forge report?
+
+---
+
+## See also
+
+- [[Home]]
+- [[Glossary]]
+- [[Implementation Map|Implementation-Map]]
+- [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]]

--- a/docs/wiki/Glossary.md
+++ b/docs/wiki/Glossary.md
@@ -1,0 +1,156 @@
+# Glossary
+
+Tags: `glossary`, `keywords`, `crosslinks`, `wiki-index`
+Status: `canonical-terms`
+
+This glossary defines canonical terms for the Areloria / WASD wiki.
+
+Use these terms consistently in PRs, issues, commits and agent prompts.
+
+---
+
+## A
+
+### Areloria
+
+The game world and product identity. See [[Areloria Vision|Areloria-Vision]].
+
+### ARE
+
+**Authentic Reality Emancipation**. The deterministic reality framework behind Areloria. See [[ARE Logic Core|ARE-Logic-Core]].
+
+### ARE Asset Forge
+
+The deterministic asset metadata processor in `scripts/are-asset-forge.mjs`. See [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]].
+
+### ARE-Erdos Attractor
+
+A research model for graph distance, stability and deterministic pruning. See [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]].
+
+### Asset Hash
+
+Stable hash attached to an asset manifest entry. Used for deterministic identification and debugging.
+
+---
+
+## D
+
+### Determinism
+
+The rule that the same inputs should produce the same authoritative result. See [[Determinism]] and [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]].
+
+### Depth Metadata
+
+Visual and interaction metadata such as `zHeight`, `isoFootprint`, `shadow` and `frame`. See [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]].
+
+---
+
+## E
+
+### Erdos Distance
+
+Topological distance from a trusted core node or singularity. Used by the [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]].
+
+---
+
+## F
+
+### Frame
+
+A rectangle inside an atlas image used to crop one sprite. Runtime anchor: `entry.frame`.
+
+### Forge Report
+
+Generated JSON report written by the Asset Forge. Expected path: `apps/client-2d/public/2d-assets/credits/are-asset-forge-report.json`.
+
+---
+
+## I
+
+### Implementation Anchor
+
+A concrete repository path that maps a wiki concept to actual code. See [[Implementation Map|Implementation-Map]].
+
+### Iso Footprint
+
+Approximate isometric footprint used for sorting, picking and collision-like visual placement.
+
+---
+
+## K
+
+### Kappa
+
+Canonical integer scaling constant. Current research convention: `kappa = 1000`. See [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model#kappa-standardization]].
+
+---
+
+## M
+
+### Manifest
+
+Runtime asset index consumed by the client. Primary path: `apps/client-2d/public/2d-assets/manifest.json`.
+
+### Matrix Energy
+
+Areloria economy/building energy concept. See [[Economy and Matrix|Economy_and_Matrix]].
+
+---
+
+## O
+
+### Observer
+
+The fifth ARE axiom: a player or agent that collapses potential world state into observed truth. See [[ARE Logic Core|ARE-Logic-Core#the-five-axioms]].
+
+### Ouroboros Cycle
+
+Closed loop of input, simulation, memory and future decision. See [[ARE Logic Core|ARE-Logic-Core#the-five-axioms]].
+
+---
+
+## P
+
+### Pickable
+
+Manifest metadata meaning the object can be selected or interacted with by client logic.
+
+### Pruning
+
+Deterministic removal, conversion or deactivation of isolated/noisy nodes. See [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model#pruning-interpretation]].
+
+---
+
+## S
+
+### Soak Test
+
+A long stability test window, usually 72 hours, where risky merges are avoided and only hard bug fixes are allowed.
+
+### Stateless Simulation
+
+Simulation style where authoritative state is derived from inputs, seeds and tick rules rather than uncontrolled mutable bloat. See [[Determinism]].
+
+### Stitch
+
+External/generated sprite atlas source used by the 2D client pipeline. See [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]].
+
+---
+
+## W
+
+### WASD
+
+The main repository and control name for the Areloria monorepo.
+
+### WorldTick
+
+Authoritative server simulation heartbeat. See [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]].
+
+---
+
+## See also
+
+- [[Home]]
+- [[Implementation Map|Implementation-Map]]
+- [[Agent Index|Agent-Index]]

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,32 +1,66 @@
-# Arelorian Wiki: Logika Axiomata
+# Arelorian Wiki: Obsidian Archive
 
-Welcome to the **Obsidian Archive**, the authoritative deep information repository for the Arelorian project. This wiki serves as a bridge between high-fantasy narrative and deterministic scientific evolution.
+Welcome to the **Obsidian Archive**, the official knowledge base for **Areloria / WASD**.
 
-## 1. Project Vision
-Arelorian is not merely a browser MMORPG. It is an **Authentic Reality Emergence (ARE)** machine. Our mission is to create a stateless, deterministic world where every action is replayable, every outcome is verifiable, and every story emerges from the collision of axiomatic laws.
+This wiki connects four layers of the project:
 
-## 2. The Five Axioms (Logika Axiomata)
+1. the [[Areloria Vision|Areloria-Vision]],
+2. the [[ARE Logic Core|ARE-Logic-Core]],
+3. the deterministic runtime around [[WorldTick|WorldTick-and-10Hz-Simulation]],
+4. the practical build, asset and deployment systems used by agents and maintainers.
 
-### I. Information Field
-The universe is a high-density logic string. Every entity, from the smallest blade of grass to the grandest kingdom, is a node within this field. State is not "stored"; it is a projection of the field at a specific tick.
-
-### II. Emergence
-Complexity is not hard-coded. It arises from the interaction of simple, deterministic rules. Conflict, economy, and culture are emergent properties of the simulation.
-
-### III. Persistence
-Truth is sovereign. Once an event occurs within the 10Hz tick, it is etched into the world hash. Persistence is achieved not through bloat, but through seeds and replayability.
-
-### IV. Ouroboros Cycle
-The loop is closed. Input feeds simulation, simulation feeds memory, memory feeds future decision. The project is self-referential and self-correcting.
-
-### V. Observer
-Reality exists because it is witnessed. The observer (player or agent) collapses the probability of the field into a concrete state, allowing the world to exist in a state of "observed truth."
+> **Wiki rule:** Every concept page should link back to this page, the [[Glossary]], and at least one implementation page. Theory without a code anchor stays marked as research.
 
 ---
 
-## 3. Navigation
-- [[Determinism]]: The math of the world.
-- [[NPC_Core]]: The soul of the machine.
-- [[Systems_Architecture]]: The heartbeat and the brain.
-- [[Economy_and_Matrix]]: The flow of energy and value.
-- [[Guard_and_Ops]]: Protecting the sovereignty of logic.
+## Start here
+
+| Area | Page | Purpose |
+| --- | --- | --- |
+| Vision | [[Areloria Vision|Areloria-Vision]] | High-level product and world goal |
+| Theory | [[ARE Logic Core|ARE-Logic-Core]] | Five axioms, deterministic reality model |
+| Math | [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]] | Kappa, Erdős distance, attractor coefficient |
+| Runtime | [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]] | Tick loop and server simulation rules |
+| Code map | [[Implementation Map|Implementation-Map]] | Maps theory to files and modules |
+| Assets | [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]] | Stitch, Pixi, atlas frames, Forge reports |
+| Agents | [[Agent Index|Agent-Index]] | Rules for Copilot, Cursor, Jules, ChatGPT |
+| Terms | [[Glossary]] | Canonical keywords and crosslinks |
+
+---
+
+## Core concepts
+
+- [[Authentic Reality Emancipation|ARE-Logic-Core#authentic-reality-emancipation-are]]
+- [[Kappa Coordinate System|ARE-Erdos-Attractor-Model#kappa-standardization]]
+- [[10Hz deterministic tick|WorldTick-and-10Hz-Simulation]]
+- [[Stateless Simulation|Determinism#stateless-simulation]]
+- [[Erdos Attractor|ARE-Erdos-Attractor-Model]]
+- [[Asset Forge|Asset-Forge-and-2D-Pipeline#are-asset-forge]]
+- [[NPC Core|NPC_Core]]
+- [[Economy and Matrix|Economy_and_Matrix]]
+- [[Guard and Ops|Guard_and_Ops]]
+
+---
+
+## Current implementation anchors
+
+- `server/src/core/WorldTick.ts` — canonical simulation heartbeat.
+- `scripts/are-asset-forge.mjs` — deterministic asset metadata forge.
+- `scripts/enrich-stitch-atlas-frames.mjs` — Stitch atlas frame preparation.
+- `apps/client-2d/src/stackedProps.ts` — Pixi prop rendering with frame cropping.
+- `apps/client-2d/public/2d-assets/manifest.json` — runtime asset manifest.
+- `.github/workflows/sync-wiki.yml` — syncs `docs/wiki/**` into the GitHub Wiki.
+
+See [[Implementation Map|Implementation-Map]] for the full mapping.
+
+---
+
+## Wiki maintenance conventions
+
+- Use `[[Page]]` or `[[Label|Page]]` links for wiki navigation.
+- Use `Tags:` near the top of every page.
+- Use `Status:` to separate **implemented**, **prototype**, **research**, and **planned**.
+- Use `Implementation anchors` for file paths.
+- Use `See also` at the bottom of every page.
+
+For exact term definitions, use [[Glossary]].

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -2,12 +2,13 @@
 
 Welcome to the **Obsidian Archive**, the official knowledge base for **Areloria / WASD**.
 
-This wiki connects four layers of the project:
+This wiki connects five layers of the project:
 
 1. the [[Areloria Vision|Areloria-Vision]],
 2. the [[ARE Logic Core|ARE-Logic-Core]],
-3. the deterministic runtime around [[WorldTick|WorldTick-and-10Hz-Simulation]],
-4. the practical build, asset and deployment systems used by agents and maintainers.
+3. the external [[Research Publications|Research-Publications]],
+4. the deterministic runtime around [[WorldTick|WorldTick-and-10Hz-Simulation]],
+5. the practical build, asset and deployment systems used by agents and maintainers.
 
 > **Wiki rule:** Every concept page should link back to this page, the [[Glossary]], and at least one implementation page. Theory without a code anchor stays marked as research.
 
@@ -18,6 +19,7 @@ This wiki connects four layers of the project:
 | Area | Page | Purpose |
 | --- | --- | --- |
 | Vision | [[Areloria Vision|Areloria-Vision]] | High-level product and world goal |
+| Research | [[Research Publications|Research-Publications]] | OSF publications and external research anchors |
 | Theory | [[ARE Logic Core|ARE-Logic-Core]] | Five axioms, deterministic reality model |
 | Math | [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]] | Kappa, Erdős distance, attractor coefficient |
 | Runtime | [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]] | Tick loop and server simulation rules |
@@ -31,6 +33,7 @@ This wiki connects four layers of the project:
 ## Core concepts
 
 - [[Authentic Reality Emancipation|ARE-Logic-Core#authentic-reality-emancipation-are]]
+- [[Research Publications|Research-Publications]]
 - [[Kappa Coordinate System|ARE-Erdos-Attractor-Model#kappa-standardization]]
 - [[10Hz deterministic tick|WorldTick-and-10Hz-Simulation]]
 - [[Stateless Simulation|Determinism#stateless-simulation]]
@@ -62,5 +65,6 @@ See [[Implementation Map|Implementation-Map]] for the full mapping.
 - Use `Status:` to separate **implemented**, **prototype**, **research**, and **planned**.
 - Use `Implementation anchors` for file paths.
 - Use `See also` at the bottom of every page.
+- Use [[Research Publications|Research-Publications]] for OSF-backed external research anchors.
 
 For exact term definitions, use [[Glossary]].

--- a/docs/wiki/Implementation-Map.md
+++ b/docs/wiki/Implementation-Map.md
@@ -1,0 +1,79 @@
+# Implementation Map
+
+Tags: `implementation`, `code-map`, `agent-anchor`, `architecture`
+Status: `living-index`
+
+This page maps Areloria theory and wiki terms to actual repository paths.
+
+Use it to keep [[ARE Logic Core|ARE-Logic-Core]] and shipped code aligned.
+
+---
+
+## Runtime core
+
+| Wiki concept | Repository anchor | Status |
+| --- | --- | --- |
+| [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]] | `server/src/core/WorldTick.ts` | active |
+| WebSocket delivery | `server/src/networking/WebSocketServer.ts` | active |
+| NPC system | `server/src/modules/npc/NPCSystem.ts` | active/evolving |
+| Quest registry | `server/src/modules/quest/QuestRegistry.ts` | active/evolving |
+| Inventory registry | `server/src/modules/inventory/ItemRegistry.ts` | active/evolving |
+
+---
+
+## ARE research anchors
+
+| Wiki concept | Repository anchor | Status |
+| --- | --- | --- |
+| [[ARE Logic Core|ARE-Logic-Core]] | `docs/wiki/ARE-Logic-Core.md` | documented |
+| [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]] | `docs/wiki/ARE-Erdos-Attractor-Model.md` | research blueprint |
+| Kappa grid | future `server/src/core/AREKernel.ts` | planned |
+| Erdos network | future `server/src/core/AREErdosNetwork.ts` | planned |
+| Self-healing | future `server/src/core/SelfHealEngine.ts` | planned/prototype |
+
+---
+
+## Client 2D / asset pipeline
+
+| Wiki concept | Repository anchor | Status |
+| --- | --- | --- |
+| [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]] | `scripts/are-asset-forge.mjs` | active |
+| Stitch frame enrichment | `scripts/enrich-stitch-atlas-frames.mjs` | active |
+| Asset validation | `scripts/validate-client-2d-assets.mjs` | active |
+| Weapon pool extraction | `scripts/extract-2d-weapon-pool.mjs` | active |
+| Asset manifest | `apps/client-2d/public/2d-assets/manifest.json` | active |
+| Pixi prop rendering | `apps/client-2d/src/stackedProps.ts` | active |
+| Client scene | `apps/client-2d/src/CyberZenIsoApp.tsx` | active |
+
+---
+
+## CI / deployment / documentation
+
+| Area | Repository anchor | Status |
+| --- | --- | --- |
+| Wiki sync | `.github/workflows/sync-wiki.yml` | active |
+| Wiki sync script | `scripts/sync-wiki.mjs` | active |
+| Client 2D smoke | `.github/workflows/client-2d-build-smoke.yml` | active |
+| Production Docker | `Dockerfile.prod` | active |
+| Deploy path | `/opt/areloria` | deployment convention |
+
+---
+
+## Agent edit rules
+
+Before changing code, agents should answer:
+
+1. Which wiki concept is this change tied to?
+2. Which implementation anchor does it modify?
+3. Is it `implemented`, `prototype`, `research` or `planned`?
+4. Does it need a validator, smoke test or deploy check?
+5. Should the wiki be updated in the same PR?
+
+---
+
+## See also
+
+- [[Home]]
+- [[Glossary]]
+- [[Agent Index|Agent-Index]]
+- [[Guard and Ops|Guard_and_Ops]]

--- a/docs/wiki/Research-Publications.md
+++ b/docs/wiki/Research-Publications.md
@@ -1,0 +1,72 @@
+# Research Publications
+
+Tags: `research`, `osf`, `publications`, `are`, `proofs`, `blueprints`
+Status: `external-research-index`
+
+This page links the Areloria / WASD wiki to external research publications and project material hosted on OSF.
+
+OSF links are treated as research anchors. They should be cited by agents when discussing the mathematical or conceptual foundation of [[ARE Logic Core|ARE-Logic-Core]], [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]] and deterministic simulation.
+
+---
+
+## OSF research anchors
+
+| Key | OSF link | Wiki relevance |
+| --- | --- | --- |
+| OSF-CUWTV | https://osf.io/cuwtv | Primary ARE / Areloria research project anchor |
+| OSF-CUWTV-Files | https://osf.io/cuwtv/files/uv9qr | File/material anchor for CUWTV project |
+| OSF-B59WS | https://osf.io/b59ws | Additional research/publication anchor |
+| OSF-8ENSZ | https://osf.io/8ensz | Additional research/publication anchor |
+| OSF-J7TRZ | https://osf.io/j7trz | Additional research/publication anchor |
+
+---
+
+## How to use these links
+
+Use these OSF anchors when a page or agent prompt discusses:
+
+- [[ARE Logic Core|ARE-Logic-Core]],
+- [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]],
+- [[Kappa|Glossary#kappa]],
+- [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]],
+- deterministic state pruning,
+- stateless simulation research,
+- mathematical blueprints behind Areloria.
+
+---
+
+## Research vs implementation
+
+OSF publications are **research anchors**, not automatic proof that a feature is implemented in the repository.
+
+Use this rule:
+
+```txt
+OSF link = research / publication anchor
+Wiki concept page = explanation and navigation
+Implementation Map = actual code anchor
+PR / commit = shipped change
+```
+
+This keeps Areloria scientifically ambitious without confusing theory with production code.
+
+---
+
+## Suggested citation pattern inside wiki pages
+
+```md
+Research anchor: [OSF-CUWTV](https://osf.io/cuwtv)
+Implementation anchor: `server/src/core/WorldTick.ts`
+Status: `research`, `planned`, `prototype`, or `implemented`
+```
+
+---
+
+## See also
+
+- [[Home]]
+- [[Glossary]]
+- [[ARE Logic Core|ARE-Logic-Core]]
+- [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]]
+- [[Implementation Map|Implementation-Map]]
+- [[Agent Index|Agent-Index]]

--- a/docs/wiki/WorldTick-and-10Hz-Simulation.md
+++ b/docs/wiki/WorldTick-and-10Hz-Simulation.md
@@ -1,0 +1,89 @@
+# WorldTick and 10Hz Simulation
+
+Tags: `worldtick`, `10hz`, `server`, `simulation`, `determinism`
+Status: `implementation-anchor`
+
+`WorldTick` is the authoritative heartbeat of the Areloria server simulation.
+
+The design target is a stable **10Hz loop**, meaning one authoritative simulation step every `100ms`. Rendering can be smooth and interpolated, but authoritative decisions should happen at tick boundaries.
+
+---
+
+## Why 10Hz matters
+
+A fixed tick rate keeps core logic reproducible:
+
+- combat timing,
+- NPC decisions,
+- resource updates,
+- collision / interaction windows,
+- event replay,
+- future [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]] propagation.
+
+---
+
+## Tick boundary rule
+
+Core simulation should prefer:
+
+```txt
+currentTick
+entityId
+logical position
+seed / deterministic input
+```
+
+and avoid hidden dependencies on:
+
+```txt
+Date.now()
+Math.random()
+floating delta time
+iteration order of unordered maps
+external API timing
+```
+
+---
+
+## Rendering boundary
+
+Client rendering may interpolate between server snapshots. That does not change the authoritative tick.
+
+Related pages:
+
+- [[Determinism]]
+- [[Systems Architecture|Systems_Architecture]]
+- [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]]
+
+---
+
+## Implementation anchors
+
+| Path | Meaning |
+| --- | --- |
+| `server/src/core/WorldTick.ts` | Authoritative simulation loop |
+| `server/src/networking/WebSocketServer.ts` | Player message delivery |
+| `client/src/engine/renderer.ts` | Client interpolation / rendering layer |
+| `apps/client-2d/src/stackedProps.ts` | 2D prop rendering path |
+
+---
+
+## Agent rules
+
+When editing tick logic:
+
+1. keep changes small,
+2. add deterministic tests when possible,
+3. avoid broad bot-generated rewrites,
+4. do not mix NPC, economy, combat and CI changes in one PR,
+5. document new tick rules in [[Implementation Map|Implementation-Map]].
+
+---
+
+## See also
+
+- [[Home]]
+- [[Glossary]]
+- [[ARE Logic Core|ARE-Logic-Core]]
+- [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]]
+- [[Implementation Map|Implementation-Map]]

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,0 +1,5 @@
+---
+
+[[Home]] · [[Glossary]] · [[Implementation Map|Implementation-Map]] · [[Research Publications|Research-Publications]] · [[Agent Index|Agent-Index]]
+
+Areloria / WASD — Obsidian Archive. Theory stays linked to implementation anchors.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,36 @@
+## Obsidian Archive
+
+### Start
+
+- [[Home]]
+- [[Glossary]]
+- [[Implementation Map|Implementation-Map]]
+- [[Research Publications|Research-Publications]]
+- [[Agent Index|Agent-Index]]
+
+### Vision and Theory
+
+- [[Areloria Vision|Areloria-Vision]]
+- [[ARE Logic Core|ARE-Logic-Core]]
+- [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]]
+- [[Determinism]]
+
+### Runtime Systems
+
+- [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]]
+- [[Systems Architecture|Systems_Architecture]]
+- [[NPC Core|NPC_Core]]
+- [[Economy and Matrix|Economy_and_Matrix]]
+
+### Assets and Client
+
+- [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]]
+
+### Operations
+
+- [[Guard and Ops|Guard_and_Ops]]
+
+---
+
+**Status:** living wiki  
+**Rule:** small PRs, clear anchors, deterministic systems first.


### PR DESCRIPTION
Adds a professional GitHub Wiki structure under docs/wiki with crosslinks, glossary, implementation map, agent guidance and ARE/Asset Forge navigation.

Scope:
- updates Home.md
- adds ARE theory pages
- adds implementation map
- adds Asset Forge page
- adds Agent Index
- adds canonical Glossary

Only docs/wiki files are changed.