### PR TITLE
fix(client-2d): harden mobile input and visual fallbacks

### DIFF
--- a/apps/client-2d/src/CyberZenIsoApp.tsx
+++ b/apps/client-2d/src/CyberZenIsoApp.tsx
@@ -230,6 +230,21 @@ function characterSelectionForName(name: string, player = false, seed = name): C
   return { tags: ["civilian"], group: chooseCivilianGroup(`npc:${seed}:${lower}`) };
 }
 
+function fallbackActorProxy(player: boolean, aura: number) {
+  const c = new Container();
+  const tunic = player ? 0x2f7dff : 0x2fbf70;
+  const trim = player ? 0x00e5ff : 0x39ff14;
+  c.addChild(new Graphics().ellipse(0, 18, 18, 6).fill({ color: 0x02040a, alpha: 0.64 }));
+  c.addChild(new Graphics().roundRect(-10, -30, 20, 32, 6).fill(tunic).stroke({ width: 2, color: trim, alpha: 0.56 }));
+  c.addChild(new Graphics().circle(0, -43, 11).fill(player ? 0xffd8a9 : 0xd4ffd7).stroke({ width: 2, color: aura, alpha: 0.82 }));
+  c.addChild(new Graphics().roundRect(-18, -25, 8, 24, 4).fill(0x1d3c6b));
+  c.addChild(new Graphics().roundRect(10, -25, 8, 24, 4).fill(0x1d3c6b));
+  c.addChild(new Graphics().roundRect(-8, 1, 6, 18, 3).fill(0x13202f));
+  c.addChild(new Graphics().roundRect(2, 1, 6, 18, 3).fill(0x13202f));
+  c.addChild(new Graphics().circle(0, -24, 21).stroke({ width: 1, color: aura, alpha: 0.28 }));
+  return c;
+}
+
 function avatar(name: string, player = false, assets?: LoadedAssets | null, weaponVisualId?: string | null, characterVisualId?: string | null) {
   const c = new Container();
   const aura = player ? 0x00e5ff : 0x39ff14;
@@ -245,10 +260,7 @@ function avatar(name: string, player = false, assets?: LoadedAssets | null, weap
   const tex = atlasFrameTextureFor(assets ?? null, entry, "idle_down") ?? textureFor(assets ?? null, entry);
   c.addChild(new Graphics().ellipse(0, 18, 23, 8).fill({ color: 0x02040a, alpha: 0.56 }));
   if (tex) c.addChild(spriteFromTexture(tex, 58, 74));
-  else {
-    c.addChild(new Graphics().ellipse(0, -8, 14, 21).fill(player ? 0x267dff : 0x249a56).stroke({ width: 2, color: aura, alpha: 0.55 }));
-    c.addChild(new Graphics().circle(0, -34, 11).fill(player ? 0xffd8a9 : 0xd4ffd7).stroke({ width: 2, color: aura, alpha: 0.82 }));
-  }
+  else c.addChild(fallbackActorProxy(player, aura));
   addWeaponSprite(c, assets, name, weaponVisualId);
   const label = new Text({ text: name, style: { fontSize: 11, fill: 0xfff0cf, stroke: { color: 0x02030a, width: 3 }, fontFamily: "monospace" } });
   label.anchor.set(0.5, 1);

--- a/apps/client-2d/src/MobileMovePad.tsx
+++ b/apps/client-2d/src/MobileMovePad.tsx
@@ -1,38 +1,53 @@
-import { useEffect, useRef } from "react";
+import { PointerEvent as ReactPointerEvent, useEffect, useRef } from "react";
 
 type MoveVector = { dx: number; dz: number };
 
 export function MobileMovePad() {
   const vector = useRef<MoveVector>({ dx: 0, dz: 0 });
+  const activePointerId = useRef<number | null>(null);
 
   useEffect(() => {
     const timer = window.setInterval(() => {
       const { dx, dz } = vector.current;
       if (!dx && !dz) return;
       window.__wasd2dMove?.({ dx, dz });
-    }, 150);
+    }, 110);
+
+    const releaseAll = () => release();
+    window.addEventListener("blur", releaseAll);
+    window.addEventListener("contextmenu", releaseAll);
 
     return () => {
       window.clearInterval(timer);
-      release();
+      window.removeEventListener("blur", releaseAll);
+      window.removeEventListener("contextmenu", releaseAll);
+      releaseAll();
     };
   }, []);
 
-  function hold(next: MoveVector) {
+  function hold(next: MoveVector, event: ReactPointerEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    activePointerId.current = event.pointerId;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
     vector.current = next;
     window.__wasd2dMove?.(next);
   }
 
-  function release() {
+  function release(event?: ReactPointerEvent<HTMLButtonElement>) {
+    event?.preventDefault();
+    event?.stopPropagation();
+    if (event && activePointerId.current !== null && event.pointerId !== activePointerId.current) return;
     vector.current = { dx: 0, dz: 0 };
+    activePointerId.current = null;
   }
 
   return (
     <nav className="az-touch-pad" aria-label="Mobile movement controls" style={{ touchAction: "none", userSelect: "none" }}>
-      <button className="up" onPointerDown={(event) => { event.preventDefault(); hold({ dx: 0, dz: 1 }); }} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▲</button>
-      <button className="left" onPointerDown={(event) => { event.preventDefault(); hold({ dx: -1, dz: 0 }); }} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>◀</button>
-      <button className="right" onPointerDown={(event) => { event.preventDefault(); hold({ dx: 1, dz: 0 }); }} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▶</button>
-      <button className="down" onPointerDown={(event) => { event.preventDefault(); hold({ dx: 0, dz: -1 }); }} onPointerUp={release} onPointerCancel={release} onPointerLeave={release}>▼</button>
+      <button className="up" onPointerDown={(event) => hold({ dx: 0, dz: 1 }, event)} onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release} aria-label="Move up">▲</button>
+      <button className="left" onPointerDown={(event) => hold({ dx: -1, dz: 0 }, event)} onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release} aria-label="Move left">◀</button>
+      <button className="right" onPointerDown={(event) => hold({ dx: 1, dz: 0 }, event)} onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release} aria-label="Move right">▶</button>
+      <button className="down" onPointerDown={(event) => hold({ dx: 0, dz: -1 }, event)} onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release} aria-label="Move down">▼</button>
     </nav>
   );
 }

--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -142,7 +142,7 @@ export function firstEntry(manifest: AssetManifest | null, category: AssetCatego
 
 export function fallbackEntry(manifest: AssetManifest | null, category: AssetCategory, fallbackKey: string): AssetEntry | null {
   const id = manifest?.fallbacks?.[fallbackKey] ?? null;
-  return getEntry(manifest, category, id) ?? firstEntry(manifest, category);
+  return getEntry(manifest, category, id) ?? firstRenderableEntry(manifest, category) ?? firstEntry(manifest, category);
 }
 
 function deterministicIndex(seed: string, length: number): number {
@@ -154,6 +154,21 @@ function deterministicIndex(seed: string, length: number): number {
   return Math.abs(hash) % length;
 }
 
+function isRenderableEntry(entry: AssetEntry | null | undefined): boolean {
+  if (!entry?.src) return false;
+  if (entry.frame) return true;
+  if (entry.sheetFrame && entry.frameSize) return true;
+  if (entry.spriteLayers?.length) return true;
+  if (entry.width && entry.height) return true;
+  return !entry.src.toLowerCase().endsWith('.json');
+}
+
+function firstRenderableEntry(manifest: AssetManifest | null, category: AssetCategory): AssetEntry | null {
+  const group = manifest?.[category];
+  if (!group) return null;
+  return Object.values(group).find(isRenderableEntry) ?? null;
+}
+
 export function pickWeaponVisual(
   manifest: AssetManifest | null,
   input: { visualId?: string | null; weaponClass?: string | null; rarity?: string | null; seed?: string | number | null },
@@ -161,17 +176,19 @@ export function pickWeaponVisual(
   const weapons = manifest?.weapons;
   if (!weapons) return null;
 
-  if (input.visualId && weapons[input.visualId]) return { id: input.visualId, entry: weapons[input.visualId] };
+  if (input.visualId && weapons[input.visualId] && isRenderableEntry(weapons[input.visualId])) return { id: input.visualId, entry: weapons[input.visualId] };
 
   const weaponClass = String(input.weaponClass || '').toLowerCase();
   const rarity = String(input.rarity || '').toLowerCase();
   const matches = Object.entries(weapons).filter(([, entry]) => {
+    if (!isRenderableEntry(entry)) return false;
     const classOk = !weaponClass || entry.weaponClass === weaponClass || entry.tags?.includes(weaponClass);
     const rarityOk = !rarity || entry.rarity === rarity || entry.tags?.includes(rarity);
     return classOk && rarityOk;
   });
 
-  const pool = matches.length > 0 ? matches : Object.entries(weapons);
+  const renderablePool = Object.entries(weapons).filter(([, entry]) => isRenderableEntry(entry));
+  const pool = matches.length > 0 ? matches : renderablePool;
   if (pool.length === 0) return null;
 
   const seed = String(input.seed ?? `${weaponClass}:${rarity}`);
@@ -186,12 +203,13 @@ export function pickCharacterVisual(
   const characters = manifest?.characters;
   if (!characters) return null;
 
-  if (input.visualId && characters[input.visualId]) return { id: input.visualId, entry: characters[input.visualId] };
+  if (input.visualId && characters[input.visualId] && isRenderableEntry(characters[input.visualId])) return { id: input.visualId, entry: characters[input.visualId] };
 
   const wantedTags = (input.tags ?? []).map((tag) => tag.toLowerCase());
   const wantedGroup = String(input.group || '').toLowerCase();
   const wantedKind = String(input.kind || '').toLowerCase();
   const matches = Object.entries(characters).filter(([, entry]) => {
+    if (!isRenderableEntry(entry)) return false;
     const tags = (entry.tags ?? []).map((tag) => String(tag).toLowerCase());
     const group = String(entry.group ?? '').toLowerCase();
     const kind = String(entry.kind ?? '').toLowerCase();
@@ -201,7 +219,8 @@ export function pickCharacterVisual(
     return tagsOk && groupOk && kindOk;
   });
 
-  const pool = matches.length > 0 ? matches : Object.entries(characters);
+  const renderablePool = Object.entries(characters).filter(([, entry]) => isRenderableEntry(entry));
+  const pool = matches.length > 0 ? matches : renderablePool;
   if (pool.length === 0) return null;
 
   const seed = String(input.seed ?? `${wantedKind}:${wantedGroup}:${wantedTags.join(',')}`);


### PR DESCRIPTION
## Summary

- hardens the 2D mobile D-pad with pointer capture, preventDefault/stopPropagation, faster repeat, and safe release on blur/context loss
- keeps mobile movement routed through the existing `window.__wasd2dMove` path instead of creating a second socket
- prefers renderable weapon/character manifest entries so JSON/non-renderable entries do not get picked as actor visuals
- improves the fallback actor proxy so player/NPC fallback is visibly humanoid instead of simple oval blobs

## Scope

Client 2D only. No Docker, deploy, server, NPC, or docs changes in this PR.

## Validation

- Diff is limited to `apps/client-2d/src/*`.
- Branch is ahead of current `main` by 3 commits and behind by 0.
- Expected manual check after deploy: `/2d/` on mobile, D-pad movement changes the same visible player entity as keyboard WASD; actor visuals prefer real manifest textures and only fall back to improved humanoid proxy when assets are missing.

## Next follow-up layer

If visuals still fall back after this PR, the next layer should inspect deployed `/2d-assets/**` and atlas metadata generation in the asset pipeline.