### PR TITLE
fix(client-2d): improve visual smoothness and depth

### DIFF
--- a/apps/client-2d/src/CyberZenIsoApp.tsx
+++ b/apps/client-2d/src/CyberZenIsoApp.tsx
@@ -24,6 +24,7 @@ import {
 import { ArelorianStitchHud } from "./ArelorianStitchHud";
 import { iso3 } from "./isometricProjection";
 import { make2dProp } from "./stackedProps";
+import { moveVisualTowards } from "./visualMotion";
 
 const TILE_W = 96;
 const TILE_H = 48;
@@ -392,7 +393,7 @@ export function CyberZenIsoApp() {
       addActor(app, actors, "self", 0, 0, playerName, true, loaded, initialWeaponId);
       addActor(app, actors, "elder", 2, 1, "Millbrook Elder", false, loaded);
       startNetwork(app, actors);
-      app.ticker.add(() => tick(app, actors));
+      app.ticker.add((ticker) => tick(app, actors, ticker.deltaTime));
     });
     return () => {
       clientRef.current?.disconnect();
@@ -507,7 +508,7 @@ export function CyberZenIsoApp() {
     c.connect();
   }
 
-  function tick(app: Application, layer: Container) {
+  function tick(app: Application, layer: Container, deltaTime = 1) {
     let dx = 0, dz = 0;
     const k = keys.current;
     if (k.has("w") || k.has("arrowup")) dz += 1;
@@ -517,11 +518,8 @@ export function CyberZenIsoApp() {
     if (dx || dz) sendMove({ dx, dz });
     entities.current.forEach((ent) => {
       const p = iso(ent.tx, ent.tz, app.screen.width, app.screen.height);
-      ent.root.x += (p.x - ent.root.x) * 0.18;
-      ent.root.y += (p.y - ent.root.y) * 0.18;
-      ent.root.zIndex = ent.root.y;
+      moveVisualTowards(ent.root, p, deltaTime);
     });
-    layer.sortChildren();
   }
 
   function sendSkill(skillId: string) {

--- a/apps/client-2d/src/visualMotion.ts
+++ b/apps/client-2d/src/visualMotion.ts
@@ -1,0 +1,23 @@
+import type { Container } from "pixi.js";
+
+const DEFAULT_BLEND = 0.22;
+const MAX_DELTA = 2;
+
+export type VisualPoint = {
+  x: number;
+  y: number;
+};
+
+export function moveVisualTowards(
+  root: Container,
+  target: VisualPoint,
+  deltaTime = 1,
+  blend = DEFAULT_BLEND,
+) {
+  const dt = Number.isFinite(deltaTime) ? Math.max(0, Math.min(deltaTime, MAX_DELTA)) : 1;
+  const amount = Math.max(0, Math.min(1, blend * dt));
+
+  root.x += (target.x - root.x) * amount;
+  root.y += (target.y - root.y) * amount;
+  root.zIndex = root.y;
+}


### PR DESCRIPTION
Client-only visual refinement for the 2D client.

Changes:
- adds a small visual motion helper
- makes actor interpolation delta-aware through the Pixi ticker
- keeps logical server targets separate from visual sprite position
- keeps zIndex tied to visual Y for depth ordering
- removes manual per-frame layer.sortChildren call

No server, input bridge, package, lockfile, or protocol changes.