### PR TITLE
feat(npc): add emergent thermal adapter

### DIFF
--- a/server/src/modules/npc/EmergentThermalAdapter.ts
+++ b/server/src/modules/npc/EmergentThermalAdapter.ts
@@ -1,0 +1,81 @@
+import { EmergentBrainKernel, type AREBrainDecision, type AREBrainInput, type AREBrainAction } from './EmergentBrain';
+import { ThermalLogic, type EnergyState, type ThermalStatus } from './ThermalLogic';
+
+export type EmergentThermalAdapterInput = {
+  brainInput: AREBrainInput;
+  energyState: Partial<EnergyState> | null | undefined;
+  currentTick: number;
+};
+
+export type EmergentThermalDecisionResult = {
+  thermalStatus: ThermalStatus;
+  brainDecision: AREBrainDecision | null;
+  actionAllowed: boolean;
+  finalAction: AREBrainAction | 'DECOMPOSITION';
+  energyStats: {
+    before: number;
+    afterDecay: number;
+    afterAction: number;
+  };
+  energyState: EnergyState;
+  decomposition: boolean;
+  reason: string;
+};
+
+export class EmergentThermalAdapter {
+  private readonly brain: EmergentBrainKernel;
+  private readonly thermal: ThermalLogic;
+
+  constructor(options: { brain?: EmergentBrainKernel; thermal?: ThermalLogic } = {}) {
+    this.brain = options.brain ?? new EmergentBrainKernel();
+    this.thermal = options.thermal ?? new ThermalLogic();
+  }
+
+  public process(input: EmergentThermalAdapterInput): EmergentThermalDecisionResult {
+    const normalizedBefore = this.thermal.normalizeState(input.energyState, input.currentTick);
+    const decay = this.thermal.applyDecay(normalizedBefore, input.currentTick);
+
+    if (decay.status === 'DECOMPOSITION') {
+      return Object.freeze({
+        thermalStatus: decay.status,
+        brainDecision: null,
+        actionAllowed: false,
+        finalAction: 'DECOMPOSITION' as const,
+        energyStats: {
+          before: normalizedBefore.currentEnergy,
+          afterDecay: decay.energy.currentEnergy,
+          afterAction: decay.energy.currentEnergy,
+        },
+        energyState: decay.energy,
+        decomposition: true,
+        reason: 'thermal_decomposition_no_action_allowed',
+      });
+    }
+
+    const brainDecision = this.brain.process({
+      ...input.brainInput,
+      energy: decay.energy.currentEnergy / decay.energy.maxEnergy,
+    });
+
+    const finalAction: AREBrainAction = decay.status === 'CRITICAL' ? 'HARVEST_RESOURCE' : brainDecision.action;
+    const effectiveCost = finalAction === brainDecision.action ? brainDecision.energyCost : 0;
+    const action = this.thermal.applyActionCost(decay.energy, effectiveCost);
+
+    return Object.freeze({
+      thermalStatus: decay.status,
+      brainDecision,
+      actionAllowed: action.afforded,
+      finalAction,
+      energyStats: {
+        before: normalizedBefore.currentEnergy,
+        afterDecay: decay.energy.currentEnergy,
+        afterAction: action.energy.currentEnergy,
+      },
+      energyState: action.energy,
+      decomposition: action.status === 'DECOMPOSITION',
+      reason: decay.status === 'CRITICAL'
+        ? 'critical_energy_harvest_override'
+        : brainDecision.reason,
+    });
+  }
+}

--- a/server/src/tests/emergent-thermal-adapter.test.ts
+++ b/server/src/tests/emergent-thermal-adapter.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { EmergentThermalAdapter } from '../modules/npc/EmergentThermalAdapter';
+import { type AREBrainInput } from '../modules/npc/EmergentBrain';
+import { type EnergyState } from '../modules/npc/ThermalLogic';
+
+function brainInput(overrides: Partial<AREBrainInput> = {}): AREBrainInput {
+  return {
+    npcId: 'npc:thermal-guardian',
+    factionId: 'heroes',
+    traits: { faith: 0.95, aggression: 0.1, curiosity: 0.3 },
+    energy: 1,
+    memoryHash: 'memory:thermal',
+    localStateHash: 'state:grove',
+    playerDeltaDrift: 0.9,
+    playerThreat: 0.05,
+    colonyUtility: 0.95,
+    resourcePressure: 0.1,
+    tick: 1000,
+    ...overrides,
+  };
+}
+
+function energyState(overrides: Partial<EnergyState> = {}): EnergyState {
+  return {
+    currentEnergy: 800,
+    maxEnergy: 1000,
+    decayRate: 1,
+    lastUpdatedTick: 1000,
+    ...overrides,
+  };
+}
+
+describe('EmergentThermalAdapter', () => {
+  it('passes stable thermal state through the brain and applies action cost', () => {
+    const adapter = new EmergentThermalAdapter();
+
+    const result = adapter.process({
+      brainInput: brainInput(),
+      energyState: energyState(),
+      currentTick: 1000,
+    });
+
+    expect(result.thermalStatus).toBe('STABLE');
+    expect(result.brainDecision?.action).toBe('ANCHOR_BUFF');
+    expect(result.finalAction).toBe('ANCHOR_BUFF');
+    expect(result.actionAllowed).toBe(true);
+    expect(result.energyStats).toEqual({ before: 800, afterDecay: 800, afterAction: 788 });
+    expect(result.decomposition).toBe(false);
+  });
+
+  it('forces critical entities to harvest resources regardless of the brain action', () => {
+    const adapter = new EmergentThermalAdapter();
+
+    const result = adapter.process({
+      brainInput: brainInput({ resourcePressure: 0 }),
+      energyState: energyState({ currentEnergy: 80 }),
+      currentTick: 1000,
+    });
+
+    expect(result.thermalStatus).toBe('CRITICAL');
+    expect(result.brainDecision?.action).not.toBe('HARVEST_RESOURCE');
+    expect(result.finalAction).toBe('HARVEST_RESOURCE');
+    expect(result.energyStats.afterAction).toBe(80);
+    expect(result.reason).toBe('critical_energy_harvest_override');
+  });
+
+  it('returns decomposition without invoking a final brain action when energy reaches zero', () => {
+    const adapter = new EmergentThermalAdapter();
+
+    const result = adapter.process({
+      brainInput: brainInput(),
+      energyState: energyState({ currentEnergy: 5, decayRate: 5, lastUpdatedTick: 1000 }),
+      currentTick: 1001,
+    });
+
+    expect(result.thermalStatus).toBe('DECOMPOSITION');
+    expect(result.brainDecision).toBeNull();
+    expect(result.finalAction).toBe('DECOMPOSITION');
+    expect(result.actionAllowed).toBe(false);
+    expect(result.decomposition).toBe(true);
+    expect(result.energyStats.afterDecay).toBe(0);
+    expect(result.energyStats.afterAction).toBe(0);
+  });
+
+  it('feeds decayed energy ratio into the brain input', () => {
+    const adapter = new EmergentThermalAdapter();
+
+    const result = adapter.process({
+      brainInput: brainInput({ playerDeltaDrift: 0.1, playerThreat: 0.8, colonyUtility: 0.2 }),
+      energyState: energyState({ currentEnergy: 500, decayRate: 5, lastUpdatedTick: 1000 }),
+      currentTick: 1010,
+    });
+
+    expect(result.energyStats.afterDecay).toBe(400);
+    expect(result.brainDecision?.nextEnergy).toBeLessThanOrEqual(400);
+  });
+});


### PR DESCRIPTION
## Summary

- adds `EmergentThermalAdapter` as the pure bridge between `ThermalLogic` and `EmergentBrainKernel`
- applies thermal decay before brain processing
- returns `DECOMPOSITION` without brain action when energy reaches zero
- forces `HARVEST_RESOURCE` while energy is critical
- applies action cost without mutating NPC state
- returns auditable energy stats before decay, after decay, and after action
- covers stable pass-through, critical override, decomposition, and decayed energy ratio behavior with tests

## Why

This keeps physical NPC mutation out of the decision layer. NPCSystem can consume the adapter output in a later PR without coupling the brain kernel directly to world-state mutation.

## Follow-up

Next PR can wire the adapter into NPCSystem and map `finalAction` to controlled NPC state transitions.