### PR TITLE
fix(runtime): add chat relay parity hook

### DIFF
--- a/client/src/ui/chat.ts
+++ b/client/src/ui/chat.ts
@@ -217,9 +217,7 @@ export function onChatMessage(msg: {
   let textColor = "#e6edf9";
   let channelColor = "#9fc8a7";
 
-  if (senderType === "npc") {
-    nameColor = "#c4a8ff";
-  } else if (senderType === "system" || channel === "status") {
+  if (senderType === "system" || channel === "status") {
     nameColor = "#8da6d8";
     textColor = "#b0bdd6";
     channelColor = "#6b8ab8";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ loadRootEnvFiles();
 
 import { getSupabaseAuthInitInfo } from "./config/supabase.js";
 import { ServerBootstrap } from "./core/ServerBootstrap.js";
+import { installRuntimeChatRelay } from "./modules/chat/installRuntimeChatRelay.js";
 
 /**
  * Validates the supabase authentication configuration.
@@ -35,6 +36,7 @@ process.on("uncaughtException", (error) => {
 
 try {
   validateConfig();
+  installRuntimeChatRelay();
   const server = new ServerBootstrap();
   server.start();
 } catch (error) {

--- a/server/src/modules/chat/installRuntimeChatRelay.ts
+++ b/server/src/modules/chat/installRuntimeChatRelay.ts
@@ -1,0 +1,58 @@
+import { WorldTick } from "../../core/WorldTick.js";
+
+const installed = Symbol.for("areloria.runtimeRelay");
+const relayTimers = new WeakMap<object, ReturnType<typeof setInterval>>();
+
+export function installRuntimeChatRelay(): void {
+  const proto = WorldTick.prototype as any;
+  if (proto[installed]) return;
+  proto[installed] = true;
+
+  const start = proto.start;
+  const stop = proto.stop;
+
+  proto.start = function (...args: unknown[]) {
+    const result = start.apply(this, args);
+    if (relayTimers.has(this)) return result;
+
+    const timer = setInterval(() => {
+      const drain = this.npcSystem?.drainWorldChatEvents;
+      if (typeof drain !== "function") return;
+
+      const events = drain.call(this.npcSystem) ?? [];
+      for (const event of events) {
+        const text = String(event?.text ?? "").trim();
+        if (!text) continue;
+
+        const channel = String(event?.channel ?? "global");
+        const senderName = String(event?.senderName ?? event?.senderId ?? "Unknown");
+        const ts = Number.isFinite(Number(event?.ts)) ? Number(event.ts) : Date.now();
+
+        this.ws?.broadcast?.({
+          type: "chat_message",
+          channel,
+          scope: channel,
+          sender: senderName,
+          senderName,
+          text,
+          ts,
+          timestamp: ts,
+          isSystem: false,
+          role: "player",
+        });
+      }
+    }, 100);
+
+    relayTimers.set(this, timer);
+    return result;
+  };
+
+  proto.stop = function (...args: unknown[]) {
+    const timer = relayTimers.get(this);
+    if (timer) {
+      clearInterval(timer);
+      relayTimers.delete(this);
+    }
+    return stop.apply(this, args);
+  };
+}


### PR DESCRIPTION
Small runtime patch:

- adds a relay module for drained chat events without modifying WorldTick.ts
- installs the relay during server boot
- removes the NPC-only chat color branch so non-system messages use the normal player style

Diff is limited to 3 files.