### PR TITLE
fix(server): parenthesize ARE shadow log tick fallback

### DIFF
--- a/server/src/core/are/AREShadowLogSink.ts
+++ b/server/src/core/are/AREShadowLogSink.ts
@@ -22,7 +22,7 @@ export class AREShadowLogSink {
 
   constructor(options: { filePath?: string; everyTicks?: number } = {}) {
     this.filePath = resolve(process.cwd(), options.filePath ?? process.env.ARE_SHADOW_LOG_PATH ?? "logs/are-shadow.jsonl");
-    this.everyTicks = Math.max(1, Math.trunc(options.everyTicks ?? Number(process.env.ARE_SHADOW_LOG_EVERY_TICKS) || 60));
+    this.everyTicks = Math.max(1, Math.trunc((options.everyTicks ?? Number(process.env.ARE_SHADOW_LOG_EVERY_TICKS)) || 60));
   }
 
   shouldWrite(tick: number): boolean {


### PR DESCRIPTION
Fixes both failing workflows by parenthesizing the mixed nullish coalescing / logical OR expression in `server/src/core/are/AREShadowLogSink.ts`.

Root failure from both jobs:

```txt
ERROR: Cannot use "||" with "??" without parentheses
```

This lets the Replit SDK smoke build and VPS Docker build continue past server transpilation.