### PR TITLE
feat(world): add npc world resonance event flow

### DIFF
--- a/server/src/modules/npc/NPCSystem.ts
+++ b/server/src/modules/npc/NPCSystem.ts
@@ -5,6 +5,8 @@ import { EmergentThermalAdapter, type EmergentThermalDecisionResult } from './Em
 import { type AREBrainInput } from './EmergentBrain';
 import { type EnergyState } from './ThermalLogic';
 import { createEmergenceCollapsePayload, type WorldEmergenceCollapsePayload } from '../world/WorldEmergenceEvent';
+import { WorldEventBus } from '../world/WorldEventBus';
+import { WorldResonanceAdapter, type LootCapsule, type WorldResonanceResult } from '../world/WorldResonanceAdapter';
 
 function deterministicNpcTraits(id: string): { faith: number; aggression: number; curiosity: number } {
     let h = 0;
@@ -69,7 +71,12 @@ export class NPCSystem {
     private updateInterval: NodeJS.Timeout | null = null;
     private readonly TICK_RATE = 100; // 10Hz in ms
     private readonly thermalAdapter = new EmergentThermalAdapter();
+    private readonly worldEventBus = new WorldEventBus();
+    private readonly worldResonanceAdapter = new WorldResonanceAdapter();
     private emergenceEvents: WorldEmergenceCollapsePayload[] = [];
+    private resonanceEvents: WorldResonanceResult[] = [];
+    private lootCapsules: LootCapsule[] = [];
+    private shadowLogs: Record<string, unknown>[] = [];
 
     public resonanceEngine: TraitResonanceEngine;
 
@@ -135,6 +142,24 @@ export class NPCSystem {
         const events = this.emergenceEvents;
         this.emergenceEvents = [];
         return events;
+    }
+
+    public drainWorldResonanceEvents(): WorldResonanceResult[] {
+        const events = this.resonanceEvents;
+        this.resonanceEvents = [];
+        return events;
+    }
+
+    public drainLootCapsules(): LootCapsule[] {
+        const capsules = this.lootCapsules;
+        this.lootCapsules = [];
+        return capsules;
+    }
+
+    public drainShadowLogs(): Record<string, unknown>[] {
+        const logs = this.shadowLogs;
+        this.shadowLogs = [];
+        return logs;
     }
 
     public handleInteraction(npcId: string, player: any, questDefs: any): any {
@@ -208,6 +233,7 @@ export class NPCSystem {
         const averageThreat = NPCSystem.average(playerContexts.map((player) => player.threat));
 
         for (const npc of this.cachedSortedNpcs) {
+            if (npc.state === 'decomposition') continue;
             this.processEmergentDecision(npc, currentTick, averageDrift, averageThreat, colonyUtility);
             if (npc.state === 'decomposition') continue;
             this.processPerception(npc, playerContexts);
@@ -310,6 +336,7 @@ export class NPCSystem {
             thermalStatus: result.thermalStatus,
             risk: result.consequence.risk,
             collapseRisk: result.consequence.collapseRisk,
+            collapseIfExecuted: result.consequence.collapseIfExecuted,
             survivalBias: result.consequence.survivalBias,
             energyBefore: result.energyStats.before,
             energyAfterDecay: result.energyStats.afterDecay,
@@ -322,20 +349,8 @@ export class NPCSystem {
             npc.state = 'decomposition';
             npc.targetId = null;
             npc.isProcessingAI = false;
-            npc.memory.resonanceFields = [];
-            this.emergenceEvents.push(createEmergenceCollapsePayload({
-                npcId: npc.id,
-                factionId: npc.faction ?? 'neutral',
-                position: npc.position,
-                tick: result.energyState.lastUpdatedTick,
-                reason: result.reason,
-                risk: result.consequence.risk,
-                sourceAction: result.finalAction,
-                energyBefore: result.energyStats.before,
-                energyAfterDecay: result.energyStats.afterDecay,
-                energyAfterAction: result.energyStats.afterAction,
-                kappaHash: result.brainDecision?.kappaHash ?? null,
-            }));
+            npc.memory.resonanceFields ??= [];
+            this.emitDecompositionResonance(npc, result);
             return;
         }
 
@@ -360,6 +375,36 @@ export class NPCSystem {
                 npc.state = 'observing';
                 break;
         }
+    }
+
+    private emitDecompositionResonance(npc: NPC, result: EmergentThermalDecisionResult): void {
+        const event = createEmergenceCollapsePayload({
+            npcId: npc.id,
+            factionId: npc.faction ?? 'neutral',
+            position: npc.position,
+            tick: result.energyState.lastUpdatedTick,
+            reason: result.reason,
+            risk: result.consequence.risk,
+            sourceAction: result.finalAction,
+            energyBefore: result.energyStats.before,
+            energyAfterDecay: result.energyStats.afterDecay,
+            energyAfterAction: result.energyStats.afterAction,
+            kappaHash: result.brainDecision?.kappaHash ?? null,
+        });
+
+        this.emergenceEvents.push(event);
+        this.worldEventBus.publish(event);
+
+        const resonance = this.worldResonanceAdapter.handleDecomposition(event, this.cachedSortedNpcs);
+        this.resonanceEvents.push(resonance);
+        this.lootCapsules.push(resonance.lootCapsule);
+        this.shadowLogs.push(resonance.shadowLog);
+        npc.memory.lastDecompositionResonance = {
+            lootCapsuleId: resonance.lootCapsule.id,
+            affectedNpcIds: resonance.affectedNpcIds,
+            finalKappaHash: event.kappaHash,
+            plexityTotal: resonance.lootCapsule.plexityTotal,
+        };
     }
 
     private static initialEnergyState(tick: number): EnergyState {

--- a/server/src/modules/world/WorldEventBus.ts
+++ b/server/src/modules/world/WorldEventBus.ts
@@ -1,0 +1,32 @@
+import { type WorldEmergenceCollapsePayload } from './WorldEmergenceEvent';
+
+export type WorldEvent = WorldEmergenceCollapsePayload;
+
+export class WorldEventBus {
+  private readonly events: WorldEvent[] = [];
+
+  public publish(event: WorldEvent): void {
+    this.events.push(Object.freeze({ ...event }));
+  }
+
+  public drain<TEvent extends WorldEvent = WorldEvent>(eventType?: TEvent['eventType']): TEvent[] {
+    const drained: TEvent[] = [];
+    const remaining: WorldEvent[] = [];
+
+    for (const event of this.events) {
+      if (eventType == null || event.eventType === eventType) {
+        drained.push(event as TEvent);
+      } else {
+        remaining.push(event);
+      }
+    }
+
+    this.events.length = 0;
+    this.events.push(...remaining);
+    return drained;
+  }
+
+  public peek(): readonly WorldEvent[] {
+    return this.events;
+  }
+}

--- a/server/src/modules/world/WorldResonanceAdapter.ts
+++ b/server/src/modules/world/WorldResonanceAdapter.ts
@@ -1,0 +1,208 @@
+import { createARESeed, SeededARERng } from '../../core/determinism/AREDeterminism.js';
+import { type WorldEmergenceCollapsePayload, type KappaCoordinate } from './WorldEmergenceEvent';
+
+export type ResonanceFieldEntry = {
+  eventType: 'SOCIAL_SHOCK';
+  sourceNpcId: string;
+  sourceFactionId: string;
+  moodShift: 'GRIEF' | 'AGGRESSION' | 'UNEASE';
+  intensity: number;
+  distance: number;
+  tick: number;
+  kappaHash: string;
+};
+
+export type LootCapsuleItem = {
+  itemId: string;
+  count: number;
+  resonanceValue: number;
+};
+
+export type LootCapsule = {
+  id: string;
+  eventType: 'LOOT_CAPSULE';
+  sourceNpcId: string;
+  factionId: string;
+  position: KappaCoordinate;
+  tick: number;
+  kappaHash: string;
+  plexityTotal: number;
+  items: LootCapsuleItem[];
+  gold: number;
+};
+
+export type ResonanceNpc = {
+  id: string;
+  faction?: string;
+  state?: string;
+  position: { x: number; y: number; z?: number };
+  memory?: any;
+};
+
+export type WorldResonanceResult = {
+  event: WorldEmergenceCollapsePayload;
+  lootCapsule: LootCapsule;
+  affectedNpcIds: string[];
+  resonanceFields: ResonanceFieldEntry[];
+  shadowLog: Record<string, unknown>;
+};
+
+const DEFAULT_RADIUS = 40;
+const GRID_CELL_SIZE = 40;
+
+function finite(value: unknown, fallback = 0): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp(value: number, min = 0, max = 1): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function distance(a: { x: number; y: number; z?: number }, b: { x: number; y: number; z?: number }): number {
+  const dx = finite(a.x) - finite(b.x);
+  const dy = finite(a.y) - finite(b.y);
+  const dz = finite(a.z) - finite(b.z);
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function worldPositionFromKappa(kappa: KappaCoordinate): { x: number; y: number; z: number } {
+  return { x: finite(kappa.x) / 1000, y: finite(kappa.y) / 1000, z: finite(kappa.z) / 1000 };
+}
+
+function stableNumberFromHash(hash: string): number {
+  let total = 0;
+  for (let i = 0; i < hash.length; i += 1) total = (Math.imul(31, total) + hash.charCodeAt(i)) | 0;
+  return Math.abs(total);
+}
+
+function spatialKey(pos: { x: number; y: number }): string {
+  return `${Math.floor(finite(pos.x) / GRID_CELL_SIZE)}:${Math.floor(finite(pos.y) / GRID_CELL_SIZE)}`;
+}
+
+function neighborKeys(center: { x: number; y: number }): string[] {
+  const cx = Math.floor(finite(center.x) / GRID_CELL_SIZE);
+  const cy = Math.floor(finite(center.y) / GRID_CELL_SIZE);
+  const keys: string[] = [];
+  for (let x = cx - 1; x <= cx + 1; x += 1) {
+    for (let y = cy - 1; y <= cy + 1; y += 1) keys.push(`${x}:${y}`);
+  }
+  return keys;
+}
+
+export class WorldResonanceAdapter {
+  public handleDecomposition(event: WorldEmergenceCollapsePayload, activeNpcs: Iterable<ResonanceNpc>, radius = DEFAULT_RADIUS): WorldResonanceResult {
+    const origin = worldPositionFromKappa(event.position);
+    const grid = this.buildSpatialGrid(activeNpcs);
+    const nearby = this.queryRadius(grid, origin, radius)
+      .filter((npc) => npc.id !== event.npcId && npc.state !== 'decomposition')
+      .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+    const resonanceFields: ResonanceFieldEntry[] = [];
+    const affectedNpcIds: string[] = [];
+
+    for (const npc of nearby) {
+      const d = distance(origin, npc.position);
+      if (d > radius) continue;
+      const field = this.createResonanceField(event, npc, d, radius);
+      npc.memory ??= {};
+      npc.memory.resonanceFields ??= [];
+      npc.memory.resonanceFields.push(field);
+      resonanceFields.push(field);
+      affectedNpcIds.push(npc.id);
+    }
+
+    const lootCapsule = this.createLootCapsule(event);
+    const shadowLog = Object.freeze({
+      type: 'NPC_DECOMPOSITION_EVENT',
+      eventType: event.eventType,
+      npcId: event.npcId,
+      factionId: event.factionId,
+      kappaCoordinate: event.position,
+      finalKappaHash: event.kappaHash,
+      plexityTotal: lootCapsule.plexityTotal,
+      lootCapsuleId: lootCapsule.id,
+      affectedNpcIds,
+      affectedCount: affectedNpcIds.length,
+      tick: event.tick,
+    });
+
+    return Object.freeze({ event, lootCapsule, affectedNpcIds, resonanceFields, shadowLog });
+  }
+
+  public createLootCapsule(event: WorldEmergenceCollapsePayload): LootCapsule {
+    const plexityTotal = this.plexityFromEvent(event);
+    const rng = new SeededARERng(createARESeed(['decomposition-loot-capsule', event.npcId, event.kappaHash, event.tick, plexityTotal]));
+    const essenceCount = 1 + (plexityTotal % 3);
+    const memoryShards = Math.max(1, Math.floor(plexityTotal / 333));
+    const salt = rng.nextRange(0, 2);
+
+    return Object.freeze({
+      id: `loot:decomposition:${event.npcId}:${event.kappaHash}`,
+      eventType: 'LOOT_CAPSULE' as const,
+      sourceNpcId: event.npcId,
+      factionId: event.factionId,
+      position: event.position,
+      tick: event.tick,
+      kappaHash: event.kappaHash,
+      plexityTotal,
+      items: Object.freeze([
+        Object.freeze({ itemId: 'resonance_essence', count: essenceCount, resonanceValue: plexityTotal }),
+        Object.freeze({ itemId: 'memory_shard', count: memoryShards + salt, resonanceValue: Math.max(1, Math.floor(plexityTotal / 2)) }),
+      ]),
+      gold: Math.max(0, Math.floor(plexityTotal / 10)),
+    });
+  }
+
+  private buildSpatialGrid(activeNpcs: Iterable<ResonanceNpc>): Map<string, ResonanceNpc[]> {
+    const grid = new Map<string, ResonanceNpc[]>();
+    for (const npc of activeNpcs) {
+      if (!npc?.position) continue;
+      const key = spatialKey(npc.position);
+      const bucket = grid.get(key);
+      if (bucket) bucket.push(npc);
+      else grid.set(key, [npc]);
+    }
+    return grid;
+  }
+
+  private queryRadius(grid: Map<string, ResonanceNpc[]>, origin: { x: number; y: number; z: number }, radius: number): ResonanceNpc[] {
+    const result: ResonanceNpc[] = [];
+    const seen = new Set<string>();
+    for (const key of neighborKeys(origin)) {
+      const bucket = grid.get(key);
+      if (!bucket) continue;
+      for (const npc of bucket) {
+        if (seen.has(npc.id)) continue;
+        seen.add(npc.id);
+        if (distance(origin, npc.position) <= radius) result.push(npc);
+      }
+    }
+    return result;
+  }
+
+  private createResonanceField(event: WorldEmergenceCollapsePayload, npc: ResonanceNpc, distanceToOrigin: number, radius: number): ResonanceFieldEntry {
+    const npcFaction = String(npc.faction ?? 'neutral');
+    const sameFaction = npcFaction === event.factionId;
+    const neutral = npcFaction === 'neutral' || event.factionId === 'neutral';
+    const intensity = clamp(1 - (distanceToOrigin / Math.max(1, radius)));
+
+    return Object.freeze({
+      eventType: 'SOCIAL_SHOCK' as const,
+      sourceNpcId: event.npcId,
+      sourceFactionId: event.factionId,
+      moodShift: sameFaction ? 'GRIEF' : neutral ? 'UNEASE' : 'AGGRESSION',
+      intensity,
+      distance: distanceToOrigin,
+      tick: event.tick,
+      kappaHash: event.kappaHash,
+    });
+  }
+
+  private plexityFromEvent(event: WorldEmergenceCollapsePayload): number {
+    const hashPressure = stableNumberFromHash(event.kappaHash) % 1000;
+    const energyDelta = Math.max(0, finite(event.energyBefore) - finite(event.energyAfterAction));
+    const positionPressure = Math.abs(event.position.x) + Math.abs(event.position.y) + Math.abs(event.position.z);
+    return Math.max(1, Math.trunc((hashPressure * 0.55) + (energyDelta * 0.35) + ((positionPressure % 1000) * 0.10)));
+  }
+}

--- a/server/src/tests/npc-system-emergent-integration.test.ts
+++ b/server/src/tests/npc-system-emergent-integration.test.ts
@@ -32,7 +32,7 @@ describe('NPCSystem emergent thermal integration', () => {
     });
   });
 
-  it('creates a collapse event when a committed decision reaches decomposition', () => {
+  it('creates a collapse event when a committed decision reaches terminal state', () => {
     const system = new NPCSystem();
     const npc: NPC = {
       id: 'npc:collapse-event',
@@ -64,6 +64,69 @@ describe('NPCSystem emergent thermal integration', () => {
       tick: 1,
       energyAfterAction: 0,
     });
+  });
+
+  it('creates deterministic world resonance, capsule, and shadow records around collapse', () => {
+    const system = new NPCSystem();
+    const source: NPC = {
+      id: 'npc:source-collapse',
+      name: 'Source Collapse',
+      faction: 'guardians',
+      position: { x: 0, y: 0, z: 0 },
+      rotation: 0,
+      visionRange: 10,
+      visionAngle: 90,
+      targetId: null,
+      isProcessingAI: false,
+      traits: { faith: 0.2, aggression: 1, curiosity: 0.1 },
+      energyState: { currentEnergy: 6, maxEnergy: 1000, decayRate: 0, lastUpdatedTick: 1 },
+    };
+    const friend: NPC = system.createNPC('npc:near-friend', 'Near Friend', 10, 0);
+    friend.faction = 'guardians';
+    const rival: NPC = system.createNPC('npc:near-rival', 'Near Rival', 20, 0);
+    rival.faction = 'raiders';
+    const far: NPC = system.createNPC('npc:far-friend', 'Far Friend', 80, 0);
+    far.faction = 'guardians';
+
+    system.addNPC(source);
+    system.tick([{ id: 'player:threat', position: { x: 0, y: 0, z: 0 }, threat: 1, deltaDrift: 0.2 }], 1);
+
+    const resonance = system.drainWorldResonanceEvents();
+    const capsules = system.drainLootCapsules();
+    const shadow = system.drainShadowLogs();
+
+    expect(resonance).toHaveLength(1);
+    expect(capsules).toHaveLength(1);
+    expect(shadow).toHaveLength(1);
+    expect(friend.memory?.resonanceFields?.[0]).toMatchObject({ eventType: 'SOCIAL_SHOCK', moodShift: 'GRIEF' });
+    expect(rival.memory?.resonanceFields?.[0]).toMatchObject({ eventType: 'SOCIAL_SHOCK', moodShift: 'AGGRESSION' });
+    expect(far.memory?.resonanceFields).toBeUndefined();
+    expect(capsules[0].sourceNpcId).toBe('npc:source-collapse');
+    expect(shadow[0]).toMatchObject({ type: 'NPC_DECOMPOSITION_EVENT', affectedCount: 2 });
+  });
+
+  it('does not re-emit collapse resonance on later ticks', () => {
+    const system = new NPCSystem();
+    const npc: NPC = {
+      id: 'npc:single-collapse',
+      name: 'Single Collapse',
+      faction: 'guardians',
+      position: { x: 0, y: 0, z: 0 },
+      rotation: 0,
+      visionRange: 10,
+      visionAngle: 90,
+      targetId: null,
+      isProcessingAI: false,
+      traits: { faith: 0.2, aggression: 1, curiosity: 0.1 },
+      energyState: { currentEnergy: 6, maxEnergy: 1000, decayRate: 0, lastUpdatedTick: 1 },
+    };
+
+    system.addNPC(npc);
+    system.tick([], 1);
+    expect(system.drainWorldResonanceEvents()).toHaveLength(1);
+
+    system.tick([], 2);
+    expect(system.drainWorldResonanceEvents()).toEqual([]);
   });
 
   it('drains emergence events exactly once', () => {


### PR DESCRIPTION
## PR #1202

Adds deterministic world resonance handling for NPC terminal-state events.

### Changes
- Adds `WorldEventBus`.
- Adds `WorldResonanceAdapter` for spatial-grid neighborhood effects.
- Adds deterministic loot capsule derivation from final kappa hash and plexity pressure.
- Adds audit-style shadow records for downstream logging.
- Extends `NPCSystem` drain methods for resonance events, loot capsules, and shadow records.
- Prevents duplicate event emission on later ticks for already-terminal NPCs.
- Extends integration coverage for nearby ally/rival/far NPC behavior.

Note: existing `WorldEmergenceEvent` event type remains compatibility-stable in this PR. The new semantic marker appears in the shadow/audit record as `NPC_DECOMPOSITION_EVENT`.