### PR TITLE
Add Arelorian HUD state mapper

### DIFF
--- a/apps/client-2d/src/App.tsx
+++ b/apps/client-2d/src/App.tsx
@@ -2,20 +2,14 @@ import { useEffect, useRef, useState } from "react";
 import { Application, Graphics, Text } from "pixi.js";
 import { createClient, type AgentState, type PlayerState } from "@wasd/core-network";
 import { createArelorianHud, formatCooldownTicks, type ArelorianHud } from "./ui/ArelorianHud";
+import { HUD_TICK_MS, mapToArelorianHudState, msToHudCooldownTicks } from "./ui/ArelorianHudStateMapper";
 
 const TILE_SIZE = 32;
 const SCALE = 2;
 const MOVE_SEND_FRAME_INTERVAL = 9;
-const CLIENT_TICK_HZ = 10;
-const CLIENT_TICK_MS = 1000 / CLIENT_TICK_HZ;
 
 function mapWorldToScreen(x: number, z: number, w: number, h: number) {
   return { sx: w / 2 + x * TILE_SIZE * SCALE, sy: h / 2 - z * TILE_SIZE * SCALE };
-}
-
-function msToCooldownTicks(ms: number): number {
-  if (!Number.isFinite(ms)) return 0;
-  return Math.max(0, Math.floor(ms / CLIENT_TICK_MS));
 }
 
 interface Entity { graphics: Graphics; label: Text; tx: number; tz: number }
@@ -55,8 +49,8 @@ export function App() {
   ]);
   const [skills, setSkills] = useState<Skill[]>([
     { id: "atk", name: "Attack", cooldownTicksRemaining: 0, ready: true, ico: "⚔️" },
-    { id: "def", name: "Defend", cooldownTicksRemaining: msToCooldownTicks(5000), ready: false, ico: "🛡️" },
-    { id: "mag", name: "Magic", cooldownTicksRemaining: msToCooldownTicks(3000), ready: false, ico: "✨" },
+    { id: "def", name: "Defend", cooldownTicksRemaining: msToHudCooldownTicks(5000), ready: false, ico: "🛡️" },
+    { id: "mag", name: "Magic", cooldownTicksRemaining: msToHudCooldownTicks(3000), ready: false, ico: "✨" },
     { id: "int", name: "Interact", cooldownTicksRemaining: 0, ready: true, ico: "👆" },
   ]);
   const [inv, setInv] = useState<Item[]>([
@@ -86,19 +80,11 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    hudRef.current?.updateState({
-      health: char.hp,
-      maxHealth: char.maxHp,
-      energy: char.mp,
-      maxEnergy: char.maxMp,
-      stamina: skills.filter((skill) => skill.ready).length,
-      maxStamina: Math.max(1, skills.length),
-      matrixEnergy: char.gold,
-      playerName: char.name,
-      zoneName: conn ? "Millbrook" : "Areloria",
-      skillSlots: skills.slice(0, 5).map((_, index) => `${index + 1}`),
-      skillCooldownTicks: skills.slice(0, 5).map((skill) => skill.cooldownTicksRemaining),
-    });
+    hudRef.current?.updateState(mapToArelorianHudState({
+      character: char,
+      skills,
+      connected: conn,
+    }));
   }, [char, skills, conn]);
 
   useEffect(() => {
@@ -127,19 +113,11 @@ export function App() {
     app.init({ background: 0x0f0f1a, resizeTo: cRef.current, antialias: true, resolution: window.devicePixelRatio || 1, autoDensity: true })
       .then(() => {
         cRef.current?.appendChild(app.canvas);
-        const hud = createArelorianHud({
-          health: char.hp,
-          maxHealth: char.maxHp,
-          energy: char.mp,
-          maxEnergy: char.maxMp,
-          stamina: skills.filter((skill) => skill.ready).length,
-          maxStamina: Math.max(1, skills.length),
-          matrixEnergy: char.gold,
-          playerName: char.name,
-          zoneName: "Areloria",
-          skillSlots: skills.slice(0, 5).map((_, index) => `${index + 1}`),
-          skillCooldownTicks: skills.slice(0, 5).map((skill) => skill.cooldownTicksRemaining),
-        }, {}, {
+        const hud = createArelorianHud(mapToArelorianHudState({
+          character: char,
+          skills,
+          connected: conn,
+        }), {}, {
           onSkillSlot: (slotIndex) => {
             const skill = skills[slotIndex];
             if (skill) useSkill(skill.id);
@@ -190,8 +168,8 @@ export function App() {
 
     app.ticker.add((ticker) => {
       clientTickAccumulator.current += ticker.deltaMS;
-      while (clientTickAccumulator.current >= CLIENT_TICK_MS) {
-        clientTickAccumulator.current -= CLIENT_TICK_MS;
+      while (clientTickAccumulator.current >= HUD_TICK_MS) {
+        clientTickAccumulator.current -= HUD_TICK_MS;
         runClientTick();
       }
 

--- a/apps/client-2d/src/ui/ArelorianHudStateMapper.ts
+++ b/apps/client-2d/src/ui/ArelorianHudStateMapper.ts
@@ -1,0 +1,64 @@
+import type { ArelorianHudState } from './ArelorianHud';
+
+export const HUD_TICK_HZ = 10;
+export const HUD_TICK_MS = 1000 / HUD_TICK_HZ;
+
+export type HudCharacterSource = {
+  name?: string;
+  hp?: number;
+  maxHp?: number;
+  mp?: number;
+  maxMp?: number;
+  gold?: number;
+};
+
+export type HudSkillSource = {
+  id: string;
+  ready?: boolean;
+  cooldownTicksRemaining?: number;
+  cooldownTicks?: number;
+  cdTicks?: number;
+  cd?: number;
+};
+
+export type HudStateSource = {
+  character: HudCharacterSource;
+  skills: HudSkillSource[];
+  connected: boolean;
+  zoneName?: string;
+};
+
+function integerTicks(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return Math.max(0, Math.trunc(value));
+}
+
+export function msToHudCooldownTicks(ms: number): number {
+  if (!Number.isFinite(ms)) return 0;
+  return Math.max(0, Math.floor(ms / HUD_TICK_MS));
+}
+
+export function getSkillCooldownTicks(skill: HudSkillSource): number {
+  return integerTicks(skill.cooldownTicksRemaining)
+    ?? integerTicks(skill.cooldownTicks)
+    ?? integerTicks(skill.cdTicks)
+    ?? msToHudCooldownTicks(typeof skill.cd === 'number' ? skill.cd : 0);
+}
+
+export function mapToArelorianHudState(source: HudStateSource): Partial<ArelorianHudState> {
+  const skillCooldownTicks = source.skills.slice(0, 5).map(getSkillCooldownTicks);
+
+  return {
+    health: source.character.hp ?? 100,
+    maxHealth: source.character.maxHp ?? 100,
+    energy: source.character.mp ?? 0,
+    maxEnergy: source.character.maxMp ?? 1,
+    stamina: source.skills.filter((skill) => getSkillCooldownTicks(skill) <= 0).length,
+    maxStamina: Math.max(1, source.skills.length),
+    matrixEnergy: source.character.gold ?? 0,
+    playerName: source.character.name ?? 'Player',
+    zoneName: source.zoneName ?? (source.connected ? 'Millbrook' : 'Areloria'),
+    skillSlots: source.skills.slice(0, 5).map((_, index) => `${index + 1}`),
+    skillCooldownTicks,
+  };
+}


### PR DESCRIPTION
Adds a dedicated HUD state mapper for the 2D client. It centralizes translation from character, skill and connection state into ArelorianHudState. Tick cooldowns are preferred directly, with millisecond values only converted at the boundary as a fallback. App.tsx now routes HUD updates and initialization through the mapper.