### PR TITLE
fix monster determinism

### DIFF
--- a/server/src/modules/monster/MonsterDNA.ts
+++ b/server/src/modules/monster/MonsterDNA.ts
@@ -1,10 +1,24 @@
-export function generateMonsterDNA(species: string) {
+import { type ARERng, SeededARERng, createARESeed } from "../../core/determinism/AREDeterminism.js";
+
+export interface MonsterDNA {
+  species: string;
+  strength: number;
+  speed: number;
+  aggression: number;
+  intelligence: number;
+  resilience: number;
+}
+
+export function generateMonsterDNA(
+  species: string,
+  rng: ARERng = new SeededARERng(createARESeed(["monster-dna", species]))
+): MonsterDNA {
   return {
     species,
-    strength: Math.random(),
-    speed: Math.random(),
-    aggression: Math.random(),
-    intelligence: Math.random(),
-    resilience: Math.random()
+    strength: rng.nextFloat(),
+    speed: rng.nextFloat(),
+    aggression: rng.nextFloat(),
+    intelligence: rng.nextFloat(),
+    resilience: rng.nextFloat()
   };
 }

--- a/server/src/modules/monster/MonsterMutation.ts
+++ b/server/src/modules/monster/MonsterMutation.ts
@@ -1,5 +1,16 @@
-export function mutateMonster(dna: any, biome: string) {
-  const clone = { ...dna, mutations: [] as string[] };
+import { type ARERng, SeededARERng, createARESeed } from "../../core/determinism/AREDeterminism.js";
+import { type MonsterDNA } from "./MonsterDNA.js";
+
+export interface MutatedMonster extends MonsterDNA {
+  mutations: string[];
+}
+
+export function mutateMonster(
+  dna: MonsterDNA,
+  biome: string,
+  rng: ARERng = new SeededARERng(createARESeed(["monster-mutation", dna.species, biome]))
+): MutatedMonster {
+  const clone: MutatedMonster = { ...dna, mutations: [] as string[] };
 
   if (biome === "snow") {
     clone.resilience += 0.2;
@@ -11,7 +22,7 @@ export function mutateMonster(dna: any, biome: string) {
     clone.mutations.push("swamp_hunger");
   }
 
-  if (Math.random() < 0.08) {
+  if (rng.nextFloat() < 0.08) {
     clone.mutations.push("rare_variant");
   }
 

--- a/server/src/modules/monster/MonsterSpawner.ts
+++ b/server/src/modules/monster/MonsterSpawner.ts
@@ -1,9 +1,10 @@
+import { type ARERng } from "../../core/determinism/AREDeterminism.js";
 import { generateMonsterDNA } from "./MonsterDNA.js";
 import { mutateMonster } from "./MonsterMutation.js";
 
 export class MonsterSpawner {
-  spawn(species: string, biome: string) {
-    const dna = generateMonsterDNA(species);
-    return mutateMonster(dna, biome);
+  spawn(species: string, biome: string, rng?: ARERng) {
+    const dna = generateMonsterDNA(species, rng);
+    return mutateMonster(dna, biome, rng);
   }
 }


### PR DESCRIPTION
Focused rescue from old PR 1229. Keeps only deterministic monster generation and mutation changes using the existing ARE RNG primitives. Excludes package, workspace and lockfile drift.