### PR TITLE
feat(are): persist ARE shadow JSONL logs

### DIFF
--- a/server/src/core/are/AREShadowAdapter.ts
+++ b/server/src/core/are/AREShadowAdapter.ts
@@ -6,6 +6,7 @@ import { AREGuard } from './AREGuard';
 import { ARENpcEvolution } from './ARENpcEvolution';
 import { AREPayloadFactory, type AREPayloadNormalizationOptions, type IAREPayload } from './AREPayload';
 import type { AREReplayBuffer } from './AREReplayBuffer';
+import { AREShadowLogSink } from './AREShadowLogSink';
 import { AREShadowState, type AREShadowEcosystemStats } from './AREShadowState';
 
 export interface AREShadowTickInput {
@@ -50,6 +51,8 @@ function kappaCellOf(position: unknown): string {
 
 export class AREShadowAdapter {
   private static readonly defaultEcosystemState = new AREShadowState();
+  private static readonly logSink = new AREShadowLogSink();
+  private static lastLoggedTick: number | null = null;
   private static topologyTick: number | null = null;
   private static topologyCells = new Map<string, string[]>();
 
@@ -86,6 +89,19 @@ export class AREShadowAdapter {
     const bucket = this.topologyCells.get(cell) ?? [];
     bucket.push(entityId);
     this.topologyCells.set(cell, bucket);
+  }
+
+  private static writeShadowLog(input: AREShadowTickInput, stateHash: number | undefined): void {
+    if (this.lastLoggedTick === input.tick) return;
+    this.lastLoggedTick = input.tick;
+    this.logSink.write(input.tick, {
+      capacity: input.buffer.capacity,
+      size: input.buffer.size,
+      latestTick: input.tick,
+      latestEntityId: input.entityId,
+      latestStateHash: stateHash ?? null,
+      ecosystem: this.getEcosystemTelemetry(),
+    });
   }
 
   static executeShadowTick(input: AREShadowTickInput): AREShadowTickResult {
@@ -132,6 +148,7 @@ export class AREShadowAdapter {
         return recorded;
       });
 
+      AREShadowAdapter.writeShadowLog(input, entry.stateHash);
       return { skipped: false, recorded: true, stateHash: entry.stateHash };
     } catch (error) {
       return { skipped: false, recorded: false, error };

--- a/server/src/core/are/AREShadowLogSink.ts
+++ b/server/src/core/are/AREShadowLogSink.ts
@@ -1,0 +1,62 @@
+import { mkdir, appendFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+export type AREShadowLogEntry = {
+  tick: number;
+  at: string;
+  capacity: number | null;
+  size: number | null;
+  latestTick: number | null;
+  latestEntityId: string | null;
+  latestStateHash: string | null;
+  divergence: unknown;
+  ecosystem: unknown;
+  economy: unknown;
+  electroweakPruning: unknown;
+};
+
+export class AREShadowLogSink {
+  private readonly filePath: string;
+  private readonly everyTicks: number;
+  private pending: Promise<void> = Promise.resolve();
+
+  constructor(options: { filePath?: string; everyTicks?: number } = {}) {
+    this.filePath = resolve(process.cwd(), options.filePath ?? process.env.ARE_SHADOW_LOG_PATH ?? "logs/are-shadow.jsonl");
+    this.everyTicks = Math.max(1, Math.trunc(options.everyTicks ?? Number(process.env.ARE_SHADOW_LOG_EVERY_TICKS) || 60));
+  }
+
+  shouldWrite(tick: number): boolean {
+    return tick > 0 && tick % this.everyTicks === 0;
+  }
+
+  write(tick: number, stats: any): void {
+    if (!this.shouldWrite(tick)) return;
+    const entry: AREShadowLogEntry = {
+      tick,
+      at: new Date().toISOString(),
+      capacity: Number.isFinite(Number(stats?.capacity)) ? Number(stats.capacity) : null,
+      size: Number.isFinite(Number(stats?.size)) ? Number(stats.size) : null,
+      latestTick: Number.isFinite(Number(stats?.latestTick)) ? Number(stats.latestTick) : null,
+      latestEntityId: stats?.latestEntityId ? String(stats.latestEntityId) : null,
+      latestStateHash: stats?.latestStateHash ? String(stats.latestStateHash) : null,
+      divergence: stats?.divergence ?? null,
+      ecosystem: stats?.ecosystem ?? null,
+      economy: stats?.economy ?? null,
+      electroweakPruning: stats?.electroweakPruning ?? null,
+    };
+
+    const line = `${JSON.stringify(entry)}\n`;
+    this.pending = this.pending
+      .then(async () => {
+        await mkdir(dirname(this.filePath), { recursive: true });
+        await appendFile(this.filePath, line, "utf8");
+      })
+      .catch((error) => {
+        console.error("[AREShadowLogSink] Failed to write ARE shadow log", error);
+      });
+  }
+
+  getPath(): string {
+    return this.filePath;
+  }
+}


### PR DESCRIPTION
## Summary

- adds `AREShadowLogSink` for compact JSONL AREShadow telemetry
- writes one AREShadow log entry per configured interval, defaulting to every 60 ticks
- stores logs at `logs/are-shadow.jsonl` by default
- supports overrides via `ARE_SHADOW_LOG_PATH` and `ARE_SHADOW_LOG_EVERY_TICKS`

## Why

AREShadow already streams telemetry through `WORLD_HEARTBEAT` / `world_tick`, but there was no durable VPS-side log trail. This gives us a persistent debugging trail for latest tick/entity/state hash and ecosystem telemetry.

## Runtime notes

Default path:

```txt
logs/are-shadow.jsonl
```

Useful VPS command after deploy:

```bash
tail -f logs/are-shadow.jsonl
```
