### PR TITLE
fix(pixi): ignore staging files and allow readmes

### DIFF
--- a/scripts/validate-pixi-assets.mjs
+++ b/scripts/validate-pixi-assets.mjs
@@ -73,12 +73,16 @@ function isBlockedPack(pack, metadata, blockedById) {
   );
 }
 
-function isAllowedIncomingArchive(relative, extension) {
-  return relative.startsWith('incoming/') && extension === '.zip';
+function isIgnoredStagingFile(relative) {
+  return relative.startsWith('incoming/');
 }
 
 function isAllowedPackDocumentation(relative, extension) {
-  return relative.startsWith('ui/kenney-ui-pack/') && extension === '.txt';
+  const basename = path.basename(relative).toLowerCase();
+  return (
+    (basename === 'readme.md' && extension === '.md')
+    || (relative.startsWith('ui/kenney-ui-pack/') && extension === '.txt')
+  );
 }
 
 function assertUrlDrift(pack, metadata, allowlist, errors) {
@@ -145,7 +149,7 @@ async function main() {
       continue;
     }
 
-    if (isAllowedIncomingArchive(relative, extension) || isAllowedPackDocumentation(relative, extension)) {
+    if (isIgnoredStagingFile(relative) || isAllowedPackDocumentation(relative, extension)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes the remaining Pixi asset validator failures found by the Kenney import workflow.

## Failure

Validation failed on:

- `biomes/biome_atlas_v2/README.md`
- `incoming/kenney-ui-pack/1`
- `weapons/modular/README.md`

## Changes

- Ignores all files under `apps/client-2d/public/2d-assets/incoming/` because this is staging/input, not runtime asset output.
- Allows `README.md` documentation files in asset folders.
- Keeps runtime asset extensions strict for actual visual/audio/runtime assets.

## Safety

- No WorldTick changes.
- No AREKernel changes.
- No server registry changes.
- No networking changes.
- No gameplay state changes.