### PR TITLE
Add client-2d VPS build fallback

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -81,7 +81,8 @@ RUN pnpm --filter @wasd/client --if-present build || \
 
 RUN rm -rf /tmp/wasd-3d-dist && mkdir -p /tmp/wasd-3d-dist && cp -a client/dist/. /tmp/wasd-3d-dist/
 
-RUN pnpm --filter @wasd/client-2d --if-present build && \
+RUN pnpm --filter @wasd/client-2d --if-present build || \
+    (mkdir -p apps/client-2d/dist && printf '%s\n' '<!doctype html><html><head><title>Arelorian 2D</title><meta name="viewport" content="width=device-width,initial-scale=1" /></head><body style="margin:0;background:#05060b;color:#f4f7ff;font-family:system-ui;display:grid;min-height:100vh;place-items:center"><main style="max-width:620px;padding:28px;border:1px solid rgba(0,229,255,.35);border-radius:22px;background:rgba(4,8,14,.82)"><h1>Arelorian 2D temporarily unavailable</h1><p>The server is online, but the 2D client build was skipped on this VPS deploy because the build process exceeded available memory.</p><p>Retry the deploy or build the client artifact outside the VPS Docker build.</p></main></body></html>' > apps/client-2d/dist/index.html) && \
     test -f apps/client-2d/dist/index.html
 
 RUN VITE_BASE_PATH=/portal/ pnpm --filter @wasd/portal --if-present build || \


### PR DESCRIPTION
Prevents VPS Docker deploy from failing completely when the client-2d Vite build is killed by memory pressure.

Observed failure:
- vite build killed with exit 137 during Docker build
- 3D client already has a fallback path
- 2D client had no fallback and killed the deploy

Change:
- keep existing 3D fallback
- add 2D fallback HTML when @wasd/client-2d build is killed
- still require apps/client-2d/dist/index.html so runtime entrypoints remain valid

This keeps the server deployable while we separately optimize or externalize the client build artifact.