### PR TITLE
docs(agents): add agent learning notes

### DIFF
--- a/.cursor/rules/areloria-agent-skillbook.mdc
+++ b/.cursor/rules/areloria-agent-skillbook.mdc
@@ -20,6 +20,7 @@ Read and follow `docs/agents/ARELORIA_AGENT_SKILLBOOK.md` before making architec
 - Route events through WorldTick before adding rewards, resonance, or visuals.
 - One PR equals one system layer.
 - Preserve existing import conventions and `.js` runtime suffixes.
+- Add reusable findings as compact Skillbook learnings before changing broad rules.
 
 ## Layer order
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,7 @@ docs/agents/ARELORIA_AGENT_SKILLBOOK.md
 - Surface world events before adding rewards, resonance, or visuals.
 - Respect existing TypeScript import style and `.js` runtime suffixes.
 - Add tests for new deterministic logic.
+- Put reusable agent learnings in the Skillbook as short, practical notes before changing broad rules.
 
 ## Architecture order
 

--- a/docs/agents/ARELORIA_AGENT_SKILLBOOK.md
+++ b/docs/agents/ARELORIA_AGENT_SKILLBOOK.md
@@ -97,6 +97,77 @@ Before editing:
 5. Avoid new dependencies unless necessary.
 6. Prefer stable ordering and deterministic hashes.
 
+## Agent Learnings
+
+### Documentation-only learning PRs
+
+Context: When a task asks to persist reusable agent knowledge, keep it separate from runtime fixes.
+
+Rule:
+
+- Use a small docs-only branch and PR.
+- Update `docs/agents/ARELORIA_AGENT_SKILLBOOK.md` first.
+- Touch `.github/copilot-instructions.md` or `.cursor/rules/areloria-agent-skillbook.mdc` only for short routing reminders.
+- Do not include source-code fixes in the same PR unless explicitly requested.
+
+Anti-pattern:
+
+```txt
+fix runtime bug + rewrite agent rules + update cursor rules in one PR
+```
+
+Recommended PR layer: agent knowledge / documentation.
+
+Test requirement: No runtime tests are required for docs-only changes. Verify Markdown structure and that the instructions remain agent-readable.
+
+### Reusable error documentation format
+
+Context: Concrete incidents should teach future agents without turning one-off logs into permanent doctrine.
+
+Rule: Document repeatable failures with this shape:
+
+```txt
+Symptom: observable failure text or behavior.
+Cause: general root cause, not only the one incident.
+Safe diagnosis: command, file, log, or invariant that proves it.
+Recommended fix: minimal repeatable repair.
+Affected paths: likely files, workflows, scripts, or deployment surfaces.
+```
+
+Anti-pattern:
+
+```txt
+Today deployment failed because commit abc123 was broken.
+```
+
+Recommended PR layer: field note or agent learning.
+
+Test requirement: Link the learning to the diagnostic command or affected path when possible.
+
+### Architecture learning format
+
+Context: Architecture notes must protect emergence and determinism without freezing NPC behavior.
+
+Rule: Document reusable architecture guidance with this shape:
+
+```txt
+Context: where the rule applies.
+Rule: what future agents must do.
+Anti-pattern: what must not be introduced.
+Recommended PR layer: the correct layer in the chain.
+Test requirement: what proves deterministic behavior.
+```
+
+Anti-pattern:
+
+```txt
+NPCs must always pick action X when condition Y happens.
+```
+
+Recommended PR layer: pure module, adapter, commit point, WorldTick event surface, reward consequence, resonance echo, or portal/client visualization.
+
+Test requirement: Prefer deterministic unit tests for pure logic and event-shape tests for WorldTick surfaces.
+
 ## Current ladder
 
 ```txt


### PR DESCRIPTION
## Summary

- Add compact Agent Learnings to `docs/agents/ARELORIA_AGENT_SKILLBOOK.md`.
- Document the reusable format for documentation-only learning PRs.
- Document the reusable format for repeatable error notes and architecture learnings.
- Add short routing reminders to Copilot and Cursor rules.

## Scope

Docs only. No runtime code fix is included.

## Validation

- Verified the diff only touches agent documentation files.
- Runtime tests are not required for this docs-only PR.

## Next follow-up layer

Use these notes when future PRs discover reusable build, deployment, architecture, test, or workflow findings.