### PR TITLE
chore(scripts): add Pixi asset import commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dev:3d": "pnpm -r --filter @wasd/client dev",
     "dev:all": "concurrently \"pnpm dev:2d\" \"pnpm dev:3d\" \"pnpm dev:web\"",
     "build:all": "pnpm build:2d && pnpm build:3d && pnpm build:web",
+    "assets:pixi:plan": "node scripts/import-pixi-dev-hub-assets.mjs --dry-run",
+    "assets:pixi:prepare": "node scripts/import-pixi-dev-hub-assets.mjs",
     "guard:monorepo": "node scripts/monorepo-guard.mjs",
     "guard:monorepo:frozen": "MONOREPO_GUARD_RUN_PNPM=1 node scripts/monorepo-guard.mjs",
     "guard:architecture": "node scripts/arelorian-architecture-lint.mjs",


### PR DESCRIPTION
## Summary

Adds root-level pnpm commands for the Pixi Dev Hub asset import planner.

## Updated

- `package.json`

## New scripts

- `pnpm assets:pixi:plan` runs the import planner in dry-run mode
- `pnpm assets:pixi:prepare` runs the write-mode planner

## Why

Agents, CI and Replit workflows can now call the Pixi asset pipeline through stable package scripts instead of hardcoding the script path.

## Safety

No binary assets are imported. This only adds script aliases.