### PR TITLE
docs(agents): add Areloria agent skillbook

### DIFF
--- a/.cursor/rules/areloria-agent-skillbook.mdc
+++ b/.cursor/rules/areloria-agent-skillbook.mdc
@@ -1,0 +1,32 @@
+---
+description: Areloria agent architecture contract for deterministic emergent development
+globs:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.md"
+alwaysApply: true
+---
+
+# Areloria Agent Rule
+
+Read and follow `docs/agents/ARELORIA_AGENT_SKILLBOOK.md` before making architecture changes.
+
+## Non-negotiables
+
+- Do not replace autonomy with hard behavior overrides.
+- Use consequence pressure, risk analysis, survival bias, and deterministic scoring.
+- Start with pure modules and tests.
+- Mutate world state only in explicit commit points.
+- Route events through WorldTick before adding rewards, resonance, or visuals.
+- One PR equals one system layer.
+- Preserve existing import conventions and `.js` runtime suffixes.
+
+## Layer order
+
+```txt
+pure module -> adapter -> NPCSystem commit -> WorldTick event -> reward -> resonance -> portal/client
+```
+
+## If blocked by tooling
+
+Use calmer branch, commit, and PR wording while preserving the technical intent.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,33 @@
+# Copilot Instructions for WASD / Areloria
+
+Follow the repository-wide agent contract in:
+
+```txt
+docs/agents/ARELORIA_AGENT_SKILLBOOK.md
+```
+
+## Critical rules
+
+- Build emergence through deterministic world laws, not hard behavioral cages.
+- Keep one PR to one architecture layer.
+- Preserve NPC autonomy unless the world state is final.
+- Pure logic first, mutation only at explicit commit points.
+- Surface world events before adding rewards, resonance, or visuals.
+- Respect existing TypeScript import style and `.js` runtime suffixes.
+- Add tests for new deterministic logic.
+
+## Architecture order
+
+```txt
+pure module
+adapter
+NPCSystem commit point
+WorldTick event surface
+reward consequence
+resonance echo
+portal or client visualization
+```
+
+## Current guidance
+
+After WorldTick surfaces an event batch, the next layer should consume it without mixing in UI or resonance side effects.

--- a/docs/agents/ARELORIA_AGENT_SKILLBOOK.md
+++ b/docs/agents/ARELORIA_AGENT_SKILLBOOK.md
@@ -1,0 +1,135 @@
+# Areloria Agent Skillbook
+
+This file is the shared working contract for future coding agents in the WASD / Areloria repository.
+
+## Core rule
+
+Build emergence through deterministic world laws, not hard behavioral cages.
+
+## PR chain protocol
+
+1. Check the previous PR status.
+2. If it is merged, branch from current main or the merge commit.
+3. Keep one PR to one architecture layer.
+4. Do not mix pure logic, mutation, WorldTick routing, rewards, resonance, and UI in one PR.
+5. Always name the next follow-up layer in the PR body.
+
+Preferred order:
+
+```txt
+pure module
+adapter
+NPCSystem commit point
+WorldTick event surface
+reward consequence
+resonance echo
+portal or client visualization
+```
+
+## Emergence over forced behavior
+
+Wrong:
+
+```txt
+critical energy -> force one action
+```
+
+Right:
+
+```txt
+critical energy -> survivalBias + risk + consequence projection
+```
+
+NPCs should keep autonomy. The world should answer with measurable consequences.
+
+## Pure logic before mutation
+
+Use this shape whenever possible:
+
+```txt
+EmergentBrain
+-> ThermalLogic
+-> EmergentThermalAdapter
+-> NPCSystem
+-> WorldTick
+-> Reward / Echo / Visual
+```
+
+Adapters return audit data. Commit points mutate state.
+
+## Deterministic event language
+
+World events should be explicit payloads. Include as many of these fields as apply:
+
+```txt
+eventType
+sourceId or npcId
+factionId
+position or kappa coordinate
+tick
+reason
+risk
+sourceAction
+state or energy delta
+kappaHash
+```
+
+Do not add rewards, faction mood changes, or UI effects before the event payload exists.
+
+## GitHub connector safety mode
+
+If a tool call is blocked:
+
+1. Keep the same technical intent.
+2. Use calmer branch and PR names.
+3. Avoid dramatic language in branch names, commit messages, and PR bodies.
+4. Preserve existing constants if already in code.
+5. Retry with neutral wording.
+
+## WASD monorepo style
+
+Before editing:
+
+1. Fetch the actual file from main.
+2. Respect import style, especially `.js` runtime suffixes.
+3. Keep changes minimal.
+4. Add tests for new logic.
+5. Avoid new dependencies unless necessary.
+6. Prefer stable ordering and deterministic hashes.
+
+## Current ladder
+
+```txt
+#1198 EmergentBrainKernel
+#1199 ThermalLogic
+#1200 EmergentThermalAdapter
+#1201 Autonomous Thermal Risk Model
+#1202 World Event Payload
+#1203 NPCSystem Integration
+#1204 WorldTick Event Surface
+#1205 Deterministic Event Rewards
+#1206 Resonance Echo
+#1207 Portal / Client Visualization
+```
+
+## Fast command semantics
+
+```txt
+los / weiter / ok weiter / zuegig
+-> verify status, branch, patch, PR, short report
+
+ist gemerged
+-> verify PR, continue next layer
+
+mach das ins repo
+-> make a branch and PR, do not only write a prompt
+```
+
+## Design contract
+
+- No random decisions where deterministic scoring works.
+- Preserve NPC autonomy unless the world state is final.
+- Make consequences auditable.
+- Surface events in WorldTick before rewards, mood, or visuals.
+- Keep the world stateless where possible.
+- Commit only explicit state transitions.


### PR DESCRIPTION
## Summary

- adds a repository skillbook for future coding agents
- adds GitHub Copilot instructions pointing to the shared agent contract
- adds Cursor rules that enforce deterministic emergent architecture style
- documents PR chain discipline, pure-logic layering, event-first design, and safety-resilient connector workflow

## Why

Future agents need a findable, repo-local contract so Areloria development keeps using deterministic world laws, explicit event payloads, and small architecture-layer PRs.

## Follow-up

Next development PR can continue with deterministic event rewards using the same skillbook rules.