### PR TITLE
fix combat are clock

### DIFF
--- a/server/src/modules/combat/CombatService.ts
+++ b/server/src/modules/combat/CombatService.ts
@@ -1,3 +1,4 @@
+import { type AREClock, SystemAREClock } from "../../core/determinism/AREDeterminism.js";
 import { ComboValidator, type ComboResult } from "./ComboValidator.js";
 
 export interface CombatState {
@@ -19,8 +20,8 @@ export interface CombatExecutionResult {
 export class CombatService {
     private comboValidator: ComboValidator;
 
-    constructor() {
-        this.comboValidator = new ComboValidator();
+    constructor(private readonly clock: AREClock = new SystemAREClock()) {
+        this.comboValidator = new ComboValidator(undefined, clock);
     }
 
     public handleSkillRequest(
@@ -57,7 +58,7 @@ export class CombatService {
         const newState: CombatState = {
             comboIndex: nextIndex,
             lastSkillId: skill.id,
-            lastTimestamp: Date.now()
+            lastTimestamp: this.clock.now()
         };
 
         this.updatePlayerCombatState(playerId, newState);

--- a/server/src/modules/combat/ComboValidator.ts
+++ b/server/src/modules/combat/ComboValidator.ts
@@ -13,6 +13,8 @@
  * - Position verification
  */
 
+import { type AREClock, SystemAREClock } from "../../core/determinism/AREDeterminism.js";
+
 export interface Vector3 {
   x: number;
   y: number;
@@ -127,7 +129,10 @@ export class ComboValidator {
   private cooldowns: Map<string, number>;
   private tickCount: number = 0;
 
-  constructor(definitions?: Map<string, ComboDefinition>) {
+  constructor(
+    definitions?: Map<string, ComboDefinition>,
+    private readonly clock: AREClock = new SystemAREClock(),
+  ) {
     this.comboDefinitions = definitions || DEFAULT_COMBO_DEFINITIONS;
     this.playerStates = new Map();
     this.cooldowns = new Map();
@@ -142,7 +147,7 @@ export class ComboValidator {
   }
 
   public getServerTimestamp(): number {
-    return Date.now();
+    return this.clock.now();
   }
 
   public calculateDistance(a: Vector3, b: Vector3): number {


### PR DESCRIPTION
Focused cherry-pick from old PR 1230. Uses the ARE clock for combo and combat timing without unrelated changes.