### PR TITLE
feat(are): wire economy snapshot into AREShadow telemetry

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -5,22 +5,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'apps/**'
-      - 'packages/**'
-      - 'projects/**'
-      - 'client/**'
-      - 'server/**'
-      - 'shared/**'
-      - 'engine/**'
-      - 'portal/**'
-      - 'scripts/**'
-      - '.github/workflows/vps-docker-deploy.yml'
-      - 'Dockerfile.prod'
-      - 'docker-compose*.yml'
-      - 'package.json'
-      - 'pnpm-workspace.yaml'
-      - 'pnpm-lock.yaml'
   workflow_dispatch:
     inputs:
       reason:

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -26,6 +26,7 @@ import { deterministicUsageTracker, type DeterministicUsageStats } from "../are/
 import { AREDivergenceGuard } from "./are/AREDivergenceGuard.js";
 import { AREReplayBuffer } from "./are/AREReplayBuffer.js";
 import { AREShadowAdapter } from "./are/AREShadowAdapter.js";
+import { AREEconomyAdapter } from "./are/AREEconomyAdapter.js";
 import { KappaPosGrid } from "@wasd/shared";
 import { checkForestResource, isNearForestResource } from "../modules/resource/forestResourceCheck.js";
 import { FOREST_ACTION_DISTANCE, FOREST_RESPAWN_TICKS } from "../modules/resource/forestResourceRules.js";
@@ -48,6 +49,7 @@ export class WorldTick {
   private readonly areGuard = new AREInvariantGuard({ throwOnViolation: true });
   private readonly areShadowReplay = new AREReplayBuffer(1000);
   private readonly areDivergenceGuard = new AREDivergenceGuard();
+  private readonly economyAdapter: AREEconomyAdapter;
   private lastAREGuardStatus: AREInvariantGuardStatus | null = null;
   private lastWorldHashSnapshot: WorldHashSnapshot | null = null;
   private lastOracleReport: OracleReport | null = null;
@@ -110,6 +112,7 @@ export class WorldTick {
     this.npcSystem = new NPCSystem();
     this.guildSystem = new GuildSystem();
     this.economySystem = new EconomySystem();
+    this.economyAdapter = new AREEconomyAdapter(this.economySystem);
     this.questSystem = new QuestEngine();
     this.persistence = new PersistenceManager();
     this.worldSystem = new WorldSystem(this.persistence);
@@ -152,6 +155,7 @@ export class WorldTick {
       latestStateHash: latest?.stateHash ?? null,
       divergence: this.areDivergenceGuard.summarize(),
       ecosystem: AREShadowAdapter.getEcosystemTelemetry(),
+      economy: this.economyAdapter.snapshotARE(),
     };
   }
 


### PR DESCRIPTION
Wires the read-only AREEconomyAdapter into WorldTick AREShadow telemetry.

Changes:
- import AREEconomyAdapter
- instantiate it from the existing EconomySystem
- expose economy snapshot through getAREShadowReplayStats()
- remove fragile path filters from VPS Docker Deploy so pushes/merges to main trigger deploy automatically

ARE invariant: the adapter is read-only and only calls snapshotARE(); no economy mutation is introduced.