### PR TITLE
perf pathfinding open nodes

### DIFF
--- a/server/src/utils/Pathfinding.ts
+++ b/server/src/utils/Pathfinding.ts
@@ -17,6 +17,10 @@ class Node {
   }
 }
 
+function nodeKey(x: number, y: number): string {
+  return `${x},${y}`;
+}
+
 export class Pathfinding {
   private static readonly GRID_SIZE = 1.0; // 1 unit per grid cell
 
@@ -28,6 +32,7 @@ export class Pathfinding {
     const endNode = new Node(Math.round(end.x), Math.round(end.y));
 
     const openList: Node[] = [startNode];
+    const openMap: Map<string, Node> = new Map([[nodeKey(startNode.x, startNode.y), startNode]]);
     const closedList: Set<string> = new Set();
 
     const maxIterations = 200; // Prevent infinite loops
@@ -46,7 +51,8 @@ export class Pathfinding {
 
       const currentNode = openList[currentIndex];
       openList.splice(currentIndex, 1);
-      closedList.add(`${currentNode.x},${currentNode.y}`);
+      openMap.delete(nodeKey(currentNode.x, currentNode.y));
+      closedList.add(nodeKey(currentNode.x, currentNode.y));
 
       // Reached destination
       if (Math.abs(currentNode.x - endNode.x) < 1 && Math.abs(currentNode.y - endNode.y) < 1) {
@@ -60,7 +66,6 @@ export class Pathfinding {
       }
 
       // Generate neighbors (8 directions)
-      const neighbors: Node[] = [];
       for (let dx = -1; dx <= 1; dx++) {
         for (let dy = -1; dy <= 1; dy++) {
           if (dx === 0 && dy === 0) continue;
@@ -68,26 +73,26 @@ export class Pathfinding {
           const nx = currentNode.x + dx;
           const ny = currentNode.y + dy;
 
-          if (closedList.has(`${nx},${ny}`)) continue;
+          if (closedList.has(nodeKey(nx, ny))) continue;
           if (isObstacle(nx, ny)) continue;
 
           // Diagonal movement cost is sqrt(2), straight is 1
           const g = currentNode.g + (dx !== 0 && dy !== 0 ? 1.414 : 1);
           const h = Math.abs(nx - endNode.x) + Math.abs(ny - endNode.y); // Manhattan distance
           
-          const existingNode = openList.find(n => n.x === nx && n.y === ny);
+          const existingNode = openMap.get(nodeKey(nx, ny));
           if (existingNode) {
             if (g < existingNode.g) {
               existingNode.g = g;
               existingNode.parent = currentNode;
             }
           } else {
-            neighbors.push(new Node(nx, ny, g, h, currentNode));
+            const newNode = new Node(nx, ny, g, h, currentNode);
+            openList.push(newNode);
+            openMap.set(nodeKey(nx, ny), newNode);
           }
         }
       }
-
-      openList.push(...neighbors);
     }
 
     // No path found or limit reached, return linear path as fallback


### PR DESCRIPTION
Focused cherry-pick from old PR 1228. Keeps only the Pathfinding open-node Map optimization and excludes unrelated package and lockfile changes.