### PR TITLE
add WorldHeart monitor

### DIFF
--- a/apps/client-2d/src/WorldHeartMonitor.tsx
+++ b/apps/client-2d/src/WorldHeartMonitor.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef } from "react";
+import { Application, Container, Graphics, Text } from "pixi.js";
+
+type WorldHeartStatus = "STABLE" | "WATCH" | "CRITICAL" | "DECOMPOSITION";
+
+type WorldHeartSnapshot = {
+  divergence: number;
+  entropy: number;
+  stability: number;
+  npcCritical: number;
+  npcDecomposition: number;
+  status: WorldHeartStatus;
+};
+
+const DEFAULT_SNAPSHOT: WorldHeartSnapshot = {
+  divergence: 0,
+  entropy: 0,
+  stability: 1,
+  npcCritical: 0,
+  npcDecomposition: 0,
+  status: "STABLE",
+};
+
+function statusColor(status: WorldHeartStatus): number {
+  switch (status) {
+    case "DECOMPOSITION": return 0x9900ff;
+    case "CRITICAL": return 0xff3300;
+    case "WATCH": return 0xffcc00;
+    case "STABLE":
+    default: return 0x00ff99;
+  }
+}
+
+class WorldHeartPixi extends Container {
+  private readonly core = new Graphics();
+  private readonly label = new Text({ text: "ARELORIA HEART", style: { fontFamily: "monospace", fontSize: 12, fill: 0xffffff } });
+  private readonly metrics = new Text({ text: "status: STABLE", style: { fontFamily: "monospace", fontSize: 10, fill: 0xffffff } });
+  private pulse = 0;
+  private snapshot: WorldHeartSnapshot = DEFAULT_SNAPSHOT;
+
+  constructor() {
+    super();
+    this.label.anchor.set(0.5);
+    this.metrics.anchor.set(0.5);
+    this.label.y = 58;
+    this.metrics.y = 76;
+    this.addChild(this.core, this.label, this.metrics);
+  }
+
+  setSnapshot(snapshot: Partial<WorldHeartSnapshot>) {
+    this.snapshot = { ...DEFAULT_SNAPSHOT, ...snapshot };
+  }
+
+  update(delta: number) {
+    const divergence = Number(this.snapshot.divergence || 0);
+    const stability = Math.max(0, Math.min(1, Number(this.snapshot.stability ?? 1)));
+    const instability = 1 - stability;
+    this.pulse += 0.05 * delta + divergence * 20;
+    const radius = 34 + Math.sin(this.pulse) * (3 + instability * 13);
+    const color = statusColor(this.snapshot.status);
+
+    this.core.clear();
+    this.core.circle(0, 0, radius + 14).fill({ color, alpha: 0.16 });
+    this.core.circle(0, 0, radius).fill({ color, alpha: 0.82 });
+    this.core.circle(0, 0, radius + 7).stroke({ width: 2, color: 0xffffff, alpha: 0.28 });
+
+    this.metrics.text = `status: ${this.snapshot.status}\ndiv: ${divergence.toFixed(5)} ent: ${Number(this.snapshot.entropy || 0).toFixed(3)}\ncrit: ${this.snapshot.npcCritical || 0} deco: ${this.snapshot.npcDecomposition || 0}`;
+  }
+}
+
+export function WorldHeartMonitor() {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const appRef = useRef<Application | null>(null);
+
+  useEffect(() => {
+    if (!hostRef.current || appRef.current) return;
+
+    const app = new Application();
+    appRef.current = app;
+    let interval: number | undefined;
+    let destroyed = false;
+
+    app.init({ backgroundAlpha: 0, width: 210, height: 150, antialias: true, autoDensity: true, resolution: Math.min(devicePixelRatio || 1, 2) }).then(() => {
+      if (destroyed || !hostRef.current) {
+        app.destroy(true);
+        return;
+      }
+
+      hostRef.current.appendChild(app.canvas);
+      const heart = new WorldHeartPixi();
+      heart.x = 105;
+      heart.y = 48;
+      app.stage.addChild(heart);
+      app.ticker.add((ticker) => heart.update(ticker.deltaTime));
+
+      const fetchSnapshot = async () => {
+        try {
+          const response = await fetch("/api/world-heart", { cache: "no-store" });
+          if (!response.ok) return;
+          heart.setSnapshot(await response.json());
+        } catch {
+          heart.setSnapshot({ status: "WATCH" });
+        }
+      };
+
+      fetchSnapshot();
+      interval = window.setInterval(fetchSnapshot, 1000);
+    });
+
+    return () => {
+      destroyed = true;
+      if (interval) window.clearInterval(interval);
+      app.destroy(true);
+      appRef.current = null;
+    };
+  }, []);
+
+  return <div ref={hostRef} className="az-world-heart" aria-label="Areloria WorldHeart live entropy monitor" />;
+}

--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -8,6 +8,7 @@ import { WorldHeartMonitor } from "./WorldHeartMonitor";
 import { installClient2DDepthRuntime } from "./client2dDepthRuntime";
 import "./theme.css";
 import "./liveReality.css";
+import "./worldHeart.css";
 
 installClient2DDepthRuntime();
 

--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -4,6 +4,7 @@ import { CyberZenLoginGate } from "./CyberZenLoginGate";
 import { CyberZenIsoApp } from "./CyberZenIsoApp";
 import { LiveRealityBridge } from "./LiveRealityBridge";
 import { MobileMovePad } from "./MobileMovePad";
+import { WorldHeartMonitor } from "./WorldHeartMonitor";
 import { installClient2DDepthRuntime } from "./client2dDepthRuntime";
 import "./theme.css";
 import "./liveReality.css";
@@ -15,6 +16,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <CyberZenLoginGate>
       <CyberZenIsoApp />
       <LiveRealityBridge />
+      <WorldHeartMonitor />
       <MobileMovePad />
     </CyberZenLoginGate>
   </React.StrictMode>

--- a/apps/client-2d/src/worldHeart.css
+++ b/apps/client-2d/src/worldHeart.css
@@ -1,0 +1,32 @@
+.az-world-heart {
+  position: absolute;
+  right: 124px;
+  top: 14px;
+  z-index: 25;
+  width: 210px;
+  height: 150px;
+  pointer-events: none;
+  border: 1px solid rgba(0, 255, 153, 0.22);
+  border-radius: 22px;
+  background: rgba(4, 8, 14, 0.48);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 0 26px rgba(0, 255, 153, 0.10), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+@media (max-width: 920px) {
+  .az-world-heart {
+    right: 10px;
+    top: 150px;
+    width: 188px;
+    height: 136px;
+    transform: scale(0.9);
+    transform-origin: top right;
+  }
+}
+
+@media (max-width: 520px) {
+  .az-world-heart {
+    display: none;
+  }
+}

--- a/server/src/api/worldHeartRoute.ts
+++ b/server/src/api/worldHeartRoute.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { worldResonanceAdapter } from "../core/WorldResonanceAdapter.js";
+
+export function worldHeartRouter(): Router {
+  const router = Router();
+
+  router.get("/", (_req, res) => {
+    try {
+      const snapshot = worldResonanceAdapter.loadLatestShadowEntry();
+      res.setHeader("Cache-Control", "no-store");
+      res.json(snapshot);
+    } catch {
+      res.setHeader("Cache-Control", "no-store");
+      res.status(200).json(worldResonanceAdapter.getSnapshot());
+    }
+  });
+
+  return router;
+}

--- a/server/src/core/WorldResonanceAdapter.ts
+++ b/server/src/core/WorldResonanceAdapter.ts
@@ -1,0 +1,117 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export type WorldResonanceStatus = "STABLE" | "WATCH" | "CRITICAL" | "DECOMPOSITION";
+
+export interface WorldResonanceSnapshot {
+  tick: number;
+  timestamp: number;
+  divergence: number;
+  entropy: number;
+  stability: number;
+  npcCritical: number;
+  npcDecomposition: number;
+  status: WorldResonanceStatus;
+}
+
+export interface WorldResonanceTickInput {
+  tick?: number | null;
+  divergence?: number | null;
+  entropy?: number | null;
+  npcCritical?: number | null;
+  npcDecomposition?: number | null;
+}
+
+const DEFAULT_SNAPSHOT: WorldResonanceSnapshot = {
+  tick: 0,
+  timestamp: Date.now(),
+  divergence: 0,
+  entropy: 0,
+  stability: 1,
+  npcCritical: 0,
+  npcDecomposition: 0,
+  status: "STABLE",
+};
+
+function finiteNonNegative(value: unknown, fallback = 0): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.max(0, numeric);
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+export class WorldResonanceAdapter {
+  private snapshot: WorldResonanceSnapshot = { ...DEFAULT_SNAPSHOT };
+
+  constructor(private readonly shadowLogPath = path.resolve(process.cwd(), "logs", "are-shadow.jsonl")) {}
+
+  public getSnapshot(): WorldResonanceSnapshot {
+    return { ...this.snapshot, timestamp: Date.now() };
+  }
+
+  public updateFromTick(input: WorldResonanceTickInput): WorldResonanceSnapshot {
+    const divergence = finiteNonNegative(input.divergence);
+    const npcCritical = Math.trunc(finiteNonNegative(input.npcCritical));
+    const npcDecomposition = Math.trunc(finiteNonNegative(input.npcDecomposition));
+    const entropy = finiteNonNegative(
+      input.entropy,
+      divergence * 1000 + npcCritical * 0.05 + npcDecomposition * 0.15,
+    );
+    const stability = clamp01(1 - entropy);
+    const tick = Math.trunc(finiteNonNegative(input.tick, this.snapshot.tick));
+    const status = this.resolveStatus({ divergence, stability, npcCritical, npcDecomposition });
+
+    this.snapshot = {
+      tick,
+      timestamp: Date.now(),
+      divergence,
+      entropy,
+      stability,
+      npcCritical,
+      npcDecomposition,
+      status,
+    };
+
+    return this.getSnapshot();
+  }
+
+  public loadLatestShadowEntry(): WorldResonanceSnapshot {
+    if (!existsSync(this.shadowLogPath)) return this.getSnapshot();
+
+    try {
+      const raw = readFileSync(this.shadowLogPath, "utf8").trim();
+      if (!raw) return this.getSnapshot();
+
+      const lastLine = raw.split(/\r?\n/).filter(Boolean).at(-1);
+      if (!lastLine) return this.getSnapshot();
+
+      const parsed = JSON.parse(lastLine) as Record<string, unknown>;
+      return this.updateFromTick({
+        tick: (parsed.tick ?? parsed.l ?? parsed.logicalIndex) as number,
+        divergence: (parsed.divergence ?? parsed.drift ?? parsed.delta) as number,
+        entropy: parsed.entropy as number,
+        npcCritical: (parsed.npcCritical ?? parsed.criticalNpcCount ?? parsed.critical) as number,
+        npcDecomposition: (parsed.npcDecomposition ?? parsed.decompositionNpcCount ?? parsed.decomposition) as number,
+      });
+    } catch {
+      return this.getSnapshot();
+    }
+  }
+
+  public resolveStatus(input: {
+    divergence: number;
+    stability: number;
+    npcCritical: number;
+    npcDecomposition: number;
+  }): WorldResonanceStatus {
+    if (input.npcDecomposition > 0 || input.stability < 0.25) return "DECOMPOSITION";
+    if (input.npcCritical > 0 || input.divergence > 0.01) return "CRITICAL";
+    if (input.divergence > 0.001 || input.stability < 0.8) return "WATCH";
+    return "STABLE";
+  }
+}
+
+export const worldResonanceAdapter = new WorldResonanceAdapter();

--- a/server/src/tests/worldResonanceAdapter.test.ts
+++ b/server/src/tests/worldResonanceAdapter.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { WorldResonanceAdapter } from "../core/WorldResonanceAdapter.js";
+
+describe("WorldResonanceAdapter", () => {
+  it("returns a stable default snapshot when the shadow log is missing", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "world-heart-"));
+    const adapter = new WorldResonanceAdapter(path.join(dir, "missing.jsonl"));
+
+    expect(adapter.loadLatestShadowEntry()).toMatchObject({
+      divergence: 0,
+      entropy: 0,
+      stability: 1,
+      npcCritical: 0,
+      npcDecomposition: 0,
+      status: "STABLE",
+    });
+  });
+
+  it("marks high divergence as critical", () => {
+    const adapter = new WorldResonanceAdapter("/not-used.jsonl");
+
+    expect(adapter.updateFromTick({ tick: 12, divergence: 0.02 }).status).toBe("CRITICAL");
+  });
+
+  it("marks decomposing NPC state as decomposition", () => {
+    const adapter = new WorldResonanceAdapter("/not-used.jsonl");
+
+    expect(adapter.updateFromTick({ tick: 13, divergence: 0, npcDecomposition: 1 }).status).toBe("DECOMPOSITION");
+  });
+});


### PR DESCRIPTION
Adds a safe WorldHeart monitor branch.

Included:
- server resonance adapter
- safe world-heart router file
- adapter tests
- PIXI monitor component
- monitor CSS
- client mount

Note: the server route file is included. The final bootstrap registration may need a tiny follow-up edit if CI shows the endpoint is not mounted, because the connector blocked a direct edit of the large bootstrap file.

Safety:
- no raw log serving
- no secrets
- read-only visualization
- no entity mutation