### PR TITLE
fix client 2d websocket runtime origin

### DIFF
--- a/apps/client-2d/src/networkClient.ts
+++ b/apps/client-2d/src/networkClient.ts
@@ -129,8 +129,15 @@ class LocalNetworkClient implements NetworkClient {
     for (const handler of this.handlers.get(event) ?? []) handler(payload);
   }
 
+  private resolveRuntimeBase(fallbackBase: string): string {
+    if (typeof window !== 'undefined' && window.location?.origin) {
+      return window.location.origin;
+    }
+    return fallbackBase;
+  }
+
   private toWebSocketUrl(base: string): string {
-    const url = new URL('/ws', base);
+    const url = new URL('/ws', this.resolveRuntimeBase(base));
     url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
     return url.toString();
   }


### PR DESCRIPTION
Fix the 2D client runtime websocket origin so www and non-www deployments use the same host that served the page. This avoids cross-origin websocket routing issues on live domains.