### PR TITLE
feat(client-2d): add pixi visual packages

### DIFF
--- a/apps/client-2d/package.json
+++ b/apps/client-2d/package.json
@@ -11,6 +11,10 @@
     "validate:assets": "node ../../scripts/are-asset-forge.mjs && node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs"
   },
   "dependencies": {
+    "@pixi/particle-emitter": "^5.0.8",
+    "@pixi/sound": "^6.0.1",
+    "@pixi/tilemap": "^5.0.2",
+    "pixi-filters": "^6.1.4",
     "pixi.js": "^8.18.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",


### PR DESCRIPTION
## Summary

- Add the modern Pixi visual packages to `@wasd/client-2d`.
- Include tilemap, particles, filters, and sound package entries.
- Keep the change limited to `apps/client-2d/package.json`.

## Packages

- `@pixi/tilemap`
- `@pixi/particle-emitter`
- `pixi-filters`
- `@pixi/sound`

## Important follow-up

This environment cannot run `pnpm install`, so `pnpm-lock.yaml` was not regenerated here. If CI fails on frozen lockfile, run:

```bash
pnpm install --lockfile-only
pnpm install --frozen-lockfile
pnpm -r --filter @wasd/client-2d build
pnpm -r --filter @wasd/client-2d validate:assets
```

Then commit the updated lockfile to this PR.

## Scope

Dependency manifest only. No runtime wiring, server logic, WorldTick logic, NPC logic, or gameplay authority changes.

## Next follow-up layer

Wire these packages into `apps/client-2d/src/client2dPixiModules.ts` for visible tilemap, particle, filter, and sound upgrades.