### PR TITLE
fix(client-2d): use native world websocket login

### DIFF
--- a/packages/core-network/src/network.ts
+++ b/packages/core-network/src/network.ts
@@ -1,4 +1,3 @@
-import { io, Socket, ManagerOptions } from "socket.io-client";
 import type { ServerEvent, ConnectionConfig } from "./types";
 
 type EventListener<T extends ServerEvent = ServerEvent> = (event: T) => void;
@@ -9,8 +8,35 @@ declare global {
   }
 }
 
+function toWebSocketUrl(url: string): string {
+  const base = new URL(url || window.location.origin, window.location.origin);
+  base.protocol = base.protocol === "https:" ? "wss:" : "ws:";
+  base.pathname = "/ws";
+  base.search = "";
+  base.hash = "";
+  return base.toString();
+}
+
+function parseJsonMessage(raw: MessageEvent["data"]): any | null {
+  try {
+    const text = typeof raw === "string" ? raw : "";
+    if (!text) return null;
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function readClient2DIdentity() {
+  const handle = localStorage.getItem("wasd:2d:name") || "architect";
+  const publicKey = localStorage.getItem("wasd:2d:publicKey") || `are-client2d-${handle}`;
+  const identityHash = localStorage.getItem("wasd:2d:identityHash") || publicKey;
+  const role = localStorage.getItem("wasd:2d:role") || "Scavenger";
+  return { handle, publicKey, identityHash, role };
+}
+
 export class ArelorianClient {
-  private socket: Socket | null = null;
+  private socket: WebSocket | null = null;
   private listeners: Map<string, Set<EventListener>> = new Map();
   private config: ConnectionConfig;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -21,7 +47,7 @@ export class ArelorianClient {
     this.config = {
       reconnectInterval: 5000,
       heartbeatInterval: 30000,
-      ...config
+      ...config,
     };
   }
 
@@ -34,44 +60,58 @@ export class ArelorianClient {
   }
 
   connect(): void {
-    if (this.socket?.connected) return;
+    if (this.socket && (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)) return;
     if (typeof window !== "undefined") window.__areloriaClient = this;
 
-    const options: ManagerOptions = {
-      transports: ["websocket"],
-      reconnection: true,
-      reconnectionAttempts: Infinity,
-      reconnectionDelay: this.config.reconnectInterval,
-      timeout: 10000
-    };
+    const wsUrl = toWebSocketUrl(this.config.url);
+    this.socket = new WebSocket(wsUrl);
 
-    this.socket = io(this.config.url, options);
-
-    this.socket.on("connect", () => {
+    this.socket.addEventListener("open", () => {
       this._connected = true;
-      console.log("[Arelorian] Connected to", this.config.url);
+      const identity = readClient2DIdentity();
+      this.sendRaw({
+        type: "login",
+        source: "client-2d",
+        name: identity.handle,
+        handle: identity.handle,
+        publicKey: identity.publicKey,
+        identityHash: identity.identityHash,
+        role: identity.role,
+        class: identity.role,
+        appearance: "client-2d",
+      });
+      console.log("[Arelorian] Connected to native world socket", wsUrl);
       this.dispatch({ type: "connect" as any, payload: {} } as ServerEvent);
       this.startHeartbeat();
     });
 
-    this.socket.on("disconnect", () => {
+    this.socket.addEventListener("close", () => {
       this._connected = false;
-      console.log("[Arelorian] Disconnected");
+      console.log("[Arelorian] Native world socket disconnected");
       this.dispatch({ type: "disconnect" as any, payload: {} } as ServerEvent);
       this.stopHeartbeat();
+      window.setTimeout(() => this.connect(), this.config.reconnectInterval);
     });
 
-    this.socket.onAny((event: string, payload: any = {}) => {
-      const serverEvent = { type: event, payload } as ServerEvent;
-      if (event === "WORLD_HEARTBEAT") this._worldState = payload;
-      console.log("[Arelorian] Event:", event, payload);
+    this.socket.addEventListener("message", (event) => {
+      const msg = parseJsonMessage(event.data);
+      if (!msg?.type) return;
+      const payload = msg.payload ?? msg;
+      const serverEvent = { type: msg.type, payload } as ServerEvent;
+      if (msg.type === "WORLD_HEARTBEAT") this._worldState = payload;
+      if (msg.type === "world_tick") this._worldState = { players: msg.players, agents: msg.npcs, npcs: msg.npcs, loot: msg.loot, tick: msg.tick };
+      console.log("[Arelorian] Event:", msg.type, payload);
       this.dispatch(serverEvent);
+    });
+
+    this.socket.addEventListener("error", () => {
+      this.dispatch({ type: "disconnect" as any, payload: {} } as ServerEvent);
     });
   }
 
   disconnect(): void {
     this.stopHeartbeat();
-    this.socket?.disconnect();
+    this.socket?.close();
     this.socket = null;
     this._connected = false;
     if (typeof window !== "undefined" && window.__areloriaClient === this) delete window.__areloriaClient;
@@ -79,9 +119,7 @@ export class ArelorianClient {
 
   private startHeartbeat(): void {
     this.heartbeatTimer = setInterval(() => {
-      if (this.socket?.connected) {
-        this.socket.emit("ping");
-      }
+      this.sendRaw({ type: "ping" });
     }, this.config.heartbeatInterval);
   }
 
@@ -111,14 +149,26 @@ export class ArelorianClient {
     this.listeners.get(type)?.delete(listener as EventListener);
   }
 
-  emit(event: string, payload: Record<string, unknown>): void {
-    if (this.socket?.connected) {
-      this.socket.emit(event, payload);
+  private sendRaw(payload: Record<string, unknown>): void {
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      this.socket.send(JSON.stringify(payload));
     }
   }
 
+  emit(event: string, payload: Record<string, unknown>): void {
+    this.sendRaw({ type: event, ...payload });
+  }
+
   sendPlayerAction(action: string, payload: Record<string, unknown>): void {
-    this.emit("player_action", { action, payload });
+    if (action === "MOVE") {
+      this.sendRaw({ type: "MOVE", ...payload });
+      return;
+    }
+    if (action === "USE_SKILL") {
+      this.sendRaw({ type: "USE_SKILL", ...payload });
+      return;
+    }
+    this.sendRaw({ type: action, ...payload });
   }
 }
 

--- a/packages/core-network/src/network.ts
+++ b/packages/core-network/src/network.ts
@@ -40,8 +40,10 @@ export class ArelorianClient {
   private listeners: Map<string, Set<EventListener>> = new Map();
   private config: ConnectionConfig;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _worldState: any = null;
   private _connected = false;
+  private intentionalClose = false;
 
   constructor(config: ConnectionConfig) {
     this.config = {
@@ -60,13 +62,17 @@ export class ArelorianClient {
   }
 
   connect(): void {
+    this.intentionalClose = false;
+    this.clearReconnectTimer();
     if (this.socket && (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)) return;
     if (typeof window !== "undefined") window.__areloriaClient = this;
 
     const wsUrl = toWebSocketUrl(this.config.url);
-    this.socket = new WebSocket(wsUrl);
+    const socket = new WebSocket(wsUrl);
+    this.socket = socket;
 
-    this.socket.addEventListener("open", () => {
+    socket.addEventListener("open", () => {
+      if (this.socket !== socket || this.intentionalClose) return;
       this._connected = true;
       const identity = readClient2DIdentity();
       this.sendRaw({
@@ -85,15 +91,19 @@ export class ArelorianClient {
       this.startHeartbeat();
     });
 
-    this.socket.addEventListener("close", () => {
+    socket.addEventListener("close", () => {
+      if (this.socket === socket) this.socket = null;
       this._connected = false;
       console.log("[Arelorian] Native world socket disconnected");
       this.dispatch({ type: "disconnect" as any, payload: {} } as ServerEvent);
       this.stopHeartbeat();
-      window.setTimeout(() => this.connect(), this.config.reconnectInterval);
+      if (!this.intentionalClose) {
+        this.reconnectTimer = setTimeout(() => this.connect(), this.config.reconnectInterval);
+      }
     });
 
-    this.socket.addEventListener("message", (event) => {
+    socket.addEventListener("message", (event) => {
+      if (this.socket !== socket || this.intentionalClose) return;
       const msg = parseJsonMessage(event.data);
       if (!msg?.type) return;
       const payload = msg.payload ?? msg;
@@ -104,20 +114,25 @@ export class ArelorianClient {
       this.dispatch(serverEvent);
     });
 
-    this.socket.addEventListener("error", () => {
+    socket.addEventListener("error", () => {
+      if (this.socket !== socket || this.intentionalClose) return;
       this.dispatch({ type: "disconnect" as any, payload: {} } as ServerEvent);
     });
   }
 
   disconnect(): void {
+    this.intentionalClose = true;
+    this.clearReconnectTimer();
     this.stopHeartbeat();
-    this.socket?.close();
+    const socket = this.socket;
     this.socket = null;
+    socket?.close();
     this._connected = false;
     if (typeof window !== "undefined" && window.__areloriaClient === this) delete window.__areloriaClient;
   }
 
   private startHeartbeat(): void {
+    this.stopHeartbeat();
     this.heartbeatTimer = setInterval(() => {
       this.sendRaw({ type: "ping" });
     }, this.config.heartbeatInterval);
@@ -127,6 +142,13 @@ export class ArelorianClient {
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
     }
   }
 

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import { existsSync } from "node:fs";
 import { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import { WorldTick } from "./WorldTick.js";
+import { installClient2DPublicKeyLoginBridge } from "./installClient2DPublicKeyLoginBridge.js";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { mcpRoute } from "../api/mcpRoute.js";
@@ -166,6 +167,7 @@ export class ServerBootstrap {
     const ws = new GameWebSocketServer(httpServer);
     ws.start();
     const tick = new WorldTick(ws);
+    installClient2DPublicKeyLoginBridge(ws, tick);
     (this as any)._tick = tick;
     await tick.init();
     this.initializing = false;

--- a/server/src/core/installClient2DPublicKeyLoginBridge.ts
+++ b/server/src/core/installClient2DPublicKeyLoginBridge.ts
@@ -1,0 +1,109 @@
+import type { GameWebSocketServer } from "../networking/WebSocketServer.js";
+import type { WorldTick } from "./WorldTick.js";
+
+function sanitizeIdentityPart(value: unknown, fallback: string): string {
+  const raw = String(value ?? fallback).trim().toLowerCase();
+  const cleaned = raw.replace(/[^a-z0-9:_-]+/g, "-").replace(/-+/g, "-").slice(0, 96);
+  return cleaned || fallback;
+}
+
+function numericSpawn(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.max(-64, Math.min(64, Math.trunc(n))) : fallback;
+}
+
+function readSpawn(msg: any): { x: number; y: number; z: number } {
+  const parsed = (() => {
+    if (typeof msg?.spawn === "string") {
+      try { return JSON.parse(msg.spawn); } catch { return null; }
+    }
+    return msg?.spawn && typeof msg.spawn === "object" ? msg.spawn : null;
+  })();
+
+  return {
+    x: numericSpawn(parsed?.x ?? msg?.x, 0),
+    y: numericSpawn(parsed?.y ?? parsed?.z ?? msg?.z ?? msg?.y, 0),
+    z: numericSpawn(parsed?.z ?? 0, 0),
+  };
+}
+
+function isClient2DPublicKeyLogin(msg: any): boolean {
+  return msg?.type === "login" && !msg?.token && Boolean(msg?.publicKey || msg?.identityHash) && (msg?.source === "client-2d" || msg?.appearance === "client-2d");
+}
+
+export function installClient2DPublicKeyLoginBridge(ws: GameWebSocketServer, tick: WorldTick): void {
+  const originalHandler = ws.onPlayerMessage?.bind(ws);
+
+  ws.onPlayerMessage = async (socketId: string, msg: any) => {
+    if (!isClient2DPublicKeyLogin(msg)) {
+      if (originalHandler) await originalHandler(socketId, msg);
+      return;
+    }
+
+    const uid = `client2d:${sanitizeIdentityPart(msg.identityHash ?? msg.publicKey, "anonymous")}`;
+    const name = String(msg.name ?? msg.handle ?? "Architect").trim().slice(0, 48) || "Architect";
+    const role = String(msg.role ?? msg.class ?? "Explorer").trim().slice(0, 32) || "Explorer";
+    const spawn = readSpawn(msg);
+
+    const playerSystem = (tick as any).playerSystem;
+    let player = playerSystem.getPlayer(uid);
+    if (!player) {
+      player = playerSystem.createPlayer(uid, name, role, "client-2d");
+      if (typeof (tick as any).hydratePlayer === "function") (tick as any).hydratePlayer(player);
+      player.position.x = spawn.x;
+      player.position.y = spawn.y;
+      player.position.z = spawn.z;
+    }
+
+    player.name = name;
+    player.class = role;
+    player.appearance = "client-2d";
+    player.isOffline = false;
+    player.state = "idle";
+
+    (tick as any).socketToPlayer?.set(socketId, uid);
+    (tick as any).playerToSocket?.set(uid, socketId);
+    tick.observerEngine.register(socketId, { x: player.position.x, y: player.position.y });
+
+    ws.sendToPlayer(socketId, {
+      type: "welcome",
+      id: uid,
+      playerName: player.name,
+      stats: {
+        gold: player.gold ?? 0,
+        xp: player.xp ?? 0,
+        hp: player.health ?? 100,
+        maxHp: player.maxHealth ?? 100,
+        mp: player.mana ?? 25,
+        maxMp: player.maxMana ?? 25,
+        level: player.level || 1,
+      },
+      inventory: player.inventory ?? [],
+      equipment: player.equipment ?? {},
+      quests: player.quests ?? [],
+      auth: "client2d-public-key",
+    });
+
+    ws.sendToPlayer(socketId, {
+      type: "WORLD_HEARTBEAT",
+      payload: {
+        players: {
+          [uid]: {
+            id: uid,
+            name: player.name,
+            x: player.position.x,
+            y: player.position.y,
+            z: player.position.z ?? 0,
+          },
+        },
+        self: {
+          id: uid,
+          name: player.name,
+          x: player.position.x,
+          y: player.position.y,
+          z: player.position.z ?? 0,
+        },
+      },
+    });
+  };
+}


### PR DESCRIPTION
## Summary

Moves the 2D client network path away from the old Socket.IO layer and onto the live native `/ws` world socket.

## Why

The live Areloria server uses `GameWebSocketServer` on `/ws`, while the 2D client was still using the old Socket.IO-style client. Firebase token login is also no longer the active auth model for this client. The 2D gate already creates a deterministic public-key identity, so this PR bridges that identity into the authoritative `WorldTick` player state.

## Changes

- Replaces `packages/core-network/src/network.ts` with a native WebSocket transport.
- Connects to `/ws` using `ws`/`wss` based on page origin.
- Sends `login` with `publicKey`, `identityHash`, handle, role and `source: client-2d`.
- Sends `MOVE` as native WorldTick messages.
- Sends `USE_SKILL` as native WorldTick messages.
- Adds `installClient2DPublicKeyLoginBridge()` on the server.
- Mounts that bridge in `ServerBootstrap.ts` after `WorldTick` construction.
- Creates a real `PlayerSystem` player for client-2d public-key logins.
- Maps socket id to player id so movement and combat messages reach the real `WorldTick` path.

## Safety

- No local fallback simulation.
- No fake NPC rendering.
- Keeps existing token login path for non-client2d messages.
- Server-authoritative movement remains in `WorldTick`.