### PR TITLE
feat(npc): add autonomous thermal risk model

### DIFF
--- a/server/src/modules/npc/EmergentBrain.ts
+++ b/server/src/modules/npc/EmergentBrain.ts
@@ -23,6 +23,7 @@ export type AREBrainInput = {
   playerThreat: number;
   colonyUtility: number;
   resourcePressure?: number;
+  survivalBias?: number;
   tick: number;
 };
 
@@ -97,6 +98,7 @@ export class EmergentBrainKernel {
       playerThreat: kappa(input.playerThreat),
       colonyUtility: kappa(input.colonyUtility),
       resourcePressure: kappa(input.resourcePressure ?? 0),
+      survivalBias: kappa(input.survivalBias ?? 0),
       tick: Math.max(0, Math.trunc(finite(input.tick, 0))),
     });
   }
@@ -112,6 +114,7 @@ export class EmergentBrainKernel {
       input.playerThreat,
       input.colonyUtility,
       input.resourcePressure,
+      input.survivalBias,
       input.tick % KAPPA,
       kappa(input.traits.faith),
       kappa(input.traits.aggression),
@@ -126,12 +129,12 @@ export class EmergentBrainKernel {
     const energyDeficit = KAPPA - input.energy;
 
     return {
-      ANCHOR_BUFF: input.colonyUtility * 0.32 + faith * 0.42 + input.playerDeltaDrift * 0.12 - input.playerThreat * 0.22 - energyDeficit * 0.18,
-      WITHDRAW: input.playerDeltaDrift * 0.38 + input.playerThreat * 0.42 + energyDeficit * 0.24 - aggression * 0.22,
+      ANCHOR_BUFF: input.colonyUtility * 0.32 + faith * 0.42 + input.playerDeltaDrift * 0.12 - input.playerThreat * 0.22 - energyDeficit * 0.18 - input.survivalBias * 0.16,
+      WITHDRAW: input.playerDeltaDrift * 0.38 + input.playerThreat * 0.42 + energyDeficit * 0.24 - aggression * 0.22 + input.survivalBias * 0.18,
       WARN_FACTION: input.playerThreat * 0.36 + input.colonyUtility * 0.25 + faith * 0.16 + curiosity * 0.08,
-      OBSERVE: curiosity * 0.34 + input.playerDeltaDrift * 0.08 + input.energy * 0.08 - input.playerThreat * 0.06,
-      HARVEST_RESOURCE: input.resourcePressure * 0.45 + energyDeficit * 0.22 + curiosity * 0.10 - input.playerThreat * 0.14,
-      DEFEND_COLONY: input.colonyUtility * 0.36 + input.playerThreat * 0.30 + aggression * 0.30 + faith * 0.10,
+      OBSERVE: curiosity * 0.34 + input.playerDeltaDrift * 0.08 + input.energy * 0.08 - input.playerThreat * 0.06 - input.survivalBias * 0.08,
+      HARVEST_RESOURCE: input.resourcePressure * 0.45 + energyDeficit * 0.22 + curiosity * 0.10 - input.playerThreat * 0.14 + input.survivalBias * 0.46,
+      DEFEND_COLONY: input.colonyUtility * 0.36 + input.playerThreat * 0.30 + aggression * 0.30 + faith * 0.10 - input.survivalBias * 0.12,
     };
   }
 

--- a/server/src/modules/npc/EmergentThermalAdapter.ts
+++ b/server/src/modules/npc/EmergentThermalAdapter.ts
@@ -1,6 +1,17 @@
 import { EmergentBrainKernel, type AREBrainDecision, type AREBrainInput, type AREBrainAction } from './EmergentBrain';
 import { ThermalLogic, type EnergyState, type ThermalStatus } from './ThermalLogic';
 
+export type EnergyRisk = 'NONE' | 'STRAINED' | 'CRITICAL' | 'COLLAPSE_IMMINENT';
+
+export type DecisionConsequence = {
+  allowed: boolean;
+  risk: EnergyRisk;
+  finalAction: AREBrainAction | 'DECOMPOSITION';
+  collapseRisk: boolean;
+  survivalBias: number;
+  energyAfterAction: number;
+};
+
 export type EmergentThermalAdapterInput = {
   brainInput: AREBrainInput;
   energyState: Partial<EnergyState> | null | undefined;
@@ -12,6 +23,7 @@ export type EmergentThermalDecisionResult = {
   brainDecision: AREBrainDecision | null;
   actionAllowed: boolean;
   finalAction: AREBrainAction | 'DECOMPOSITION';
+  consequence: DecisionConsequence;
   energyStats: {
     before: number;
     afterDecay: number;
@@ -21,6 +33,10 @@ export type EmergentThermalDecisionResult = {
   decomposition: boolean;
   reason: string;
 };
+
+function clamp(value: number, min = 0, max = 1): number {
+  return Math.max(min, Math.min(max, value));
+}
 
 export class EmergentThermalAdapter {
   private readonly brain: EmergentBrainKernel;
@@ -36,11 +52,21 @@ export class EmergentThermalAdapter {
     const decay = this.thermal.applyDecay(normalizedBefore, input.currentTick);
 
     if (decay.status === 'DECOMPOSITION') {
+      const consequence: DecisionConsequence = Object.freeze({
+        allowed: false,
+        risk: 'COLLAPSE_IMMINENT',
+        finalAction: 'DECOMPOSITION' as const,
+        collapseRisk: true,
+        survivalBias: 1,
+        energyAfterAction: decay.energy.currentEnergy,
+      });
+
       return Object.freeze({
         thermalStatus: decay.status,
         brainDecision: null,
         actionAllowed: false,
         finalAction: 'DECOMPOSITION' as const,
+        consequence,
         energyStats: {
           before: normalizedBefore.currentEnergy,
           afterDecay: decay.energy.currentEnergy,
@@ -52,30 +78,58 @@ export class EmergentThermalAdapter {
       });
     }
 
+    const survivalBias = this.calculateSurvivalBias(decay.energy);
     const brainDecision = this.brain.process({
       ...input.brainInput,
       energy: decay.energy.currentEnergy / decay.energy.maxEnergy,
+      survivalBias,
     });
 
-    const finalAction: AREBrainAction = decay.status === 'CRITICAL' ? 'HARVEST_RESOURCE' : brainDecision.action;
-    const effectiveCost = finalAction === brainDecision.action ? brainDecision.energyCost : 0;
-    const action = this.thermal.applyActionCost(decay.energy, effectiveCost);
+    const consequence = this.analyzeConsequence(decay.energy, brainDecision, survivalBias);
+    const action = this.thermal.applyActionCost(decay.energy, brainDecision.energyCost);
 
     return Object.freeze({
       thermalStatus: decay.status,
       brainDecision,
-      actionAllowed: action.afforded,
-      finalAction,
+      actionAllowed: consequence.allowed,
+      finalAction: consequence.finalAction,
+      consequence,
       energyStats: {
         before: normalizedBefore.currentEnergy,
         afterDecay: decay.energy.currentEnergy,
         afterAction: action.energy.currentEnergy,
       },
       energyState: action.energy,
-      decomposition: action.status === 'DECOMPOSITION',
-      reason: decay.status === 'CRITICAL'
-        ? 'critical_energy_harvest_override'
-        : brainDecision.reason,
+      decomposition: consequence.collapseRisk || action.status === 'DECOMPOSITION',
+      reason: consequence.collapseRisk ? `${brainDecision.reason}:thermal_risk` : brainDecision.reason,
     });
+  }
+
+  private analyzeConsequence(energy: EnergyState, decision: AREBrainDecision, survivalBias: number): DecisionConsequence {
+    const energyAfterAction = Math.max(0, energy.currentEnergy - Math.max(0, decision.energyCost));
+    const ratioAfterAction = energyAfterAction / energy.maxEnergy;
+    const collapseRisk = energyAfterAction <= 0;
+    const risk = this.riskFor(ratioAfterAction, collapseRisk);
+
+    return Object.freeze({
+      allowed: true,
+      risk,
+      finalAction: decision.action,
+      collapseRisk,
+      survivalBias,
+      energyAfterAction,
+    });
+  }
+
+  private calculateSurvivalBias(energy: EnergyState): number {
+    const energyRatio = energy.currentEnergy / energy.maxEnergy;
+    return clamp(1 - energyRatio);
+  }
+
+  private riskFor(energyRatio: number, collapseRisk: boolean): EnergyRisk {
+    if (collapseRisk) return 'COLLAPSE_IMMINENT';
+    if (energyRatio < 0.1) return 'CRITICAL';
+    if (energyRatio < 0.25) return 'STRAINED';
+    return 'NONE';
   }
 }

--- a/server/src/tests/emergent-thermal-adapter.test.ts
+++ b/server/src/tests/emergent-thermal-adapter.test.ts
@@ -44,11 +44,13 @@ describe('EmergentThermalAdapter', () => {
     expect(result.brainDecision?.action).toBe('ANCHOR_BUFF');
     expect(result.finalAction).toBe('ANCHOR_BUFF');
     expect(result.actionAllowed).toBe(true);
+    expect(result.consequence.risk).toBe('NONE');
+    expect(result.consequence.survivalBias).toBeCloseTo(0.2);
     expect(result.energyStats).toEqual({ before: 800, afterDecay: 800, afterAction: 788 });
     expect(result.decomposition).toBe(false);
   });
 
-  it('forces critical entities to harvest resources regardless of the brain action', () => {
+  it('keeps autonomy in critical state and reports risk instead of forcing harvest', () => {
     const adapter = new EmergentThermalAdapter();
 
     const result = adapter.process({
@@ -58,13 +60,34 @@ describe('EmergentThermalAdapter', () => {
     });
 
     expect(result.thermalStatus).toBe('CRITICAL');
-    expect(result.brainDecision?.action).not.toBe('HARVEST_RESOURCE');
-    expect(result.finalAction).toBe('HARVEST_RESOURCE');
-    expect(result.energyStats.afterAction).toBe(80);
-    expect(result.reason).toBe('critical_energy_harvest_override');
+    expect(result.brainDecision).not.toBeNull();
+    expect(result.finalAction).toBe(result.brainDecision?.action);
+    expect(result.actionAllowed).toBe(true);
+    expect(result.consequence.risk).toBe('CRITICAL');
+    expect(result.consequence.survivalBias).toBeCloseTo(0.92);
+    expect(result.consequence.collapseRisk).toBe(false);
+    expect(result.reason).not.toBe('critical_energy_harvest_override');
   });
 
-  it('returns decomposition without invoking a final brain action when energy reaches zero', () => {
+  it('marks collapse risk when a chosen action would consume remaining energy', () => {
+    const adapter = new EmergentThermalAdapter();
+
+    const result = adapter.process({
+      brainInput: brainInput({ resourcePressure: 0 }),
+      energyState: energyState({ currentEnergy: 6, decayRate: 0 }),
+      currentTick: 1000,
+    });
+
+    expect(result.brainDecision).not.toBeNull();
+    expect(result.actionAllowed).toBe(true);
+    expect(result.consequence.risk).toBe('COLLAPSE_IMMINENT');
+    expect(result.consequence.collapseRisk).toBe(true);
+    expect(result.energyStats.afterAction).toBe(0);
+    expect(result.decomposition).toBe(true);
+    expect(result.reason).toContain('thermal_risk');
+  });
+
+  it('returns decomposition without invoking a final brain action when energy reaches zero after decay', () => {
     const adapter = new EmergentThermalAdapter();
 
     const result = adapter.process({
@@ -77,12 +100,13 @@ describe('EmergentThermalAdapter', () => {
     expect(result.brainDecision).toBeNull();
     expect(result.finalAction).toBe('DECOMPOSITION');
     expect(result.actionAllowed).toBe(false);
+    expect(result.consequence.allowed).toBe(false);
     expect(result.decomposition).toBe(true);
     expect(result.energyStats.afterDecay).toBe(0);
     expect(result.energyStats.afterAction).toBe(0);
   });
 
-  it('feeds decayed energy ratio into the brain input', () => {
+  it('feeds decayed energy ratio and survival bias into the brain input', () => {
     const adapter = new EmergentThermalAdapter();
 
     const result = adapter.process({
@@ -92,6 +116,7 @@ describe('EmergentThermalAdapter', () => {
     });
 
     expect(result.energyStats.afterDecay).toBe(400);
+    expect(result.consequence.survivalBias).toBeCloseTo(0.6);
     expect(result.brainDecision?.nextEnergy).toBeLessThanOrEqual(400);
   });
 });


### PR DESCRIPTION
## Summary

- replaces the critical-energy hard override with an auditable consequence model
- adds `survivalBias` to `AREBrainInput` and feeds it into action scoring
- keeps NPC autonomy: critical energy no longer forces `HARVEST_RESOURCE`
- adds `EnergyRisk` and `DecisionConsequence` to report risk, survival pressure, and projected energy after action
- keeps the adapter pure: it predicts and returns consequences without mutating NPC state
- updates tests to cover autonomous critical decisions, thermal risk, and collapse projection

## Why

Emergent behavior should be shaped by world laws and consequence pressure, not by hard-coded command overrides. This lets an NPC make a risky or heroic decision while still making the result deterministic and measurable.

## Follow-up

NPCSystem can consume the consequence model in a later PR and commit state changes atomically.