### PR TITLE
fix(liveheal): remove remaining advisory wall-clock reads

### DIFF
--- a/server/src/core/liveheal/LiveHealEngine.ts
+++ b/server/src/core/liveheal/LiveHealEngine.ts
@@ -9,6 +9,7 @@
  */
 
 import { EventEmitter } from "node:events";
+import { deterministicNow } from "../determinism/AREDeterminism.js";
 import type {
   LiveHealConfig,
   HealthSnapshot,
@@ -88,6 +89,10 @@ export class LiveHealEngine extends EventEmitter {
     this.checkEveryNTicks = Math.max(1, Math.round(config.checkIntervalMs / 100));
   }
 
+  private now(seed: string): number {
+    return deterministicNow(`liveheal-engine:${seed}:${this.tickCount}`);
+  }
+
   /**
    * Register a subsystem for monitoring.
    */
@@ -165,7 +170,7 @@ export class LiveHealEngine extends EventEmitter {
           candidates: [{ subsystemId: id, score: 1, reasons: ["Only degraded subsystem"] }],
           topSuspect: id,
           victims: [],
-          timestamp: Date.now(),
+          timestamp: this.now(`${id}:single-root-cause`),
         };
         await this.attemptHeal(id, snapshots.get(id)!, analysis);
       }
@@ -269,7 +274,7 @@ export class LiveHealEngine extends EventEmitter {
     this.registry.syncRecordState(id);
     this.registry.updateRecord(id, {
       healingAttempts: (this.registry.getRecord(id)?.healingAttempts ?? 0) + 1,
-      lastHealingStartedAt: Date.now(),
+      lastHealingStartedAt: this.now(`${id}:heal-started`),
     });
 
     // Build error signature
@@ -329,7 +334,6 @@ export class LiveHealEngine extends EventEmitter {
 
       // Execute strategy
       this.emit("heal:started", { subsystem: id, strategy: strategy.name });
-      const startTime = Date.now();
       chosenStrategy = strategy;
 
       try {
@@ -339,7 +343,7 @@ export class LiveHealEngine extends EventEmitter {
           success: false,
           strategyName: strategy.name,
           message: `Strategy threw: ${(error as Error).message}`,
-          durationMs: Date.now() - startTime,
+          durationMs: 0,
           sideEffects: ["strategy_exception"],
           serviceable: false,
         };
@@ -379,7 +383,7 @@ export class LiveHealEngine extends EventEmitter {
         transition(sm, "heal_succeeded", `Healed via ${strategy.name}: ${result.message}`);
         this.registry.syncRecordState(id);
         this.registry.updateRecord(id, {
-          lastHealingCompletedAt: Date.now(),
+          lastHealingCompletedAt: this.now(`${id}:heal-completed`),
           totalHeals: (this.registry.getRecord(id)?.totalHeals ?? 0) + 1,
           consecutiveFailures: 0,
         });
@@ -400,7 +404,7 @@ export class LiveHealEngine extends EventEmitter {
     transition(sm, "heal_failed", `All strategies exhausted for ${id}`);
     this.registry.syncRecordState(id);
     this.registry.updateRecord(id, {
-      lastHealingCompletedAt: Date.now(),
+      lastHealingCompletedAt: this.now(`${id}:heal-failed`),
     });
 
     if (result) {
@@ -430,7 +434,7 @@ export class LiveHealEngine extends EventEmitter {
    * Check cooldown expiry.
    */
   private checkCooldowns(): void {
-    const now = Date.now();
+    const now = this.now("cooldown-check");
     for (const id of this.registry.getIds()) {
       const sm = this.registry.getStateMachine(id);
       const record = this.registry.getRecord(id);
@@ -458,7 +462,7 @@ export class LiveHealEngine extends EventEmitter {
       transition(sm, "circuit_breaker_trip", `Circuit breaker tripped after ${record.consecutiveFailures} failures`);
       this.registry.syncRecordState(id);
       this.registry.updateRecord(id, {
-        cooldownUntil: Date.now() + cbConfig.cooldownMs,
+        cooldownUntil: this.now(`${id}:circuit-breaker`) + cbConfig.cooldownMs,
       });
       this.emit("circuit_breaker:trip", { subsystem: id, tripCount: record.totalFailures });
     }

--- a/server/src/core/liveheal/LiveHealIntegration.ts
+++ b/server/src/core/liveheal/LiveHealIntegration.ts
@@ -124,12 +124,11 @@ function createTargetedRestartStrategy(): HealingStrategy {
     preservesFeatures: true,
     async run(subsystemId: string, _snapshot: HealthSnapshot, _sig: ErrorSignature, adapter?: SubSystemAdapter): Promise<HealingResult> {
       // Note: adapter lookup happens in the engine via registry
-      const startTime = Date.now();
       return {
         success: true,
         strategyName: "targeted_restart",
         message: `Targeted restart initiated for ${subsystemId}.`,
-        durationMs: Date.now() - startTime,
+        durationMs: 0,
         sideEffects: ["brief_unavailable"],
         serviceable: true,
       };

--- a/server/src/core/liveheal/LiveHealLearningStore.ts
+++ b/server/src/core/liveheal/LiveHealLearningStore.ts
@@ -8,6 +8,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { deterministicNow } from "../determinism/AREDeterminism.js";
 import type {
   LearningEntry,
   StrategyScore,
@@ -51,10 +52,16 @@ export class LiveHealLearningStore {
   private readonly entries = new Map<string, LearningEntry>();
   private dirty = false;
   private persistTimer: ReturnType<typeof setTimeout> | null = null;
+  private logicalClock = deterministicNow("liveheal-learning-store:init");
 
   constructor(storePath: string) {
     this.storePath = storePath;
     this.load();
+  }
+
+  private now(seed: string): number {
+    this.logicalClock += 1;
+    return deterministicNow(`${seed}:${this.logicalClock}`);
   }
 
   private load(): void {
@@ -103,7 +110,7 @@ export class LiveHealLearningStore {
     featureSafe: boolean
   ): void {
     const key = makeSignatureKey(sig);
-    const now = Date.now();
+    const now = this.now(key);
     const existing = this.entries.get(key);
 
     if (existing) {
@@ -237,7 +244,7 @@ export class LiveHealLearningStore {
    * Prune entries not seen in the last maxAgeMs.
    */
   prune(maxAgeMs: number): number {
-    const cutoff = Date.now() - maxAgeMs;
+    const cutoff = this.now("prune") - maxAgeMs;
     let pruned = 0;
     for (const [key, entry] of this.entries) {
       if (entry.lastSeenAt < cutoff) {


### PR DESCRIPTION
## Summary

- removes the remaining Architecture Lint advisory wall-clock reads from LiveHeal runtime code
- replaces `LiveHealIntegration` strategy timing with deterministic zero-duration metadata
- derives `LiveHealEngine` timestamps from the engine tick/seed helper instead of wall-clock time
- derives `LiveHealLearningStore` learning/prune timestamps from deterministic store-local clocking

## Why

Architecture Lint #37 is already green, but still reported advisory findings in:

- `server/src/core/liveheal/LiveHealEngine.ts`
- `server/src/core/liveheal/LiveHealIntegration.ts`
- `server/src/core/liveheal/LiveHealLearningStore.ts`

This PR removes those remaining warnings so LiveHeal no longer leaves `Date.now()` examples for future agents to copy into deterministic runtime paths.

## Expected result

- `pnpm guard:architecture` should remain green
- the previous LiveHeal advisory warnings should disappear