### PR TITLE
fix(client-2d): require real Pixi build in deploy

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -43,6 +43,7 @@ jobs:
       ARELORIAN_DOCKER_NETWORK: ${{ inputs.docker_network || 'areloria_arelorian-network' }}
       SSH_PORT: ${{ inputs.ssh_port || secrets.SSH_PORT || '22' }}
       CLIENT_2D_ARCHIVE: wasd-client-2d-dist-${{ github.sha }}.tgz
+      CLIENT_2D_MARKER: REAL_PIXI_CLIENT
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -68,6 +69,7 @@ jobs:
         run: |
           pnpm --filter @wasd/client-2d --if-present build
           test -f apps/client-2d/dist/index.html
+          grep -q "${CLIENT_2D_MARKER}" apps/client-2d/dist/index.html
           tar -C apps/client-2d -czf "${CLIENT_2D_ARCHIVE}" dist
           ls -lh "${CLIENT_2D_ARCHIVE}"
 
@@ -104,12 +106,13 @@ jobs:
             -o ServerAliveInterval=30 \
             -o ServerAliveCountMax=10 \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            "DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_BRANCH='${DEPLOY_BRANCH}' ARELORIAN_PORT='${ARELORIAN_PORT}' ARELORIAN_DOCKER_NETWORK='${ARELORIAN_DOCKER_NETWORK}' CLIENT_2D_ARCHIVE='${CLIENT_2D_ARCHIVE}' bash -s" << 'EOF'
+            "DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_BRANCH='${DEPLOY_BRANCH}' ARELORIAN_PORT='${ARELORIAN_PORT}' ARELORIAN_DOCKER_NETWORK='${ARELORIAN_DOCKER_NETWORK}' CLIENT_2D_ARCHIVE='${CLIENT_2D_ARCHIVE}' CLIENT_2D_MARKER='${CLIENT_2D_MARKER}' bash -s" << 'EOF'
           set -Eeuo pipefail
           APP_DIR="${DEPLOY_PATH:-/opt/areloria}"
           BRANCH="${DEPLOY_BRANCH:-main}"
           REPO_URL="https://github.com/${{ github.repository }}.git"
           CLIENT_2D_ARCHIVE="${CLIENT_2D_ARCHIVE:-}"
+          CLIENT_2D_MARKER="${CLIENT_2D_MARKER:-REAL_PIXI_CLIENT}"
 
           echo "=== VPS Docker deploy entry ==="
           echo "App dir: $APP_DIR"
@@ -133,8 +136,9 @@ jobs:
             mkdir -p apps/client-2d
             tar -xzf "$APP_DIR/$CLIENT_2D_ARCHIVE" -C apps/client-2d
             test -f apps/client-2d/dist/index.html
+            grep -q "$CLIENT_2D_MARKER" apps/client-2d/dist/index.html
           else
-            echo "WARN: No prebuilt client-2d artifact found; Dockerfile may fall back to VPS build."
+            echo "WARN: No prebuilt client-2d artifact found; Dockerfile must build and verify client-2d."
           fi
 
           chmod +x scripts/deploy-vps-docker.sh scripts/vps-docker-inline-deploy.sh 2>/dev/null || true
@@ -148,7 +152,7 @@ jobs:
 
       - name: Public health check
         run: |
-          for path in /health / /portal/ /2d/; do
+          for path in /health / /portal/; do
             echo "Checking https://arelorian.de${path}"
             STATUS="$(curl -k -s -o /dev/null -w "%{http_code}" "https://arelorian.de${path}" || true)"
             echo "Status: ${STATUS}"
@@ -157,3 +161,12 @@ jobs:
               exit 1
             fi
           done
+
+          echo "Checking https://arelorian.de/2d/ for real client marker"
+          BODY="$(curl -k -sS -L --max-time 20 "https://arelorian.de/2d/" || true)"
+          if ! echo "$BODY" | grep -q "${CLIENT_2D_MARKER}"; then
+            echo "ERROR: /2d/ did not serve the real Pixi client marker (${CLIENT_2D_MARKER}). Refusing silent placeholder route."
+            echo "$BODY" | head -c 800
+            exit 1
+          fi
+          echo "2D client marker OK: ${CLIENT_2D_MARKER}"

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -104,7 +104,7 @@ RUN pnpm --filter @wasd/core-logic --if-present run build:runtime && \
 
 # Force client-2d build and verify the builder artifact exists.
 RUN pnpm --filter ./apps/client-2d... run build
-RUN test -f /app/apps/client-2d/dist/index.html
+RUN test -f /app/apps/client-2d/dist/index.html && grep -q 'REAL_PIXI_CLIENT' /app/apps/client-2d/dist/index.html
 
 # Prune dev dependencies
 RUN pnpm prune --prod
@@ -146,7 +146,7 @@ COPY --from=builder /app/prod-server ./
 # Copy client-2d runtime assets into the Express static directory.
 # ServerBootstrap serves production frontend files from ./client/dist.
 COPY --from=builder /app/apps/client-2d/dist ./client/dist/2d
-RUN test -f /app/client/dist/2d/index.html
+RUN test -f /app/client/dist/2d/index.html && grep -q 'REAL_PIXI_CLIENT' /app/client/dist/2d/index.html
 
 # Permissions
 RUN chown -R nodeuser:nodejs /app

--- a/apps/client-2d/index.html
+++ b/apps/client-2d/index.html
@@ -4,15 +4,17 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <meta name="theme-color" content="#0f0f1a" />
-  <title>Arelorian 2D</title>
+  <meta name="areloria-client" content="REAL_PIXI_CLIENT" />
+  <title>Arelorian 2D · REAL_PIXI_CLIENT</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body, #root { width: 100%; height: 100%; overflow: hidden; background: #0f0f1a; }
     body { touch-action: none; }
   </style>
 </head>
-<body>
+<body data-areloria-client="REAL_PIXI_CLIENT">
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
+  <!-- REAL_PIXI_CLIENT -->
 </body>
 </html>


### PR DESCRIPTION
## Summary

Stops the public `/2d/` route from silently passing deploy checks when an old placeholder/offline client is served.

## Changes

- Adds a `REAL_PIXI_CLIENT` marker to the real `apps/client-2d` HTML shell.
- Requires the marker in `Dockerfile.prod` after building and after copying into the runtime image.
- Requires the marker in the prebuilt GitHub Actions client-2d artifact.
- Requires the public `https://arelorian.de/2d/` route to contain the marker during deploy health checks.

## Why

HTTP 200 is not enough for `/2d/`. The old fallback client can return 200 while showing placeholder squares. This makes the deploy fail loudly instead of shipping a fake playable surface.

## Safety

- No gameplay logic changes.
- No WorldTick changes.
- No server API changes.
- Build/deploy validation only.