### PR TITLE
fix(pixi): allow Kenney SVG and license text assets

### DIFF
--- a/scripts/validate-pixi-assets.mjs
+++ b/scripts/validate-pixi-assets.mjs
@@ -16,6 +16,7 @@ const allowedBinaryExtensions = new Set([
   '.jpeg',
   '.webp',
   '.gif',
+  '.svg',
   '.ogg',
   '.mp3',
   '.wav',
@@ -74,6 +75,10 @@ function isBlockedPack(pack, metadata, blockedById) {
 
 function isAllowedIncomingArchive(relative, extension) {
   return relative.startsWith('incoming/') && extension === '.zip';
+}
+
+function isAllowedPackDocumentation(relative, extension) {
+  return relative.startsWith('ui/kenney-ui-pack/') && extension === '.txt';
 }
 
 function assertUrlDrift(pack, metadata, allowlist, errors) {
@@ -140,7 +145,7 @@ async function main() {
       continue;
     }
 
-    if (isAllowedIncomingArchive(relative, extension)) {
+    if (isAllowedIncomingArchive(relative, extension) || isAllowedPackDocumentation(relative, extension)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes Pixi asset validation after the Kenney UI Pack importer successfully extracts the uploaded ZIP.

## Why

The import workflow successfully completed:

- ZIP verification
- Dry-run import
- Real import

but validation failed afterwards because the Kenney UI Pack contains valid UI asset formats that the validator did not yet allow:

- `.svg` vector UI assets
- `.txt` documentation/license text inside the Kenney UI Pack folder

## Changes

- Allows `.svg` as a valid visual asset extension.
- Allows `.txt` only under:
  `apps/client-2d/public/2d-assets/ui/kenney-ui-pack/`
- Keeps `.zip` allowed only under:
  `apps/client-2d/public/2d-assets/incoming/`
- Keeps runtime asset validation strict everywhere else.

## Safety

- No WorldTick changes.
- No AREKernel changes.
- No server registry changes.
- No networking changes.
- No gameplay state changes.