### PR TITLE
feat(agora): add Open Collective live monitor foundation

### DIFF
--- a/client/public/agora.html
+++ b/client/public/agora.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ouroboros Agora Live Monitor</title>
+  <style>
+    :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #090b10; color: #f4f7fb; }
+    body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top, #1a2440 0, #090b10 46%, #050608 100%); }
+    main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 44px; }
+    header { display: grid; gap: 10px; margin-bottom: 20px; }
+    h1 { margin: 0; font-size: clamp(2rem, 8vw, 4.5rem); line-height: 0.95; letter-spacing: -0.06em; }
+    p { color: #b8c2d8; line-height: 1.55; }
+    a { color: #9fd2ff; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; }
+    .card { border: 1px solid rgba(255,255,255,0.12); border-radius: 22px; padding: 18px; background: rgba(10, 14, 24, 0.78); box-shadow: 0 18px 44px rgba(0,0,0,0.28); backdrop-filter: blur(12px); }
+    .label { color: #8593ad; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.12em; }
+    .value { margin-top: 8px; font-size: 1.25rem; font-weight: 750; overflow-wrap: anywhere; }
+    .ok { color: #7ef2a5; }
+    .bad { color: #ff9a9a; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.9rem; }
+    pre { white-space: pre-wrap; word-break: break-word; margin: 0; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; }
+    .button { display: inline-flex; align-items: center; justify-content: center; min-height: 42px; border-radius: 999px; padding: 0 16px; border: 1px solid rgba(255,255,255,0.16); background: rgba(255,255,255,0.08); color: #fff; text-decoration: none; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="label">Areloria / Ouroboros Collective</div>
+      <h1>Agora Live Monitor</h1>
+      <p>Public trust dashboard for server health, ARE status and Open Collective readiness. No secrets are exposed here.</p>
+      <div class="actions">
+        <a class="button" href="/agora/auth/opencollective/login">Login with Open Collective</a>
+        <a class="button" href="/agora/api/live">Open live JSON</a>
+      </div>
+    </header>
+
+    <section class="grid" id="cards">
+      <div class="card"><div class="label">Status</div><div class="value" id="status">Loading...</div></div>
+      <div class="card"><div class="label">Uptime</div><div class="value" id="uptime">-</div></div>
+      <div class="card"><div class="label">Build</div><div class="value mono" id="build">-</div></div>
+      <div class="card"><div class="label">Port</div><div class="value" id="port">-</div></div>
+      <div class="card"><div class="label">Open Collective</div><div class="value" id="oc">-</div></div>
+      <div class="card"><div class="label">World Hash</div><div class="value mono" id="worldHash">-</div></div>
+    </section>
+
+    <section class="card" style="margin-top:14px">
+      <div class="label">ARE / Replay / Persistence</div>
+      <pre class="mono" id="details">Waiting for monitor payload...</pre>
+    </section>
+  </main>
+
+  <script>
+    const $ = (id) => document.getElementById(id);
+    const formatUptime = (seconds) => {
+      const s = Number(seconds || 0);
+      const h = Math.floor(s / 3600);
+      const m = Math.floor((s % 3600) / 60);
+      return `${h}h ${m}m ${s % 60}s`;
+    };
+
+    async function refresh() {
+      try {
+        const response = await fetch('/agora/api/live', { cache: 'no-store' });
+        const data = await response.json();
+        $('status').textContent = data.status || 'unknown';
+        $('status').className = `value ${data.ok ? 'ok' : 'bad'}`;
+        $('uptime').textContent = formatUptime(data.uptimeSeconds);
+        $('build').textContent = data.buildHash || 'dev';
+        $('port').textContent = data.port ?? '-';
+        $('oc').textContent = data.openCollective?.clientIdConfigured ? 'configured' : 'not configured';
+        $('oc').className = `value ${data.openCollective?.clientIdConfigured ? 'ok' : 'bad'}`;
+        $('worldHash').textContent = data.are?.worldHash || '-';
+        $('details').textContent = JSON.stringify({ are: data.are, persistence: data.persistence, warfront: data.warfront }, null, 2);
+      } catch (error) {
+        $('status').textContent = 'offline';
+        $('status').className = 'value bad';
+        $('details').textContent = String(error);
+      }
+    }
+
+    refresh();
+    setInterval(refresh, 5000);
+  </script>
+</body>
+</html>

--- a/docs/agora-monitor.md
+++ b/docs/agora-monitor.md
@@ -1,0 +1,45 @@
+# Ouroboros Agora Live Monitor
+
+The Agora Live Monitor connects the Areloria/Ouroboros project with Open Collective identity and transparent project monitoring.
+
+## Purpose
+
+- Provide a public trust and project status dashboard.
+- Expose safe live health data for the Areloria server.
+- Prepare Open Collective OAuth login for future supporter, grant, and admin workflows.
+- Keep all secrets server-side only.
+
+## Planned routes
+
+- `/agora` public dashboard shell
+- `/agora/api/live` safe live monitor JSON
+- `/agora/api/finance` safe finance summary placeholder
+- `/agora/api/config` safe public configuration state
+- `/agora/auth/opencollective/login` OAuth login start
+- `/agora/auth/opencollective/callback` OAuth callback
+
+## Security rules
+
+- Never commit real Open Collective secrets.
+- `OPEN_COLLECTIVE_CLIENT_SECRET` must only exist on the server or VPS environment.
+- Public JSON endpoints must expose booleans and status only, never tokens.
+- Browser code must not receive the client secret.
+
+## Environment variables
+
+```env
+OPEN_COLLECTIVE_CLIENT_ID=
+OPEN_COLLECTIVE_CLIENT_SECRET=
+OPEN_COLLECTIVE_CALLBACK_URL=https://areloria.de/agora/auth/opencollective/callback
+OPEN_COLLECTIVE_SLUG=ouroboros-collective-are
+OPEN_COLLECTIVE_PROJECT_SLUG=agora-project
+```
+
+## Future expansion
+
+- Open Collective GraphQL finance sync
+- Grant request dashboard
+- Reimbursement dashboard
+- Supporter-gated admin panels
+- WorldTick divergence and ARE guard visualization
+- VPS and GitHub deployment monitor

--- a/server/src/api/agoraRoute.ts
+++ b/server/src/api/agoraRoute.ts
@@ -1,0 +1,26 @@
+import express from "express";
+import { createAgoraMonitorRouter } from "../modules/agora/AgoraMonitorApi.js";
+import { createOpenCollectiveAuthRouter } from "../modules/agora/OpenCollectiveAuth.js";
+
+type AgoraRouteDeps = {
+  getTick?: () => any;
+  isInitializing?: () => boolean;
+  getPort?: () => number;
+};
+
+export function agoraRouter(deps: AgoraRouteDeps = {}) {
+  const router = express.Router();
+
+  router.use("/auth/opencollective", createOpenCollectiveAuthRouter());
+  router.use("/api", createAgoraMonitorRouter(deps));
+
+  router.get("/", (_req, res) => {
+    res.json({
+      ok: true,
+      monitor: "Ouroboros Agora Live Monitor",
+      routes: ["/agora/api/live", "/agora/api/finance", "/agora/api/config", "/agora/auth/opencollective/login"],
+    });
+  });
+
+  return router;
+}

--- a/server/src/modules/agora/AgoraMonitorApi.ts
+++ b/server/src/modules/agora/AgoraMonitorApi.ts
@@ -29,7 +29,7 @@ function safeValue<T>(fn: () => T, fallback: T): T {
   }
 }
 
-export function createAgoraMonitorRouter(deps: AgoraMonitorDeps = express.Router() as never) {
+export function createAgoraMonitorRouter(deps: AgoraMonitorDeps = {}) {
   const router = express.Router();
 
   router.get("/config", (_req, res) => {

--- a/server/src/modules/agora/AgoraMonitorApi.ts
+++ b/server/src/modules/agora/AgoraMonitorApi.ts
@@ -1,0 +1,81 @@
+import express from "express";
+import type { AgoraFinanceSummary, AgoraOAuthConfigStatus, AgoraLiveStatus } from "./AgoraTypes.js";
+
+type AgoraMonitorDeps = {
+  getTick?: () => any;
+  isInitializing?: () => boolean;
+  getPort?: () => number;
+};
+
+function envConfigured(key: string): boolean {
+  return Boolean(process.env[key]?.trim());
+}
+
+export function getAgoraOAuthConfigStatus(): AgoraOAuthConfigStatus {
+  return {
+    clientIdConfigured: envConfigured("OPEN_COLLECTIVE_CLIENT_ID"),
+    clientSecretConfigured: envConfigured("OPEN_COLLECTIVE_CLIENT_SECRET"),
+    callbackConfigured: envConfigured("OPEN_COLLECTIVE_CALLBACK_URL"),
+    collectiveSlug: process.env.OPEN_COLLECTIVE_SLUG || "ouroboros-collective-are",
+    projectSlug: process.env.OPEN_COLLECTIVE_PROJECT_SLUG || "agora-project",
+  };
+}
+
+function safeValue<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+export function createAgoraMonitorRouter(deps: AgoraMonitorDeps = express.Router() as never) {
+  const router = express.Router();
+
+  router.get("/config", (_req, res) => {
+    const config = getAgoraOAuthConfigStatus();
+    res.json({
+      clientIdConfigured: config.clientIdConfigured,
+      callbackConfigured: config.callbackConfigured,
+      collectiveSlug: config.collectiveSlug,
+      projectSlug: config.projectSlug,
+    });
+  });
+
+  router.get("/finance", (_req, res) => {
+    const config = getAgoraOAuthConfigStatus();
+    const body: AgoraFinanceSummary = {
+      configured: config.clientIdConfigured && config.clientSecretConfigured,
+      collectiveSlug: config.collectiveSlug,
+      projectSlug: config.projectSlug,
+      note: "Safe placeholder. Real Open Collective finance sync can be added later through a server-side GraphQL/API integration.",
+    };
+    res.json(body);
+  });
+
+  router.get("/live", (_req, res) => {
+    const tick = deps.getTick?.();
+    const initializing = Boolean(deps.isInitializing?.());
+    const body: AgoraLiveStatus = {
+      ok: !initializing,
+      status: initializing ? "initializing" : "ok",
+      project: "ARELORIAN MMORPG",
+      monitor: "Ouroboros Agora Live Monitor",
+      uptimeSeconds: Math.round(process.uptime()),
+      port: deps.getPort?.() ?? Number(process.env.PORT || 3000),
+      buildHash: process.env.BUILD_COMMIT_SHA || "dev",
+      nodeEnv: process.env.NODE_ENV || "development",
+      openCollective: getAgoraOAuthConfigStatus(),
+      persistence: safeValue(() => tick?.getPersistenceStats?.() ?? { status: "unknown" }, { status: "unknown" }),
+      are: {
+        guard: safeValue(() => tick?.getAREGuardStatus?.() ?? null, null),
+        worldHash: safeValue(() => tick?.getWorldHashSnapshot?.()?.worldHash ?? null, null),
+        replay: safeValue(() => tick?.getReplayRecorderStats?.() ?? null, null),
+      },
+      warfront: safeValue(() => tick?.warfrontSystem?.getCycleSnapshot?.() ?? null, null),
+    };
+    res.status(initializing ? 503 : 200).json(body);
+  });
+
+  return router;
+}

--- a/server/src/modules/agora/AgoraTypes.ts
+++ b/server/src/modules/agora/AgoraTypes.ts
@@ -1,0 +1,35 @@
+export type AgoraRole = "public" | "backer" | "admin";
+
+export type AgoraOAuthConfigStatus = {
+  clientIdConfigured: boolean;
+  clientSecretConfigured: boolean;
+  callbackConfigured: boolean;
+  collectiveSlug: string;
+  projectSlug: string;
+};
+
+export type AgoraLiveStatus = {
+  ok: boolean;
+  status: "initializing" | "ok" | "degraded";
+  project: string;
+  monitor: string;
+  uptimeSeconds: number;
+  port: number;
+  buildHash: string;
+  nodeEnv: string;
+  openCollective: AgoraOAuthConfigStatus;
+  persistence?: unknown;
+  are?: {
+    guard?: unknown;
+    worldHash?: string | null;
+    replay?: unknown;
+  };
+  warfront?: unknown;
+};
+
+export type AgoraFinanceSummary = {
+  configured: boolean;
+  collectiveSlug: string;
+  projectSlug: string;
+  note: string;
+};

--- a/server/src/modules/agora/OpenCollectiveAuth.ts
+++ b/server/src/modules/agora/OpenCollectiveAuth.ts
@@ -1,0 +1,29 @@
+import express from "express";
+
+export function createOpenCollectiveAuthRouter() {
+  const router = express.Router();
+
+  router.get("/login", (_req, res) => {
+    return res.status(501).json({
+      error: "open_collective_oauth_pending",
+      message: "Open Collective login route is reserved for server-side OAuth implementation. Configure it on the VPS with private environment variables only.",
+    });
+  });
+
+  router.get("/callback", (_req, res) => {
+    return res.status(501).json({
+      error: "open_collective_oauth_pending",
+      message: "OAuth callback route is present but token exchange must be enabled server-side without exposing secrets.",
+    });
+  });
+
+  router.post("/logout", (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  router.get("/me", (_req, res) => {
+    res.json({ loggedIn: false, role: "public" });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Adds the foundation for an Ouroboros Agora Live Monitor connected to the Areloria server architecture.

## Added

- `docs/agora-monitor.md` documentation
- `server/src/modules/agora/AgoraTypes.ts`
- `server/src/modules/agora/AgoraMonitorApi.ts`
- `server/src/modules/agora/OpenCollectiveAuth.ts` safe auth skeleton
- `server/src/api/agoraRoute.ts`
- `client/public/agora.html` Android-friendly monitor dashboard

## Security

- No real Open Collective secrets are committed.
- OAuth token exchange is intentionally left as a safe server-side follow-up because connector safety filters blocked committing the full token-exchange implementation.
- Public endpoints are designed to expose safe health/config status only.

## Notes

The next implementation step is to mount `agoraRouter` in `server/src/core/ServerBootstrap.ts` under `/agora` and optionally serve `client/public/agora.html` directly at `/agora`.

Suggested mount:

```ts
import { agoraRouter } from "../api/agoraRoute.js";

app.use("/agora", agoraRouter({
  getTick: () => (this as any)._tick as WorldTick | undefined,
  isInitializing: () => this.initializing,
  getPort: () => Number(process.env.PORT || 3000),
}));
```

## Test plan

- `pnpm --filter @wasd/server build`
- Open `/agora.html`
- Open `/agora/api/live` after router is mounted
