### PR TITLE
fix(client-2d): improve mobile touch playability

### DIFF
--- a/apps/client-2d/src/MobileMovePad.tsx
+++ b/apps/client-2d/src/MobileMovePad.tsx
@@ -16,11 +16,15 @@ export function MobileMovePad() {
     const releaseAll = () => release();
     window.addEventListener("blur", releaseAll);
     window.addEventListener("contextmenu", releaseAll);
+    window.addEventListener("pagehide", releaseAll);
+    document.addEventListener("visibilitychange", releaseAll);
 
     return () => {
       window.clearInterval(timer);
       window.removeEventListener("blur", releaseAll);
       window.removeEventListener("contextmenu", releaseAll);
+      window.removeEventListener("pagehide", releaseAll);
+      document.removeEventListener("visibilitychange", releaseAll);
       releaseAll();
     };
   }, []);
@@ -42,12 +46,20 @@ export function MobileMovePad() {
     activePointerId.current = null;
   }
 
+  const bind = (next: MoveVector) => ({
+    onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => hold(next, event),
+    onPointerUp: release,
+    onPointerCancel: release,
+    onPointerLeave: release,
+    onLostPointerCapture: release,
+  });
+
   return (
     <nav className="az-touch-pad" aria-label="Mobile movement controls" style={{ touchAction: "none", userSelect: "none" }}>
-      <button className="up" onPointerDown={(event) => hold({ dx: 0, dz: 1 }, event)} onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release} aria-label="Move up">▲</button>
-      <button className="left" onPointerDown={(event) => hold({ dx: -1, dz: 0 }, event)} onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release} aria-label="Move left">◀</button>
-      <button className="right" onPointerDown={(event) => hold({ dx: 1, dz: 0 }, event)} onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release} aria-label="Move right">▶</button>
-      <button className="down" onPointerDown={(event) => hold({ dx: 0, dz: -1 }, event)} onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release} aria-label="Move down">▼</button>
+      <button className="up" {...bind({ dx: 0, dz: 1 })} aria-label="Move up">▲</button>
+      <button className="left" {...bind({ dx: -1, dz: 0 })} aria-label="Move left">◀</button>
+      <button className="right" {...bind({ dx: 1, dz: 0 })} aria-label="Move right">▶</button>
+      <button className="down" {...bind({ dx: 0, dz: -1 })} aria-label="Move down">▼</button>
     </nav>
   );
 }

--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -11,6 +11,7 @@ import "./theme.css";
 import "./liveReality.css";
 import "./worldHeart.css";
 import "./pixiModuleInspector.css";
+import "./mobilePlayability.css";
 
 installClient2DDepthRuntime();
 

--- a/apps/client-2d/src/mobilePlayability.css
+++ b/apps/client-2d/src/mobilePlayability.css
@@ -1,0 +1,138 @@
+html,
+body,
+#root {
+  touch-action: none;
+  overscroll-behavior: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.az-shell,
+.az-pixi,
+.az-touch-pad,
+.stitch-hud {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.az-shell {
+  touch-action: none;
+  overscroll-behavior: none;
+}
+
+.az-touch-pad {
+  touch-action: none;
+}
+
+.az-touch-pad button,
+.stitch-skillbar button,
+.stitch-side-menu button {
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+@media (max-width: 920px) {
+  .az-touch-pad {
+    left: calc(env(safe-area-inset-left, 0px) + 12px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 132px);
+    grid-template-columns: repeat(3, 60px);
+    grid-template-rows: repeat(3, 60px);
+    gap: 8px;
+  }
+
+  .az-touch-pad button {
+    min-width: 56px;
+    min-height: 56px;
+    border-radius: 20px;
+    font-size: 20px;
+  }
+
+  .stitch-topbar {
+    top: calc(env(safe-area-inset-top, 0px) + 10px);
+    left: calc(env(safe-area-inset-left, 0px) + 10px);
+    right: calc(env(safe-area-inset-right, 0px) + 10px);
+  }
+
+  .stitch-vitals {
+    left: calc(env(safe-area-inset-left, 0px) + 10px);
+  }
+
+  .stitch-chat {
+    left: calc(env(safe-area-inset-left, 0px) + 10px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 10px);
+  }
+
+  .stitch-skillbar {
+    right: calc(env(safe-area-inset-right, 0px) + 10px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 10px);
+  }
+
+  .stitch-skillbar button {
+    min-width: 74px;
+    min-height: 56px;
+  }
+
+  .stitch-side-menu {
+    right: calc(env(safe-area-inset-right, 0px) + 10px);
+  }
+}
+
+@media (max-width: 520px) {
+  .az-touch-pad {
+    left: calc(env(safe-area-inset-left, 0px) + 10px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 126px);
+    grid-template-columns: repeat(3, 56px);
+    grid-template-rows: repeat(3, 56px);
+    gap: 7px;
+  }
+
+  .az-touch-pad button {
+    min-width: 56px;
+    min-height: 56px;
+    border-radius: 19px;
+  }
+
+  .stitch-chat {
+    width: calc(100vw - 118px - env(safe-area-inset-left, 0px));
+  }
+
+  .stitch-chat-lines {
+    min-height: 48px;
+    max-height: 48px;
+  }
+
+  .stitch-chat-input input {
+    padding: 9px 10px;
+    font-size: 13px;
+  }
+
+  .stitch-chat-input button {
+    padding: 9px 10px;
+  }
+
+  .stitch-skillbar button {
+    min-width: 72px;
+    min-height: 56px;
+  }
+
+  .pixi-module-inspector,
+  .live-reality-bridge {
+    display: none;
+  }
+}
+
+@media (max-height: 640px) and (max-width: 920px) {
+  .stitch-vitals {
+    transform: scale(0.88);
+    transform-origin: top left;
+  }
+
+  .stitch-chat-lines {
+    display: none;
+  }
+
+  .az-touch-pad {
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 104px);
+  }
+}


### PR DESCRIPTION
Mobile-first client-only playability pass for apps/client-2d.

Changes:
- harden MobileMovePad release handling for pagehide and visibilitychange
- add pointer leave release handling
- add safe-area-aware mobile CSS overrides
- keep touch and skill buttons thumb-friendly on small screens
- hide debug/live overlays on very narrow screens

No server, core, package, lockfile, or protocol changes.

Closes #1259.