### PR TITLE
feat(npc): add thermal logic energy decay

### DIFF
--- a/server/src/modules/npc/ThermalLogic.ts
+++ b/server/src/modules/npc/ThermalLogic.ts
@@ -1,0 +1,126 @@
+export type ThermalStatus = 'DECOMPOSITION' | 'CRITICAL' | 'STABLE' | 'OVERHEATED';
+
+export type EnergyState = {
+  currentEnergy: number;
+  maxEnergy: number;
+  decayRate: number;
+  lastUpdatedTick: number;
+};
+
+export type ThermalTickResult = {
+  energy: EnergyState;
+  status: ThermalStatus;
+  ticksPassed: number;
+  totalLoss: number;
+  canAct: boolean;
+};
+
+export type ThermalActionResult = {
+  energy: EnergyState;
+  status: ThermalStatus;
+  afforded: boolean;
+  appliedCost: number;
+};
+
+export type ThermalLogicOptions = {
+  entropyConstant?: number;
+  criticalRatio?: number;
+  overheatedRatio?: number;
+  overheatDecayMultiplier?: number;
+};
+
+const DEFAULT_MAX_ENERGY = 1000;
+const DEFAULT_DECAY_RATE = 1;
+
+function finite(value: unknown, fallback = 0): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp(value: number, min = 0, max = DEFAULT_MAX_ENERGY): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export class ThermalLogic {
+  private readonly entropyConstant: number;
+  private readonly criticalRatio: number;
+  private readonly overheatedRatio: number;
+  private readonly overheatDecayMultiplier: number;
+
+  constructor(options: ThermalLogicOptions = {}) {
+    this.entropyConstant = Math.max(0, Math.trunc(finite(options.entropyConstant, 5)));
+    this.criticalRatio = Math.max(0, Math.min(1, finite(options.criticalRatio, 0.1)));
+    this.overheatedRatio = Math.max(0, Math.min(1, finite(options.overheatedRatio, 0.9)));
+    this.overheatDecayMultiplier = Math.max(1, finite(options.overheatDecayMultiplier, 1.5));
+  }
+
+  public normalizeState(state: Partial<EnergyState> | null | undefined, currentTick = 0): EnergyState {
+    const maxEnergy = Math.max(1, Math.trunc(finite(state?.maxEnergy, DEFAULT_MAX_ENERGY)));
+    return Object.freeze({
+      currentEnergy: clamp(Math.trunc(finite(state?.currentEnergy, maxEnergy)), 0, maxEnergy),
+      maxEnergy,
+      decayRate: Math.max(0, Math.trunc(finite(state?.decayRate, DEFAULT_DECAY_RATE))),
+      lastUpdatedTick: Math.max(0, Math.trunc(finite(state?.lastUpdatedTick, currentTick))),
+    });
+  }
+
+  public calculateDecay(state: Partial<EnergyState> | null | undefined, currentTick: number): number {
+    return this.applyDecay(state, currentTick).energy.currentEnergy;
+  }
+
+  public applyDecay(state: Partial<EnergyState> | null | undefined, currentTick: number): ThermalTickResult {
+    const normalized = this.normalizeState(state, currentTick);
+    const tick = Math.max(0, Math.trunc(finite(currentTick, normalized.lastUpdatedTick)));
+    const ticksPassed = Math.max(0, tick - normalized.lastUpdatedTick);
+    const baseLossPerTick = normalized.decayRate + this.entropyConstant;
+    const multiplier = this.statusOf(normalized) === 'OVERHEATED' ? this.overheatDecayMultiplier : 1;
+    const totalLoss = Math.trunc(ticksPassed * baseLossPerTick * multiplier);
+    const currentEnergy = clamp(normalized.currentEnergy - totalLoss, 0, normalized.maxEnergy);
+    const energy = Object.freeze({ ...normalized, currentEnergy, lastUpdatedTick: tick });
+    const status = this.statusOf(energy);
+
+    return Object.freeze({
+      energy,
+      status,
+      ticksPassed,
+      totalLoss,
+      canAct: status !== 'DECOMPOSITION',
+    });
+  }
+
+  public canAffordAction(state: Partial<EnergyState> | null | undefined, cost: number): boolean {
+    const normalized = this.normalizeState(state);
+    const actionCost = Math.max(0, Math.trunc(finite(cost, 0)));
+    return normalized.currentEnergy >= actionCost && this.statusOf(normalized) !== 'DECOMPOSITION';
+  }
+
+  public applyActionCost(state: Partial<EnergyState> | null | undefined, cost: number): ThermalActionResult {
+    const normalized = this.normalizeState(state);
+    const actionCost = Math.max(0, Math.trunc(finite(cost, 0)));
+    const afforded = this.canAffordAction(normalized, actionCost);
+    const currentEnergy = afforded ? clamp(normalized.currentEnergy - actionCost, 0, normalized.maxEnergy) : normalized.currentEnergy;
+    const energy = Object.freeze({ ...normalized, currentEnergy });
+
+    return Object.freeze({
+      energy,
+      status: this.statusOf(energy),
+      afforded,
+      appliedCost: afforded ? actionCost : 0,
+    });
+  }
+
+  public allowedActionsForCritical<TAction extends string>(status: ThermalStatus, actions: readonly TAction[], harvestAction: TAction): TAction[] {
+    if (status === 'DECOMPOSITION') return [];
+    if (status === 'CRITICAL') return actions.includes(harvestAction) ? [harvestAction] : [];
+    return [...actions];
+  }
+
+  public statusOf(state: Partial<EnergyState> | null | undefined): ThermalStatus {
+    const normalized = this.normalizeState(state);
+    if (normalized.currentEnergy <= 0) return 'DECOMPOSITION';
+    const ratio = normalized.currentEnergy / normalized.maxEnergy;
+    if (ratio < this.criticalRatio) return 'CRITICAL';
+    if (ratio > this.overheatedRatio) return 'OVERHEATED';
+    return 'STABLE';
+  }
+}

--- a/server/src/tests/thermal-logic.test.ts
+++ b/server/src/tests/thermal-logic.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { ThermalLogic, type EnergyState } from '../modules/npc/ThermalLogic';
+
+describe('ThermalLogic', () => {
+  it('applies deterministic decay from elapsed ticks', () => {
+    const thermal = new ThermalLogic({ entropyConstant: 5 });
+    const state: EnergyState = { currentEnergy: 1000, maxEnergy: 1000, decayRate: 1, lastUpdatedTick: 10 };
+
+    const result = thermal.applyDecay(state, 20);
+
+    expect(result.ticksPassed).toBe(10);
+    expect(result.totalLoss).toBe(90);
+    expect(result.energy.currentEnergy).toBe(910);
+    expect(result.energy.lastUpdatedTick).toBe(20);
+    expect(result.status).toBe('OVERHEATED');
+  });
+
+  it('does not decay backwards in time', () => {
+    const thermal = new ThermalLogic();
+    const state: EnergyState = { currentEnergy: 500, maxEnergy: 1000, decayRate: 2, lastUpdatedTick: 50 };
+
+    const result = thermal.applyDecay(state, 40);
+
+    expect(result.ticksPassed).toBe(0);
+    expect(result.totalLoss).toBe(0);
+    expect(result.energy.currentEnergy).toBe(500);
+    expect(result.energy.lastUpdatedTick).toBe(40);
+  });
+
+  it('checks and applies action costs without mutation', () => {
+    const thermal = new ThermalLogic();
+    const state: EnergyState = { currentEnergy: 100, maxEnergy: 1000, decayRate: 1, lastUpdatedTick: 0 };
+
+    expect(thermal.canAffordAction(state, 80)).toBe(true);
+    expect(thermal.canAffordAction(state, 120)).toBe(false);
+
+    const action = thermal.applyActionCost(state, 80);
+    expect(action.afforded).toBe(true);
+    expect(action.appliedCost).toBe(80);
+    expect(action.energy.currentEnergy).toBe(20);
+    expect(state.currentEnergy).toBe(100);
+  });
+
+  it('normalizes invalid energy state safely', () => {
+    const thermal = new ThermalLogic();
+
+    const state = thermal.normalizeState({
+      currentEnergy: Number.NaN,
+      maxEnergy: Number.NEGATIVE_INFINITY,
+      decayRate: Number.POSITIVE_INFINITY,
+      lastUpdatedTick: Number.NaN,
+    }, 123);
+
+    expect(state).toEqual({
+      currentEnergy: 1000,
+      maxEnergy: 1000,
+      decayRate: 1,
+      lastUpdatedTick: 123,
+    });
+  });
+
+  it('classifies decomposition, critical, stable, and overheated states', () => {
+    const thermal = new ThermalLogic();
+
+    expect(thermal.statusOf({ currentEnergy: 0, maxEnergy: 1000, decayRate: 1, lastUpdatedTick: 0 })).toBe('DECOMPOSITION');
+    expect(thermal.statusOf({ currentEnergy: 50, maxEnergy: 1000, decayRate: 1, lastUpdatedTick: 0 })).toBe('CRITICAL');
+    expect(thermal.statusOf({ currentEnergy: 500, maxEnergy: 1000, decayRate: 1, lastUpdatedTick: 0 })).toBe('STABLE');
+    expect(thermal.statusOf({ currentEnergy: 950, maxEnergy: 1000, decayRate: 1, lastUpdatedTick: 0 })).toBe('OVERHEATED');
+  });
+
+  it('restricts critical entities to harvest and decomposition entities to no actions', () => {
+    const thermal = new ThermalLogic();
+    const actions = ['OBSERVE', 'HARVEST_RESOURCE', 'DEFEND_COLONY'] as const;
+
+    expect(thermal.allowedActionsForCritical('CRITICAL', actions, 'HARVEST_RESOURCE')).toEqual(['HARVEST_RESOURCE']);
+    expect(thermal.allowedActionsForCritical('DECOMPOSITION', actions, 'HARVEST_RESOURCE')).toEqual([]);
+    expect(thermal.allowedActionsForCritical('STABLE', actions, 'HARVEST_RESOURCE')).toEqual([...actions]);
+  });
+});


### PR DESCRIPTION
## Summary

- adds `ThermalLogic` as an isolated deterministic energy utility
- supports base decay, entropy constant, overheated decay multiplier, action-cost checks, and action-cost application
- classifies entity energy into `DECOMPOSITION`, `CRITICAL`, `STABLE`, and `OVERHEATED`
- restricts critical entities to harvest-only action sets and decomposition entities to no actions
- normalizes invalid energy state without NaN propagation
- covers decay, affordability, invalid state normalization, status classification, and action restrictions with tests

## Why

This provides the thermal layer before wiring NPCSystem mutations or construction contracts. The module is intentionally pure so NPC integration can consume it safely.

## Follow-up

A later PR can connect `ThermalLogic` to `EmergentBrainKernel` and then NPCSystem.