### PR TITLE
feat(client-2d): add Pixi Dev Hub asset integration maps

### DIFF
--- a/apps/client-2d/public/2d-assets/manifests/pixi-dev-hub-first-batch.json
+++ b/apps/client-2d/public/2d-assets/manifests/pixi-dev-hub-first-batch.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "1.0.0",
+  "name": "pixi-dev-hub-first-batch",
+  "description": "First CC0-friendly 2D asset batch selected from the PixiJS Developer Hub for WASD/Arelorian client-2d.",
+  "source": "https://pixi-js-dev-hub--arschniga1337.replit.app/hub-data.json",
+  "authorityPolicy": "visual-only: WorldTick and AREKernel remain authoritative",
+  "packs": [
+    {
+      "id": "kenney-tiny-town",
+      "kind": "atlas",
+      "license": "CC0",
+      "targetPath": "/2d-assets/atlases/kenney-tiny-town/",
+      "status": "planned",
+      "use": ["town", "road", "house", "tree", "interior", "admin-map"]
+    },
+    {
+      "id": "kenney-tiny-dungeon",
+      "kind": "atlas",
+      "license": "CC0",
+      "targetPath": "/2d-assets/atlases/kenney-tiny-dungeon/",
+      "status": "planned",
+      "use": ["dungeon", "door", "chest", "trap", "enemy-placeholder", "boss-room"]
+    },
+    {
+      "id": "ninja-adventure",
+      "kind": "atlas",
+      "license": "CC0",
+      "targetPath": "/2d-assets/atlases/ninja-adventure/",
+      "status": "planned",
+      "use": ["terrain", "character", "item", "vfx", "prototype-scene"]
+    },
+    {
+      "id": "explosion-animations",
+      "kind": "vfx",
+      "license": "CC0",
+      "targetPath": "/2d-assets/vfx/explosion-animations/",
+      "status": "planned",
+      "use": ["impact-buster", "spell-hit", "loot-burst", "are-shockwave", "combat-feedback"]
+    },
+    {
+      "id": "pixel-food",
+      "kind": "icons",
+      "license": "CC0",
+      "targetPath": "/2d-assets/icons/food/",
+      "status": "planned",
+      "use": ["food-icon", "consumable", "merchant-ui", "crafting-ui"]
+    },
+    {
+      "id": "kenney-ui-pack",
+      "kind": "ui",
+      "license": "CC0",
+      "targetPath": "/2d-assets/ui/kenney-ui-pack/",
+      "status": "planned",
+      "use": ["hud", "skillbar", "inventory", "mobile-ui", "admin-ui"]
+    },
+    {
+      "id": "pixel-prototype-player",
+      "kind": "characters",
+      "license": "CC0",
+      "targetPath": "/2d-assets/characters/prototype-player/",
+      "status": "planned",
+      "use": ["player-placeholder", "npc-placeholder", "animation-test", "movement-test"]
+    }
+  ],
+  "validation": {
+    "requiredBeforeRuntimeUse": [
+      "source-url-recorded",
+      "license-recorded",
+      "filenames-normalized",
+      "atlas-or-manifest-generated",
+      "mobile-size-budget-checked",
+      "credits-added-if-needed"
+    ],
+    "command": "pnpm --filter @wasd/client-2d validate:assets"
+  }
+}

--- a/docs/archive/pixi-dev-hub-asset-pack-integration.md
+++ b/docs/archive/pixi-dev-hub-asset-pack-integration.md
@@ -1,0 +1,80 @@
+# PixiJS Dev Hub Asset Pack Integration for WASD / Arelorian
+
+Source: https://pixi-js-dev-hub--arschniga1337.replit.app/hub-data.json
+
+## Goal
+
+Use the useful 2D asset packs from the PixiJS Developer Hub as visual content for the existing `apps/client-2d` pipeline without changing the authoritative Arelorian simulation.
+
+## Hard rules
+
+- Asset packs are visual input only.
+- `WorldTick` and `AREKernel` remain authoritative.
+- No sprite, atlas, tile, animation or Pixi scene may create authoritative gameplay state.
+- Server registries and snapshots define real items, NPCs, entities, positions and combat results.
+- Imported assets must pass license, attribution, filename, atlas, manifest and mobile-performance validation.
+- Prefer CC0 packs for direct repo integration.
+- Attribution-required and ShareAlike packs must stay isolated with explicit credits metadata.
+
+## First integration batch
+
+| Asset pack | Decision | Priority | License | Use in Arelorian |
+|---|---:|---:|---|---|
+| Kenney Tiny Town | adopt | P0 | CC0 | Towns, roads, houses, trees, interiors, admin-map placeholders |
+| Kenney Tiny Dungeon | adopt | P0 | CC0 | Dungeon rooms, doors, chests, traps, enemy placeholders, boss rooms |
+| Ninja Adventure | adopt | P0 | CC0 | Broad top-down RPG terrain, characters, items and VFX prototype pack |
+| Explosion Animations | adopt | P0 | CC0 | Impact Buster, spell hit, loot burst, ARE shockwave, combat feedback |
+| Free Pixel Food | adopt | P1 | CC0 | Food, consumable and crafting inventory icons |
+| Kenney UI Pack | adopt | P1 | CC0 | HUD, skillbar, inventory, mobile UI, admin UI prototypes |
+| Pixel Prototype Player Sprites | adopt | P1 | CC0 | Temporary player and NPC placeholders for animation and movement tests |
+
+## Recommended repo targets
+
+```txt
+apps/client-2d/public/2d-assets/incoming/<pack-id>/
+apps/client-2d/public/2d-assets/atlases/<pack-id>/
+apps/client-2d/public/2d-assets/icons/<category>/
+apps/client-2d/public/2d-assets/vfx/<pack-id>/
+apps/client-2d/public/2d-assets/ui/<pack-id>/
+apps/client-2d/public/2d-assets/characters/<pack-id>/
+apps/client-2d/public/2d-assets/manifests/
+apps/client-2d/public/2d-assets/credits/
+```
+
+## Use model
+
+The client may render imported sprites, icons, effects and tiles from server-approved snapshots or events:
+
+```ts
+pixiHud.render(snapshot);
+pixiVfx.play(serverApprovedCombatEvent);
+pixiMap.draw(serverDerivedChunkMap);
+```
+
+The client must not derive core gameplay truth from visual asset placement:
+
+```ts
+// forbidden
+sprite.x += velocity * delta;
+clientWorld.spawnLootFromSpriteCollision();
+```
+
+## Adapt later
+
+These packs are useful but must not be bulk-imported without license and attribution handling:
+
+- Shikashi fantasy icons: CC-BY attribution required.
+- Pixel isometric tiles: CC-BY attribution required.
+- LPC base assets: CC-BY-SA, ShareAlike isolation required.
+- LPC tile atlas: CC-BY-SA, ShareAlike isolation required.
+- CraftPix/GameArt2D freebies: verify exact terms per selected pack before import.
+
+## Agent checklist
+
+1. Download only from official source pages.
+2. Keep exact source URL and license in credits metadata.
+3. Normalize filenames to kebab-case.
+4. Build Pixi-compatible manifests and atlas metadata.
+5. Keep binary imports small and mobile-friendly.
+6. Run `pnpm --filter @wasd/client-2d validate:assets` after import.
+7. Do not change `WorldTick`, `AREKernel`, network authority or server registries during asset import.

--- a/public/archive/wasd-pixi-asset-packs.json
+++ b/public/archive/wasd-pixi-asset-packs.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "1.0.0",
+  "project": "WASD / Arelorian",
+  "source": "https://pixi-js-dev-hub--arschniga1337.replit.app/hub-data.json",
+  "purpose": "Machine-readable integration manifest for useful 2D asset packs from the PixiJS Developer Hub.",
+  "coreRules": [
+    "Asset packs are visual content only.",
+    "WorldTick and AREKernel remain authoritative.",
+    "No sprite placement may create authoritative gameplay state.",
+    "Imported assets require license, attribution, filename, atlas, manifest and mobile-performance validation.",
+    "Prefer CC0 packs for direct integration; isolate CC-BY and CC-BY-SA packs with credits metadata."
+  ],
+  "repoTargets": {
+    "incoming": "apps/client-2d/public/2d-assets/incoming/",
+    "atlases": "apps/client-2d/public/2d-assets/atlases/",
+    "icons": "apps/client-2d/public/2d-assets/icons/",
+    "vfx": "apps/client-2d/public/2d-assets/vfx/",
+    "ui": "apps/client-2d/public/2d-assets/ui/",
+    "characters": "apps/client-2d/public/2d-assets/characters/",
+    "manifests": "apps/client-2d/public/2d-assets/manifests/",
+    "credits": "apps/client-2d/public/2d-assets/credits/"
+  },
+  "firstIntegrationBatch": [
+    {
+      "id": "kenney-tiny-town",
+      "decision": "adopt",
+      "priority": "P0",
+      "license": "CC0",
+      "target": "apps/client-2d/public/2d-assets/atlases/kenney-tiny-town/",
+      "use": ["towns", "roads", "houses", "trees", "interiors", "admin-map placeholders"]
+    },
+    {
+      "id": "kenney-tiny-dungeon",
+      "decision": "adopt",
+      "priority": "P0",
+      "license": "CC0",
+      "target": "apps/client-2d/public/2d-assets/atlases/kenney-tiny-dungeon/",
+      "use": ["dungeon rooms", "doors", "chests", "traps", "enemy placeholders", "boss rooms"]
+    },
+    {
+      "id": "ninja-adventure",
+      "decision": "adopt",
+      "priority": "P0",
+      "license": "CC0",
+      "target": "apps/client-2d/public/2d-assets/atlases/ninja-adventure/",
+      "use": ["top-down RPG terrain", "characters", "items", "VFX", "prototype scenes"]
+    },
+    {
+      "id": "explosion-animations",
+      "decision": "adopt",
+      "priority": "P0",
+      "license": "CC0",
+      "target": "apps/client-2d/public/2d-assets/vfx/explosion-animations/",
+      "use": ["Impact Buster", "spell hits", "loot bursts", "ARE shockwaves", "combat feedback"]
+    },
+    {
+      "id": "pixel-food",
+      "decision": "adopt",
+      "priority": "P1",
+      "license": "CC0",
+      "target": "apps/client-2d/public/2d-assets/icons/food/",
+      "use": ["food icons", "consumables", "merchant UI", "crafting UI"]
+    },
+    {
+      "id": "kenney-ui-pack",
+      "decision": "adopt",
+      "priority": "P1",
+      "license": "CC0",
+      "target": "apps/client-2d/public/2d-assets/ui/kenney-ui-pack/",
+      "use": ["HUD", "skillbar", "inventory panels", "mobile UI", "admin UI"]
+    },
+    {
+      "id": "pixel-prototype-player",
+      "decision": "adopt",
+      "priority": "P1",
+      "license": "CC0",
+      "target": "apps/client-2d/public/2d-assets/characters/prototype-player/",
+      "use": ["player placeholders", "NPC placeholders", "animation tests", "movement tests"]
+    }
+  ],
+  "adaptLater": [
+    {
+      "id": "shikashi-fantasy-icons",
+      "reason": "Useful fantasy icons, but CC-BY attribution is required."
+    },
+    {
+      "id": "pixel-isometric-tiles",
+      "reason": "Useful for 2.5D/editor experiments, but CC-BY attribution is required."
+    },
+    {
+      "id": "lpc-base-assets",
+      "reason": "Large RPG library, but CC-BY-SA requires strict ShareAlike tracking and isolation."
+    },
+    {
+      "id": "lpc-tile-atlas",
+      "reason": "Useful atlas reference, but CC-BY-SA requires strict ShareAlike tracking and isolation."
+    }
+  ],
+  "agentSteps": [
+    "Download firstIntegrationBatch only from official source pages.",
+    "Normalize filenames to kebab-case.",
+    "Generate Pixi-compatible manifests and atlas metadata.",
+    "Record credits before committing attribution-required assets.",
+    "Run apps/client-2d asset validation before merging binary assets.",
+    "Do not modify WorldTick, AREKernel, network authority or server registries during asset import."
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the first safe integration layer for useful 2D asset packs from the PixiJS Developer Hub.

## Added

- `docs/archive/pixi-dev-hub-asset-pack-integration.md`
- `public/archive/wasd-pixi-asset-packs.json`
- `apps/client-2d/public/2d-assets/manifests/pixi-dev-hub-first-batch.json`

## Policy

- Asset packs are visual-only.
- `WorldTick` and `AREKernel` remain authoritative.
- First batch prioritizes CC0-friendly packs.
- Attribution/ShareAlike packs are marked for later isolated handling.

## Next step

A follow-up agent can download the selected first batch from official source pages, normalize filenames, generate Pixi manifests/atlases, and run `pnpm --filter @wasd/client-2d validate:assets` before adding binaries.