### PR TITLE
chore(det): ban async clocks in determinism gate

### DIFF
--- a/scripts/check-determinism-gate.mjs
+++ b/scripts/check-determinism-gate.mjs
@@ -32,6 +32,9 @@ const deny = [
   { pattern: /\bMath\.random\s*\(/, label: 'Math.random()' },
   { pattern: /\bDate\.now\s*\(/, label: 'Date.now()' },
   { pattern: /\bnew\s+Date\s*\(/, label: 'new Date()' },
+  { pattern: /\bsetTimeout\s*\(/, label: 'setTimeout()' },
+  { pattern: /\bsetInterval\s*\(/, label: 'setInterval()' },
+  { pattern: /\bperformance\.now\s*\(/, label: 'performance.now()' },
   { pattern: /\bcrypto\.randomUUID\s*\(/, label: 'crypto.randomUUID()' },
   { pattern: /\brandomUUID\s*\(/, label: 'randomUUID()' },
 ];


### PR DESCRIPTION
Extends scripts/check-determinism-gate.mjs so strict world-state paths also reject setTimeout(), setInterval(), and performance.now().