### PR TITLE
ci: trigger VPS deploy workflow updates

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -15,6 +15,7 @@ on:
       - 'engine/**'
       - 'portal/**'
       - 'scripts/**'
+      - '.github/workflows/vps-docker-deploy.yml'
       - 'Dockerfile.prod'
       - 'docker-compose*.yml'
       - 'package.json'


### PR DESCRIPTION
Adds the VPS Docker deploy workflow file to its own push path filter so future workflow updates can trigger the deploy workflow. This PR changes one line only.