### PR TITLE
feat(npc): add deterministic heuristic goal pruner

### DIFF
--- a/server/src/modules/npc/HeuristicGoalPruner.ts
+++ b/server/src/modules/npc/HeuristicGoalPruner.ts
@@ -1,0 +1,45 @@
+export type GoalLike = {
+  id?: string;
+  isCritical?: boolean;
+  priority?: number;
+  [key: string]: unknown;
+};
+
+export type Position2D = {
+  x: number;
+  y: number;
+};
+
+export class HeuristicGoalPruner {
+  private readonly scanRadiusSq: number;
+  private readonly echoThreshold: number;
+
+  constructor(options: { scanRadius?: number; echoThreshold?: number } = {}) {
+    const scanRadius = Number.isFinite(options.scanRadius) ? Number(options.scanRadius) : 40;
+    this.scanRadiusSq = Math.trunc(scanRadius * scanRadius);
+    this.echoThreshold = Number.isFinite(options.echoThreshold) ? Number(options.echoThreshold) : 0.7;
+  }
+
+  public prune<TGoal extends GoalLike>(goals: readonly TGoal[] | null | undefined, echoIntensity: number): TGoal[] {
+    const source = Array.isArray(goals) ? goals : [];
+    const intensity = Number.isFinite(echoIntensity) ? echoIntensity : 0;
+
+    if (intensity >= this.echoThreshold) {
+      return source.filter((goal) => goal.isCritical === true);
+    }
+
+    return [...source];
+  }
+
+  public isTargetInRange(posA: Position2D, posB: Position2D): boolean {
+    const ax = Number.isFinite(posA.x) ? posA.x : 0;
+    const ay = Number.isFinite(posA.y) ? posA.y : 0;
+    const bx = Number.isFinite(posB.x) ? posB.x : 0;
+    const by = Number.isFinite(posB.y) ? posB.y : 0;
+
+    const dx = ax - bx;
+    const dy = ay - by;
+
+    return dx * dx + dy * dy < this.scanRadiusSq;
+  }
+}

--- a/server/src/tests/heuristic-goal-pruner.test.ts
+++ b/server/src/tests/heuristic-goal-pruner.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { HeuristicGoalPruner } from '../modules/npc/HeuristicGoalPruner';
+
+describe('HeuristicGoalPruner', () => {
+  it('keeps all goals below the echo threshold and returns a new array', () => {
+    const pruner = new HeuristicGoalPruner();
+    const goals = [
+      { id: 'walk', isCritical: false },
+      { id: 'defend', isCritical: true },
+    ];
+
+    const pruned = pruner.prune(goals, 0.5);
+
+    expect(pruned).toHaveLength(2);
+    expect(pruned).toEqual(goals);
+    expect(pruned).not.toBe(goals);
+  });
+
+  it('reduces goals to critical goals at or above the echo threshold', () => {
+    const pruner = new HeuristicGoalPruner();
+    const goals = [
+      { id: 'walk', isCritical: false },
+      { id: 'defend', isCritical: true },
+      { id: 'celebrate', isCritical: false },
+    ];
+
+    const pruned = pruner.prune(goals, 0.8);
+
+    expect(pruned).toEqual([{ id: 'defend', isCritical: true }]);
+  });
+
+  it('treats invalid goal input and invalid echo intensity deterministically', () => {
+    const pruner = new HeuristicGoalPruner();
+
+    expect(pruner.prune(null, Number.NaN)).toEqual([]);
+    expect(pruner.prune(undefined, Number.POSITIVE_INFINITY)).toEqual([]);
+  });
+
+  it('uses squared distance checks without mutating positions', () => {
+    const pruner = new HeuristicGoalPruner({ scanRadius: 40 });
+    const origin = { x: 0, y: 0 };
+    const near = { x: 24, y: 31 };
+    const far = { x: 40, y: 0 };
+
+    expect(pruner.isTargetInRange(origin, near)).toBe(true);
+    expect(pruner.isTargetInRange(origin, far)).toBe(false);
+    expect(origin).toEqual({ x: 0, y: 0 });
+  });
+
+  it('supports custom thresholds deterministically', () => {
+    const pruner = new HeuristicGoalPruner({ echoThreshold: 0.25 });
+    const goals = [
+      { id: 'idle', isCritical: false },
+      { id: 'guard', isCritical: true },
+    ];
+
+    expect(pruner.prune(goals, 0.24)).toHaveLength(2);
+    expect(pruner.prune(goals, 0.25)).toEqual([{ id: 'guard', isCritical: true }]);
+  });
+});


### PR DESCRIPTION
## Summary

- adds `HeuristicGoalPruner` as an isolated NPC utility module
- keeps the implementation pure: no mutation, no world-state writes, no runtime imports outside its domain
- adds deterministic fallback handling for invalid goal lists and invalid echo intensity
- adds squared-distance range checks for 10 Hz NPC loops
- covers behavior with Vitest tests

## Why

This prepares NPC goal focus compression without coupling it to memory injection or global world events. The pruner is intentionally only responsible for CPU-focused goal selection.

## Follow-up

The next clean step should be a separate module for world event memory injection, e.g. `NPCFactionMoodBroadcaster` or `WorldEventMemoryInjector`, listening for events like `QUEST_COMPLETED_BOSS`.