### PR TITLE
fix(npc): optimize deterministic perception loop

### DIFF
--- a/server/src/modules/npc/NPCSystem.ts
+++ b/server/src/modules/npc/NPCSystem.ts
@@ -51,6 +51,12 @@ export interface NPC {
     phaseShift?: number;
 }
 
+type PlayerPerceptionContext = {
+    id: string;
+    position: Vector3;
+    stealthLevel: number;
+};
+
 export class NPCSystem {
     private npcs: Map<string, NPC> = new Map();
     private updateInterval: NodeJS.Timeout | null = null;
@@ -59,6 +65,8 @@ export class NPCSystem {
     public resonanceEngine: TraitResonanceEngine;
 
     private sovereigntyEngine: GuildSovereigntyEngine;
+    private cachedSortedNpcs: NPC[] = [];
+    private npcsDirty = true;
 
     constructor() {
         // Initialize stub dependencies
@@ -68,10 +76,13 @@ export class NPCSystem {
 
     public addNPC(npc: NPC): void {
         this.npcs.set(npc.id, npc);
+        this.npcsDirty = true;
     }
 
     public removeNPC(id: string): boolean {
-        return this.npcs.delete(id);
+        const deleted = this.npcs.delete(id);
+        if (deleted) this.npcsDirty = true;
+        return deleted;
     }
 
     public createNPC(id: string, name: string, x: number, y: number): NPC {
@@ -154,15 +165,25 @@ export class NPCSystem {
     }
 
     private update(onlinePlayers: any[]): void {
-        const sortedNpcs = Array.from(this.npcs.values()).sort((a, b) =>
-            String(a?.id ?? "").localeCompare(String(b?.id ?? ""))
-        );
+        if (this.npcsDirty) {
+            this.cachedSortedNpcs = Array.from(this.npcs.values()).sort((a, b) =>
+                String(a?.id ?? "").localeCompare(String(b?.id ?? ""))
+            );
+            this.npcsDirty = false;
+        }
+
         const sortedPlayers = [...onlinePlayers].sort((a, b) =>
             String(a?.id ?? "").localeCompare(String(b?.id ?? ""))
         );
 
-        for (const npc of sortedNpcs) {
-            this.processPerception(npc, sortedPlayers);
+        const playerContexts: PlayerPerceptionContext[] = sortedPlayers.map((player) => ({
+            id: player?.id != null && String(player.id).length > 0 ? String(player.id) : "unknown_player",
+            position: NPCSystem.vec3ForPerception(player?.position),
+            stealthLevel: Number.isFinite(Number(player?.stealthValue)) ? Number(player.stealthValue) : 0,
+        }));
+
+        for (const npc of this.cachedSortedNpcs) {
+            this.processPerception(npc, playerContexts);
         }
     }
 
@@ -175,30 +196,44 @@ export class NPCSystem {
         };
     }
 
-    private processPerception(npc: NPC, sortedPlayers: any[]): void {
+    /** Zero-allocation broad phase for avoiding full stealth checks on obviously distant players. */
+    private static isWithinRangeSquared(a: Vector3, b: Vector3, range: number): boolean {
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const dz = a.z - b.z;
+        return dx * dx + dy * dy + dz * dz <= range * range;
+    }
+
+    private processPerception(npc: NPC, playerContexts: PlayerPerceptionContext[]): void {
         let detectedPlayerId: string | null = null;
         const npcPos = NPCSystem.vec3ForPerception(npc.position);
+        const visionRange = Number.isFinite(Number(npc.visionRange)) ? Number(npc.visionRange) : 10;
+        const broadPhaseRange = visionRange * 1.5;
 
-        for (const player of sortedPlayers) {
+        for (const player of playerContexts) {
+            if (!NPCSystem.isWithinRangeSquared(npcPos, player.position, broadPhaseRange)) {
+                continue;
+            }
+
             const result = checkStealthDeterministic(
                 {
                     npcId: npc.id,
                     position: npcPos,
                     phaseShift: npc.phaseShift ?? 0,
-                    perceptionRadius: npc.visionRange,
+                    perceptionRadius: visionRange,
                     lastPerceptionTick: 0
                 },
                 {
-                    playerId: String(player?.id ?? ""),
-                    position: NPCSystem.vec3ForPerception(player?.position),
-                    stealthLevel: player?.stealthValue ?? 0,
+                    playerId: player.id,
+                    position: player.position,
+                    stealthLevel: player.stealthLevel,
                     isCrouching: false, // Crouching state not yet implemented in PlayerSystem
                     lastVisibleTick: 0
                 }
             );
 
             if (result.visible) {
-                detectedPlayerId = player?.id != null && String(player.id).length > 0 ? String(player.id) : "unknown_player";
+                detectedPlayerId = player.id;
                 break;
             }
         }


### PR DESCRIPTION
Manual extraction from #1129.

This PR applies only the safe NPCSystem perception-loop optimization:

- cache the sorted NPC list until NPC membership changes
- precompute player perception context once per tick
- use a deterministic broad-phase squared-distance check before full stealth/perception logic

It intentionally excludes unrelated dependency, lockfile, Vite, workflow, package, and build-script drift from the original draft PR.