### PR TITLE
fix(vite): allow top-level await in frontend builds

### DIFF
--- a/apps/client-2d/vite.config.ts
+++ b/apps/client-2d/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+    target: "esnext",
     sourcemap: false,
     minify: "esbuild"
   },

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -73,6 +73,7 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: isItchBuild ? "dist-itch" : "dist",
       emptyOutDir: true,
+      target: "esnext",
       // Production minification
       minify: minify,
       cssCodeSplit: true,

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
   optimizeDeps: {
     include: ["react", "react-dom", "react-dom/client", "eventemitter3"],
   },
+  build: {
+    target: "esnext",
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],


### PR DESCRIPTION
Sets Vite build target to esnext for client, portal, and 2D client so generated chunks with top-level await can pass esbuild transpilation during Docker builds.