### PR TITLE
fix(det): purge async timers from AI and respawn state

### DIFF
--- a/server/src/core/AIOrchestrator.ts
+++ b/server/src/core/AIOrchestrator.ts
@@ -6,6 +6,15 @@ interface TaskPayload {
     priority: number; // e.g. P1 = 1 (highest), P3 = 3 (lowest)
 }
 
+interface RepolessPollState {
+    sessionId: string;
+    fallbackFn: () => any;
+    wakeupTick: number;
+    deadlineTick: number;
+    resolve: (value: any) => void;
+    inFlight: boolean;
+}
+
 /**
  * AIOrchestrator manages task queuing and execution for external AI services.
  * Uses global fetch API (Node 18+) or requires 'node-fetch' types/polyfill.
@@ -13,6 +22,10 @@ interface TaskPayload {
 export class AIOrchestrator {
    private static readonly GITHUB_DISPATCH_URL = "https://api.github.com/repos/OuroborosCollective/Areloria/dispatches";
    private static readonly JULES_API_URL = "https://jules.googleapis.com/v1alpha";
+
+   private static readonly REPOLLESS_TIMEOUT_TICKS = 5 * 60 * 10;
+   private static readonly POLL_ERROR_SLEEP_TICKS = 100;
+   private static readonly POLL_SLEEP_TICKS = 150;
 
    // Limits for AI Pro (100 tasks/day)
    private static readonly MAX_DAILY_TASKS = 100;
@@ -22,10 +35,87 @@ export class AIOrchestrator {
 
    private static taskQueue: TaskPayload[] = [];
    private static isProcessingQueue = false;
+   private static repolessPolls: RepolessPollState[] = [];
 
    private static now(): number {
        this.logicalClock += 1;
        return this.logicalClock;
+   }
+
+   /**
+    * Drives pending AI polling from the deterministic world tick.
+    */
+   public static update(currentWorldTick: number): void {
+       const tick = Math.trunc(currentWorldTick);
+
+       for (const poll of [...this.repolessPolls]) {
+           if (tick >= poll.deadlineTick) {
+               this.resolveRepolessPoll(poll, poll.fallbackFn());
+               continue;
+           }
+
+           if (poll.inFlight || tick < poll.wakeupTick) continue;
+
+           poll.inFlight = true;
+           void this.pollRepolessSession(poll, tick);
+       }
+   }
+
+   private static resolveRepolessPoll(poll: RepolessPollState, value: any): void {
+       const index = this.repolessPolls.indexOf(poll);
+       if (index < 0) return;
+
+       this.repolessPolls.splice(index, 1);
+       poll.resolve(value);
+   }
+
+   private static async pollRepolessSession(poll: RepolessPollState, currentWorldTick: number): Promise<void> {
+       try {
+           const pollRes = await fetch(`${this.JULES_API_URL}/sessions/${poll.sessionId}/activities?pageSize=50`, {
+               headers: {
+                   "x-goog-api-key": process.env.JULES_API_KEY || ''
+               }
+           });
+
+           if (this.repolessPolls.indexOf(poll) < 0) return;
+
+           if (!pollRes.ok) {
+               poll.wakeupTick = currentWorldTick + this.POLL_ERROR_SLEEP_TICKS;
+               return;
+           }
+
+           const data = await pollRes.json() as any;
+           const activities = data.activities || [];
+
+           for (const activity of activities) {
+               if (activity.artifacts) {
+                   for (const artifact of activity.artifacts) {
+                       if (artifact.bashOutput) {
+                           try {
+                               this.resolveRepolessPoll(poll, JSON.parse(artifact.bashOutput.output));
+                           } catch (e) {
+                               this.resolveRepolessPoll(poll, artifact.bashOutput.output);
+                           }
+                           return;
+                       }
+                   }
+               }
+               if (activity.status === 'ERROR') {
+                   console.error("[AI-Orchestrator] Repoless Session failed.");
+                   this.resolveRepolessPoll(poll, poll.fallbackFn());
+                   return;
+               }
+           }
+
+           poll.wakeupTick = currentWorldTick + this.POLL_SLEEP_TICKS;
+       } catch (err) {
+           console.error("[AI-Orchestrator] Repoless polling error.", err);
+           if (this.repolessPolls.indexOf(poll) >= 0) {
+               poll.wakeupTick = currentWorldTick + this.POLL_ERROR_SLEEP_TICKS;
+           }
+       } finally {
+           poll.inFlight = false;
+       }
    }
 
    /**
@@ -38,9 +128,9 @@ export class AIOrchestrator {
    }
 
    private static resetTaskCountIfNeeded() {
-       const ONE_DAY = 24 * 60 * 60 * 1000;
+       const ONE_DAY_TICKS = 24 * 60 * 60 * 10;
        const now = this.now();
-       if (now - this.lastTaskReset > ONE_DAY) {
+       if (now - this.lastTaskReset > ONE_DAY_TICKS) {
            this.taskCount = 0;
            this.lastTaskReset = now;
        }
@@ -95,7 +185,7 @@ export class AIOrchestrator {
    }
 
    /**
-    * Executes a Repoless session for data generation and waits for the result via polling.
+    * Executes a Repoless session for data generation and waits for the result via tick-driven polling.
     */
    public static async runRepolessSession(prompt: string, title: string, fallbackFn: () => any): Promise<any> {
         this.resetTaskCountIfNeeded();
@@ -128,48 +218,18 @@ export class AIOrchestrator {
                  return fallbackFn();
             }
 
-            const startTime = this.now();
-            const TIMEOUT_MS = 5 * 60 * 1000;
+            const startTick = Math.trunc(this.now());
 
-            while (this.now() - startTime < TIMEOUT_MS) {
-                const pollRes = await fetch(`${this.JULES_API_URL}/sessions/${sessionId}/activities?pageSize=50`, {
-                    headers: {
-                        "x-goog-api-key": process.env.JULES_API_KEY || ''
-                    }
+            return new Promise((resolve) => {
+                this.repolessPolls.push({
+                    sessionId,
+                    fallbackFn,
+                    wakeupTick: startTick,
+                    deadlineTick: startTick + this.REPOLLESS_TIMEOUT_TICKS,
+                    resolve,
+                    inFlight: false,
                 });
-
-                if (!pollRes.ok) {
-                     await new Promise(resolve => setTimeout(resolve, 10000));
-                     continue;
-                }
-
-                const data = await pollRes.json() as any;
-                const activities = data.activities || [];
-
-                for (const activity of activities) {
-                    if (activity.artifacts) {
-                        for (const artifact of activity.artifacts) {
-                            if (artifact.bashOutput) {
-                                try {
-                                    return JSON.parse(artifact.bashOutput.output);
-                                } catch (e) {
-                                    return artifact.bashOutput.output;
-                                }
-                            }
-                        }
-                    }
-                    if (activity.status === 'ERROR') {
-                         console.error("[AI-Orchestrator] Repoless Session failed.");
-                         return fallbackFn();
-                    }
-                }
-
-                await new Promise(resolve => setTimeout(resolve, 15000));
-            }
-
-            console.warn("[AI-Orchestrator] Repoless session timed out. Returning fallback.");
-            return fallbackFn();
-
+            });
         } catch (err) {
             console.error("[AI-Orchestrator] Repoless Session Error.", err);
             return fallbackFn();

--- a/server/src/modules/combat/deathRespawnSystem.ts
+++ b/server/src/modules/combat/deathRespawnSystem.ts
@@ -1,9 +1,6 @@
-/**
- * Death & Respawn system — handles player death state, respawn timers,
- * and zone-based respawn point resolution.
- */
-
-export const RESPAWN_DELAY_MS = 8_000;
+export const WORLD_TICK_MS = 100;
+export const RESPAWN_DELAY_TICKS = 80;
+export const RESPAWN_DELAY_MS = RESPAWN_DELAY_TICKS * WORLD_TICK_MS;
 
 export interface RespawnPoint {
   id: string;
@@ -17,6 +14,8 @@ export interface DeathCapablePlayer {
   id: string;
   dead: boolean;
   deathAt: number;
+  deathTick?: number;
+  respawnTick?: number;
   health: number;
   maxHealth: number;
   mana: number;
@@ -28,6 +27,7 @@ export interface DeathCapablePlayer {
 }
 
 export interface RespawnableWorld {
+  players?: Iterable<DeathCapablePlayer>;
   respawnPoints?: RespawnPoint[];
 }
 
@@ -35,28 +35,39 @@ export function handlePlayerDeath(
   player: DeathCapablePlayer,
   world: RespawnableWorld,
   sendToPlayer: (type: string, payload: unknown) => void,
-  scheduleRespawn = true,
-): { respawnTimer?: ReturnType<typeof setTimeout> } {
+  currentTick: number,
+): { respawnTick?: number } {
+  void world;
   if (player.dead) return {};
-
+  const tick = Math.trunc(currentTick);
   player.dead = true;
   player.health = 0;
-  player.deathAt = Date.now();
+  player.deathTick = tick;
+  player.deathAt = tick * WORLD_TICK_MS;
+  player.respawnTick = tick + RESPAWN_DELAY_TICKS;
   player.totalDeaths = (player.totalDeaths ?? 0) + 1;
   player.combatTargetNpcId = undefined;
-
   sendToPlayer("player_died", {
     respawnInMs: RESPAWN_DELAY_MS,
+    respawnTick: player.respawnTick,
     message: "Du wurdest besiegt...",
   });
+  return { respawnTick: player.respawnTick };
+}
 
-  if (!scheduleRespawn) return {};
-
-  const timer = setTimeout(() => {
-    respawnPlayer(player, world, sendToPlayer);
-  }, RESPAWN_DELAY_MS);
-
-  return { respawnTimer: timer };
+export function processRespawns(
+  world: RespawnableWorld,
+  currentTick: number,
+  sendToPlayerById: (playerId: string, type: string, payload: unknown) => void,
+): number {
+  const tick = Math.trunc(currentTick);
+  let count = 0;
+  for (const player of world.players ?? []) {
+    if (!player.dead || player.respawnTick === undefined || tick < player.respawnTick) continue;
+    respawnPlayer(player, world, (type, payload) => sendToPlayerById(player.id, type, payload));
+    count += 1;
+  }
+  return count;
 }
 
 export function respawnPlayer(
@@ -65,14 +76,14 @@ export function respawnPlayer(
   sendToPlayer: (type: string, payload: unknown) => void,
 ): void {
   const spawnPoint = getNearestRespawnPoint(player, world);
-
   player.dead = false;
-  player.health = Math.floor((player.maxHealth ?? 100) * 0.3);
-  player.mana = Math.floor((player.maxMana ?? 25) * 0.3);
+  player.health = Math.floor(((player.maxHealth ?? 100) * 300) / 1000);
+  player.mana = Math.floor(((player.maxMana ?? 25) * 300) / 1000);
   player.position.x = spawnPoint.x;
   player.position.y = spawnPoint.z;
   player.deathAt = 0;
-
+  player.deathTick = undefined;
+  player.respawnTick = undefined;
   sendToPlayer("player_respawned", {
     x: spawnPoint.x,
     z: spawnPoint.z,
@@ -87,19 +98,16 @@ export function getNearestRespawnPoint(
   world: RespawnableWorld,
 ): RespawnPoint {
   const points = world.respawnPoints ?? [];
-
-  if (!points.length) {
-    return { id: "default", zoneId: "didis_hub", x: 0, z: 0, label: "Hub" };
-  }
-
-  const zonePoints = player.currentZone
-    ? points.filter((p) => p.zoneId === player.currentZone)
-    : [];
+  if (!points.length) return { id: "default", zoneId: "didis_hub", x: 0, z: 0, label: "Hub" };
+  const zonePoints = player.currentZone ? points.filter((p) => p.zoneId === player.currentZone) : [];
   const pool = zonePoints.length ? zonePoints : points;
-
   return pool.reduce((best, p) => {
-    const dBest = Math.hypot(best.x - player.position.x, best.z - player.position.y);
-    const dThis = Math.hypot(p.x - player.position.x, p.z - player.position.y);
-    return dThis < dBest ? p : best;
+    const dxBest = Math.trunc(best.x) - Math.trunc(player.position.x);
+    const dzBest = Math.trunc(best.z) - Math.trunc(player.position.y);
+    const dxThis = Math.trunc(p.x) - Math.trunc(player.position.x);
+    const dzThis = Math.trunc(p.z) - Math.trunc(player.position.y);
+    const bestDistanceSq = dxBest * dxBest + dzBest * dzBest;
+    const thisDistanceSq = dxThis * dxThis + dzThis * dzThis;
+    return thisDistanceSq < bestDistanceSq ? p : best;
   });
 }

--- a/server/src/tests/death-respawn.test.ts
+++ b/server/src/tests/death-respawn.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   handlePlayerDeath,
+  processRespawns,
   respawnPlayer,
   getNearestRespawnPoint,
   RESPAWN_DELAY_MS,
+  RESPAWN_DELAY_TICKS,
+  WORLD_TICK_MS,
   type DeathCapablePlayer,
   type RespawnableWorld,
 } from "../modules/combat/deathRespawnSystem.js";
@@ -25,8 +28,9 @@ function makePlayer(overrides: Partial<DeathCapablePlayer> = {}): DeathCapablePl
   };
 }
 
-function makeWorld(points?: RespawnableWorld["respawnPoints"]): RespawnableWorld {
+function makeWorld(points?: RespawnableWorld["respawnPoints"], players?: DeathCapablePlayer[]): RespawnableWorld {
   return {
+    players,
     respawnPoints: points ?? [
       { id: "rp_hub", zoneId: "didis_hub", x: 0, z: 0, label: "Hub Center" },
       { id: "rp_outpost", zoneId: "didis_hub", x: 50, z: 50, label: "Outpost" },
@@ -37,29 +41,32 @@ function makeWorld(points?: RespawnableWorld["respawnPoints"]): RespawnableWorld
 
 describe("Death & Respawn System", () => {
   describe("handlePlayerDeath", () => {
-    it("marks player as dead with zero health", () => {
+    it("marks player as dead with zero health and deterministic ticks", () => {
       const player = makePlayer();
       const send = vi.fn();
-      handlePlayerDeath(player, makeWorld(), send, false);
-
+      const currentTick = 123;
+      handlePlayerDeath(player, makeWorld(), send, currentTick);
       expect(player.dead).toBe(true);
       expect(player.health).toBe(0);
-      expect(player.deathAt).toBeGreaterThan(0);
+      expect(player.deathTick).toBe(currentTick);
+      expect(player.deathAt).toBe(currentTick * WORLD_TICK_MS);
+      expect(player.respawnTick).toBe(currentTick + RESPAWN_DELAY_TICKS);
       expect(player.combatTargetNpcId).toBeUndefined();
     });
 
     it("increments totalDeaths", () => {
       const player = makePlayer({ totalDeaths: 3 });
-      handlePlayerDeath(player, makeWorld(), vi.fn(), false);
+      handlePlayerDeath(player, makeWorld(), vi.fn(), 10);
       expect(player.totalDeaths).toBe(4);
     });
 
-    it("sends player_died message with respawn delay", () => {
+    it("sends player_died message with respawn delay and tick", () => {
       const send = vi.fn();
-      handlePlayerDeath(makePlayer(), makeWorld(), send, false);
-
+      const currentTick = 50;
+      handlePlayerDeath(makePlayer(), makeWorld(), send, currentTick);
       expect(send).toHaveBeenCalledWith("player_died", {
         respawnInMs: RESPAWN_DELAY_MS,
+        respawnTick: currentTick + RESPAWN_DELAY_TICKS,
         message: "Du wurdest besiegt...",
       });
     });
@@ -67,45 +74,56 @@ describe("Death & Respawn System", () => {
     it("does nothing if already dead", () => {
       const player = makePlayer({ dead: true });
       const send = vi.fn();
-      handlePlayerDeath(player, makeWorld(), send, false);
+      handlePlayerDeath(player, makeWorld(), send, 10);
       expect(send).not.toHaveBeenCalled();
     });
 
-    it("returns a respawn timer when scheduleRespawn is true", () => {
+    it("returns a respawn tick", () => {
       const player = makePlayer();
-      const result = handlePlayerDeath(player, makeWorld(), vi.fn(), true);
-      expect(result.respawnTimer).toBeDefined();
-      clearTimeout(result.respawnTimer!);
+      const result = handlePlayerDeath(player, makeWorld(), vi.fn(), 20);
+      expect(result.respawnTick).toBe(20 + RESPAWN_DELAY_TICKS);
+    });
+  });
+
+  describe("processRespawns", () => {
+    it("respawns only players whose respawnTick has arrived", () => {
+      const ready = makePlayer({ id: "ready", dead: true, health: 0, mana: 0, deathTick: 10, deathAt: 10 * WORLD_TICK_MS, respawnTick: 90 });
+      const waiting = makePlayer({ id: "waiting", dead: true, health: 0, mana: 0, deathTick: 20, deathAt: 20 * WORLD_TICK_MS, respawnTick: 120 });
+      const sendById = vi.fn();
+      const count = processRespawns(makeWorld(undefined, [ready, waiting]), 90, sendById);
+      expect(count).toBe(1);
+      expect(ready.dead).toBe(false);
+      expect(ready.deathTick).toBeUndefined();
+      expect(ready.respawnTick).toBeUndefined();
+      expect(waiting.dead).toBe(true);
+      expect(waiting.respawnTick).toBe(120);
+      expect(sendById).toHaveBeenCalledWith("ready", "player_respawned", expect.objectContaining({ health: 30, mana: 7 }));
     });
   });
 
   describe("respawnPlayer", () => {
-    it("revives player at 30% HP/mana", () => {
-      const player = makePlayer({ dead: true, health: 0, mana: 0 });
+    it("revives player at 30% HP/mana and clears death ticks", () => {
+      const player = makePlayer({ dead: true, health: 0, mana: 0, deathTick: 10, respawnTick: 90 });
       respawnPlayer(player, makeWorld(), vi.fn());
-
       expect(player.dead).toBe(false);
-      expect(player.health).toBe(30); // 30% of 100
-      expect(player.mana).toBe(7); // floor(30% of 25)
+      expect(player.health).toBe(30);
+      expect(player.mana).toBe(7);
       expect(player.deathAt).toBe(0);
+      expect(player.deathTick).toBeUndefined();
+      expect(player.respawnTick).toBeUndefined();
     });
 
     it("sends player_respawned with coordinates", () => {
       const player = makePlayer({ dead: true, health: 0, position: { x: 5, y: 5 } });
       const send = vi.fn();
       respawnPlayer(player, makeWorld(), send);
-
-      expect(send).toHaveBeenCalledWith("player_respawned", expect.objectContaining({
-        health: expect.any(Number),
-        mana: expect.any(Number),
-      }));
+      expect(send).toHaveBeenCalledWith("player_respawned", expect.objectContaining({ health: expect.any(Number), mana: expect.any(Number) }));
     });
 
     it("moves player to the respawn point position", () => {
       const player = makePlayer({ dead: true, health: 0, position: { x: 5, y: 5 } });
       const world = makeWorld([{ id: "rp", zoneId: "didis_hub", x: 42, z: 99, label: "Test" }]);
       respawnPlayer(player, world, vi.fn());
-
       expect(player.position.x).toBe(42);
       expect(player.position.y).toBe(99);
     });
@@ -113,29 +131,20 @@ describe("Death & Respawn System", () => {
 
   describe("getNearestRespawnPoint", () => {
     it("returns default when no points defined", () => {
-      const result = getNearestRespawnPoint(
-        { position: { x: 10, y: 20 }, currentZone: "any" },
-        { respawnPoints: [] },
-      );
+      const result = getNearestRespawnPoint({ position: { x: 10, y: 20 }, currentZone: "any" }, { respawnPoints: [] });
       expect(result.id).toBe("default");
     });
 
     it("prefers same-zone points", () => {
       const world = makeWorld();
-      const result = getNearestRespawnPoint(
-        { position: { x: 45, y: 45 }, currentZone: "didis_hub" },
-        world,
-      );
+      const result = getNearestRespawnPoint({ position: { x: 45, y: 45 }, currentZone: "didis_hub" }, world);
       expect(result.zoneId).toBe("didis_hub");
       expect(result.id).toBe("rp_outpost");
     });
 
     it("falls back to all points if no zone match", () => {
       const world = makeWorld();
-      const result = getNearestRespawnPoint(
-        { position: { x: 95, y: 95 }, currentZone: "unknown_zone" },
-        world,
-      );
+      const result = getNearestRespawnPoint({ position: { x: 95, y: 95 }, currentZone: "unknown_zone" }, world);
       expect(result).toBeDefined();
       expect(result.id).toBe("rp_other");
     });


### PR DESCRIPTION
## Summary
- Replaces Repoless polling sleeps in `AIOrchestrator` with tick-driven in-memory poll state and `AIOrchestrator.update(currentWorldTick)`.
- Replaces death/respawn wall-clock state and timer respawns with deterministic `deathTick` / `respawnTick` logic.
- Adds `processRespawns(world, currentTick, sendToPlayerById)` and updates death-respawn tests to avoid fake timers and clearTimeout.
- Replaces respawn distance checks with squared integer distance and 30% restores with base-1000 integer math.

## Validation
I could not run local commands from this connector session. Please run:
- `pnpm test -- --run death-respawn`
- `pnpm exec node scripts/check-determinism-gate.mjs`

## Note
`WorldTick.ts` was not modified because writing a partial patch to the central tick loop through the connector would have required full-file replacement. The new APIs are ready for the obvious tick-loop wiring once applied safely in a workspace/agent with local checkout.