### PR TITLE
feat(world): add emergence collapse event payload

### DIFF
--- a/server/src/modules/world/WorldEmergenceEvent.ts
+++ b/server/src/modules/world/WorldEmergenceEvent.ts
@@ -1,0 +1,106 @@
+export type WorldEmergenceEventType = 'WORLD_EVENT_EMERGENCE_COLLAPSE';
+
+export type KappaCoordinate = {
+  x: number;
+  y: number;
+  z: number;
+};
+
+export type WorldEmergenceCollapsePayload = {
+  eventType: WorldEmergenceEventType;
+  npcId: string;
+  factionId: string;
+  position: KappaCoordinate;
+  tick: number;
+  reason: string;
+  risk: string;
+  kappaHash: string;
+  sourceAction: string;
+  energyBefore: number;
+  energyAfterDecay: number;
+  energyAfterAction: number;
+};
+
+const KAPPA = 1000;
+
+function finite(value: unknown, fallback = 0): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function kappaCoordinate(value: unknown): number {
+  return Math.trunc(finite(value, 0) * KAPPA);
+}
+
+function stableHash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+export function toKappaCoordinate(position: { x?: unknown; y?: unknown; z?: unknown } | null | undefined): KappaCoordinate {
+  return Object.freeze({
+    x: kappaCoordinate(position?.x),
+    y: kappaCoordinate(position?.y),
+    z: kappaCoordinate(position?.z),
+  });
+}
+
+export function createEmergenceCollapsePayload(input: {
+  npcId: string;
+  factionId?: string | null;
+  position: { x?: unknown; y?: unknown; z?: unknown } | null | undefined;
+  tick: number;
+  reason: string;
+  risk: string;
+  sourceAction: string;
+  energyBefore: number;
+  energyAfterDecay: number;
+  energyAfterAction: number;
+  kappaHash?: string | null;
+}): WorldEmergenceCollapsePayload {
+  const position = toKappaCoordinate(input.position);
+  const tick = Math.max(0, Math.trunc(finite(input.tick, 0)));
+  const npcId = String(input.npcId || 'npc:unknown');
+  const factionId = String(input.factionId || 'neutral');
+  const reason = String(input.reason || 'emergence_collapse');
+  const risk = String(input.risk || 'COLLAPSE_IMMINENT');
+  const sourceAction = String(input.sourceAction || 'UNKNOWN');
+  const energyBefore = Math.max(0, Math.trunc(finite(input.energyBefore, 0)));
+  const energyAfterDecay = Math.max(0, Math.trunc(finite(input.energyAfterDecay, 0)));
+  const energyAfterAction = Math.max(0, Math.trunc(finite(input.energyAfterAction, 0)));
+  const kappaHash = input.kappaHash && String(input.kappaHash).length > 0
+    ? String(input.kappaHash)
+    : stableHash([
+      npcId,
+      factionId,
+      position.x,
+      position.y,
+      position.z,
+      tick,
+      reason,
+      risk,
+      sourceAction,
+      energyBefore,
+      energyAfterDecay,
+      energyAfterAction,
+    ].join('|'));
+
+  return Object.freeze({
+    eventType: 'WORLD_EVENT_EMERGENCE_COLLAPSE' as const,
+    npcId,
+    factionId,
+    position,
+    tick,
+    reason,
+    risk,
+    kappaHash,
+    sourceAction,
+    energyBefore,
+    energyAfterDecay,
+    energyAfterAction,
+  });
+}

--- a/server/src/tests/world-emergence-event.test.ts
+++ b/server/src/tests/world-emergence-event.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { createEmergenceCollapsePayload, toKappaCoordinate } from '../modules/world/WorldEmergenceEvent';
+
+describe('WorldEmergenceEvent', () => {
+  it('normalizes world positions into deterministic kappa coordinates', () => {
+    expect(toKappaCoordinate({ x: 1.25, y: -2.5, z: 0.125 })).toEqual({
+      x: 1250,
+      y: -2500,
+      z: 125,
+    });
+  });
+
+  it('creates deterministic emergence collapse payloads', () => {
+    const input = {
+      npcId: 'npc:heroic-guard',
+      factionId: 'heroes',
+      position: { x: 4.2, y: 8.1, z: 0 },
+      tick: 1234,
+      reason: 'defend_colony:thermal_risk',
+      risk: 'COLLAPSE_IMMINENT',
+      sourceAction: 'DEFEND_COLONY',
+      energyBefore: 12,
+      energyAfterDecay: 10,
+      energyAfterAction: 0,
+    };
+
+    const first = createEmergenceCollapsePayload(input);
+    const second = createEmergenceCollapsePayload(input);
+
+    expect(second).toEqual(first);
+    expect(first).toMatchObject({
+      eventType: 'WORLD_EVENT_EMERGENCE_COLLAPSE',
+      npcId: 'npc:heroic-guard',
+      factionId: 'heroes',
+      position: { x: 4200, y: 8100, z: 0 },
+      tick: 1234,
+      reason: 'defend_colony:thermal_risk',
+      risk: 'COLLAPSE_IMMINENT',
+      sourceAction: 'DEFEND_COLONY',
+      energyBefore: 12,
+      energyAfterDecay: 10,
+      energyAfterAction: 0,
+    });
+    expect(first.kappaHash).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('uses provided kappa hash when available', () => {
+    const payload = createEmergenceCollapsePayload({
+      npcId: 'npc:known-hash',
+      factionId: 'heroes',
+      position: { x: 0, y: 0, z: 0 },
+      tick: 1,
+      reason: 'known',
+      risk: 'CRITICAL',
+      sourceAction: 'OBSERVE',
+      energyBefore: 1,
+      energyAfterDecay: 1,
+      energyAfterAction: 1,
+      kappaHash: 'abc123',
+    });
+
+    expect(payload.kappaHash).toBe('abc123');
+  });
+
+  it('normalizes invalid values without NaN propagation', () => {
+    const payload = createEmergenceCollapsePayload({
+      npcId: '',
+      factionId: null,
+      position: { x: Number.NaN, y: Number.POSITIVE_INFINITY, z: undefined },
+      tick: Number.NaN,
+      reason: '',
+      risk: '',
+      sourceAction: '',
+      energyBefore: Number.NaN,
+      energyAfterDecay: Number.POSITIVE_INFINITY,
+      energyAfterAction: Number.NEGATIVE_INFINITY,
+    });
+
+    expect(payload).toMatchObject({
+      npcId: 'npc:unknown',
+      factionId: 'neutral',
+      position: { x: 0, y: 0, z: 0 },
+      tick: 0,
+      reason: 'emergence_collapse',
+      risk: 'COLLAPSE_IMMINENT',
+      sourceAction: 'UNKNOWN',
+      energyBefore: 0,
+      energyAfterDecay: 0,
+      energyAfterAction: 0,
+    });
+    expect(Object.values(payload.position).every(Number.isFinite)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- adds `WORLD_EVENT_EMERGENCE_COLLAPSE` payload creation
- normalizes collapse positions into deterministic kappa coordinates
- includes npc id, faction, tick, reason, risk, source action, energy stats, and kappa hash
- keeps the module pure: no NPC mutation, no loot spawning, no portal coupling
- covers deterministic payload creation, provided hash passthrough, and invalid input normalization with tests

## Why

This gives the world a stable event language for committed emergence collapse before adding loot capsules, NPC resonance echoes, or portal visuals.

## Note

PR #1201 is still open, so this PR intentionally does not depend on its consequence types yet. NPCSystem can connect both layers after #1201 is merged.