### PR TITLE
fix(security): harden runtime config and external execution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-                    run_install: false
+          run_install: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -58,7 +58,7 @@ jobs:
             --account-name ${{ secrets.AZURE_STORAGE_ACCOUNT }} \
             --public-access blob \
             --auth-mode key || true
-          
+
           az storage blob upload-batch \
             --account-name ${{ secrets.AZURE_STORAGE_ACCOUNT }} \
             --destination "cdn-assets" \
@@ -99,33 +99,41 @@ jobs:
           target: "${{ secrets.DEPLOY_PATH }}/server/dist"
           strip_components: 1
 
-      - name: SSH Orchestration & PM2 Restart
+      - name: SSH Orchestration & Workflow Env Restart
         uses: appleboy/ssh-action@master
+        env:
+          NODE_ENV: production
+          API_KEY: ${{ secrets.API_KEY }}
+          API_KEYS: ${{ secrets.API_KEYS }}
+          ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
+          envs: NODE_ENV,API_KEY,API_KEYS,ALLOWED_ORIGINS,CORS_ORIGINS,DATABASE_URL
           script: |
             set -e
             cd ${{ secrets.DEPLOY_PATH }}
-            
+
             echo "--- UPDATING CORE SOURCE ---"
             git fetch origin main
             git reset --hard origin/main
-            
+
             echo "--- CONFIGURING RUNTIME ENVIRONMENT ---"
             mkdir -p server/dist
             echo '{"type": "module"}' > server/dist/package.json
-            
+
             export PNPM_HOME="/home/${{ secrets.SSH_USER }}/.local/share/pnpm"
             export PATH="$PNPM_HOME:$PATH"
-            
+
             pnpm install --prod --no-frozen-lockfile
-            
-            echo "--- RESTARTING PM2 INSTANCE ---"
+
+            echo "--- RESTARTING PM2 INSTANCE WITH WORKFLOW ENV ---"
             pm2 delete areloria || true
             pm2 start server/dist/index.js --name areloria --update-env
-            
+
             echo "--- DEPLOYMENT SUCCESSFUL ---"
 
       - name: Verify Deployment Health
@@ -134,7 +142,7 @@ jobs:
           MAX_RETRIES=8
           RETRY_COUNT=0
           WAIT_TIME=10
-          
+
           until $(curl --output /dev/null --silent --head --fail http://${{ secrets.PRODUCTION_IP }}); do
             RETRY_COUNT=$((RETRY_COUNT + 1))
             if [ $RETRY_COUNT -gt $MAX_RETRIES ]; then
@@ -145,5 +153,5 @@ jobs:
             sleep $WAIT_TIME
             WAIT_TIME=$((WAIT_TIME * 2))
           done
-          
+
           echo "Areloria WASD Service is Healthy and responding on http://${{ secrets.PRODUCTION_IP }}"

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -19,6 +19,12 @@ jobs:
 
     env:
       VPS_PATH: /opt/areloria
+      NODE_ENV: production
+      API_KEY: ${{ secrets.API_KEY }}
+      API_KEYS: ${{ secrets.API_KEYS }}
+      ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
+      CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Checkout Repository
@@ -36,10 +42,10 @@ jobs:
 
       - name: Deploy to VPS (Git sync + deploy/update.sh)
         run: |
-          REPO_CLONE_URL="https://github.com/${{ github.repository }}.git"
           sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
             -o StrictHostKeyChecking=no \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'EOF'
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "NODE_ENV='${NODE_ENV}' API_KEY='${API_KEY}' API_KEYS='${API_KEYS}' ALLOWED_ORIGINS='${ALLOWED_ORIGINS}' CORS_ORIGINS='${CORS_ORIGINS}' DATABASE_URL='${DATABASE_URL}' bash -s" << 'EOF'
             set -euo pipefail
             APP_DIR="/opt/areloria"
             echo "→ Navigating to project"
@@ -56,6 +62,7 @@ jobs:
             git reset --hard origin/main
 
             echo "→ Build, restart PM2, verify (deploy/update.sh)"
+            export NODE_ENV API_KEY API_KEYS ALLOWED_ORIGINS CORS_ORIGINS DATABASE_URL
             bash deploy/update.sh
 
           echo "→ Deploy finished"
@@ -81,4 +88,4 @@ jobs:
       - name: Deployment Summary
         run: |
           echo "Deployment finished on VPS:"
-          echo "${{ secrets.SSH_HOST }} -> ${VPS_PATH }}"
+          echo "${{ secrets.SSH_HOST }} -> ${VPS_PATH}"

--- a/deploy/.env.production.template
+++ b/deploy/.env.production.template
@@ -20,6 +20,16 @@ CLIENT_ROOT_DIR=/opt/areloria/client
 PUBLIC_WEBSOCKET_URL=wss://DEINE-DOMAIN/ws
 # NEXT_PUBLIC_WEBSOCKET_URL=   # nur falls du Next/anderes Frontend nutzt
 
+# --- Runtime API / CORS Security ---
+# API_KEY oder API_KEYS schützen serverseitige Admin-/World-API-Routen.
+# API_KEYS kann mehrere Schlüssel per Komma enthalten.
+API_KEY=CHANGE_ME_LONG_RANDOM_SECRET
+# API_KEYS=CHANGE_ME_KEY_1,CHANGE_ME_KEY_2
+
+# Erlaubte Browser-Ursprünge für Socket.io/CORS in Production.
+ALLOWED_ORIGINS=https://areloria.de,https://www.areloria.de
+# CORS_ORIGINS=https://areloria.de,https://www.areloria.de
+
 # --- Client Auth (VITE_* werden beim BUILD des Clients eingebettet — in .env am Repo-Root vor pnpm build setzen) ---
 # Auf dem VPS: vor deploy/build dieselben Werte in die .env legen, die `pnpm run build` liest (meist Repo-Root .env).
 # VITE_AUTH_PROVIDER=***

--- a/server/src/core/api/APIServer.ts
+++ b/server/src/core/api/APIServer.ts
@@ -2,7 +2,7 @@
  * @file server/src/core/api/APIServer.ts
  * @description High-performance API Server.
  * Provides REST endpoints and WebSocket integration.
- * 
+ *
  * Uses existing Express server if available.
  */
 
@@ -25,9 +25,61 @@ function fromFP(fp: number): number {
  * API Key configuration
  */
 const API_KEY_HEADER = 'x-api-key';
-const VALID_API_KEYS = new Set([
-  process.env.API_KEY || 'dev-key-change-in-production',
-]);
+
+function parseCsvEnv(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean);
+}
+
+function getValidApiKeys(): Set<string> {
+  const keys = parseCsvEnv(process.env.API_KEYS ?? process.env.API_KEY);
+
+  if (process.env.NODE_ENV === 'production' && keys.length === 0) {
+    throw new Error('API_KEY or API_KEYS must be configured in production.');
+  }
+
+  return new Set(keys);
+}
+
+function isAuthorizedRequest(req: any): boolean {
+  const validApiKeys = getValidApiKeys();
+  if (validApiKeys.size === 0) {
+    return process.env.NODE_ENV !== 'production';
+  }
+
+  const headerValue = req.headers?.[API_KEY_HEADER];
+  const candidate = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  return typeof candidate === 'string' && validApiKeys.has(candidate);
+}
+
+function requireApiKey(req: any, res: any, next: any): void {
+  if (isAuthorizedRequest(req)) {
+    next();
+    return;
+  }
+
+  res.status(401).json({ error: 'Unauthorized' });
+}
+
+function getAllowedOrigins(): string[] | boolean {
+  const configured = parseCsvEnv(process.env.ALLOWED_ORIGINS ?? process.env.CORS_ORIGINS);
+  if (configured.length > 0) return configured;
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('ALLOWED_ORIGINS or CORS_ORIGINS must be configured in production.');
+  }
+
+  return [
+    'http://localhost:3000',
+    'http://localhost:3001',
+    'http://localhost:5173',
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1:3001',
+    'http://127.0.0.1:5173',
+  ];
+}
 
 /**
  * World heartbeat broadcast interval (10 ticks = 1 second)
@@ -62,9 +114,9 @@ export class APIServer {
     });
 
     // World status (protected)
-    app.get('/api/v1/world/status', (req: any, res: any) => {
+    app.get('/api/v1/world/status', requireApiKey, (req: any, res: any) => {
       const worldState = worldStateRegistry.getCurrentState();
-      
+
       // Calculate global energy
       let totalEnergy = 0;
       let totalCorruption = 0;
@@ -88,7 +140,7 @@ export class APIServer {
     });
 
     // Region details (protected)
-    app.get('/api/v1/regions/:id', (req: any, res: any) => {
+    app.get('/api/v1/regions/:id', requireApiKey, (req: any, res: any) => {
       const regionId = req.params.id;
       const worldState = worldStateRegistry.getCurrentState();
       const region = worldState.regions.get(regionId);
@@ -121,8 +173,9 @@ export class APIServer {
     import('socket.io').then(({ Server }) => {
       this.io = new Server(server, {
         cors: {
-          origin: '*',
+          origin: getAllowedOrigins(),
           methods: ['GET', 'POST'],
+          credentials: false,
         },
       });
 

--- a/server/src/modules/monitoring/BackupManager.ts
+++ b/server/src/modules/monitoring/BackupManager.ts
@@ -1,7 +1,45 @@
-import { exec } from 'child_process';
-import util from 'util';
+import { spawn } from 'child_process';
+import path from 'path';
 
-const execAsync = util.promisify(exec);
+const BACKUP_DIR = '/tmp';
+const SAFE_LABEL_PATTERN = /^[a-zA-Z0-9._-]{1,64}$/;
+
+function assertSafeLabel(label: string): void {
+  if (!SAFE_LABEL_PATTERN.test(label)) {
+    throw new Error('Backup label may only contain letters, numbers, dot, dash and underscore.');
+  }
+}
+
+function resolveBackupPath(fileNameOrPath: string): string {
+  const resolved = path.resolve(BACKUP_DIR, path.basename(fileNameOrPath));
+  if (!resolved.startsWith(`${BACKUP_DIR}${path.sep}`)) {
+    throw new Error('Backup path escapes the allowed backup directory.');
+  }
+  return resolved;
+}
+
+function runCommand(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+    });
+
+    let stderr = '';
+    child.stderr.on('data', chunk => {
+      stderr += String(chunk);
+    });
+
+    child.on('error', reject);
+    child.on('close', code => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} exited with code ${code}${stderr ? `: ${stderr}` : ''}`));
+    });
+  });
+}
 
 export class BackupManager {
   /**
@@ -12,26 +50,26 @@ export class BackupManager {
   async createLogicalBackup(label: string): Promise<{ label: string; file: string; createdAt: number }> {
     const dbUrl = process.env.DATABASE_URL;
     if (!dbUrl) {
-      throw new Error("DATABASE_URL is not configured.");
+      throw new Error('DATABASE_URL is not configured.');
     }
+
+    assertSafeLabel(label);
 
     const timestamp = Date.now();
     const fileName = `backup_${label}_${timestamp}.sql`;
-    const filePath = `/tmp/${fileName}`;
+    const filePath = resolveBackupPath(fileName);
 
     try {
-      // Execute pg_dump
-      // Note: pg_dump must be installed on the system running this code
-      await execAsync(`pg_dump "${dbUrl}" -F c -f "${filePath}"`);
+      await runCommand('pg_dump', [dbUrl, '-F', 'c', '-f', filePath]);
       console.log(`Logical backup created successfully at ${filePath}`);
-      
+
       return {
         label,
         file: filePath,
-        createdAt: timestamp
+        createdAt: timestamp,
       };
     } catch (error) {
-      console.error("Failed to create logical backup:", error);
+      console.error('Failed to create logical backup:', error);
       throw error;
     }
   }
@@ -43,16 +81,17 @@ export class BackupManager {
   async restoreLogicalBackup(filePath: string): Promise<boolean> {
     const dbUrl = process.env.DATABASE_URL;
     if (!dbUrl) {
-      throw new Error("DATABASE_URL is not configured.");
+      throw new Error('DATABASE_URL is not configured.');
     }
 
+    const safeFilePath = resolveBackupPath(filePath);
+
     try {
-      // Execute pg_restore
-      await execAsync(`pg_restore -d "${dbUrl}" -c -1 "${filePath}"`);
-      console.log(`Logical backup restored successfully from ${filePath}`);
+      await runCommand('pg_restore', ['-d', dbUrl, '-c', '-1', safeFilePath]);
+      console.log(`Logical backup restored successfully from ${safeFilePath}`);
       return true;
     } catch (error) {
-      console.error("Failed to restore logical backup:", error);
+      console.error('Failed to restore logical backup:', error);
       throw error;
     }
   }
@@ -62,11 +101,11 @@ export class BackupManager {
    */
   getBackupStrategy() {
     return {
-      primary: "AWS RDS Automated Backups (Snapshots)",
-      retentionPeriod: "7-35 days (configurable in AWS Console)",
-      pointInTimeRecovery: "Enabled via AWS RDS transaction logs",
-      logicalBackups: "Available via BackupManager.createLogicalBackup() for manual exports",
-      disasterRecovery: "Cross-region read replicas can be promoted to primary in case of regional failure"
+      primary: 'AWS RDS Automated Backups (Snapshots)',
+      retentionPeriod: '7-35 days (configurable in AWS Console)',
+      pointInTimeRecovery: 'Enabled via AWS RDS transaction logs',
+      logicalBackups: 'Available via BackupManager.createLogicalBackup() for manual exports',
+      disasterRecovery: 'Cross-region read replicas can be promoted to primary in case of regional failure',
     };
   }
 }


### PR DESCRIPTION
## Manual security hardening

This PR manually re-applies the useful security ideas from the closed bot PR queue without carrying over broad unrelated drift.

### Changes
- Replaces shell-string backup execution with `spawn(..., { shell: false })`.
- Restricts backup labels to a safe character set.
- Normalizes backup/restore paths to the allowed `/tmp` backup directory.
- Removes hardcoded API key fallback from `APIServer`.
- Supports `API_KEYS` / `API_KEY` from environment only.
- Requires explicit API keys and allowed origins in production.
- Restricts Socket.io CORS origins via `ALLOWED_ORIGINS` / `CORS_ORIGINS`.
- Keeps local development usable with localhost origins when not in production.

### Manual review notes
Production now needs environment variables configured:

```bash
API_KEY=your-secret-key
# or
API_KEYS=key1,key2

ALLOWED_ORIGINS=https://areloria.de,https://www.areloria.de
# or
CORS_ORIGINS=https://areloria.de,https://www.areloria.de
```

### Why manual
The original bot PRs had useful security intent but were too noisy/stale to merge directly.