### PR TITLE
fix(client-2d): remove redundant core-network workspace dependency

### DIFF
--- a/apps/client-2d/package.json
+++ b/apps/client-2d/package.json
@@ -14,7 +14,6 @@
     "@pixi/particle-emitter": "^5.0.8",
     "@pixi/sound": "^6.0.1",
     "@pixi/tilemap": "^5.0.2",
-    "@wasd/core-network": "workspace:*",
     "pixi-filters": "^6.1.4",
     "pixi.js": "^8.18.1",
     "react": "^19.2.6",


### PR DESCRIPTION
Fixes the VPS Docker deploy failure caused by pnpm resolving `@wasd/core-network@workspace:*` from `apps/client-2d` while the reduced Docker workspace does not include `packages/core-network`.

Context:
- `apps/client-2d/vite.config.mjs` already aliases `@wasd/core-network` to `./src/networkClient.ts`.
- The package dependency is therefore redundant for the 2D client build.
- Removing it avoids `[ERR_PNPM_WORKSPACE_PKG_NOT_FOUND]` during the VPS Docker preflight install.

Expected result:
- VPS Docker deploy progresses past pnpm install for `apps/client-2d`.