### PR TITLE
ci(ops): add VPS log snapshot workflow

### DIFF
--- a/.github/workflows/vps-log-snapshot.yml
+++ b/.github/workflows/vps-log-snapshot.yml
@@ -1,0 +1,194 @@
+name: VPS Log Snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      lines:
+        description: "How many log lines to collect per source"
+        required: false
+        default: "300"
+      include_docker:
+        description: "Collect Docker and Docker Compose status/logs"
+        required: false
+        default: "true"
+      include_pm2:
+        description: "Collect PM2 status/logs"
+        required: false
+        default: "true"
+      include_nginx:
+        description: "Collect nginx status/logs"
+        required: false
+        default: "true"
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  collect-vps-logs:
+    name: Collect VPS logs
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    env:
+      SNAPSHOT_NAME: areloria-vps-log-snapshot-${{ github.run_id }}
+      VPS_PATH: /opt/areloria
+
+    steps:
+      - name: Validate SSH secrets
+        run: |
+          set -euo pipefail
+          test -n "${{ secrets.SSH_HOST }}" || { echo "Missing SSH_HOST secret"; exit 1; }
+          test -n "${{ secrets.SSH_USER }}" || { echo "Missing SSH_USER secret"; exit 1; }
+          test -n "${{ secrets.SSH_PASSWORD }}" || { echo "Missing SSH_PASSWORD secret"; exit 1; }
+
+      - name: Collect snapshot on VPS
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          LINES: ${{ github.event.inputs.lines || '300' }}
+          INCLUDE_DOCKER: ${{ github.event.inputs.include_docker || 'true' }}
+          INCLUDE_PM2: ${{ github.event.inputs.include_pm2 || 'true' }}
+          INCLUDE_NGINX: ${{ github.event.inputs.include_nginx || 'true' }}
+          SNAPSHOT_NAME: ${{ env.SNAPSHOT_NAME }}
+          VPS_PATH: ${{ env.VPS_PATH }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          envs: LINES,INCLUDE_DOCKER,INCLUDE_PM2,INCLUDE_NGINX,SNAPSHOT_NAME,VPS_PATH
+          script: |
+            set -euo pipefail
+
+            case "${LINES:-300}" in
+              ''|*[!0-9]*) LINES=300 ;;
+            esac
+            if [ "$LINES" -lt 20 ]; then LINES=20; fi
+            if [ "$LINES" -gt 5000 ]; then LINES=5000; fi
+
+            OUT="/tmp/${SNAPSHOT_NAME}"
+            ARCHIVE="/tmp/${SNAPSHOT_NAME}.tar.gz"
+            rm -rf "$OUT" "$ARCHIVE"
+            mkdir -p "$OUT"
+
+            redact_file() {
+              local file="$1"
+              [ -f "$file" ] || return 0
+              sed -E -i \
+                -e 's/(token|secret|password|passwd|authorization|cookie|api[_-]?key|firebase[_-]?key|private[_-]?key)([=: ]+)[^[:space:]"'"'<>]+/\1\2[REDACTED]/Ig' \
+                -e 's/(Bearer )[A-Za-z0-9._~+\/-]+/\1[REDACTED]/g' \
+                -e 's/(ghp_|github_pat_)[A-Za-z0-9_]+/[GITHUB_TOKEN_REDACTED]/g' \
+                "$file" || true
+            }
+
+            write_cmd() {
+              local file="$1"
+              shift
+              {
+                echo "### $*"
+                "$@"
+              } > "$OUT/$file" 2>&1 || true
+              redact_file "$OUT/$file"
+            }
+
+            {
+              echo "=== Areloria VPS Log Snapshot ==="
+              echo "created_at=$(date -Is)"
+              echo "host=$(hostname)"
+              echo "path=$VPS_PATH"
+              echo "lines=$LINES"
+              echo "workflow_run=${GITHUB_RUN_ID:-unknown}"
+              echo
+              uptime || true
+              echo
+              df -h || true
+              echo
+              free -h || true
+            } > "$OUT/00-summary.txt" 2>&1
+            redact_file "$OUT/00-summary.txt"
+
+            write_cmd "01-health.txt" sh -lc 'curl -k -I --max-time 15 https://arelorian.de; echo; curl -k --max-time 15 https://arelorian.de/health || true; echo; curl -k --max-time 15 https://arelorian.de/portal/ || true'
+            write_cmd "02-processes.txt" sh -lc 'ps aux --sort=-%mem | head -80'
+            write_cmd "03-ports.txt" sh -lc 'ss -tulpn || netstat -tulpn || true'
+
+            if [ -d "$VPS_PATH" ]; then
+              cd "$VPS_PATH"
+              write_cmd "10-git-state.txt" sh -lc 'git rev-parse HEAD; git status --short; git log -1 --oneline'
+              write_cmd "11-local-log-index.txt" sh -lc 'find logs -maxdepth 3 -type f 2>/dev/null | sort || true'
+
+              if [ -f "logs/are-shadow.jsonl" ]; then
+                tail -n "$LINES" logs/are-shadow.jsonl > "$OUT/are-shadow.tail.jsonl" 2>&1 || true
+                redact_file "$OUT/are-shadow.tail.jsonl"
+              fi
+
+              if [ -d logs ]; then
+                find logs -maxdepth 2 -type f \( -name "*.log" -o -name "*.jsonl" -o -name "*.txt" \) 2>/dev/null | sort | while read -r log_file; do
+                  safe_name="$(echo "$log_file" | sed 's#^logs/##; s#[^A-Za-z0-9._-]#_#g')"
+                  tail -n "$LINES" "$log_file" > "$OUT/local-${safe_name}.tail.txt" 2>&1 || true
+                  redact_file "$OUT/local-${safe_name}.tail.txt"
+                done
+              fi
+
+              if [ "${INCLUDE_DOCKER:-true}" = "true" ]; then
+                write_cmd "20-docker-ps.txt" sh -lc 'docker ps -a'
+                write_cmd "21-docker-stats.txt" sh -lc 'docker stats --no-stream || true'
+                write_cmd "22-docker-compose-ps.txt" sh -lc 'docker compose ps || true'
+                write_cmd "23-docker-compose-logs.txt" sh -lc "docker compose logs --tail=$LINES || true"
+              fi
+
+              if [ "${INCLUDE_PM2:-true}" = "true" ]; then
+                write_cmd "30-pm2-status.txt" sh -lc 'pm2 status || true'
+                write_cmd "31-pm2-jlist.txt" sh -lc 'pm2 jlist || true'
+                write_cmd "32-pm2-logs.txt" sh -lc "pm2 logs --nostream --lines $LINES || true"
+              fi
+            else
+              echo "VPS_PATH not found: $VPS_PATH" > "$OUT/10-git-state.txt"
+            fi
+
+            if [ "${INCLUDE_NGINX:-true}" = "true" ]; then
+              write_cmd "40-nginx-status.txt" sh -lc 'systemctl status nginx --no-pager || true'
+              if [ -f /var/log/nginx/error.log ]; then
+                tail -n "$LINES" /var/log/nginx/error.log > "$OUT/41-nginx-error.tail.txt" 2>&1 || true
+                redact_file "$OUT/41-nginx-error.tail.txt"
+              fi
+              if [ -f /var/log/nginx/access.log ]; then
+                tail -n "$LINES" /var/log/nginx/access.log > "$OUT/42-nginx-access.tail.txt" 2>&1 || true
+                redact_file "$OUT/42-nginx-access.tail.txt"
+              fi
+            fi
+
+            tar -czf "$ARCHIVE" -C "$OUT" .
+            ls -lh "$ARCHIVE"
+
+      - name: Download snapshot archive
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          source: /tmp/${{ env.SNAPSHOT_NAME }}.tar.gz
+          target: .
+
+      - name: Upload snapshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SNAPSHOT_NAME }}
+          path: ./tmp/${{ env.SNAPSHOT_NAME }}.tar.gz
+          retention-days: 7
+
+      - name: Cleanup remote snapshot
+        if: always()
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          SNAPSHOT_NAME: ${{ env.SNAPSHOT_NAME }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          envs: SNAPSHOT_NAME
+          script: |
+            rm -rf "/tmp/${SNAPSHOT_NAME}" "/tmp/${SNAPSHOT_NAME}.tar.gz" || true


### PR DESCRIPTION
## Summary

- adds a manual and scheduled GitHub Actions workflow for VPS log snapshots
- collects health checks, process/port snapshots, git state, local logs, AREShadow JSONL tail, Docker, PM2, and nginx logs
- uploads the snapshot as a 7-day GitHub artifact
- masks common tokens/secrets before packaging logs
- cleans up the temporary VPS archive after upload

## Usage

Run **Actions → VPS Log Snapshot → Run workflow**.

Inputs:

- `lines`: how many tail lines per log source, clamped from 20 to 5000
- `include_docker`: collect Docker/Docker Compose status and logs
- `include_pm2`: collect PM2 status and logs
- `include_nginx`: collect nginx status and logs

The workflow also runs every 6 hours at `17 */6 * * *`.

## Requirements

Uses existing VPS secrets:

- `SSH_HOST`
- `SSH_USER`
- `SSH_PASSWORD`

## Artifact

Uploaded artifact name pattern:

```txt
areloria-vps-log-snapshot-<github-run-id>
```

Retention: 7 days.