### PR TITLE
fix(ci): force client-2d build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,8 @@ ENV NODE_OPTIONS="--max-old-space-size=12288"
 RUN pnpm --filter @wasd/core-logic --if-present run build:runtime && \
     pnpm --filter @wasd/shared --if-present build && \
     pnpm --filter @wasd/server --if-present build
+RUN pnpm --filter ./apps/client-2d... run build
+RUN test -f /app/apps/client-2d/dist/index.html
 
 # Prune dev dependencies
 RUN pnpm prune --prod


### PR DESCRIPTION
Forces the Docker builder stage to build apps/client-2d and verifies that dist/index.html exists before runtime packaging. Only the root Dockerfile is changed.