### PR TITLE
fix(core): make world state sync time deterministic

### DIFF
--- a/server/src/core/state/RegionState.ts
+++ b/server/src/core/state/RegionState.ts
@@ -130,13 +130,21 @@ export interface WorldState {
 }
 
 /**
+ * Converts a tick into a deterministic timestamp surrogate.
+ * The value is not wall-clock time; it is the simulation tick index encoded as a number.
+ */
+export function deterministicSyncTimestampFromTick(tick: bigint): number {
+  return Number(tick);
+}
+
+/**
  * Creates a default WorldState
  */
 export function createDefaultWorldState(): WorldState {
   return {
     regions: new Map(),
     globalTick: BigInt(0),
-    lastSyncTimestamp: Date.now(),
+    lastSyncTimestamp: deterministicSyncTimestampFromTick(BigInt(0)),
   };
 }
 

--- a/server/src/core/state/WorldStateRegistry.ts
+++ b/server/src/core/state/WorldStateRegistry.ts
@@ -9,6 +9,7 @@ import {
   WorldState, 
   createDefaultRegionState,
   createDefaultWorldState,
+  deterministicSyncTimestampFromTick,
   type IRegionState,
   type IWorldState,
 } from './RegionState.js';
@@ -59,11 +60,12 @@ export class WorldStateRegistry {
    * Must only be called by Arelorian Tick Orchestrator (ATO)
    */
   public commitMutations(): void {
+    const nextTick = this.currentState.globalTick + BigInt(1);
     // Start new world state from current (copy)
     const newState: WorldState = {
       regions: new Map(this.currentState.regions),
-      globalTick: this.currentState.globalTick + BigInt(1),
-      lastSyncTimestamp: Date.now(),
+      globalTick: nextTick,
+      lastSyncTimestamp: deterministicSyncTimestampFromTick(nextTick),
     };
     
     // Apply each mutation


### PR DESCRIPTION
## Summary

- removes `Date.now()` from deterministic world-state initialization
- derives `lastSyncTimestamp` from the simulation tick instead of wall-clock time
- updates `WorldStateRegistry.commitMutations()` to use the next tick as deterministic sync-time source

## Why

After PR #1284 removed the pnpm lockfile blocker, the Architecture Guard reached the real failure: non-deterministic wall-clock time inside `server/src/core/state`.

The guard scans deterministic roots and rejects `Date.now()` / `Math.random()` in world-state simulation code. `RegionState.ts` and `WorldStateRegistry.ts` both used `Date.now()` for `lastSyncTimestamp`, which breaks replayability and ARE/Ouroboros determinism.

## Notes

`lastSyncTimestamp` remains a number for compatibility, but now represents a deterministic simulation tick surrogate, not wall-clock time.