### PR TITLE
fix(agora): correct Open Collective callback domain

### DIFF
--- a/docs/agora-monitor.md
+++ b/docs/agora-monitor.md
@@ -30,7 +30,7 @@ The Agora Live Monitor connects the Areloria/Ouroboros project with Open Collect
 ```env
 OPEN_COLLECTIVE_CLIENT_ID=
 OPEN_COLLECTIVE_CLIENT_SECRET=
-OPEN_COLLECTIVE_CALLBACK_URL=https://areloria.de/agora/auth/opencollective/callback
+OPEN_COLLECTIVE_CALLBACK_URL=https://arelorian.de/agora/auth/opencollective/callback
 OPEN_COLLECTIVE_SLUG=ouroboros-collective-are
 OPEN_COLLECTIVE_PROJECT_SLUG=agora-project
 ```


### PR DESCRIPTION
## Summary

Corrects the documented Open Collective callback URL from `areloria.de` to the correct domain `arelorian.de`.

## Changed

- `OPEN_COLLECTIVE_CALLBACK_URL=https://arelorian.de/agora/auth/opencollective/callback`

## Notes

No secrets are changed or committed. This only fixes the documented environment variable example.