### PR TITLE
feat(client-2d): add itch export build

### DIFF
--- a/.github/workflows/client-2d-itch-export.yml
+++ b/.github/workflows/client-2d-itch-export.yml
@@ -1,0 +1,54 @@
+name: Client 2D itch export
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/client-2d/**"
+      - "packages/core-network/**"
+      - "scripts/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+jobs:
+  build-itch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VITE_ARELORIA_LIVE_URL: https://arelorian.de
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Build itch 2D client
+        run: pnpm --filter @wasd/client-2d build:itch
+
+      - name: Add upload notes
+        run: |
+          cat > apps/client-2d/dist-itch/ARELORIA_ITCH_README.txt <<'EOF'
+          Areloria 2D Live itch.io build
+
+          Upload this artifact as an HTML/browser game on itch.io.
+          The build uses relative asset paths and connects to https://arelorian.de for live state.
+          EOF
+
+      - name: Upload itch artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: areloria-2d-live-itch
+          path: apps/client-2d/dist-itch

--- a/apps/client-2d/package.json
+++ b/apps/client-2d/package.json
@@ -7,7 +7,9 @@
     "prebuild": "node ../../scripts/are-asset-forge.mjs && node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs && node ../../scripts/extract-2d-weapon-pool.mjs",
     "dev": "vite",
     "build": "vite build",
+    "build:itch": "vite build --config vite.config.itch.ts",
     "preview": "vite preview",
+    "preview:itch": "vite preview --outDir dist-itch",
     "validate:assets": "node ../../scripts/are-asset-forge.mjs && node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs"
   },
   "dependencies": {

--- a/apps/client-2d/src/LiveRealityBridge.tsx
+++ b/apps/client-2d/src/LiveRealityBridge.tsx
@@ -10,6 +10,8 @@ type LivePoint = {
   kind: "player" | "npc" | "loot";
 };
 
+const LIVE_SERVER_URL = import.meta.env.VITE_ARELORIA_LIVE_URL || "https://arelorian.de";
+
 function toPoint(entity: LiveRealityEntity, kind: LivePoint["kind"], index: number): LivePoint {
   return {
     id: `${kind}:${liveId(entity, `${kind}-${index}`)}`,
@@ -49,7 +51,7 @@ export function LiveRealityBridge() {
   const feedAt = useRef(0);
 
   useEffect(() => {
-    const client = createClient({ url: "https://arelorian.de", heartbeatInterval: 30000 });
+    const client = createClient({ url: LIVE_SERVER_URL, heartbeatInterval: 30000 });
 
     function ingest(event: any, source: "heartbeat" | "world_tick") {
       const payload = livePayload(event);
@@ -73,7 +75,7 @@ export function LiveRealityBridge() {
       }
     }
 
-    client.on("connect" as any, () => { setConnected(true); setFeed("2D live reality bridge connected."); });
+    client.on("connect" as any, () => { setConnected(true); setFeed(`2D live reality bridge connected to ${LIVE_SERVER_URL}.`); });
     client.on("disconnect" as any, () => setConnected(false));
     client.on("WORLD_HEARTBEAT" as any, (event: any) => ingest(event, "heartbeat"));
     client.on("world_tick" as any, (event: any) => ingest(event, "world_tick"));

--- a/apps/client-2d/vite.config.itch.ts
+++ b/apps/client-2d/vite.config.itch.ts
@@ -1,0 +1,16 @@
+import { defineConfig, mergeConfig } from "vite";
+import baseConfig from "./vite.config";
+
+export default mergeConfig(baseConfig, defineConfig({
+  base: "./",
+  build: {
+    outDir: "dist-itch",
+    emptyOutDir: true,
+    target: "esnext",
+    sourcemap: false,
+    minify: "esbuild"
+  },
+  define: {
+    __ARELORIA_EXPORT_TARGET__: JSON.stringify("itch.io")
+  }
+}));


### PR DESCRIPTION
Adds an itch.io-ready export path for the existing 2D client without forking the client code.

Changes:
- Adds Vite itch config using relative asset base `./` and output `dist-itch`.
- Adds `build:itch` and `preview:itch` scripts to `@wasd/client-2d`.
- Makes the live server URL configurable via `VITE_ARELORIA_LIVE_URL`, defaulting to `https://arelorian.de`.
- Adds GitHub Actions workflow that builds and uploads the `areloria-2d-live-itch` artifact.

This keeps the itch build connected to the same live game state as the internal 2D client.