### PR TITLE
fix client 2d TypeScript path mapping

### DIFF
--- a/apps/client-2d/tsconfig.json
+++ b/apps/client-2d/tsconfig.json
@@ -10,7 +10,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@wasd/core-network": ["./src/networkClient.ts"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Follow-up fix for the 2D client. Adds the TypeScript path mapping that matches the existing Vite alias so local module resolution stays healthy after the deploy fix.