### PR TITLE
fix(determinism): harden AREClock usage in farming and genealogy

### DIFF
--- a/scripts/check-are-determinism.mjs
+++ b/scripts/check-are-determinism.mjs
@@ -12,6 +12,11 @@ const criticalRoots = [
   'server/src/modules/loot',
   'server/src/modules/warfront',
   'server/src/modules/oracle',
+  'server/src/modules/farming',
+  'server/src/modules/growth',
+  'server/src/modules/genealogy',
+  'server/src/modules/monster',
+  'server/src/modules/npc',
 ];
 
 const criticalFilePatterns = [

--- a/server/src/modules/farming/FarmingSystem.ts
+++ b/server/src/modules/farming/FarmingSystem.ts
@@ -1,5 +1,9 @@
+import { type AREClock, SystemAREClock } from "../../core/determinism/AREDeterminism.js";
+
 export class FarmingSystem {
+  constructor(private readonly clock: AREClock = new SystemAREClock()) {}
+
   plant(seedId: string, plotId: string) {
-    return { seedId, plotId, plantedAt: Date.now() };
+    return { seedId, plotId, plantedAt: this.clock.now() };
   }
 }

--- a/server/src/modules/farming/TreeGrowthSystem.ts
+++ b/server/src/modules/farming/TreeGrowthSystem.ts
@@ -1,7 +1,11 @@
+import { type AREClock, SystemAREClock } from "../../core/determinism/AREDeterminism.js";
+
 export class TreeGrowthSystem {
+  constructor(private readonly clock: AREClock = new SystemAREClock()) {}
+
   grow(tree: any) {
     tree.stage = Math.min((tree.stage || 0) + 1, 4);
-    tree.lastGrowthAt = Date.now();
+    tree.lastGrowthAt = this.clock.now();
     return tree;
   }
 }

--- a/server/src/modules/genealogy/FamilyGenerationSystem.ts
+++ b/server/src/modules/genealogy/FamilyGenerationSystem.ts
@@ -1,10 +1,18 @@
+import { type AREClock, SystemAREClock } from "../../core/determinism/AREDeterminism.js";
+
 export class FamilyGenerationSystem {
+  constructor(private readonly clock: AREClock = new SystemAREClock()) {}
+
   createChild(parents: string[], house: string) {
+    const now = this.clock.now();
+    const parentKey = [...parents].sort().join(",");
+    const id = `child:${house}:${parentKey}:${now}`;
+
     return {
-      id: `child:${house}:${Date.now()}`,
+      id,
       parents,
       house,
-      bornAt: Date.now()
+      bornAt: now,
     };
   }
 }

--- a/server/src/modules/growth/FarmingSystem.ts
+++ b/server/src/modules/growth/FarmingSystem.ts
@@ -1,10 +1,14 @@
+import { type AREClock, SystemAREClock } from "../../core/determinism/AREDeterminism.js";
+
 export class FarmingSystem {
+  constructor(private readonly clock: AREClock = new SystemAREClock()) {}
+
   plant(seedId: string, biome: string) {
     return {
       seedId,
       biome,
-      plantedAt: Date.now(),
-      growth: 0
+      plantedAt: this.clock.now(),
+      growth: 0,
     };
   }
 

--- a/server/src/modules/npc/NPCChatAgent.ts
+++ b/server/src/modules/npc/NPCChatAgent.ts
@@ -56,7 +56,11 @@ Maintain character consistency at all times. Respond concisely and in accordance
             ? "Recent Significant World Events:\n" + context.worldHistory
                 .sort((a, b) => b.timestamp - a.timestamp)
                 .slice(0, 5)
-                .map(event => `[${new Date(event.timestamp).toLocaleTimeString()}] ${event.description}`)
+                .map(event => {
+                    // @are-telemetry-side-channel: this formats an already-stored event timestamp for LLM context only.
+                    const timeStr = new Date(event.timestamp).toLocaleTimeString("en-US", { hour12: false });
+                    return `[${timeStr}] ${event.description}`;
+                })
                 .join("\n")
             : "No significant recent world events.";
 

--- a/server/src/modules/npc/NPCChatBridge.ts
+++ b/server/src/modules/npc/NPCChatBridge.ts
@@ -2,11 +2,12 @@ import { NPCMemoryCache, type MemoryEvent } from "./NPCMemoryCache.js";
 import type { NPCTraits } from "./NPCTraits.js";
 import type { NPCContext } from "./NPCChatTypes.js";
 import { WorldHistory } from "../history/WorldHistory.js";
+import { type AREClock, SystemAREClock } from "../../core/determinism/AREDeterminism.js";
 
 export class NPCChatBridge {
     private memoryCache: NPCMemoryCache;
 
-    constructor(memoryCache: NPCMemoryCache) {
+    constructor(memoryCache: NPCMemoryCache, private readonly clock: AREClock = new SystemAREClock()) {
         this.memoryCache = memoryCache;
     }
 
@@ -72,7 +73,11 @@ export class NPCChatBridge {
             return "(no recorded world events yet)";
         }
         return evs
-            .map((e) => `- ${e.title}: ${e.description} @${new Date(e.timestamp).toISOString()}`)
+            .map((e) => {
+                // @are-telemetry-side-channel: formats an already-recorded event timestamp for NPC prompt context only.
+                const timeString = new Date(e.timestamp).toISOString();
+                return `- ${e.title}: ${e.description} @${timeString}`;
+            })
             .join("\n");
     }
 
@@ -98,7 +103,8 @@ export class NPCChatBridge {
             },
             worldState: {
                 currentLocation: "unknown",
-                currentTime: new Date().toISOString(),
+                // @are-telemetry-side-channel: deterministic clock value is formatted for NPC prompt context only.
+                currentTime: new Date(this.clock.now()).toISOString(),
                 environmentConditions: "default",
             },
             worldHistory,

--- a/server/src/modules/npc/NPCMemoryCache.ts
+++ b/server/src/modules/npc/NPCMemoryCache.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck: optional external DB client types in minimal builds.
+/** @are-telemetry-side-channel */
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { deterministicNow } from "../../core/determinism/AREDeterminism.js";
 import type { NPCTraits } from "./NPCTraits.js";
@@ -103,7 +104,7 @@ export class NPCMemoryCache {
                     npc_id: m.npcId,
                     content: m.content,
                     importance: m.importance,
-                    created_at: new Date(m.timestamp).toISOString(),
+                    created_at: new Date(m.timestamp).toISOString(), // @are-telemetry-side-channel: persistence metadata only.
                     tags: m.tags
                 })));
 

--- a/server/src/modules/npc/NPCMemoryPersistence.ts
+++ b/server/src/modules/npc/NPCMemoryPersistence.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/** @are-telemetry-side-channel */
 /**
  * NPCMemoryPersistence — Layer 2: Supabase-backed long-term NPC memory.
  *
@@ -63,7 +64,7 @@ export async function saveNpcMemory(state: NPCMemoryState): Promise<boolean> {
         trade_history: state.tradeHistory.slice(-50),
         reputation: state.reputation,
         event_log: state.eventLog.slice(-100),
-        last_updated: new Date().toISOString(),
+        last_updated: new Date().toISOString(), // @are-telemetry-side-channel: persistence metadata only.
       },
       { onConflict: "npc_id" },
     );

--- a/server/src/tests/farming.test.ts
+++ b/server/src/tests/farming.test.ts
@@ -2,14 +2,17 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { FarmingSystem } from "../modules/farming/FarmingSystem.js";
 import { TreeGrowthSystem } from "../modules/farming/TreeGrowthSystem.js";
 import { SeasonalGrowthBridge } from "../modules/weather/SeasonalGrowthBridge.js";
+import { FixedAREClock } from "../core/determinism/AREDeterminism.js";
 
 // ---------------------------------------------------------------------------
 // FarmingSystem
 // ---------------------------------------------------------------------------
 describe("FarmingSystem", () => {
   let farming: FarmingSystem;
+  const mockNow = 1700000000000;
+  const clock = new FixedAREClock(mockNow);
 
-  beforeEach(() => { farming = new FarmingSystem(); });
+  beforeEach(() => { farming = new FarmingSystem(clock); });
 
   it("plant() returns an object with the correct seedId", () => {
     const result = farming.plant("wheat_seed", "plot_1");
@@ -21,12 +24,9 @@ describe("FarmingSystem", () => {
     expect(result.plotId).toBe("plot_1");
   });
 
-  it("plant() includes a plantedAt timestamp", () => {
-    const before = Date.now();
+  it("plant() includes a deterministic plantedAt timestamp from AREClock", () => {
     const result = farming.plant("carrot_seed", "plot_2");
-    const after = Date.now();
-    expect(result.plantedAt).toBeGreaterThanOrEqual(before);
-    expect(result.plantedAt).toBeLessThanOrEqual(after);
+    expect(result.plantedAt).toBe(mockNow);
   });
 
   it("plant() creates a distinct object per call", () => {
@@ -41,8 +41,10 @@ describe("FarmingSystem", () => {
 // ---------------------------------------------------------------------------
 describe("TreeGrowthSystem", () => {
   let trees: TreeGrowthSystem;
+  const mockNow = 1700000000000;
+  const clock = new FixedAREClock(mockNow);
 
-  beforeEach(() => { trees = new TreeGrowthSystem(); });
+  beforeEach(() => { trees = new TreeGrowthSystem(clock); });
 
   it("grow() increments tree stage by 1", () => {
     const tree: any = { stage: 2 };
@@ -74,13 +76,10 @@ describe("TreeGrowthSystem", () => {
     expect(tree.stage).toBe(1);
   });
 
-  it("grow() attaches a lastGrowthAt timestamp", () => {
-    const before = Date.now();
+  it("grow() attaches a deterministic lastGrowthAt timestamp from AREClock", () => {
     const tree: any = { stage: 0 };
     trees.grow(tree);
-    const after = Date.now();
-    expect(tree.lastGrowthAt).toBeGreaterThanOrEqual(before);
-    expect(tree.lastGrowthAt).toBeLessThanOrEqual(after);
+    expect(tree.lastGrowthAt).toBe(mockNow);
   });
 
   it("multiple grow() calls advance stage sequentially up to max", () => {


### PR DESCRIPTION
## Summary

Clean replacement for #1411, rebased on current `main` and stripped down to the useful determinism hardening only.

## What changed

- Expands `scripts/check-are-determinism.mjs` to scan additional simulation-critical roots:
  - `server/src/modules/farming`
  - `server/src/modules/growth`
  - `server/src/modules/genealogy`
  - `server/src/modules/monster`
  - `server/src/modules/npc`
- Replaces host-clock timestamps with `AREClock` in:
  - `server/src/modules/farming/FarmingSystem.ts`
  - `server/src/modules/farming/TreeGrowthSystem.ts`
  - `server/src/modules/growth/FarmingSystem.ts`
  - `server/src/modules/genealogy/FamilyGenerationSystem.ts`
- Keeps NPC prompt/persistence timestamp formatting explicitly marked as telemetry side-channel only.
- Updates `server/src/tests/farming.test.ts` to assert deterministic timestamps through `FixedAREClock`.

## Deliberately excluded

- No Warfront type changes.
- No WeatherFarmingBridge.
- No Watchdog/Brain/Plexity changes.
- No lockfile changes.
- No portal dependency changes.

## Safety

- No WorldTick changes.
- No AREKernel changes.
- No networking changes.
- No gameplay authority changes.
- Determinism-only hardening.

Supersedes #1411.