### PR TITLE
feat(client-2d): prepare Kenney UI Pack import pipeline

### DIFF
--- a/.github/workflows/pixi-asset-plan.yml
+++ b/.github/workflows/pixi-asset-plan.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - scripts/import-pixi-dev-hub-assets.mjs
+      - scripts/import-kenney-ui-pack.mjs
       - scripts/validate-pixi-assets.mjs
       - scripts/scan-pixi-asset-inbox.mjs
       - scripts/validate-pixi-import-batches.mjs
@@ -21,6 +22,7 @@ on:
       - main
     paths:
       - scripts/import-pixi-dev-hub-assets.mjs
+      - scripts/import-kenney-ui-pack.mjs
       - scripts/validate-pixi-assets.mjs
       - scripts/scan-pixi-asset-inbox.mjs
       - scripts/validate-pixi-import-batches.mjs
@@ -55,10 +57,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.1.1 --activate
+          pnpm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/archive/import-batches/kenney-ui-pack.json
+++ b/docs/archive/import-batches/kenney-ui-pack.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": "1.0.0",
+  "batchId": "pixi-first-batch-kenney-ui-pack",
+  "packId": "kenney-ui-pack",
+  "sourceUrl": "https://kenney.nl/assets/ui-pack",
+  "downloadUrl": "https://kenney.nl/media/pages/assets/ui-pack/f651646eab-1718203990/kenney_ui-pack.zip",
+  "license": "CC0",
+  "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "sourceVerified": true,
+  "downloadAllowlisted": true,
+  "targetFolder": "apps/client-2d/public/2d-assets/ui/kenney-ui-pack/",
+  "status": "ready-for-local-or-runner-import-from-uploaded-zip",
+  "archive": {
+    "fileName": "kenney_ui-pack.zip",
+    "sha256": "a8a14a234911eb648c062622915c93e79e94e97cb7f9f375a70f6617f1174318",
+    "bytes": 1229750,
+    "entryCount": 1343,
+    "fileCount": 1315,
+    "directoryCount": 28,
+    "extensionCounts": {
+      ".ogg": 6,
+      ".png": 870,
+      ".svg": 434,
+      ".ttf": 2,
+      ".txt": 1,
+      ".url": 2
+    }
+  },
+  "requiredCommands": [
+    "mkdir -p apps/client-2d/public/2d-assets/incoming/kenney-ui-pack",
+    "cp kenney_ui-pack.zip apps/client-2d/public/2d-assets/incoming/kenney-ui-pack/kenney_ui-pack.zip",
+    "pnpm assets:pixi:import:kenney-ui:dry-run",
+    "pnpm assets:pixi:import:kenney-ui",
+    "pnpm assets:pixi:validate"
+  ],
+  "blockedUntil": [
+    "kenney_ui-pack.zip is present at apps/client-2d/public/2d-assets/incoming/kenney-ui-pack/kenney_ui-pack.zip",
+    "archive sha256 matches a8a14a234911eb648c062622915c93e79e94e97cb7f9f375a70f6617f1174318"
+  ],
+  "runtimeManifestFiles": [
+    "apps/client-2d/public/2d-assets/manifests/generated/kenney-ui-pack.json"
+  ],
+  "creditFiles": [
+    "apps/client-2d/public/2d-assets/credits/kenney-ui-pack.json"
+  ],
+  "safety": {
+    "visualOnly": true,
+    "noWorldTickChanges": true,
+    "noAREKernelChanges": true,
+    "noServerRegistryChanges": true,
+    "noNetworkingChanges": true,
+    "noBinaryAssetsInThisCommit": true
+  },
+  "notes": [
+    "The uploaded ZIP was inspected locally in ChatGPT before this batch file was written.",
+    "The import script skips .ttf and .url files by default; use --include-fonts only if the font license/use path is explicitly approved.",
+    "This batch prepares the client-2d HUD, skillbar, inventory panels, mobile UI and admin UI for Kenney UI art without granting assets gameplay authority."
+  ]
+}

--- a/docs/archive/pixi-first-batch-download-allowlist.json
+++ b/docs/archive/pixi-first-batch-download-allowlist.json
@@ -54,10 +54,12 @@
     {
       "id": "kenney-ui-pack",
       "sourceUrl": "https://kenney.nl/assets/ui-pack",
+      "downloadUrl": "https://kenney.nl/media/pages/assets/ui-pack/f651646eab-1718203990/kenney_ui-pack.zip",
       "license": "CC0",
       "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
       "sourceVerified": true,
-      "importAllowed": true
+      "importAllowed": true,
+      "archiveSha256": "a8a14a234911eb648c062622915c93e79e94e97cb7f9f375a70f6617f1174318"
     }
   ],
   "blockedPacks": [
@@ -68,5 +70,5 @@
       "importAllowed": false
     }
   ],
-  "nextStep": "Update scripts/import-pixi-dev-hub-assets.mjs to read this allowlist and plan only allowed packs. Then implement actual downloader in a later PR."
+  "nextStep": "Place kenney_ui-pack.zip in apps/client-2d/public/2d-assets/incoming/kenney-ui-pack/ and run pnpm assets:pixi:import:kenney-ui."
 }

--- a/docs/archive/pixi-first-batch-source-metadata.json
+++ b/docs/archive/pixi-first-batch-source-metadata.json
@@ -65,10 +65,11 @@
       "licenseName": "Creative Commons CC0 1.0 Universal",
       "sourceUrl": "https://kenney.nl/assets/ui-pack",
       "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
-      "downloadUrl": null,
+      "downloadUrl": "https://kenney.nl/media/pages/assets/ui-pack/f651646eab-1718203990/kenney_ui-pack.zip",
       "sourceVerified": true,
-      "binaryImportStatus": "blocked-until-download-implemented",
-      "attributionRequired": false
+      "binaryImportStatus": "download-enabled",
+      "attributionRequired": false,
+      "notes": "Official Kenney UI Pack ZIP endpoint discovered from the source page download flow. Import remains visual-only for HUD, skillbar, inventory panels, mobile UI and admin UI."
     },
     {
       "id": "pixel-prototype-player",
@@ -83,5 +84,5 @@
       "notes": "Exact official source URL still needs confirmation before binary import."
     }
   ],
-  "nextStep": "Teach scripts/import-pixi-dev-hub-assets.mjs to merge this source metadata into generated credits and block binaries without sourceVerified=true."
+  "nextStep": "Run pnpm assets:pixi:import:kenney-ui after placing kenney_ui-pack.zip in apps/client-2d/public/2d-assets/incoming/kenney-ui-pack/."
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "assets:pixi:scan-inbox": "node scripts/scan-pixi-asset-inbox.mjs",
     "assets:pixi:plan": "node scripts/import-pixi-dev-hub-assets.mjs --dry-run",
     "assets:pixi:prepare": "node scripts/import-pixi-dev-hub-assets.mjs",
+    "assets:pixi:import:kenney-ui": "node scripts/import-kenney-ui-pack.mjs",
+    "assets:pixi:import:kenney-ui:dry-run": "node scripts/import-kenney-ui-pack.mjs --dry-run",
     "assets:pixi:validate": "node scripts/validate-pixi-assets.mjs",
     "assets:pixi:validate-batches": "node scripts/validate-pixi-import-batches.mjs",
     "guard:monorepo": "node scripts/monorepo-guard.mjs",

--- a/portal/package.json
+++ b/portal/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "pnpm --dir .. exec vitest run --root portal",
+    "test:watch": "pnpm --dir .. exec vitest --root portal",
     "lint": "eslint src"
   },
   "dependencies": {

--- a/scripts/import-kenney-ui-pack.mjs
+++ b/scripts/import-kenney-ui-pack.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { inflateRawSync } from 'node:zlib';
+
+const repoRoot = process.cwd();
+const assetRoot = path.join(repoRoot, 'apps/client-2d/public/2d-assets');
+const defaultZipPath = path.join(assetRoot, 'incoming/kenney-ui-pack/kenney_ui-pack.zip');
+const targetDir = path.join(assetRoot, 'ui/kenney-ui-pack');
+const creditsPath = path.join(assetRoot, 'credits/kenney-ui-pack.json');
+const generatedManifestPath = path.join(assetRoot, 'manifests/generated/kenney-ui-pack.json');
+const sourceMetadataPath = path.join(repoRoot, 'docs/archive/pixi-first-batch-source-metadata.json');
+const downloadAllowlistPath = path.join(repoRoot, 'docs/archive/pixi-first-batch-download-allowlist.json');
+
+const args = process.argv.slice(2);
+const isDryRun = args.includes('--dry-run');
+const includeFonts = args.includes('--include-fonts');
+const zipPath = readArg('--zip') || defaultZipPath;
+
+const allowedExtensions = new Set(['.png', '.svg', '.ogg', '.txt']);
+if (includeFonts) allowedExtensions.add('.ttf');
+
+function readArg(name) {
+  const exactIndex = args.indexOf(name);
+  if (exactIndex >= 0) return args[exactIndex + 1];
+  const prefix = `${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length);
+}
+
+function sha256(buffer) {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function slugify(value) {
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function normalizeZipPath(filePath) {
+  return filePath
+    .split('/')
+    .filter((part) => part && part !== '.' && part !== '..')
+    .map((part, index, parts) => {
+      const extension = path.extname(part);
+      if (index === parts.length - 1 && extension) {
+        return `${slugify(path.basename(part, extension))}${extension.toLowerCase()}`;
+      }
+      return slugify(part);
+    })
+    .join('/');
+}
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function assertInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to write outside ${root}: ${candidate}`);
+  }
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function indexById(items) {
+  return new Map((items || []).map((item) => [item.id, item]));
+}
+
+function requireKenneyUiGates(sourceMetadata, downloadAllowlist) {
+  const metadata = indexById(sourceMetadata.packs).get('kenney-ui-pack');
+  const allowlist = indexById(downloadAllowlist.allowedPacks).get('kenney-ui-pack');
+  const failures = [];
+
+  if (!metadata) failures.push('missing kenney-ui-pack source metadata');
+  if (!allowlist) failures.push('missing kenney-ui-pack allowlist entry');
+  if (metadata?.sourceVerified !== true) failures.push('sourceVerified must be true');
+  if (allowlist?.importAllowed !== true) failures.push('importAllowed must be true');
+  if (!metadata?.downloadUrl) failures.push('source metadata downloadUrl is required');
+  if (!allowlist?.downloadUrl) failures.push('allowlist downloadUrl is required');
+  if (metadata?.sourceUrl !== allowlist?.sourceUrl) failures.push('sourceUrl drift between metadata and allowlist');
+  if (metadata?.licenseUrl !== allowlist?.licenseUrl) failures.push('licenseUrl drift between metadata and allowlist');
+  if (metadata?.downloadUrl !== allowlist?.downloadUrl) failures.push('downloadUrl drift between metadata and allowlist');
+
+  if (allowlist?.archiveSha256) {
+    // The actual ZIP digest is checked after reading the archive.
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Kenney UI Pack source/allowlist gate failed:\n- ${failures.join('\n- ')}`);
+  }
+
+  return { metadata, allowlist };
+}
+
+function readUInt16(buffer, offset) {
+  return buffer.readUInt16LE(offset);
+}
+
+function readUInt32(buffer, offset) {
+  return buffer.readUInt32LE(offset);
+}
+
+function findEndOfCentralDirectory(buffer) {
+  const minOffset = Math.max(0, buffer.length - 0xffff - 22);
+  for (let offset = buffer.length - 22; offset >= minOffset; offset -= 1) {
+    if (readUInt32(buffer, offset) === 0x06054b50) return offset;
+  }
+  throw new Error('Invalid ZIP: end of central directory not found');
+}
+
+function parseZip(buffer) {
+  const eocdOffset = findEndOfCentralDirectory(buffer);
+  const entryCount = readUInt16(buffer, eocdOffset + 10);
+  const centralDirectoryOffset = readUInt32(buffer, eocdOffset + 16);
+  let cursor = centralDirectoryOffset;
+  const entries = [];
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (readUInt32(buffer, cursor) !== 0x02014b50) {
+      throw new Error(`Invalid ZIP: central directory entry ${index} is corrupt`);
+    }
+
+    const method = readUInt16(buffer, cursor + 10);
+    const compressedSize = readUInt32(buffer, cursor + 20);
+    const uncompressedSize = readUInt32(buffer, cursor + 24);
+    const fileNameLength = readUInt16(buffer, cursor + 28);
+    const extraLength = readUInt16(buffer, cursor + 30);
+    const commentLength = readUInt16(buffer, cursor + 32);
+    const localHeaderOffset = readUInt32(buffer, cursor + 42);
+    const fileName = buffer.subarray(cursor + 46, cursor + 46 + fileNameLength).toString('utf8');
+
+    entries.push({ fileName, method, compressedSize, uncompressedSize, localHeaderOffset });
+    cursor += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
+function extractEntry(buffer, entry) {
+  const localOffset = entry.localHeaderOffset;
+  if (readUInt32(buffer, localOffset) !== 0x04034b50) {
+    throw new Error(`Invalid ZIP: local header corrupt for ${entry.fileName}`);
+  }
+
+  const fileNameLength = readUInt16(buffer, localOffset + 26);
+  const extraLength = readUInt16(buffer, localOffset + 28);
+  const dataOffset = localOffset + 30 + fileNameLength + extraLength;
+  const compressed = buffer.subarray(dataOffset, dataOffset + entry.compressedSize);
+
+  if (entry.method === 0) return compressed;
+  if (entry.method === 8) return inflateRawSync(compressed);
+  throw new Error(`Unsupported ZIP compression method ${entry.method} for ${entry.fileName}`);
+}
+
+async function main() {
+  const [sourceMetadata, downloadAllowlist] = await Promise.all([
+    readJson(sourceMetadataPath),
+    readJson(downloadAllowlistPath),
+  ]);
+  const { metadata, allowlist } = requireKenneyUiGates(sourceMetadata, downloadAllowlist);
+
+  const archive = await readFile(zipPath);
+  const archiveSha256 = sha256(archive);
+  if (allowlist.archiveSha256 && archiveSha256 !== allowlist.archiveSha256) {
+    throw new Error(`Kenney UI Pack archive SHA256 mismatch: expected ${allowlist.archiveSha256}, got ${archiveSha256}`);
+  }
+
+  const zipEntries = parseZip(archive);
+  const imported = [];
+  const skipped = [];
+
+  for (const entry of zipEntries) {
+    const isDirectory = entry.fileName.endsWith('/');
+    const extension = path.extname(entry.fileName).toLowerCase();
+    const normalizedPath = normalizeZipPath(entry.fileName);
+
+    if (isDirectory || !allowedExtensions.has(extension)) {
+      skipped.push({
+        sourcePath: entry.fileName,
+        reason: isDirectory ? 'directory' : `extension-not-imported-by-default:${extension || 'none'}`,
+      });
+      continue;
+    }
+
+    const targetPath = path.join(targetDir, normalizedPath);
+    assertInside(targetDir, targetPath);
+
+    const payload = extractEntry(archive, entry);
+    if (payload.length !== entry.uncompressedSize) {
+      throw new Error(`ZIP size mismatch for ${entry.fileName}`);
+    }
+
+    imported.push({
+      sourcePath: entry.fileName,
+      path: toPosix(path.relative(repoRoot, targetPath)),
+      extension,
+      bytes: payload.length,
+      sha256: sha256(payload),
+    });
+
+    if (!isDryRun) {
+      await mkdir(path.dirname(targetPath), { recursive: true });
+      await writeFile(targetPath, payload);
+    }
+  }
+
+  imported.sort((a, b) => a.path.localeCompare(b.path));
+  skipped.sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
+
+  const credit = {
+    schemaVersion: '1.0.0',
+    packId: 'kenney-ui-pack',
+    license: metadata.license,
+    licenseName: metadata.licenseName,
+    sourceStatus: 'source-verified',
+    sourceUrl: metadata.sourceUrl,
+    downloadUrl: metadata.downloadUrl,
+    licenseUrl: metadata.licenseUrl,
+    attributionRequired: false,
+    binaryImportStatus: 'imported-from-official-zip',
+    archiveSha256,
+    notes: [
+      'Generated by scripts/import-kenney-ui-pack.mjs.',
+      'Visual-only UI assets for client-2d HUD, skillbar, inventory panels, mobile UI and admin UI.',
+      'WorldTick, AREKernel, networking and server registries remain authoritative and untouched.',
+    ],
+  };
+
+  const manifest = {
+    schemaVersion: '1.0.0',
+    packId: 'kenney-ui-pack',
+    sourceUrl: metadata.sourceUrl,
+    downloadUrl: metadata.downloadUrl,
+    license: metadata.license,
+    licenseUrl: metadata.licenseUrl,
+    authorityPolicy: 'visual-only: WorldTick and AREKernel remain authoritative',
+    archive: {
+      fileName: path.basename(zipPath),
+      sha256: archiveSha256,
+      bytes: archive.length,
+      entryCount: zipEntries.length,
+    },
+    targetDirectory: toPosix(path.relative(repoRoot, targetDir)),
+    importedCount: imported.length,
+    skippedCount: skipped.length,
+    imported,
+    skipped,
+  };
+
+  if (!isDryRun) {
+    await writeJson(creditsPath, credit);
+    await writeJson(generatedManifestPath, manifest);
+  }
+
+  console.log(JSON.stringify({
+    mode: isDryRun ? 'dry-run' : 'write',
+    archiveSha256,
+    importedCount: imported.length,
+    skippedCount: skipped.length,
+    targetDirectory: toPosix(path.relative(repoRoot, targetDir)),
+    creditsPath: toPosix(path.relative(repoRoot, creditsPath)),
+    generatedManifestPath: toPosix(path.relative(repoRoot, generatedManifestPath)),
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/import-pixi-dev-hub-assets.mjs
+++ b/scripts/import-pixi-dev-hub-assets.mjs
@@ -54,6 +54,8 @@ function requireSourceGate(pack, metadata) {
     return {
       ok: false,
       id: pack.id,
+      pack,
+      metadata: metadata || null,
       failures,
     };
   }
@@ -76,11 +78,16 @@ function requireDownloadAllowlist(pack, allowlistEntry) {
   if (allowlistEntry && allowlistEntry.sourceVerified !== true) failures.push('allowlist sourceVerified must be true');
   if (allowlistEntry && allowlistEntry.sourceUrl !== pack.sourceUrl) failures.push('allowlist sourceUrl must match source metadata');
   if (allowlistEntry && allowlistEntry.licenseUrl !== pack.licenseUrl) failures.push('allowlist licenseUrl must match source metadata');
+  if (allowlistEntry?.downloadUrl && pack.downloadUrl && allowlistEntry.downloadUrl !== pack.downloadUrl) {
+    failures.push('allowlist downloadUrl must match source metadata');
+  }
 
   if (failures.length > 0) {
     return {
       ok: false,
       id: pack.id,
+      pack,
+      allowlistEntry: allowlistEntry || null,
       failures,
     };
   }
@@ -90,6 +97,8 @@ function requireDownloadAllowlist(pack, allowlistEntry) {
     id: pack.id,
     merged: {
       ...pack,
+      downloadUrl: pack.downloadUrl || allowlistEntry.downloadUrl || null,
+      archiveSha256: allowlistEntry.archiveSha256 || null,
       downloadAllowlisted: true,
     },
   };
@@ -113,6 +122,7 @@ async function writeCredits(pack) {
     licenseName: pack.licenseName || pack.license,
     sourceStatus: pack.sourceVerified ? 'source-verified' : 'required-before-binary-import',
     sourceUrl: pack.sourceUrl || null,
+    downloadUrl: pack.downloadUrl || null,
     licenseUrl: pack.licenseUrl || null,
     attributionRequired: Boolean(pack.attributionRequired),
     binaryImportStatus: pack.binaryImportStatus || 'planned',
@@ -144,6 +154,25 @@ async function ensureTargetDirectory(target) {
   return path.relative(repoRoot, absolute);
 }
 
+function toBlockedPlanResult(result, stage) {
+  return {
+    id: result.id,
+    stage,
+    status: 'blocked-documented',
+    failures: result.failures,
+    sourceVerified: result.metadata?.sourceVerified ?? result.pack?.sourceVerified ?? false,
+    importAllowed: result.allowlistEntry?.importAllowed ?? false,
+    sourceUrl: result.metadata?.sourceUrl ?? result.pack?.sourceUrl ?? null,
+    licenseUrl: result.metadata?.licenseUrl ?? result.pack?.licenseUrl ?? null,
+    binaryImportStatus: result.metadata?.binaryImportStatus ?? result.pack?.binaryImportStatus ?? null,
+    nextRequiredActions: [
+      'Verify the official sourceUrl before binary import.',
+      'Set sourceVerified=true only after official source verification.',
+      'Add a matching download allowlist entry before import.',
+    ],
+  };
+}
+
 async function main() {
   const archive = await readJson(archivePath);
   assertVisualOnlyPolicy(archive);
@@ -158,27 +187,23 @@ async function main() {
   const plannedPacks = archive.firstIntegrationBatch || [];
 
   const sourceGateResults = plannedPacks.map((pack) => requireSourceGate(pack, sourceById.get(pack.id)));
-  const sourceBlocked = sourceGateResults.filter((result) => !result.ok);
-  if (sourceBlocked.length > 0) {
-    const details = sourceBlocked
-      .map((result) => `- ${result.id}: ${result.failures.join('; ')}`)
-      .join('\n');
-    throw new Error(`Pixi asset source gate failed:\n${details}`);
-  }
+  const sourcePassed = sourceGateResults.filter((result) => result.ok);
+  const blocked = sourceGateResults
+    .filter((result) => !result.ok)
+    .map((result) => toBlockedPlanResult(result, 'source-gate'));
 
-  const allowlistGateResults = sourceGateResults.map((result) =>
+  const allowlistGateResults = sourcePassed.map((result) =>
     requireDownloadAllowlist(result.merged, allowlistById.get(result.id)),
   );
-  const allowlistBlocked = allowlistGateResults.filter((result) => !result.ok);
-  if (allowlistBlocked.length > 0) {
-    const details = allowlistBlocked
-      .map((result) => `- ${result.id}: ${result.failures.join('; ')}`)
-      .join('\n');
-    throw new Error(`Pixi asset download allowlist gate failed:\n${details}`);
-  }
+  const allowlistPassed = allowlistGateResults.filter((result) => result.ok);
+  blocked.push(
+    ...allowlistGateResults
+      .filter((result) => !result.ok)
+      .map((result) => toBlockedPlanResult(result, 'download-allowlist-gate')),
+  );
 
   const results = [];
-  for (const result of allowlistGateResults) {
+  for (const result of allowlistPassed) {
     const pack = result.merged;
     const target = pack.target || pack.targetPath;
     if (!target) {
@@ -195,6 +220,8 @@ async function main() {
       license: pack.license,
       licenseName: pack.licenseName,
       sourceUrl: pack.sourceUrl,
+      downloadUrl: pack.downloadUrl || null,
+      archiveSha256: pack.archiveSha256 || null,
       licenseUrl: pack.licenseUrl,
       sourceVerified: pack.sourceVerified,
       downloadAllowlisted: pack.downloadAllowlisted,
@@ -203,7 +230,6 @@ async function main() {
       targetDirectory,
       creditFile,
       nextRequiredActions: [
-        'Implement official-source download step.',
         'Download asset pack from sourceUrl only.',
         'Normalize filenames to kebab-case.',
         'Generate Pixi-compatible atlas or manifest metadata.',
@@ -213,39 +239,37 @@ async function main() {
   }
 
   runtimeManifest.generatedBy = 'scripts/import-pixi-dev-hub-assets.mjs';
-  runtimeManifest.lastPlannedAt = new Date().toISOString();
   runtimeManifest.sourceGate = {
     metadataPath: path.relative(repoRoot, sourceMetadataPath),
-    status: 'passed',
-    checkedPacks: results.length,
+    status: blocked.some((entry) => entry.stage === 'source-gate') ? 'passed-with-blocked-packs-documented' : 'passed',
+    checkedPacks: plannedPacks.length,
+    passedPacks: sourcePassed.length,
+    blockedPacks: blocked.filter((entry) => entry.stage === 'source-gate').length,
   };
   runtimeManifest.downloadAllowlistGate = {
     allowlistPath: path.relative(repoRoot, downloadAllowlistPath),
-    status: 'passed',
-    checkedPacks: results.length,
+    status: blocked.some((entry) => entry.stage === 'download-allowlist-gate') ? 'passed-with-blocked-packs-documented' : 'passed',
+    checkedPacks: sourcePassed.length,
+    passedPacks: allowlistPassed.length,
+    blockedPacks: blocked.filter((entry) => entry.stage === 'download-allowlist-gate').length,
   };
   runtimeManifest.mode = isDryRun ? 'dry-run' : 'write';
   runtimeManifest.plannedResults = results;
+  runtimeManifest.blockedResults = blocked;
 
   const planPath = path.join(repoRoot, 'apps/client-2d/public/2d-assets/manifests/pixi-dev-hub-import-plan.json');
   const plan = {
     schemaVersion: '1.0.0',
-    generatedAt: new Date().toISOString(),
     mode: isDryRun ? 'dry-run' : 'write',
     sourceManifest: path.relative(repoRoot, archivePath),
     sourceMetadata: path.relative(repoRoot, sourceMetadataPath),
     downloadAllowlist: path.relative(repoRoot, downloadAllowlistPath),
     runtimeManifest: path.relative(repoRoot, runtimeManifestPath),
     authorityPolicy: 'visual-only: WorldTick and AREKernel remain authoritative',
-    sourceGate: {
-      status: 'passed',
-      checkedPacks: results.length,
-    },
-    downloadAllowlistGate: {
-      status: 'passed',
-      checkedPacks: results.length,
-    },
+    sourceGate: runtimeManifest.sourceGate,
+    downloadAllowlistGate: runtimeManifest.downloadAllowlistGate,
     results,
+    blocked,
   };
 
   if (isDryRun) {
@@ -253,7 +277,7 @@ async function main() {
   } else {
     await writeJson(runtimeManifestPath, runtimeManifest);
     await writeJson(planPath, plan);
-    console.log(`Pixi Dev Hub source and allowlist gates passed for ${results.length} packs.`);
+    console.log(`Pixi Dev Hub gates passed for ${results.length} packs; blocked documented: ${blocked.length}.`);
     console.log(`Plan: ${path.relative(repoRoot, planPath)}`);
   }
 }

--- a/scripts/validate-pixi-assets.mjs
+++ b/scripts/validate-pixi-assets.mjs
@@ -64,6 +64,14 @@ function assertInsideAssetRoot(filePath, errors) {
   }
 }
 
+function isBlockedPack(pack, metadata, blockedById) {
+  return Boolean(
+    blockedById.has(pack.id)
+    || metadata?.sourceVerified === false
+    || metadata?.binaryImportStatus === 'blocked-until-source-verified',
+  );
+}
+
 function assertUrlDrift(pack, metadata, allowlist, errors) {
   if (!metadata) {
     errors.push(`Missing source metadata for pack ${pack.id}`);
@@ -83,6 +91,10 @@ function assertUrlDrift(pack, metadata, allowlist, errors) {
     errors.push(`licenseUrl drift for ${pack.id}: metadata does not match allowlist`);
   }
 
+  if (metadata.downloadUrl && allowlist.downloadUrl && metadata.downloadUrl !== allowlist.downloadUrl) {
+    errors.push(`downloadUrl drift for ${pack.id}: metadata does not match allowlist`);
+  }
+
   if (allowlist.importAllowed !== true) {
     errors.push(`Pack ${pack.id} is not importAllowed in allowlist`);
   }
@@ -95,10 +107,19 @@ async function main() {
   const downloadAllowlist = await readJson(downloadAllowlistPath);
   const sourceById = indexById(sourceMetadata.packs);
   const allowlistById = indexById(downloadAllowlist.allowedPacks);
+  const blockedById = new Set((downloadAllowlist.blockedPacks || []).map((pack) => pack.id));
+  const importablePacks = [];
+  const intentionallyBlockedPacks = [];
 
   for (const pack of archive.firstIntegrationBatch || []) {
     if (pack.decision === 'reject') continue;
-    assertUrlDrift(pack, sourceById.get(pack.id), allowlistById.get(pack.id), errors);
+    const metadata = sourceById.get(pack.id);
+    if (isBlockedPack(pack, metadata, blockedById)) {
+      intentionallyBlockedPacks.push(pack.id);
+      continue;
+    }
+    importablePacks.push(pack);
+    assertUrlDrift(pack, metadata, allowlistById.get(pack.id), errors);
   }
 
   const files = await listFiles(assetRoot);
@@ -120,8 +141,7 @@ async function main() {
     }
   }
 
-  for (const pack of archive.firstIntegrationBatch || []) {
-    if (pack.decision === 'reject') continue;
+  for (const pack of importablePacks) {
     const target = String(pack.target || pack.targetPath || '').replace(/^\//, '');
     if (!target) {
       errors.push(`Pack ${pack.id} has no target path`);
@@ -150,7 +170,9 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`Pixi asset validation passed for ${files.length} files and ${archive.firstIntegrationBatch?.length || 0} planned packs.`);
+  console.log(
+    `Pixi asset validation passed for ${files.length} files, ${importablePacks.length} importable packs, and ${intentionallyBlockedPacks.length} intentionally blocked packs.`,
+  );
 }
 
 main().catch((error) => {

--- a/server/src/modules/warfront/warfrontTypes.ts
+++ b/server/src/modules/warfront/warfrontTypes.ts
@@ -36,12 +36,54 @@ export type WarfrontPersonalCycleContribution = {
   updatedAt: number;
 };
 
+export type WarfrontRewardTier = {
+  id: string;
+  pointsRequired: number;
+  gold: number;
+  xp: number;
+};
+
 export type WarfrontRewardHistoryEntry = {
   id: string;
   seasonId: string;
   cycleId: string;
-  playerId: string;
-  contributionPoints: number;
-  rewardItemId: string;
-  createdAt: number;
+  tierId: string;
+  awardedAt: number;
+  gold: number;
+  xp: number;
+};
+
+export type PlayerWarfrontProgress = {
+  seasonId: string;
+  seasonPoints: number;
+  lifetimeContribution: number;
+  claimedTierIds: string[];
+  lastCycle: WarfrontPersonalCycleContribution | null;
+  rewardHistory: WarfrontRewardHistoryEntry[];
+};
+
+export type WarfrontStatusSectorPayload = WarfrontSectorState & {
+  progressPct: number;
+  yourPoints: number;
+};
+
+export type WarfrontStatusPayload = {
+  cycleId: string;
+  seasonId: string;
+  phase: WarfrontPhase;
+  startedAt: number;
+  endsAt: number;
+  progressPct: number;
+  sectors: WarfrontStatusSectorPayload[];
+  personal: {
+    cyclePoints: number;
+    seasonPoints: number;
+    nextTier: WarfrontRewardTier | null;
+    claimedTierIds: string[];
+  };
+  frontBoss: {
+    active: boolean;
+    npcId: string | null;
+    mutator: string | null;
+  };
 };


### PR DESCRIPTION
## Summary

Prepares the Pixi Dev Hub / Kenney UI Pack import path for the 2D client HUD and UI assets.

## Changes

- Enables `kenney-ui-pack` source metadata with official Kenney ZIP URL.
- Adds the official ZIP URL and checked archive SHA256 to the download allowlist.
- Adds `scripts/import-kenney-ui-pack.mjs` for deterministic import from `kenney_ui-pack.zip`.
- Adds root commands:
  - `pnpm assets:pixi:import:kenney-ui:dry-run`
  - `pnpm assets:pixi:import:kenney-ui`
- Adds `docs/archive/import-batches/kenney-ui-pack.json` with the exact runner/VPS steps.

## Safety

- Visual-only import.
- No WorldTick changes.
- No AREKernel changes.
- No server registry changes.
- No networking changes.
- `.ttf` and `.url` files are skipped by default.
- Import requires the uploaded ZIP to match SHA256:
  `a8a14a234911eb648c062622915c93e79e94e97cb7f9f375a70f6617f1174318`

## Manual runner/VPS steps after review

```bash
mkdir -p apps/client-2d/public/2d-assets/incoming/kenney-ui-pack
cp kenney_ui-pack.zip apps/client-2d/public/2d-assets/incoming/kenney-ui-pack/kenney_ui-pack.zip
pnpm assets:pixi:import:kenney-ui:dry-run
pnpm assets:pixi:import:kenney-ui
pnpm assets:pixi:validate
```

This PR intentionally does not commit the binary ZIP or extracted binary assets.