### PR TITLE
fix(brain): process reality fissures deterministically

### DIFF
--- a/server/src/modules/brain/RealityFissureBrain.ts
+++ b/server/src/modules/brain/RealityFissureBrain.ts
@@ -31,8 +31,11 @@ export class RealityFissureBrain {
 
   public getCriticalFissures(now = 0): FissureData[] {
       const critical: FissureData[] = [];
+      const fissures = Array.from(this.activeFissures.entries()).sort(([leftChunkId], [rightChunkId]) =>
+          leftChunkId.localeCompare(rightChunkId)
+      );
 
-      for (const [chunkId, fissure] of this.activeFissures.entries()) {
+      for (const [chunkId, fissure] of fissures) {
           // Decay severity over time (heal)
           const timeSinceActive = now - fissure.lastAnalyzed;
           if (timeSinceActive > 30000) { // 30 seconds of no paradoxes heals it slightly


### PR DESCRIPTION
Clean manual extraction from #1251 without package.json, pnpm-workspace.yaml, pnpm-lock.yaml, or portal churn.

Change:
- Iterates RealityFissureBrain.activeFissures in sorted chunkId order before applying decay/deletion/critical collection.

Why:
- Keeps simulation behavior deterministic even when Map insertion order differs between equivalent runs.