### PR TITLE
feat(assets): validate Pixi import batch plans

### DIFF
--- a/.github/workflows/pixi-asset-plan.yml
+++ b/.github/workflows/pixi-asset-plan.yml
@@ -6,10 +6,12 @@ on:
       - scripts/import-pixi-dev-hub-assets.mjs
       - scripts/validate-pixi-assets.mjs
       - scripts/scan-pixi-asset-inbox.mjs
+      - scripts/validate-pixi-import-batches.mjs
       - .asset-inbox/pixi/**
       - public/archive/wasd-pixi-asset-packs.json
       - docs/archive/pixi-first-batch-source-metadata.json
       - docs/archive/pixi-first-batch-download-allowlist.json
+      - docs/archive/import-batches/**
       - apps/client-2d/public/2d-assets/**
       - package.json
       - pnpm-lock.yaml
@@ -21,10 +23,12 @@ on:
       - scripts/import-pixi-dev-hub-assets.mjs
       - scripts/validate-pixi-assets.mjs
       - scripts/scan-pixi-asset-inbox.mjs
+      - scripts/validate-pixi-import-batches.mjs
       - .asset-inbox/pixi/**
       - public/archive/wasd-pixi-asset-packs.json
       - docs/archive/pixi-first-batch-source-metadata.json
       - docs/archive/pixi-first-batch-download-allowlist.json
+      - docs/archive/import-batches/**
       - apps/client-2d/public/2d-assets/**
       - package.json
       - pnpm-lock.yaml
@@ -67,3 +71,6 @@ jobs:
 
       - name: Validate Pixi assets
         run: pnpm assets:pixi:validate
+
+      - name: Validate Pixi import batches
+        run: pnpm assets:pixi:validate-batches

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "assets:pixi:plan": "node scripts/import-pixi-dev-hub-assets.mjs --dry-run",
     "assets:pixi:prepare": "node scripts/import-pixi-dev-hub-assets.mjs",
     "assets:pixi:validate": "node scripts/validate-pixi-assets.mjs",
+    "assets:pixi:validate-batches": "node scripts/validate-pixi-import-batches.mjs",
     "guard:monorepo": "node scripts/monorepo-guard.mjs",
     "guard:monorepo:frozen": "MONOREPO_GUARD_RUN_PNPM=1 node scripts/monorepo-guard.mjs",
     "guard:architecture": "node scripts/arelorian-architecture-lint.mjs",

--- a/scripts/validate-pixi-import-batches.mjs
+++ b/scripts/validate-pixi-import-batches.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const batchDir = path.join(repoRoot, 'docs/archive/import-batches');
+
+const requiredStringFields = [
+  'schemaVersion',
+  'batchId',
+  'packId',
+  'sourceUrl',
+  'license',
+  'licenseUrl',
+  'targetFolder',
+  'status',
+];
+
+const requiredBooleanFields = [
+  'sourceVerified',
+  'downloadAllowlisted',
+];
+
+const requiredSafetyFlags = [
+  'visualOnly',
+  'noWorldTickChanges',
+  'noAREKernelChanges',
+  'noServerRegistryChanges',
+  'noNetworkingChanges',
+  'noBinaryAssetsInThisCommit',
+];
+
+async function findJsonFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true }).catch((error) => {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  });
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+}
+
+function requireString(batch, field, errors, file) {
+  if (typeof batch[field] !== 'string' || batch[field].trim().length === 0) {
+    errors.push(`${file}: missing or empty string field: ${field}`);
+  }
+}
+
+function requireBoolean(batch, field, errors, file) {
+  if (typeof batch[field] !== 'boolean') {
+    errors.push(`${file}: missing boolean field: ${field}`);
+  }
+}
+
+function requireStringArray(batch, field, errors, file) {
+  if (!Array.isArray(batch[field]) || batch[field].length === 0 || batch[field].some((value) => typeof value !== 'string' || value.trim().length === 0)) {
+    errors.push(`${file}: missing non-empty string array field: ${field}`);
+  }
+}
+
+function validateBatch(batch, file) {
+  const errors = [];
+
+  for (const field of requiredStringFields) requireString(batch, field, errors, file);
+  for (const field of requiredBooleanFields) requireBoolean(batch, field, errors, file);
+
+  requireStringArray(batch, 'requiredCommands', errors, file);
+  requireStringArray(batch, 'blockedUntil', errors, file);
+  requireStringArray(batch, 'runtimeManifestFiles', errors, file);
+  requireStringArray(batch, 'creditFiles', errors, file);
+
+  if (!batch.safety || typeof batch.safety !== 'object' || Array.isArray(batch.safety)) {
+    errors.push(`${file}: missing safety object`);
+  } else {
+    for (const flag of requiredSafetyFlags) {
+      if (batch.safety[flag] !== true) errors.push(`${file}: safety.${flag} must be true`);
+    }
+  }
+
+  if (typeof batch.targetFolder === 'string' && !batch.targetFolder.startsWith('apps/client-2d/public/2d-assets/')) {
+    errors.push(`${file}: targetFolder must stay inside apps/client-2d/public/2d-assets`);
+  }
+
+  if (typeof batch.sourceUrl === 'string' && !batch.sourceUrl.startsWith('https://')) {
+    errors.push(`${file}: sourceUrl must be https`);
+  }
+
+  return errors;
+}
+
+async function main() {
+  const files = await findJsonFiles(batchDir);
+  const errors = [];
+  const checked = [];
+
+  for (const absoluteFile of files) {
+    const relativeFile = path.relative(repoRoot, absoluteFile);
+    let batch;
+    try {
+      batch = JSON.parse(await readFile(absoluteFile, 'utf8'));
+    } catch (error) {
+      errors.push(`${relativeFile}: invalid JSON: ${error.message}`);
+      continue;
+    }
+
+    checked.push(relativeFile);
+    errors.push(...validateBatch(batch, relativeFile));
+  }
+
+  const report = {
+    schemaVersion: '1.0.0',
+    checkedCount: checked.length,
+    checked,
+    errors,
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+
+  if (errors.length > 0) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds validation for machine-readable Pixi import batch JSON files.

Changes:
- adds scripts/validate-pixi-import-batches.mjs
- adds pnpm assets:pixi:validate-batches
- wires batch validation into the Pixi asset workflow
- watches docs/archive/import-batches/**

Checks:
- required batch fields
- required command arrays
- safety flags
- target folder boundary
- HTTPS source URL

Safety:
- no binary assets
- no engine changes