### PR TITLE
feat(npc): add emergent brain decision kernel

### DIFF
--- a/server/src/modules/npc/EmergentBrain.ts
+++ b/server/src/modules/npc/EmergentBrain.ts
@@ -1,0 +1,194 @@
+export type AREBrainAction =
+  | 'ANCHOR_BUFF'
+  | 'WITHDRAW'
+  | 'WARN_FACTION'
+  | 'OBSERVE'
+  | 'HARVEST_RESOURCE'
+  | 'DEFEND_COLONY';
+
+export type AREBrainTraits = {
+  faith: number;
+  aggression: number;
+  curiosity: number;
+};
+
+export type AREBrainInput = {
+  npcId: string;
+  factionId: string;
+  traits: Partial<AREBrainTraits>;
+  energy: number;
+  memoryHash: string;
+  localStateHash: string;
+  playerDeltaDrift: number;
+  playerThreat: number;
+  colonyUtility: number;
+  resourcePressure?: number;
+  tick: number;
+};
+
+export type AREBrainDecision = {
+  action: AREBrainAction;
+  confidence: number;
+  reason: string;
+  energyCost: number;
+  nextEnergy: number;
+  kappaHash: string;
+  scores: Record<AREBrainAction, number>;
+};
+
+const KAPPA = 1000;
+const ACTION_ORDER: readonly AREBrainAction[] = [
+  'ANCHOR_BUFF',
+  'WITHDRAW',
+  'WARN_FACTION',
+  'OBSERVE',
+  'HARVEST_RESOURCE',
+  'DEFEND_COLONY',
+];
+
+function finite(value: unknown, fallback = 0): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp(value: number, min = 0, max = 1): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function kappa(value: unknown): number {
+  return Math.trunc(clamp(finite(value, 0)) * KAPPA);
+}
+
+function stableHash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+function normalizeTraits(traits: Partial<AREBrainTraits>): AREBrainTraits {
+  return {
+    faith: clamp(finite(traits.faith, 0.5)),
+    aggression: clamp(finite(traits.aggression, 0.5)),
+    curiosity: clamp(finite(traits.curiosity, 0.5)),
+  };
+}
+
+export class EmergentBrainKernel {
+  public process(input: AREBrainInput): AREBrainDecision {
+    const normalized = this.normalizeInput(input);
+    const kappaHash = this.foldAREBrainHash(normalized);
+    const scores = this.scoreActions(normalized);
+    return this.chooseDeterministicAction(normalized, scores, kappaHash);
+  }
+
+  private normalizeInput(input: AREBrainInput) {
+    const traits = normalizeTraits(input.traits ?? {});
+    return Object.freeze({
+      npcId: String(input.npcId || 'npc:unknown'),
+      factionId: String(input.factionId || 'neutral'),
+      traits,
+      energy: kappa(input.energy),
+      memoryHash: String(input.memoryHash || 'memory:0'),
+      localStateHash: String(input.localStateHash || 'state:0'),
+      playerDeltaDrift: kappa(input.playerDeltaDrift),
+      playerThreat: kappa(input.playerThreat),
+      colonyUtility: kappa(input.colonyUtility),
+      resourcePressure: kappa(input.resourcePressure ?? 0),
+      tick: Math.max(0, Math.trunc(finite(input.tick, 0))),
+    });
+  }
+
+  private foldAREBrainHash(input: ReturnType<EmergentBrainKernel['normalizeInput']>): string {
+    return stableHash([
+      input.npcId,
+      input.factionId,
+      input.memoryHash,
+      input.localStateHash,
+      input.energy,
+      input.playerDeltaDrift,
+      input.playerThreat,
+      input.colonyUtility,
+      input.resourcePressure,
+      input.tick % KAPPA,
+      kappa(input.traits.faith),
+      kappa(input.traits.aggression),
+      kappa(input.traits.curiosity),
+    ].join('|'));
+  }
+
+  private scoreActions(input: ReturnType<EmergentBrainKernel['normalizeInput']>): Record<AREBrainAction, number> {
+    const faith = kappa(input.traits.faith);
+    const aggression = kappa(input.traits.aggression);
+    const curiosity = kappa(input.traits.curiosity);
+    const energyDeficit = KAPPA - input.energy;
+
+    return {
+      ANCHOR_BUFF: input.colonyUtility * 0.32 + faith * 0.42 + input.playerDeltaDrift * 0.12 - input.playerThreat * 0.22 - energyDeficit * 0.18,
+      WITHDRAW: input.playerDeltaDrift * 0.38 + input.playerThreat * 0.42 + energyDeficit * 0.24 - aggression * 0.22,
+      WARN_FACTION: input.playerThreat * 0.36 + input.colonyUtility * 0.25 + faith * 0.16 + curiosity * 0.08,
+      OBSERVE: curiosity * 0.34 + input.playerDeltaDrift * 0.08 + input.energy * 0.08 - input.playerThreat * 0.06,
+      HARVEST_RESOURCE: input.resourcePressure * 0.45 + energyDeficit * 0.22 + curiosity * 0.10 - input.playerThreat * 0.14,
+      DEFEND_COLONY: input.colonyUtility * 0.36 + input.playerThreat * 0.30 + aggression * 0.30 + faith * 0.10,
+    };
+  }
+
+  private chooseDeterministicAction(
+    input: ReturnType<EmergentBrainKernel['normalizeInput']>,
+    scores: Record<AREBrainAction, number>,
+    kappaHash: string,
+  ): AREBrainDecision {
+    let bestAction: AREBrainAction = 'OBSERVE';
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (const action of ACTION_ORDER) {
+      const score = finite(scores[action], Number.NEGATIVE_INFINITY);
+      if (score > bestScore) {
+        bestAction = action;
+        bestScore = score;
+      }
+    }
+
+    const secondBest = ACTION_ORDER
+      .filter((action) => action !== bestAction)
+      .reduce((max, action) => Math.max(max, finite(scores[action], Number.NEGATIVE_INFINITY)), Number.NEGATIVE_INFINITY);
+    const confidence = clamp((bestScore - secondBest + 100) / KAPPA);
+    const energyCost = this.energyCostFor(bestAction);
+
+    return Object.freeze({
+      action: bestAction,
+      confidence,
+      reason: this.reasonFor(bestAction),
+      energyCost,
+      nextEnergy: Math.max(0, input.energy - energyCost),
+      kappaHash,
+      scores: Object.freeze({ ...scores }),
+    });
+  }
+
+  private energyCostFor(action: AREBrainAction): number {
+    switch (action) {
+      case 'ANCHOR_BUFF': return 12;
+      case 'WITHDRAW': return 8;
+      case 'WARN_FACTION': return 6;
+      case 'HARVEST_RESOURCE': return 10;
+      case 'DEFEND_COLONY': return 14;
+      case 'OBSERVE':
+      default: return 2;
+    }
+  }
+
+  private reasonFor(action: AREBrainAction): string {
+    switch (action) {
+      case 'ANCHOR_BUFF': return 'player_drift_high_colony_alignment_positive';
+      case 'WITHDRAW': return 'self_preservation_drift_or_threat_dominant';
+      case 'WARN_FACTION': return 'threat_detected_faction_signal_useful';
+      case 'HARVEST_RESOURCE': return 'resource_pressure_or_energy_deficit_dominant';
+      case 'DEFEND_COLONY': return 'colony_defense_utility_dominant';
+      case 'OBSERVE':
+      default: return 'insufficient_pressure_observe_and_update_history';
+    }
+  }
+}

--- a/server/src/tests/emergent-brain.test.ts
+++ b/server/src/tests/emergent-brain.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { EmergentBrainKernel, type AREBrainInput } from '../modules/npc/EmergentBrain';
+
+function baseInput(overrides: Partial<AREBrainInput> = {}): AREBrainInput {
+  return {
+    npcId: 'npc:guardian',
+    factionId: 'heroes',
+    traits: { faith: 0.72, aggression: 0.28, curiosity: 0.45 },
+    energy: 0.9,
+    memoryHash: 'memory:alpha',
+    localStateHash: 'state:millbrook',
+    playerDeltaDrift: 0.2,
+    playerThreat: 0.1,
+    colonyUtility: 0.75,
+    resourcePressure: 0.1,
+    tick: 1200,
+    ...overrides,
+  };
+}
+
+describe('EmergentBrainKernel', () => {
+  it('returns deterministic decisions for identical input', () => {
+    const kernel = new EmergentBrainKernel();
+    const input = baseInput();
+
+    const first = kernel.process(input);
+    const second = kernel.process(input);
+
+    expect(second).toEqual(first);
+    expect(first.kappaHash).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('anchors a high-drift allied player when colony alignment is positive and threat is low', () => {
+    const kernel = new EmergentBrainKernel();
+
+    const decision = kernel.process(baseInput({
+      traits: { faith: 0.95, aggression: 0.1, curiosity: 0.3 },
+      playerDeltaDrift: 0.9,
+      playerThreat: 0.05,
+      colonyUtility: 0.95,
+      energy: 1,
+    }));
+
+    expect(decision.action).toBe('ANCHOR_BUFF');
+    expect(decision.reason).toBe('player_drift_high_colony_alignment_positive');
+    expect(decision.energyCost).toBe(12);
+    expect(decision.nextEnergy).toBe(988);
+  });
+
+  it('withdraws when player chaos and threat dominate self-preservation', () => {
+    const kernel = new EmergentBrainKernel();
+
+    const decision = kernel.process(baseInput({
+      traits: { faith: 0.1, aggression: 0.05, curiosity: 0.2 },
+      playerDeltaDrift: 1,
+      playerThreat: 1,
+      colonyUtility: 0.05,
+      energy: 0.2,
+    }));
+
+    expect(decision.action).toBe('WITHDRAW');
+    expect(decision.reason).toBe('self_preservation_drift_or_threat_dominant');
+    expect(decision.nextEnergy).toBe(192);
+  });
+
+  it('defends the colony when colony utility, threat, and aggression align', () => {
+    const kernel = new EmergentBrainKernel();
+
+    const decision = kernel.process(baseInput({
+      traits: { faith: 0.5, aggression: 0.95, curiosity: 0.1 },
+      playerDeltaDrift: 0.1,
+      playerThreat: 0.75,
+      colonyUtility: 1,
+      energy: 0.8,
+    }));
+
+    expect(decision.action).toBe('DEFEND_COLONY');
+    expect(decision.reason).toBe('colony_defense_utility_dominant');
+  });
+
+  it('harvests resources when resource pressure and energy deficit dominate', () => {
+    const kernel = new EmergentBrainKernel();
+
+    const decision = kernel.process(baseInput({
+      traits: { faith: 0.1, aggression: 0.1, curiosity: 0.9 },
+      playerDeltaDrift: 0.05,
+      playerThreat: 0.02,
+      colonyUtility: 0.05,
+      resourcePressure: 1,
+      energy: 0.05,
+    }));
+
+    expect(decision.action).toBe('HARVEST_RESOURCE');
+    expect(decision.reason).toBe('resource_pressure_or_energy_deficit_dominant');
+  });
+
+  it('normalizes invalid inputs without producing NaN scores', () => {
+    const kernel = new EmergentBrainKernel();
+
+    const decision = kernel.process(baseInput({
+      traits: { faith: Number.NaN, aggression: Number.POSITIVE_INFINITY, curiosity: Number.NEGATIVE_INFINITY },
+      energy: Number.NaN,
+      playerDeltaDrift: Number.POSITIVE_INFINITY,
+      playerThreat: Number.NaN,
+      colonyUtility: Number.NEGATIVE_INFINITY,
+      resourcePressure: Number.NaN,
+      tick: Number.NaN,
+    }));
+
+    expect(Number.isFinite(decision.confidence)).toBe(true);
+    expect(Number.isFinite(decision.energyCost)).toBe(true);
+    expect(Object.values(decision.scores).every(Number.isFinite)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- adds `EmergentBrainKernel` as a pure deterministic NPC decision kernel
- normalizes all inputs through kappa-scale integer gates
- folds NPC state, memory, local state, traits, drift, threat, utility, resource pressure, and tick into a stable hash
- scores typed AREBrain actions without `Math.random()` or external state mutation
- returns an auditable `AREBrainDecision` with action, confidence, reason, energy cost, next energy, kappa hash, and score vector
- covers deterministic replay, high drift anchor behavior, withdrawal, colony defense, resource harvesting, and invalid input normalization with tests

## Why

This establishes the isolated decision core before wiring thermal logic, NPCSystem mutations, or ConstructionContracts. The module is intentionally pure so later systems can consume decisions without turning the kernel into a behavior tree.

## Follow-up

Next PR should add thermal/entropy energy decay as a separate utility before any world-building or construction-contract layer is attached.