### PR TITLE
feat(agora): add GitHub webhook receiver

### DIFF
--- a/server/src/api/agoraRoute.ts
+++ b/server/src/api/agoraRoute.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { createAgoraMonitorRouter } from "../modules/agora/AgoraMonitorApi.js";
 import { createOpenCollectiveAuthRouter } from "../modules/agora/OpenCollectiveAuth.js";
+import { createGitHubWebhookRouter } from "../modules/agora/GitHubWebhook.js";
 
 type AgoraRouteDeps = {
   getTick?: () => any;
@@ -12,13 +13,20 @@ export function agoraRouter(deps: AgoraRouteDeps = {}) {
   const router = express.Router();
 
   router.use("/auth/opencollective", createOpenCollectiveAuthRouter());
+  router.use("/webhooks", createGitHubWebhookRouter());
   router.use("/api", createAgoraMonitorRouter(deps));
 
   router.get("/", (_req, res) => {
     res.json({
       ok: true,
       monitor: "Ouroboros Agora Live Monitor",
-      routes: ["/agora/api/live", "/agora/api/finance", "/agora/api/config", "/agora/auth/opencollective/login"],
+      routes: [
+        "/agora/api/live",
+        "/agora/api/finance",
+        "/agora/api/config",
+        "/agora/auth/opencollective/login",
+        "/agora/webhooks/github",
+      ],
     });
   });
 

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -19,6 +19,7 @@ import { areReplayRouter } from "../api/areReplayRoute.js";
 import { financeRouter } from "../api/financeRoute.js";
 import { sovereignDeployRouter } from "../api/sovereignDeployRoute.js";
 import { healthRoutes } from "../api/healthRoutes.js";
+import { agoraRouter } from "../api/agoraRoute.js";
 import { getContentDataSourceLabel, resolveContentDir } from "../modules/content/contentDataRoot.js";
 import { getSupabaseSummary, verifySupabaseToken } from "../config/supabase.js";
 import { resolveWorldAssetsDir } from "./resolveWorldAssetsDir.js";
@@ -119,6 +120,7 @@ export class ServerBootstrap {
     app.use("/api/lore", loreRouter());
     app.get("/client-config.json", (_req, res) => { res.type("application/json"); res.setHeader("Cache-Control", "no-store"); res.send(buildClientPublicConfigJson(_req)); });
     app.use("/health", healthRoutes({ getTick: () => (this as any)._tick as WorldTick | undefined, isInitializing: () => this.initializing, getPort: () => Number(process.env.PORT || 3000) }));
+    app.use("/agora", agoraRouter({ getTick: () => (this as any)._tick as WorldTick | undefined, isInitializing: () => this.initializing, getPort: () => Number(process.env.PORT || 3000) }));
     app.get("/health", (_req, res) => {
       const tick = (this as any)._tick as WorldTick | undefined;
       const selfHealingStatus = safeHealthValue(() => selfHealingRuntime.getStatus(), { active: false, config: {}, totalErrors: 0, totalHealed: 0, healingRate: 0, featuresProtected: 0 } as any);

--- a/server/src/modules/agora/GitHubWebhook.ts
+++ b/server/src/modules/agora/GitHubWebhook.ts
@@ -1,0 +1,70 @@
+import crypto from "node:crypto";
+import express, { type Request } from "express";
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  try {
+    const left = Buffer.from(a, "hex");
+    const right = Buffer.from(b, "hex");
+    return left.length === right.length && crypto.timingSafeEqual(left, right);
+  } catch {
+    return false;
+  }
+}
+
+function verifyGitHubSignature(req: Request, rawBody: Buffer): boolean {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET?.trim();
+  if (!secret) return true;
+
+  const signature = req.header("x-hub-signature-256") || "";
+  const expected = `sha256=${crypto.createHmac("sha256", secret).update(rawBody).digest("hex")}`;
+
+  if (!signature.startsWith("sha256=") || !expected.startsWith("sha256=")) return false;
+  return timingSafeEqualHex(signature.slice("sha256=".length), expected.slice("sha256=".length));
+}
+
+export function createGitHubWebhookRouter() {
+  const router = express.Router();
+
+  router.post(
+    "/github",
+    express.json({
+      limit: "2mb",
+      verify: (req, _res, buf) => {
+        (req as Request & { rawBody?: Buffer }).rawBody = Buffer.from(buf);
+      },
+    }),
+    (req, res) => {
+      const rawBody = (req as Request & { rawBody?: Buffer }).rawBody ?? Buffer.from(JSON.stringify(req.body ?? {}));
+
+      if (!verifyGitHubSignature(req, rawBody)) {
+        return res.status(401).json({ ok: false, error: "invalid_github_signature" });
+      }
+
+      const event = req.header("x-github-event") || "unknown";
+      const delivery = req.header("x-github-delivery") || "unknown";
+      const payload = req.body ?? {};
+      const repository = payload.repository?.full_name || payload.repository?.name || "unknown";
+      const ref = payload.ref || null;
+      const deleted = Boolean(payload.deleted);
+      const after = payload.after || null;
+
+      console.log("[AgoraGitHubWebhook] received", { event, delivery, repository, ref, deleted, after });
+
+      return res.json({
+        ok: true,
+        receiver: "agora-github-webhook",
+        event,
+        delivery,
+        repository,
+        ref,
+        deleted,
+      });
+    },
+  );
+
+  router.get("/github", (_req, res) => {
+    res.json({ ok: true, receiver: "agora-github-webhook", method: "POST required" });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Adds a dedicated GitHub webhook receiver for Agora and mounts the Agora router in the server bootstrap.

## Added

- `POST /agora/webhooks/github`
- `GET /agora/webhooks/github` health/info endpoint
- Optional `GITHUB_WEBHOOK_SECRET` HMAC SHA-256 verification through `X-Hub-Signature-256`
- Agora router mounted under `/agora`

## Why

GitHub webhooks were accidentally targeting the Open Collective OAuth callback URL. This separates the concerns:

- Open Collective OAuth callback: `/agora/auth/opencollective/callback`
- GitHub webhook receiver: `/agora/webhooks/github`

## Security

- No secret is committed.
- If `GITHUB_WEBHOOK_SECRET` is configured on the VPS/GitHub webhook settings, signatures are verified with timing-safe comparison.
- If no secret is configured, the route still accepts events for initial wiring but should be hardened before production use.

## Test plan

- `pnpm --filter @wasd/server exec tsc --noEmit`
- `GET /agora/webhooks/github`
- Configure GitHub webhook Payload URL to `https://arelorian.de/agora/webhooks/github`
