### PR TITLE
fix(client-2d): repair mobile input bridge

### DIFF
--- a/apps/client-2d/src/CyberZenIsoApp.tsx
+++ b/apps/client-2d/src/CyberZenIsoApp.tsx
@@ -31,6 +31,14 @@ const EQUIPPED_WEAPON_KEY = "wasd:2d:equippedWeaponVisualId";
 const FOREST_WORLD_SEED = "areloria:forest:millbrook:v1";
 const KAPPA_INVARIANT = 1000;
 
+type MoveVector = { dx: number; dz: number };
+
+declare global {
+  interface Window {
+    __wasd2dMove?: (vector: MoveVector) => void;
+  }
+}
+
 type Entity = {
   root: Container;
   tx: number;
@@ -319,6 +327,20 @@ export function CyberZenIsoApp() {
   const [equippedWeaponId, setEquippedWeaponId] = useState<string | null>(() => localStorage.getItem(EQUIPPED_WEAPON_KEY));
   const [messages, setMessages] = useState<Msg[]>([{ from: "Oracle", txt: "Cyberzen 2.5D shell online." }]);
 
+  function sendMove(vector: MoveVector) {
+    if (!clientRef.current?.connected) return;
+    if (Date.now() - moveAt.current <= 140) return;
+    moveAt.current = Date.now();
+    clientRef.current.sendPlayerAction("MOVE", vector);
+  }
+
+  useEffect(() => {
+    window.__wasd2dMove = sendMove;
+    return () => {
+      if (window.__wasd2dMove === sendMove) delete window.__wasd2dMove;
+    };
+  });
+
   useEffect(() => {
     const down = (e: KeyboardEvent) => keys.current.add(e.key.toLowerCase());
     const up = (e: KeyboardEvent) => keys.current.delete(e.key.toLowerCase());
@@ -480,10 +502,7 @@ export function CyberZenIsoApp() {
     if (k.has("s") || k.has("arrowdown")) dz -= 1;
     if (k.has("a") || k.has("arrowleft")) dx -= 1;
     if (k.has("d") || k.has("arrowright")) dx += 1;
-    if ((dx || dz) && clientRef.current?.connected && Date.now() - moveAt.current > 140) {
-      moveAt.current = Date.now();
-      clientRef.current.sendPlayerAction("MOVE", { dx, dz });
-    }
+    if (dx || dz) sendMove({ dx, dz });
     entities.current.forEach((ent) => {
       const p = iso(ent.tx, ent.tz, app.screen.width, app.screen.height);
       ent.root.x += (p.x - ent.root.x) * 0.18;

--- a/apps/client-2d/src/MobileMovePad.tsx
+++ b/apps/client-2d/src/MobileMovePad.tsx
@@ -1,32 +1,26 @@
 import { useEffect, useRef } from "react";
-import { createClient } from "@wasd/core-network";
 
 type MoveVector = { dx: number; dz: number };
 
 export function MobileMovePad() {
   const vector = useRef<MoveVector>({ dx: 0, dz: 0 });
-  const clientRef = useRef<ReturnType<typeof createClient> | null>(null);
 
   useEffect(() => {
-    const client = createClient({ url: "https://arelorian.de", heartbeatInterval: 30000 });
-    clientRef.current = client;
-    client.connect();
-
     const timer = window.setInterval(() => {
       const { dx, dz } = vector.current;
       if (!dx && !dz) return;
-      if (!client.connected) return;
-      client.sendPlayerAction("MOVE", { dx, dz });
+      window.__wasd2dMove?.({ dx, dz });
     }, 150);
 
     return () => {
       window.clearInterval(timer);
-      client.disconnect();
+      release();
     };
   }, []);
 
   function hold(next: MoveVector) {
     vector.current = next;
+    window.__wasd2dMove?.(next);
   }
 
   function release() {
@@ -34,11 +28,11 @@ export function MobileMovePad() {
   }
 
   return (
-    <nav className="az-touch-pad" aria-label="Mobile movement controls">
-      <button className="up" onPointerDown={() => hold({ dx: 0, dz: 1 })} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▲</button>
-      <button className="left" onPointerDown={() => hold({ dx: -1, dz: 0 })} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>◀</button>
-      <button className="right" onPointerDown={() => hold({ dx: 1, dz: 0 })} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▶</button>
-      <button className="down" onPointerDown={() => hold({ dx: 0, dz: -1 })} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▼</button>
+    <nav className="az-touch-pad" aria-label="Mobile movement controls" style={{ touchAction: "none", userSelect: "none" }}>
+      <button className="up" onPointerDown={(event) => { event.preventDefault(); hold({ dx: 0, dz: 1 }); }} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▲</button>
+      <button className="left" onPointerDown={(event) => { event.preventDefault(); hold({ dx: -1, dz: 0 }); }} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>◀</button>
+      <button className="right" onPointerDown={(event) => { event.preventDefault(); hold({ dx: 1, dz: 0 }); }} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▶</button>
+      <button className="down" onPointerDown={(event) => { event.preventDefault(); hold({ dx: 0, dz: -1 }); }} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▼</button>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary

- removes the duplicate mobile WebSocket client from `MobileMovePad`
- routes mobile movement through the active `CyberZenIsoApp` client/session
- keeps the existing 140ms movement throttle in the real player controller
- adds touch-action/user-select protection so Android taps do not get swallowed by browser gestures

## Why

The mobile pad was creating its own `createClient` connection, so MOVE events could land on a separate/ghost session instead of the visible local player. This PR makes mobile controls use the same input path as keyboard movement.

## Notes

This PR focuses on movement first. The next PR should address sprite/atlas clipping and fallback visuals in the 2D asset renderer.