### PR TITLE
fix(deploy): support configurable VPS SSH port

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -19,6 +19,10 @@ on:
         description: 'External Docker network'
         required: false
         default: 'areloria_arelorian-network'
+      ssh_port:
+        description: 'VPS SSH port'
+        required: false
+        default: '22'
 
 concurrency:
   group: vps-docker-deploy-${{ github.ref_name }}
@@ -37,6 +41,7 @@ jobs:
       DEPLOY_BRANCH: main
       ARELORIAN_PORT: ${{ inputs.arelorian_port || '3001' }}
       ARELORIAN_DOCKER_NETWORK: ${{ inputs.docker_network || 'areloria_arelorian-network' }}
+      SSH_PORT: ${{ inputs.ssh_port || secrets.SSH_PORT || '22' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -49,6 +54,7 @@ jobs:
       - name: Verify VPS SSH connection
         run: |
           sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
+            -p "${SSH_PORT}" \
             -o StrictHostKeyChecking=no \
             -o ConnectTimeout=20 \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
@@ -57,6 +63,7 @@ jobs:
       - name: Run Docker deploy on VPS
         run: |
           sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
+            -p "${SSH_PORT}" \
             -o StrictHostKeyChecking=no \
             -o ServerAliveInterval=30 \
             -o ServerAliveCountMax=10 \


### PR DESCRIPTION
## Fix

The VPS Docker deploy workflow now supports a configurable SSH port.

## Why

The latest deploy reached the SSH step but timed out on port 22. That means the workflow logic is now going to the VPS, but the VPS SSH endpoint may use another port or the provider firewall may not expose port 22.

## Changes

- Adds `ssh_port` workflow_dispatch input with default `22`.
- Adds `SSH_PORT` env from `inputs.ssh_port`, `secrets.SSH_PORT`, or fallback `22`.
- Passes `-p "${SSH_PORT}"` to both SSH calls.

## Usage

Set repository secret `SSH_PORT` to the real VPS SSH port, for example `22` or `2222`. Manual workflow dispatch can override it through the `ssh_port` input.