### PR TITLE
fix(client-2d): constrain terrain and resolve pipoya actors

### DIFF
--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -84,7 +84,9 @@ async function loadJson<T>(url: string): Promise<T | null> {
 function withEntryIds(entries: Record<string, AssetEntry> | undefined): Record<string, AssetEntry> {
   const out: Record<string, AssetEntry> = {};
   Object.entries(entries ?? {}).forEach(([id, entry]) => {
-    out[id] = { ...entry, id };
+    const group = String(entry.group ?? '').toLowerCase();
+    const implicitTags = group === 'female' || group === 'male' ? ['civilian'] : [];
+    out[id] = { ...entry, id, tags: [...new Set([...(entry.tags ?? []), ...implicitTags])] };
   });
   return out;
 }
@@ -208,8 +210,8 @@ export function pickCharacterVisual(
   const wantedTags = (input.tags ?? []).map((tag) => tag.toLowerCase());
   const wantedGroup = String(input.group || '').toLowerCase();
   const wantedKind = String(input.kind || '').toLowerCase();
-  const matches = Object.entries(characters).filter(([, entry]) => {
-    if (!isRenderableEntry(entry)) return false;
+  const renderablePool = Object.entries(characters).filter(([, entry]) => isRenderableEntry(entry));
+  const matches = renderablePool.filter(([, entry]) => {
     const tags = (entry.tags ?? []).map((tag) => String(tag).toLowerCase());
     const group = String(entry.group ?? '').toLowerCase();
     const kind = String(entry.kind ?? '').toLowerCase();
@@ -218,9 +220,18 @@ export function pickCharacterVisual(
     const kindOk = !wantedKind || kind === wantedKind || tags.includes(wantedKind);
     return tagsOk && groupOk && kindOk;
   });
+  const groupMatches = renderablePool.filter(([, entry]) => {
+    const tags = (entry.tags ?? []).map((tag) => String(tag).toLowerCase());
+    const group = String(entry.group ?? '').toLowerCase();
+    return Boolean(wantedGroup) && (group === wantedGroup || tags.includes(wantedGroup));
+  });
+  const kindMatches = renderablePool.filter(([, entry]) => {
+    const tags = (entry.tags ?? []).map((tag) => String(tag).toLowerCase());
+    const kind = String(entry.kind ?? '').toLowerCase();
+    return Boolean(wantedKind) && (kind === wantedKind || tags.includes(wantedKind));
+  });
 
-  const renderablePool = Object.entries(characters).filter(([, entry]) => isRenderableEntry(entry));
-  const pool = matches.length > 0 ? matches : renderablePool;
+  const pool = matches.length > 0 ? matches : groupMatches.length > 0 ? groupMatches : kindMatches.length > 0 ? kindMatches : renderablePool;
   if (pool.length === 0) return null;
 
   const seed = String(input.seed ?? `${wantedKind}:${wantedGroup}:${wantedTags.join(',')}`);

--- a/apps/client-2d/src/forestBiomePicker.ts
+++ b/apps/client-2d/src/forestBiomePicker.ts
@@ -53,6 +53,9 @@ export type ForestBiomePickInput = {
   category?: ForestBiomeAssetCategory | null;
 };
 
+const TERRAIN_KIND_RE = /(?:^|[_\-\s/])(ground|grass|floor|tile|tileset|terrain|dirt|soil|path|road|earth|moss|leaf|leaves)(?:$|[_\-\s/])/i;
+const NON_TERRAIN_RE = /(?:particle|effect|fx|icon|ui|window|door|tree|bush|flower|rock|log|stump|character|npc|monster|object|deco|decoration)/i;
+
 export async function loadForestBiomeManifest(): Promise<ForestBiomeManifest | null> {
   try {
     const response = await fetch('/2d/assets/biomes/forest/assetpack01/manifest.json', { cache: 'no-store' });
@@ -87,25 +90,39 @@ export function deterministicForestHash(parts: Array<string | number | null | un
   return hash >>> 0;
 }
 
+function entryText(entry: ForestBiomeAssetEntry): string {
+  return `${entry.id} ${entry.kind} ${entry.group} ${entry.sourceName} ${entry.sourcePath} ${(entry.tags ?? []).join(' ')}`.toLowerCase();
+}
+
+function isSemanticTerrainEntry(entry: ForestBiomeAssetEntry | null | undefined): boolean {
+  if (!entry || entry.category !== 'tilesets') return false;
+  const text = `_${entryText(entry)}_`;
+  if (NON_TERRAIN_RE.test(text)) return false;
+  return TERRAIN_KIND_RE.test(text);
+}
+
+function basePoolIds(manifest: ForestBiomeManifest, input: ForestBiomePickInput): string[] {
+  if (input.kind && manifest.byKind[input.kind]?.length) return manifest.byKind[input.kind];
+  if (input.category && manifest[input.category]) return Object.keys(manifest[input.category]);
+  return manifest.all;
+}
+
 export function pickForestBiomeAsset(
   manifest: ForestBiomeManifest | null,
   input: ForestBiomePickInput,
 ): ForestBiomeAssetEntry | null {
   if (!manifest) return null;
 
-  let poolIds: string[] = [];
-  if (input.kind && manifest.byKind[input.kind]?.length) {
-    poolIds = manifest.byKind[input.kind];
-  } else if (input.category && manifest[input.category]) {
-    poolIds = Object.keys(manifest[input.category]);
-  } else {
-    poolIds = manifest.all;
+  let poolIds = basePoolIds(manifest, input);
+  if (input.category === 'tilesets') {
+    const semanticTerrainIds = poolIds.filter((id) => isSemanticTerrainEntry(manifest.entries[id]));
+    if (semanticTerrainIds.length > 0) poolIds = semanticTerrainIds;
   }
 
   if (poolIds.length === 0) return null;
 
   const hash = deterministicForestHash([
-    'forest-biome-v1',
+    'forest-biome-v2-semantic-terrain',
     input.worldSeed,
     input.chunkX,
     input.chunkZ,
@@ -121,7 +138,10 @@ export function pickForestBiomeAsset(
 }
 
 export function pickForestGround(manifest: ForestBiomeManifest | null, input: Omit<ForestBiomePickInput, 'kind' | 'category'>) {
-  return pickForestBiomeAsset(manifest, { ...input, kind: 'ground', category: 'tilesets' });
+  return pickForestBiomeAsset(manifest, { ...input, kind: 'ground', category: 'tilesets' })
+    ?? pickForestBiomeAsset(manifest, { ...input, kind: 'floor', category: 'tilesets' })
+    ?? pickForestBiomeAsset(manifest, { ...input, kind: 'tile', category: 'tilesets' })
+    ?? pickForestBiomeAsset(manifest, { ...input, category: 'tilesets' });
 }
 
 export function pickForestGrass(manifest: ForestBiomeManifest | null, input: Omit<ForestBiomePickInput, 'kind' | 'category'>) {


### PR DESCRIPTION
## Summary

- constrain forest terrain selection to semantic ground/floor/tile/terrain assets
- block obvious non-terrain assets such as FX, UI, trees, bushes, objects, decorations, characters, and particles from being stretched as 96x48 floor tiles
- add implicit `civilian` tags for Pipoya `Female` and `Male` atlas groups
- make character visual selection fall back by group/kind before dropping to arbitrary renderable entries

## Why

The 2D view was rendering fallback actors because Pipoya character groups were not matching the requested `civilian` tag path. The terrain also looked like spray-painted multi-color noise because non-ground forest images could be picked and stretched as isometric floor tiles.

## Scope

Client 2D asset semantics only.

Changed files:
- `apps/client-2d/src/assetManifest.ts`
- `apps/client-2d/src/forestBiomePicker.ts`

## Validation

- Branch is based on current `main` `ad71f599bf91fd301dcbaedc92d7fc312da49f64`.
- Branch is ahead by 2 commits and behind by 0.
- Manual post-deploy check: `/2d/` should use real Pipoya actors for player/NPCs and terrain should no longer select obvious deco/FX/object PNGs as floor tiles.