### PR TITLE
feat(agora): expose latest GitHub webhook event

### DIFF
--- a/server/src/modules/agora/AgoraMonitorApi.ts
+++ b/server/src/modules/agora/AgoraMonitorApi.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import type { AgoraFinanceSummary, AgoraOAuthConfigStatus, AgoraLiveStatus } from "./AgoraTypes.js";
+import { getLastGitHubWebhookEvent } from "./GitHubWebhook.js";
 
 type AgoraMonitorDeps = {
   getTick?: () => any;
@@ -56,7 +57,7 @@ export function createAgoraMonitorRouter(deps: AgoraMonitorDeps = {}) {
   router.get("/live", (_req, res) => {
     const tick = deps.getTick?.();
     const initializing = Boolean(deps.isInitializing?.());
-    const body: AgoraLiveStatus = {
+    const body: AgoraLiveStatus & { github: { lastEvent: ReturnType<typeof getLastGitHubWebhookEvent> } } = {
       ok: !initializing,
       status: initializing ? "initializing" : "ok",
       project: "ARELORIAN MMORPG",
@@ -66,6 +67,9 @@ export function createAgoraMonitorRouter(deps: AgoraMonitorDeps = {}) {
       buildHash: process.env.BUILD_COMMIT_SHA || "dev",
       nodeEnv: process.env.NODE_ENV || "development",
       openCollective: getAgoraOAuthConfigStatus(),
+      github: {
+        lastEvent: getLastGitHubWebhookEvent(),
+      },
       persistence: safeValue(() => tick?.getPersistenceStats?.() ?? { status: "unknown" }, { status: "unknown" }),
       are: {
         guard: safeValue(() => tick?.getAREGuardStatus?.() ?? null, null),

--- a/server/src/modules/agora/GitHubWebhook.ts
+++ b/server/src/modules/agora/GitHubWebhook.ts
@@ -5,6 +5,30 @@ const RATE_LIMIT_WINDOW_MS = Number(process.env.ARELORIAN_WEBHOOK_RATE_LIMIT_WIN
 const RATE_LIMIT_MAX_REQUESTS = Number(process.env.ARELORIAN_WEBHOOK_RATE_LIMIT_MAX_REQUESTS || 60);
 const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
 
+export type AgoraGitHubWebhookEvent = {
+  receivedAt: string;
+  event: string;
+  delivery: string;
+  repository: string;
+  ref: string | null;
+  branch: string | null;
+  deleted: boolean;
+  before: string | null;
+  after: string | null;
+  commitSha: string | null;
+  compareUrl: string | null;
+  sender: string | null;
+  pusher: string | null;
+  headCommitMessage: string | null;
+  prNumber: number | null;
+};
+
+let lastGitHubWebhookEvent: AgoraGitHubWebhookEvent | null = null;
+
+export function getLastGitHubWebhookEvent(): AgoraGitHubWebhookEvent | null {
+  return lastGitHubWebhookEvent;
+}
+
 function getRateLimitKey(req: Request): string {
   const forwardedFor = req.header("x-forwarded-for")?.split(",")[0]?.trim();
   return forwardedFor || req.ip || req.socket.remoteAddress || "unknown";
@@ -63,6 +87,50 @@ function verifyGitHubSignature(req: Request, rawBody: Buffer): boolean {
   return timingSafeEqualHex(signature.slice("sha256=".length), expected.slice("sha256=".length));
 }
 
+function branchFromRef(ref: unknown): string | null {
+  if (typeof ref !== "string") return null;
+  return ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+}
+
+function numberFromUnknown(value: unknown): number | null {
+  const numberValue = Number(value);
+  return Number.isInteger(numberValue) && numberValue > 0 ? numberValue : null;
+}
+
+function extractPrNumber(event: string, payload: any): number | null {
+  if (event === "pull_request") return numberFromUnknown(payload.number);
+  if (event === "check_suite" || event === "check_run") return numberFromUnknown(payload.pull_requests?.[0]?.number);
+  if (event === "workflow_run") return numberFromUnknown(payload.workflow_run?.pull_requests?.[0]?.number);
+  return null;
+}
+
+function rememberGitHubWebhookEvent(req: Request, payload: any): AgoraGitHubWebhookEvent {
+  const event = req.header("x-github-event") || "unknown";
+  const ref = typeof payload.ref === "string" ? payload.ref : null;
+  const after = typeof payload.after === "string" && !/^0+$/.test(payload.after) ? payload.after : null;
+  const headCommitId = typeof payload.head_commit?.id === "string" ? payload.head_commit.id : null;
+
+  lastGitHubWebhookEvent = {
+    receivedAt: new Date().toISOString(),
+    event,
+    delivery: req.header("x-github-delivery") || "unknown",
+    repository: payload.repository?.full_name || payload.repository?.name || "unknown",
+    ref,
+    branch: branchFromRef(ref),
+    deleted: Boolean(payload.deleted),
+    before: typeof payload.before === "string" && !/^0+$/.test(payload.before) ? payload.before : null,
+    after,
+    commitSha: after || headCommitId,
+    compareUrl: typeof payload.compare === "string" ? payload.compare : null,
+    sender: payload.sender?.login || null,
+    pusher: payload.pusher?.name || null,
+    headCommitMessage: typeof payload.head_commit?.message === "string" ? payload.head_commit.message : null,
+    prNumber: extractPrNumber(event, payload),
+  };
+
+  return lastGitHubWebhookEvent;
+}
+
 export function createGitHubWebhookRouter() {
   const router = express.Router();
 
@@ -83,30 +151,28 @@ export function createGitHubWebhookRouter() {
         return res.status(401).json({ ok: false, error: "invalid_github_signature" });
       }
 
-      const event = req.header("x-github-event") || "unknown";
-      const delivery = req.header("x-github-delivery") || "unknown";
       const payload = req.body ?? {};
-      const repository = payload.repository?.full_name || payload.repository?.name || "unknown";
-      const ref = payload.ref || null;
-      const deleted = Boolean(payload.deleted);
-      const after = payload.after || null;
+      const remembered = rememberGitHubWebhookEvent(req, payload);
 
-      console.log("[AgoraGitHubWebhook] received", { event, delivery, repository, ref, deleted, after });
+      console.log("[AgoraGitHubWebhook] received", remembered);
 
       return res.json({
         ok: true,
         receiver: "agora-github-webhook",
-        event,
-        delivery,
-        repository,
-        ref,
-        deleted,
+        event: remembered.event,
+        delivery: remembered.delivery,
+        repository: remembered.repository,
+        ref: remembered.ref,
+        branch: remembered.branch,
+        deleted: remembered.deleted,
+        commitSha: remembered.commitSha,
+        prNumber: remembered.prNumber,
       });
     },
   );
 
   router.get("/github", (_req, res) => {
-    res.json({ ok: true, receiver: "agora-github-webhook", method: "POST required" });
+    res.json({ ok: true, receiver: "agora-github-webhook", method: "POST required", lastEvent: getLastGitHubWebhookEvent() });
   });
 
   return router;


### PR DESCRIPTION
## Summary

Stores the latest GitHub webhook delivery in memory and exposes it through the Agora live monitor API.

## Added

- `getLastGitHubWebhookEvent()`
- In-memory `lastGitHubWebhookEvent`
- Extracted fields:
  - `event`
  - `delivery`
  - `repository`
  - `ref`
  - `branch`
  - `deleted`
  - `before`
  - `after`
  - `commitSha`
  - `compareUrl`
  - `sender`
  - `pusher`
  - `headCommitMessage`
  - `prNumber`
- `/agora/api/live` now includes:

```json
{
  "github": {
    "lastEvent": { }
  }
}
```

## Notes

A plain GitHub `push` webhook does not include a pull request number. `prNumber` will be populated for `pull_request`, `workflow_run`, `check_suite`, or `check_run` events when GitHub provides pull request metadata.

## Why

This allows the Agora/Oracle monitor to show the latest commit SHA/ref instead of `unknown` after a webhook delivery.

## Test plan

- `pnpm --filter @wasd/server exec tsc --noEmit`
- Send test delivery to `/agora/webhooks/github`
- Open `/agora/api/live`
- Confirm `github.lastEvent.commitSha`, `github.lastEvent.ref`, and `github.lastEvent.delivery` are populated
