### PR TITLE
fix(client-2d): repair Kenney asset paths and HUD safe zones

### DIFF
--- a/apps/client-2d/src/KenneyUiLiveSkinBadge.tsx
+++ b/apps/client-2d/src/KenneyUiLiveSkinBadge.tsx
@@ -8,16 +8,32 @@ type KenneyManifest = {
   authorityPolicy?: string;
 };
 
-const MANIFEST_URL = "/2d-assets/manifests/generated/kenney-ui-pack.json";
-const BUTTON_URL = "/2d-assets/ui/kenney-ui-pack/png/blue/default/button-rectangle-depth-gradient.png";
-const ROUND_URL = "/2d-assets/ui/kenney-ui-pack/png/blue/default/button-round-depth-gradient.png";
-const ARROW_URL = "/2d-assets/ui/kenney-ui-pack/png/blue/default/arrow-basic-e-small.png";
+const BASE_URL = import.meta.env.BASE_URL || "/";
+
+function runtimeBaseUrl(): URL {
+  const base = BASE_URL === "/" && window.location.pathname.startsWith("/2d") ? "/2d/" : BASE_URL;
+  return new URL(base, window.location.origin);
+}
+
+function clientAssetUrl(path: string): string {
+  return new URL(path.replace(/^\//, ""), runtimeBaseUrl()).toString();
+}
+
+const MANIFEST_URL = clientAssetUrl("2d-assets/manifests/generated/kenney-ui-pack.json");
+const BUTTON_URL = clientAssetUrl("2d-assets/ui/kenney-ui-pack/png/blue/default/button-rectangle-depth-gradient.png");
+const ROUND_URL = clientAssetUrl("2d-assets/ui/kenney-ui-pack/png/blue/default/button-round-depth-gradient.png");
+const ARROW_URL = clientAssetUrl("2d-assets/ui/kenney-ui-pack/png/blue/default/arrow-basic-e-small.png");
 
 export function KenneyUiLiveSkinBadge() {
   const [manifest, setManifest] = useState<KenneyManifest | null>(null);
   const [state, setState] = useState<"loading" | "online" | "missing">("loading");
 
   useEffect(() => {
+    const rootStyle = document.documentElement.style;
+    rootStyle.setProperty("--kenney-ui-button-blue", `url("${BUTTON_URL}")`);
+    rootStyle.setProperty("--kenney-ui-button-round-blue", `url("${ROUND_URL}")`);
+    rootStyle.setProperty("--kenney-ui-arrow-blue", `url("${ARROW_URL}")`);
+
     let cancelled = false;
 
     fetch(MANIFEST_URL, { cache: "no-store" })
@@ -32,7 +48,7 @@ export function KenneyUiLiveSkinBadge() {
       })
       .catch((error) => {
         if (cancelled) return;
-        console.warn("[KenneyUI] Live skin manifest unavailable", error);
+        console.warn("[KenneyUI] Live skin manifest unavailable", { url: MANIFEST_URL, error });
         setState("missing");
       });
 

--- a/apps/client-2d/src/hudSafeZones.css
+++ b/apps/client-2d/src/hudSafeZones.css
@@ -1,0 +1,177 @@
+/* Mobile HUD collision pass: keep right-side menus from covering status badges and panels. */
+:root {
+  --hud-right-rail-width: 92px;
+  --hud-safe-gap: 12px;
+  --hud-bottom-pad: 14px;
+}
+
+.stitch-side-menu,
+.stitch-skillbar,
+.stitch-bottom-right,
+.kenney-live-skin-badge,
+.pixi-module-inspector,
+.live-reality-bridge,
+.world-heart-monitor {
+  box-sizing: border-box;
+}
+
+@media (max-width: 920px) {
+  :root {
+    --hud-right-rail-width: 82px;
+  }
+
+  .stitch-skillbar {
+    right: 8px;
+    bottom: 10px;
+    z-index: 36;
+    max-height: min(390px, calc(100vh - 186px));
+    overflow: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: none;
+  }
+
+  .stitch-skillbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .stitch-side-menu {
+    top: 80px;
+    right: 8px;
+    bottom: auto;
+    z-index: 35;
+    grid-template-columns: repeat(2, 44px);
+    gap: 6px;
+  }
+
+  .stitch-side-menu button {
+    width: 44px;
+    min-height: 42px;
+    border-radius: 14px;
+    padding: 5px;
+  }
+
+  .stitch-side-menu span {
+    font-size: 17px;
+  }
+
+  .stitch-side-menu small {
+    display: none;
+  }
+
+  .kenney-live-skin-badge {
+    left: 10px;
+    right: calc(var(--hud-right-rail-width) + var(--hud-safe-gap));
+    bottom: 18px;
+    top: auto;
+    z-index: 30;
+    width: auto;
+    max-width: calc(100vw - var(--hud-right-rail-width) - 28px);
+    transform: none;
+  }
+
+  .pixi-module-inspector,
+  .live-reality-bridge,
+  .world-heart-monitor {
+    right: calc(var(--hud-right-rail-width) + var(--hud-safe-gap));
+    max-width: calc(100vw - var(--hud-right-rail-width) - 28px);
+  }
+
+  .stitch-modal {
+    z-index: 60;
+    padding-right: calc(var(--hud-right-rail-width) + 8px);
+  }
+
+  .stitch-modal-card {
+    max-width: calc(100vw - var(--hud-right-rail-width) - 28px);
+  }
+}
+
+@media (max-width: 620px) {
+  :root {
+    --hud-right-rail-width: 76px;
+  }
+
+  .stitch-side-menu {
+    top: 160px;
+    grid-template-columns: repeat(2, 38px);
+  }
+
+  .stitch-side-menu button {
+    width: 38px;
+    min-height: 38px;
+  }
+
+  .stitch-skillbar {
+    right: 6px;
+    bottom: 8px;
+    padding: 6px;
+    gap: 6px;
+    max-height: min(370px, calc(100vh - 210px));
+  }
+
+  .stitch-skillbar button {
+    width: 58px;
+    height: 45px;
+    border-radius: 15px;
+  }
+
+  .stitch-skillbar span {
+    font-size: 19px;
+  }
+
+  .stitch-skillbar b {
+    font-size: 10px;
+  }
+
+  .kenney-live-skin-badge {
+    left: 8px;
+    right: calc(var(--hud-right-rail-width) + 8px);
+    bottom: 12px;
+    max-width: calc(100vw - var(--hud-right-rail-width) - 20px);
+    padding: 8px 9px;
+    gap: 7px;
+    border-radius: 16px;
+  }
+
+  .kenney-live-skin-preview {
+    width: 58px;
+    height: 34px;
+  }
+
+  .kenney-live-skin-preview img:nth-child(1) {
+    width: 50px;
+    height: 20px;
+  }
+
+  .kenney-live-skin-preview img:nth-child(2) {
+    width: 25px;
+    height: 25px;
+  }
+
+  .kenney-live-skin-preview img:nth-child(3) {
+    width: 14px;
+    height: 14px;
+  }
+
+  .kenney-live-skin-copy small,
+  .kenney-live-skin-copy span {
+    font-size: 8px;
+  }
+
+  .kenney-live-skin-copy strong {
+    font-size: 10px;
+  }
+
+  .stitch-modal {
+    padding: 8px calc(var(--hud-right-rail-width) + 8px) 8px 8px;
+    place-items: stretch;
+  }
+
+  .stitch-modal-card {
+    width: auto;
+    max-width: none;
+    max-height: calc(100vh - 16px);
+    border-radius: 22px;
+    padding: 14px;
+  }
+}

--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -17,6 +17,7 @@ import "./pixiModuleInspector.css";
 import "./mobilePlayability.css";
 import "./mobileResponsive.css";
 import "./kenneyUiLiveSkin.css";
+import "./hudSafeZones.css";
 
 installClient2DDepthRuntime();
 installViewportRuntime();


### PR DESCRIPTION
## Summary

Fixes the live 2D client UI after the real Pixi client became active.

## Changes

- Resolves Kenney UI Pack manifest and image URLs through the runtime `/2d/` base path.
- Sets Kenney CSS asset variables from the resolved runtime URLs.
- Adds mobile HUD safe zones so the right-side skill/menu rail does not overlap badges and panels.
- Loads the new HUD safe-zone CSS overrides after existing mobile styles.

## Safety

- Client-only change.
- No gameplay logic changes.
- No server/deploy changes.