### PR TITLE
wire monitor route

### DIFF
--- a/apps/client-2d/src/WorldHeartMonitor.tsx
+++ b/apps/client-2d/src/WorldHeartMonitor.tsx
@@ -21,6 +21,8 @@ const DEFAULT_SNAPSHOT: WorldHeartSnapshot = {
   status: "STABLE",
 };
 
+const WORLD_HEART_ENDPOINT = "/api/lore/world-heart";
+
 function statusColor(status: WorldHeartStatus): number {
   switch (status) {
     case "DECOMPOSITION": return 0x9900ff;
@@ -95,7 +97,7 @@ export function WorldHeartMonitor() {
 
       const fetchSnapshot = async () => {
         try {
-          const response = await fetch("/api/world-heart", { cache: "no-store" });
+          const response = await fetch(WORLD_HEART_ENDPOINT, { cache: "no-store" });
           if (!response.ok) return;
           heart.setSnapshot(await response.json());
         } catch {

--- a/server/src/api/loreRoute.ts
+++ b/server/src/api/loreRoute.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { GameConfig } from "../config/GameConfig.js";
+import { worldHeartRouter } from "./worldHeartRoute.js";
 import {
   getWorldFragmentById,
   listWorldFragmentSummaries,
@@ -13,6 +14,8 @@ import {
  */
 export function loreRouter(): Router {
   const r = Router();
+
+  r.use("/world-heart", worldHeartRouter());
 
   r.get("/interact", (_req, res) => {
     const d = GameConfig.interactDistance;


### PR DESCRIPTION
Mini follow-up after 1218.

Changes:
- expose the monitor data through the mounted lore router
- point the client monitor at that path

No raw logs are exposed.