### PR TITLE
fix(world): make loot capsule items mutable

### DIFF
--- a/server/src/modules/world/WorldResonanceAdapter.ts
+++ b/server/src/modules/world/WorldResonanceAdapter.ts
@@ -136,6 +136,10 @@ export class WorldResonanceAdapter {
     const essenceCount = 1 + (plexityTotal % 3);
     const memoryShards = Math.max(1, Math.floor(plexityTotal / 333));
     const salt = rng.nextRange(0, 2);
+    const items: LootCapsuleItem[] = [
+      { itemId: 'resonance_essence', count: essenceCount, resonanceValue: plexityTotal },
+      { itemId: 'memory_shard', count: memoryShards + salt, resonanceValue: Math.max(1, Math.floor(plexityTotal / 2)) },
+    ];
 
     return Object.freeze({
       id: `loot:decomposition:${event.npcId}:${event.kappaHash}`,
@@ -146,10 +150,7 @@ export class WorldResonanceAdapter {
       tick: event.tick,
       kappaHash: event.kappaHash,
       plexityTotal,
-      items: Object.freeze([
-        Object.freeze({ itemId: 'resonance_essence', count: essenceCount, resonanceValue: plexityTotal }),
-        Object.freeze({ itemId: 'memory_shard', count: memoryShards + salt, resonanceValue: Math.max(1, Math.floor(plexityTotal / 2)) }),
-      ]),
+      items,
       gold: Math.max(0, Math.floor(plexityTotal / 10)),
     });
   }


### PR DESCRIPTION
## Summary

Fixes the server TypeScript error from the audit logic job:

```text
src/modules/world/WorldResonanceAdapter.ts(140,5): error TS2322
readonly items array cannot be assigned to mutable LootCapsuleItem[]
```

## Change

- Creates the loot capsule `items` as a normal `LootCapsuleItem[]` before freezing the outer capsule object.
- Keeps deterministic loot values unchanged.
- Keeps the outer `Object.freeze` behavior for the capsule.

## Test plan

- `pnpm --filter @wasd/server exec tsc --noEmit`
