### PR TITLE
fix(shared): make declaration build docker safe

### DIFF
--- a/packages/shared/scripts/transpile-build.mjs
+++ b/packages/shared/scripts/transpile-build.mjs
@@ -147,10 +147,19 @@ if (process.exitCode) {
   process.exit(process.exitCode);
 }
 
-// Generate declaration files for workspace packages using @wasd/shared
+// Generate declaration files for workspace packages using @wasd/shared.
+// Use the already-installed workspace TypeScript instead of npx to avoid
+// spawning npm resolution work inside the Docker builder.
 try {
   const { execSync } = await import('node:child_process');
-  execSync('npx tsc --declaration --emitDeclarationOnly', { stdio: 'inherit' });
+  execSync('pnpm exec tsc -p tsconfig.declarations.json', {
+    cwd: root,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --max-old-space-size=1024`.trim(),
+    },
+  });
   console.log('Generated declaration files (.d.ts) for @wasd/shared');
 } catch (error) {
   console.error('Failed to generate declaration files:', error);

--- a/packages/shared/tsconfig.declarations.json
+++ b/packages/shared/tsconfig.declarations.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
+    "sourceMap": false,
+    "tsBuildInfoFile": null
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.*",
+    "src/**/*.spec.*"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a dedicated declaration tsconfig for `@wasd/shared`.
- Replace `npx tsc --declaration --emitDeclarationOnly` with `pnpm exec tsc -p tsconfig.declarations.json`.
- Disable incremental/declaration maps for this declaration-only Docker build path.
- Set a bounded Node heap for the declaration compile.

## Why

The VPS Docker deploy fails in `@wasd/shared` after JS output succeeds. The failing step is declaration generation, where `npx tsc --declaration --emitDeclarationOnly` is killed with `SIGKILL` inside the Docker builder. This is likely process/memory pressure from spawning npx/npm resolution plus a broad declaration compile.

## Scope

Only `packages/shared` build/declaration generation.

## Validation

Expected deploy validation:

```bash
pnpm --filter @wasd/shared --if-present build
pnpm --filter @wasd/server --if-present build
```

Then rerun VPS Docker Deploy.

## Next follow-up layer

If Docker still kills declaration generation, split `@wasd/shared` declarations into smaller entrypoint configs or skip declaration emission during production Docker builds only.