### PR TITLE
feat(npc): implement autonomous thermal consequence model

### DIFF
--- a/server/src/modules/npc/EmergentThermalAdapter.ts
+++ b/server/src/modules/npc/EmergentThermalAdapter.ts
@@ -7,9 +7,11 @@ export type DecisionConsequence = {
   allowed: boolean;
   risk: EnergyRisk;
   finalAction: AREBrainAction | 'DECOMPOSITION';
+  collapseIfExecuted: boolean;
   collapseRisk: boolean;
   survivalBias: number;
   energyAfterAction: number;
+  reason: string;
 };
 
 export type EmergentThermalAdapterInput = {
@@ -38,6 +40,11 @@ function clamp(value: number, min = 0, max = 1): number {
   return Math.max(min, Math.min(max, value));
 }
 
+function finite(value: unknown, fallback = 0): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 export class EmergentThermalAdapter {
   private readonly brain: EmergentBrainKernel;
   private readonly thermal: ThermalLogic;
@@ -56,9 +63,11 @@ export class EmergentThermalAdapter {
         allowed: false,
         risk: 'COLLAPSE_IMMINENT',
         finalAction: 'DECOMPOSITION' as const,
+        collapseIfExecuted: true,
         collapseRisk: true,
         survivalBias: 1,
         energyAfterAction: decay.energy.currentEnergy,
+        reason: 'thermal_decomposition_no_action_allowed',
       });
 
       return Object.freeze({
@@ -74,19 +83,22 @@ export class EmergentThermalAdapter {
         },
         energyState: decay.energy,
         decomposition: true,
-        reason: 'thermal_decomposition_no_action_allowed',
+        reason: consequence.reason,
       });
     }
 
-    const survivalBias = this.calculateSurvivalBias(decay.energy);
+    const previousConsequence = this.analyzeEnergyPressure(decay.energy);
     const brainDecision = this.brain.process({
       ...input.brainInput,
       energy: decay.energy.currentEnergy / decay.energy.maxEnergy,
-      survivalBias,
+      survivalBias: previousConsequence.survivalBias,
     });
 
-    const consequence = this.analyzeConsequence(decay.energy, brainDecision, survivalBias);
-    const action = this.thermal.applyActionCost(decay.energy, brainDecision.energyCost);
+    const consequence = this.analyzeConsequence(decay.energy, brainDecision);
+    const nextEnergyState = Object.freeze({
+      ...decay.energy,
+      currentEnergy: consequence.energyAfterAction,
+    });
 
     return Object.freeze({
       thermalStatus: decay.status,
@@ -97,39 +109,71 @@ export class EmergentThermalAdapter {
       energyStats: {
         before: normalizedBefore.currentEnergy,
         afterDecay: decay.energy.currentEnergy,
-        afterAction: action.energy.currentEnergy,
+        afterAction: nextEnergyState.currentEnergy,
       },
-      energyState: action.energy,
-      decomposition: consequence.collapseRisk || action.status === 'DECOMPOSITION',
-      reason: consequence.collapseRisk ? `${brainDecision.reason}:thermal_risk` : brainDecision.reason,
+      energyState: nextEnergyState,
+      decomposition: consequence.collapseIfExecuted,
+      reason: consequence.reason,
     });
   }
 
-  private analyzeConsequence(energy: EnergyState, decision: AREBrainDecision, survivalBias: number): DecisionConsequence {
-    const energyAfterAction = Math.max(0, energy.currentEnergy - Math.max(0, decision.energyCost));
+  private analyzeEnergyPressure(energy: EnergyState): DecisionConsequence {
+    const risk = this.riskFor(energy.currentEnergy / energy.maxEnergy, energy.currentEnergy <= 0);
+    const survivalBias = this.calculateSurvivalBias(energy, risk);
+
+    return Object.freeze({
+      allowed: energy.currentEnergy > 0,
+      risk,
+      finalAction: energy.currentEnergy <= 0 ? 'DECOMPOSITION' : 'OBSERVE',
+      collapseIfExecuted: energy.currentEnergy <= 0,
+      collapseRisk: energy.currentEnergy <= 0,
+      survivalBias,
+      energyAfterAction: energy.currentEnergy,
+      reason: `thermal_pressure_${risk.toLowerCase()}`,
+    });
+  }
+
+  private analyzeConsequence(energy: EnergyState, decision: AREBrainDecision): DecisionConsequence {
+    const actionCost = Math.max(0, Math.trunc(finite(decision.energyCost, 0)));
+    const rawEnergyAfterAction = energy.currentEnergy - actionCost;
+    const energyAfterAction = Math.max(0, rawEnergyAfterAction);
+    const collapseIfExecuted = rawEnergyAfterAction <= 0;
     const ratioAfterAction = energyAfterAction / energy.maxEnergy;
-    const collapseRisk = energyAfterAction <= 0;
-    const risk = this.riskFor(ratioAfterAction, collapseRisk);
+    const risk = this.riskFor(ratioAfterAction, collapseIfExecuted);
+    const survivalBias = this.calculateSurvivalBias({ ...energy, currentEnergy: energyAfterAction }, risk);
 
     return Object.freeze({
       allowed: true,
       risk,
       finalAction: decision.action,
-      collapseRisk,
+      collapseIfExecuted,
+      collapseRisk: collapseIfExecuted,
       survivalBias,
       energyAfterAction,
+      reason: collapseIfExecuted
+        ? `${decision.reason}:collapse_if_executed:${rawEnergyAfterAction}`
+        : `${decision.reason}:thermal_risk_${risk.toLowerCase()}`,
     });
   }
 
-  private calculateSurvivalBias(energy: EnergyState): number {
+  private calculateSurvivalBias(energy: EnergyState, risk: EnergyRisk): number {
     const energyRatio = energy.currentEnergy / energy.maxEnergy;
-    return clamp(1 - energyRatio);
+    const energyPressure = clamp(1 - energyRatio);
+    const riskPressure = risk === 'COLLAPSE_IMMINENT'
+      ? 1
+      : risk === 'CRITICAL'
+        ? 0.85
+        : risk === 'STRAINED'
+          ? 0.45
+          : 0;
+
+    return clamp((energyPressure * 0.72) + (riskPressure * 0.28));
   }
 
-  private riskFor(energyRatio: number, collapseRisk: boolean): EnergyRisk {
-    if (collapseRisk) return 'COLLAPSE_IMMINENT';
-    if (energyRatio < 0.1) return 'CRITICAL';
-    if (energyRatio < 0.25) return 'STRAINED';
+  private riskFor(energyRatio: number, collapseIfExecuted: boolean): EnergyRisk {
+    if (collapseIfExecuted) return 'COLLAPSE_IMMINENT';
+    if (energyRatio <= 0.1) return 'CRITICAL';
+    if (energyRatio <= 0.3) return 'STRAINED';
     return 'NONE';
   }
 }

--- a/server/src/modules/npc/ThermalLogic.ts
+++ b/server/src/modules/npc/ThermalLogic.ts
@@ -109,9 +109,8 @@ export class ThermalLogic {
     });
   }
 
-  public allowedActionsForCritical<TAction extends string>(status: ThermalStatus, actions: readonly TAction[], harvestAction: TAction): TAction[] {
+  public allowedActionsForCritical<TAction extends string>(status: ThermalStatus, actions: readonly TAction[], _harvestAction: TAction): TAction[] {
     if (status === 'DECOMPOSITION') return [];
-    if (status === 'CRITICAL') return actions.includes(harvestAction) ? [harvestAction] : [];
     return [...actions];
   }
 

--- a/server/src/tests/emergent-thermal-adapter.test.ts
+++ b/server/src/tests/emergent-thermal-adapter.test.ts
@@ -31,7 +31,7 @@ function energyState(overrides: Partial<EnergyState> = {}): EnergyState {
 }
 
 describe('EmergentThermalAdapter', () => {
-  it('passes stable thermal state through the brain and applies action cost', () => {
+  it('passes stable thermal state through the brain and applies action consequence', () => {
     const adapter = new EmergentThermalAdapter();
 
     const result = adapter.process({
@@ -44,8 +44,10 @@ describe('EmergentThermalAdapter', () => {
     expect(result.brainDecision?.action).toBe('ANCHOR_BUFF');
     expect(result.finalAction).toBe('ANCHOR_BUFF');
     expect(result.actionAllowed).toBe(true);
+    expect(result.consequence.allowed).toBe(true);
     expect(result.consequence.risk).toBe('NONE');
-    expect(result.consequence.survivalBias).toBeCloseTo(0.2);
+    expect(result.consequence.collapseIfExecuted).toBe(false);
+    expect(result.consequence.survivalBias).toBeGreaterThan(0);
     expect(result.energyStats).toEqual({ before: 800, afterDecay: 800, afterAction: 788 });
     expect(result.decomposition).toBe(false);
   });
@@ -63,8 +65,10 @@ describe('EmergentThermalAdapter', () => {
     expect(result.brainDecision).not.toBeNull();
     expect(result.finalAction).toBe(result.brainDecision?.action);
     expect(result.actionAllowed).toBe(true);
+    expect(result.consequence.allowed).toBe(true);
     expect(result.consequence.risk).toBe('CRITICAL');
-    expect(result.consequence.survivalBias).toBeCloseTo(0.92);
+    expect(result.consequence.survivalBias).toBeGreaterThan(0.85);
+    expect(result.consequence.collapseIfExecuted).toBe(false);
     expect(result.consequence.collapseRisk).toBe(false);
     expect(result.reason).not.toBe('critical_energy_harvest_override');
   });
@@ -80,11 +84,13 @@ describe('EmergentThermalAdapter', () => {
 
     expect(result.brainDecision).not.toBeNull();
     expect(result.actionAllowed).toBe(true);
+    expect(result.consequence.allowed).toBe(true);
     expect(result.consequence.risk).toBe('COLLAPSE_IMMINENT');
+    expect(result.consequence.collapseIfExecuted).toBe(true);
     expect(result.consequence.collapseRisk).toBe(true);
     expect(result.energyStats.afterAction).toBe(0);
     expect(result.decomposition).toBe(true);
-    expect(result.reason).toContain('thermal_risk');
+    expect(result.reason).toContain('collapse_if_executed');
   });
 
   it('returns decomposition without invoking a final brain action when energy reaches zero after decay', () => {
@@ -101,12 +107,13 @@ describe('EmergentThermalAdapter', () => {
     expect(result.finalAction).toBe('DECOMPOSITION');
     expect(result.actionAllowed).toBe(false);
     expect(result.consequence.allowed).toBe(false);
+    expect(result.consequence.collapseIfExecuted).toBe(true);
     expect(result.decomposition).toBe(true);
     expect(result.energyStats.afterDecay).toBe(0);
     expect(result.energyStats.afterAction).toBe(0);
   });
 
-  it('feeds decayed energy ratio and survival bias into the brain input', () => {
+  it('feeds decayed energy pressure and survival bias into the brain input', () => {
     const adapter = new EmergentThermalAdapter();
 
     const result = adapter.process({
@@ -116,7 +123,8 @@ describe('EmergentThermalAdapter', () => {
     });
 
     expect(result.energyStats.afterDecay).toBe(400);
-    expect(result.consequence.survivalBias).toBeCloseTo(0.6);
+    expect(result.consequence.survivalBias).toBeGreaterThan(0.35);
+    expect(result.brainDecision?.scores.HARVEST_RESOURCE).toBeGreaterThan(0);
     expect(result.brainDecision?.nextEnergy).toBeLessThanOrEqual(400);
   });
 });

--- a/server/src/tests/thermal-logic.test.ts
+++ b/server/src/tests/thermal-logic.test.ts
@@ -68,11 +68,11 @@ describe('ThermalLogic', () => {
     expect(thermal.statusOf({ currentEnergy: 950, maxEnergy: 1000, decayRate: 1, lastUpdatedTick: 0 })).toBe('OVERHEATED');
   });
 
-  it('restricts critical entities to harvest and decomposition entities to no actions', () => {
+  it('keeps critical entities autonomous and only blocks decomposition', () => {
     const thermal = new ThermalLogic();
     const actions = ['OBSERVE', 'HARVEST_RESOURCE', 'DEFEND_COLONY'] as const;
 
-    expect(thermal.allowedActionsForCritical('CRITICAL', actions, 'HARVEST_RESOURCE')).toEqual(['HARVEST_RESOURCE']);
+    expect(thermal.allowedActionsForCritical('CRITICAL', actions, 'HARVEST_RESOURCE')).toEqual([...actions]);
     expect(thermal.allowedActionsForCritical('DECOMPOSITION', actions, 'HARVEST_RESOURCE')).toEqual([]);
     expect(thermal.allowedActionsForCritical('STABLE', actions, 'HARVEST_RESOURCE')).toEqual([...actions]);
   });


### PR DESCRIPTION
## PR #1201 — Autonomous Thermal Consequence Model

This PR migrates the NPC thermal/brain path from hard constraint behavior toward deterministic consequence pressure.

### What changed
- Refactors `EmergentThermalAdapter` into a consequence analyzer:
  - keeps autonomous decisions allowed except `DECOMPOSITION`
  - records `collapseIfExecuted`
  - preserves `collapseRisk` as compatibility alias
  - computes `risk`, `survivalBias`, `energyAfterAction`, and audit `reason`
- Removes the critical-state harvest-only override from `ThermalLogic.allowedActionsForCritical(...)`.
- Updates thermal tests so critical entities retain autonomy while decomposition blocks action.
- Updates adapter tests to verify consequence pressure instead of hard override behavior.

### Architecture rule
Critical energy is no longer a cage. The brain receives survival pressure, but the selected action remains autonomous. If an NPC chooses a fatal action, the collapse is recorded as deterministic consequence rather than prevented by an override.

### Review checklist
- [ ] No forced `HARVEST_RESOURCE` override remains for critical energy.
- [ ] Only `DECOMPOSITION` sets `allowed=false`.
- [ ] `collapseIfExecuted` is audit-visible.
- [ ] `survivalBias` feeds the next brain decision path.

Note: branch currently diverged from latest `main` because `main` advanced after branch creation. GitHub should show whether an update/merge is required before landing.