### PR TITLE
feat(client-2d): add private GraphicRiver iso asset pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,11 @@ __pycache__/
 apps/client-2d/public/2d-assets/**/*.zip
 apps/client-2d/public/2d-assets/**/*.7z
 apps/client-2d/public/2d-assets/**/*.rar
+
+# Paid/private vendor asset packs: keep raw and extracted licensed art off the public repository.
+.asset-private/
+private-assets/
+vendor-assets/
+apps/client-2d/private-assets/
+apps/client-2d/public/vendor-private/
+apps/client-2d/public/client2d-assets/graphicriver-iso/

--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -81,6 +81,7 @@ function routeAsset(path: string): string {
 function normalizeEntrySrc(entry: AssetEntry): AssetEntry {
   if (!entry.src.startsWith('/')) return entry;
   if (entry.src.startsWith('/2d/')) return entry;
+  if (entry.src.startsWith('/client2d-assets/')) return entry;
   if (entry.src.startsWith('/2d-assets/') || entry.src.startsWith('/assets/')) {
     return { ...entry, src: routeAsset(entry.src) };
   }
@@ -121,8 +122,9 @@ export async function loadAssetManifest(): Promise<AssetManifest | null> {
   const modularWeaponManifest = await loadJson<WeaponManifestPayload>(routeAsset('/2d-assets/weapons/modular/weapon-manifest.json'));
   const pipoyaCharacters = await loadJson<CharacterAtlasPayload>(routeAsset('/2d-assets/characters/pipoya/pipoya-character-atlas.json'));
   const forestBiome = await loadJson<AssetManifest>(routeAsset('/assets/biomes/forest/assetpack01/manifest.json'));
+  const graphicRiverIso = await loadJson<AssetManifest>('/client2d-assets/graphicriver-iso/manifest.json');
 
-  if (!root && !weaponManifest && !modularWeaponManifest && !pipoyaCharacters && !forestBiome) return null;
+  if (!root && !weaponManifest && !modularWeaponManifest && !pipoyaCharacters && !forestBiome && !graphicRiverIso) return null;
 
   return {
     ...(root ?? { version: 1, basePath: routeAsset('/2d-assets') }),
@@ -133,27 +135,49 @@ export async function loadAssetManifest(): Promise<AssetManifest | null> {
       ...(modularWeaponManifest?.sources ?? []),
       ...(pipoyaCharacters ? [{ id: pipoyaCharacters.id ?? 'pipoya-character-atlas', source: pipoyaCharacters.source ?? 'Pipoya', groups: pipoyaCharacters.groups ?? {} }] : []),
       ...(forestBiome ? [{ id: 'assetpack01_forest_sample', source: 'AssetPack01_Forest_Sample.zip', biome: 'forest', pngCount: forestBiome.pngCount, deterministic: true }] : []),
+      ...(graphicRiverIso?.sources ?? []),
     ],
     tilesets: {
       ...normalizeEntries(root?.tilesets),
       ...normalizeEntries(forestBiome?.tilesets),
+      ...normalizeEntries(graphicRiverIso?.tilesets),
     },
     props: {
       ...normalizeEntries(root?.props),
       ...normalizeEntries(forestBiome?.props),
+      ...normalizeEntries(graphicRiverIso?.props),
     },
     ui: {
       ...normalizeEntries(root?.ui),
       ...normalizeEntries(forestBiome?.ui),
+      ...normalizeEntries(graphicRiverIso?.ui),
     },
     characters: {
       ...normalizeEntries(root?.characters),
       ...withEntryIds(pipoyaCharacters?.entries),
+      ...normalizeEntries(graphicRiverIso?.characters),
+    },
+    monsters: {
+      ...normalizeEntries(root?.monsters),
+      ...normalizeEntries(graphicRiverIso?.monsters),
+    },
+    buildings: {
+      ...normalizeEntries(root?.buildings),
+      ...normalizeEntries(graphicRiverIso?.buildings),
+    },
+    fx: {
+      ...normalizeEntries(root?.fx),
+      ...normalizeEntries(graphicRiverIso?.fx),
     },
     weapons: {
       ...normalizeEntries(root?.weapons),
       ...normalizeEntries(weaponManifest?.weapons),
       ...normalizeEntries(modularWeaponManifest?.weapons),
+      ...normalizeEntries(graphicRiverIso?.weapons),
+    },
+    fallbacks: {
+      ...(root?.fallbacks ?? {}),
+      ...(graphicRiverIso?.fallbacks ?? {}),
     },
   };
 }

--- a/scripts/client2d-graphicriver-iso-manifest.mjs
+++ b/scripts/client2d-graphicriver-iso-manifest.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.webp', '.jpg', '.jpeg']);
+const DEFAULT_PUBLIC_BASE = '/client2d-assets/graphicriver-iso';
+
+function readArg(name, fallback = null) {
+  const index = process.argv.indexOf(name);
+  if (index >= 0 && process.argv[index + 1]) return process.argv[index + 1];
+  return fallback;
+}
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const full = path.join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) walk(full, out);
+    else if (stats.isFile() && IMAGE_EXTENSIONS.has(path.extname(entry).toLowerCase())) out.push(full);
+  }
+  return out;
+}
+
+function slug(value) {
+  return String(value)
+    .replace(/\\/g, '/')
+    .replace(/\.[a-z0-9]+$/i, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 96) || 'asset';
+}
+
+function categoryFor(relativePath) {
+  const p = relativePath.toLowerCase();
+  if (p.includes('projectile') || p.includes('/fx/') || p.includes('fire') || p.includes('ice') || p.includes('tesla') || p.includes('magic')) return 'fx';
+  if (p.includes('tower') || p.includes('castle') || p.includes('building') || p.includes('cannon')) return 'buildings';
+  if (p.includes('character') || p.includes('peasant') || p.includes('child') || p.includes('knight') || p.includes('horse')) return 'characters';
+  if (p.includes('monster') || p.includes('enemy') || p.includes('rat') || p.includes('ghost') || p.includes('troll') || p.includes('ogre') || p.includes('dragon')) return 'monsters';
+  if (p.includes('tile') || p.includes('background') || p.includes('grass') || p.includes('desert') || p.includes('road')) return 'tilesets';
+  if (p.includes('nature') || p.includes('prop') || p.includes('tree') || p.includes('bush') || p.includes('plant') || p.includes('berry')) return 'props';
+  return 'props';
+}
+
+function tagsFor(relativePath, category) {
+  const p = relativePath.toLowerCase();
+  const tags = new Set(['graphicriver_iso', 'isometric']);
+  tags.add(category.replace(/s$/, ''));
+  for (const token of ['grass', 'desert', 'road', 'peasant', 'child', 'knight', 'horse', 'rat', 'ghost', 'troll', 'ogre', 'dragon', 'tower', 'castle', 'cannon', 'fire', 'ice', 'tesla', 'tree', 'bush', 'plant']) {
+    if (p.includes(token)) tags.add(token);
+  }
+  return [...tags];
+}
+
+function buildManifest(rootDir, publicBase) {
+  const files = walk(rootDir);
+  const manifest = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    basePath: publicBase,
+    sources: [{ id: 'graphicriver_iso_td_3', source: 'GraphicRiver isometric tower defense game kit 3 of 3', privateVendor: true }],
+    tilesets: {},
+    characters: {},
+    monsters: {},
+    buildings: {},
+    props: {},
+    fx: {},
+    ui: {},
+    weapons: {},
+    fallbacks: {},
+  };
+
+  for (const full of files) {
+    const relative = path.relative(rootDir, full).replace(/\\/g, '/');
+    const category = categoryFor(relative);
+    const id = `gr_iso_${slug(relative)}`;
+    manifest[category][id] = {
+      id,
+      src: `${publicBase}/${relative.split('/').map(encodeURIComponent).join('/')}`,
+      source: 'GraphicRiver Iso TD Kit 3',
+      sourcePath: relative,
+      license: 'private-paid-vendor-runtime-only',
+      kind: category.replace(/s$/, ''),
+      group: category,
+      tags: tagsFor(relative, category),
+      rules: { privateVendor: true, isometric: true, runtimeOnly: true },
+    };
+  }
+
+  const firstKey = (group) => Object.keys(group ?? {})[0] ?? null;
+  manifest.fallbacks = {
+    tile: firstKey(manifest.tilesets),
+    tree: Object.keys(manifest.props).find((id) => id.includes('tree')) ?? firstKey(manifest.props),
+    house: Object.keys(manifest.buildings).find((id) => id.includes('castle') || id.includes('tower')) ?? firstKey(manifest.buildings),
+    npc: Object.keys(manifest.characters).find((id) => id.includes('peasant') || id.includes('child')) ?? firstKey(manifest.characters),
+    player: Object.keys(manifest.characters).find((id) => id.includes('knight') || id.includes('peasant')) ?? firstKey(manifest.characters),
+    monster: firstKey(manifest.monsters),
+    fx: firstKey(manifest.fx),
+  };
+
+  manifest.counts = {
+    tilesets: Object.keys(manifest.tilesets).length,
+    characters: Object.keys(manifest.characters).length,
+    monsters: Object.keys(manifest.monsters).length,
+    buildings: Object.keys(manifest.buildings).length,
+    props: Object.keys(manifest.props).length,
+    fx: Object.keys(manifest.fx).length,
+    total: files.length,
+  };
+
+  return manifest;
+}
+
+const rootDir = path.resolve(readArg('--root', process.env.GRAPHICRIVER_ISO_ROOT ?? '/opt/areloria/private-assets/graphicriver-iso/public'));
+const outFile = path.resolve(readArg('--out', path.join(rootDir, 'manifest.json')));
+const publicBase = readArg('--public-base', DEFAULT_PUBLIC_BASE);
+
+if (!existsSync(rootDir)) {
+  console.error(`[graphicriver-iso-manifest] root not found: ${rootDir}`);
+  process.exit(1);
+}
+
+const manifest = buildManifest(rootDir, publicBase);
+writeFileSync(outFile, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+console.log(`[graphicriver-iso-manifest] wrote ${outFile}`);
+console.log(`[graphicriver-iso-manifest] total png/web images: ${manifest.counts.total}`);
+console.log(`[graphicriver-iso-manifest] characters=${manifest.counts.characters} monsters=${manifest.counts.monsters} tiles=${manifest.counts.tilesets} props=${manifest.counts.props} buildings=${manifest.counts.buildings} fx=${manifest.counts.fx}`);

--- a/server/src/api/client2dAssetUploadRoute.ts
+++ b/server/src/api/client2dAssetUploadRoute.ts
@@ -1,0 +1,109 @@
+import express, { type Request, type Response, type Router } from "express";
+import { createWriteStream, existsSync, mkdirSync, rmSync } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+const DEFAULT_ROOT = "/opt/areloria/private-assets/graphicriver-iso";
+const MAX_UPLOAD_BYTES = 900 * 1024 * 1024;
+
+function privateAssetRoot(): string {
+  return path.resolve(process.env.CLIENT2D_GRAPHICRIVER_ISO_ROOT || DEFAULT_ROOT);
+}
+
+function uploadToken(): string {
+  return process.env.CLIENT2D_ASSET_UPLOAD_TOKEN || "";
+}
+
+function requestToken(req: Request): string {
+  const auth = req.headers.authorization || "";
+  if (auth.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+  if (typeof req.query.token === "string") return req.query.token;
+  if (typeof req.headers["x-upload-token"] === "string") return req.headers["x-upload-token"];
+  return "";
+}
+
+function requireUploadToken(req: Request, res: Response): boolean {
+  const expected = uploadToken();
+  if (!expected) {
+    res.status(503).json({ error: "CLIENT2D_ASSET_UPLOAD_TOKEN not configured" });
+    return false;
+  }
+  if (requestToken(req) !== expected) {
+    res.status(401).json({ error: "Unauthorized" });
+    return false;
+  }
+  return true;
+}
+
+function run(command: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: "inherit", shell: false });
+    child.on("error", reject);
+    child.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`${command} exited with ${code}`)));
+  });
+}
+
+async function processZip(zipPath: string, publicDir: string, repoRoot: string): Promise<void> {
+  if (existsSync(publicDir)) rmSync(publicDir, { recursive: true, force: true });
+  mkdirSync(publicDir, { recursive: true });
+  await run("unzip", ["-q", "-o", zipPath, "-d", publicDir], repoRoot);
+  await run("node", [
+    "scripts/client2d-graphicriver-iso-manifest.mjs",
+    "--root", publicDir,
+    "--out", path.join(publicDir, "manifest.json"),
+    "--public-base", "/client2d-assets/graphicriver-iso",
+  ], repoRoot);
+}
+
+function statusPayload() {
+  const root = privateAssetRoot();
+  const rawZip = path.join(root, "raw", "graphicriver-iso-pack.zip");
+  const publicDir = path.join(root, "public");
+  const manifest = path.join(publicDir, "manifest.json");
+  return {
+    ok: true,
+    configured: Boolean(uploadToken()),
+    root,
+    rawZipExists: existsSync(rawZip),
+    publicDirExists: existsSync(publicDir),
+    manifestExists: existsSync(manifest),
+    manifestUrl: "/client2d-assets/graphicriver-iso/manifest.json",
+    maxUploadBytes: MAX_UPLOAD_BYTES,
+  };
+}
+
+export function client2dAssetUploadRouter(): Router {
+  const r = express.Router();
+
+  r.get("/status", (req: Request, res: Response) => {
+    if (!requireUploadToken(req, res)) return;
+    res.json(statusPayload());
+  });
+
+  r.post("/upload", async (req: Request, res: Response) => {
+    if (!requireUploadToken(req, res)) return;
+    const length = Number(req.headers["content-length"] || 0);
+    if (!Number.isFinite(length) || length <= 0) return res.status(411).json({ error: "content-length required" });
+    if (length > MAX_UPLOAD_BYTES) return res.status(413).json({ error: "zip too large", maxBytes: MAX_UPLOAD_BYTES });
+
+    const root = privateAssetRoot();
+    const rawDir = path.join(root, "raw");
+    const publicDir = path.join(root, "public");
+    const zipPath = path.join(rawDir, "graphicriver-iso-pack.zip");
+    const repoRoot = path.resolve(process.cwd());
+
+    mkdirSync(rawDir, { recursive: true });
+    mkdirSync(publicDir, { recursive: true });
+
+    try {
+      await pipeline(req, createWriteStream(zipPath));
+      await processZip(zipPath, publicDir, repoRoot);
+      res.json({ ...statusPayload(), uploaded: true });
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  return r;
+}

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -21,6 +21,7 @@ import { financeRouter } from "../api/financeRoute.js";
 import { sovereignDeployRouter } from "../api/sovereignDeployRoute.js";
 import { healthRoutes } from "../api/healthRoutes.js";
 import { agoraRouter } from "../api/agoraRoute.js";
+import { client2dAssetUploadRouter } from "../api/client2dAssetUploadRoute.js";
 import { getContentDataSourceLabel, resolveContentDir } from "../modules/content/contentDataRoot.js";
 import { getSupabaseSummary, verifySupabaseToken } from "../config/supabase.js";
 import { resolveWorldAssetsDir } from "./resolveWorldAssetsDir.js";
@@ -65,6 +66,11 @@ function resolvePlaytesterMonitorHtmlPath(clientRoot: string, distPath: string):
 function resolvePlaytesterPublisherHtmlPath(clientRoot: string, distPath: string): string | null {
   for (const p of [path.join(distPath, "playtester-render-publisher.html"), path.join(clientRoot, "public", "playtester-render-publisher.html"), path.join(clientRoot, "playtester-render-publisher.html")]) if (existsSync(p)) return p;
   return null;
+}
+
+function resolveClient2DGraphicRiverIsoPublicDir(): string {
+  const root = process.env.CLIENT2D_GRAPHICRIVER_ISO_ROOT || "/opt/areloria/private-assets/graphicriver-iso";
+  return path.join(path.resolve(root), "public");
 }
 
 export function resolveSupabaseProxyBaseUrl(): string | null {
@@ -116,6 +122,7 @@ export class ServerBootstrap {
     await initRedisClient();
     app.use("/api/mcp", mcpRoute());
     app.use("/api/v1", scienceMascotRouter());
+    app.use("/api/client2d-assets", client2dAssetUploadRouter());
     app.use("/api/leaderboard", leaderboardRouter());
     app.use("/api/questlines", questlineRouter());
     app.use("/api/lore", loreRouter());
@@ -210,6 +217,8 @@ export class ServerBootstrap {
       app.use((req, res, next) => { if (req.url?.endsWith(".wasm")) { res.setHeader("Content-Type", "application/wasm"); res.setHeader("Cross-Origin-Opener-Policy", "same-origin"); res.setHeader("Cross-Origin-Embedder-Policy", "require-corp"); } next(); });
       app.use(express.static(clientPath));
     }
+    const client2DGraphicRiverIsoDir = resolveClient2DGraphicRiverIsoPublicDir();
+    if (existsSync(client2DGraphicRiverIsoDir)) app.use("/client2d-assets/graphicriver-iso", express.static(client2DGraphicRiverIsoDir, { maxAge: process.env.NODE_ENV === "production" ? "7d" : 0, fallthrough: false }));
     const mirroredWorld = resolveMirroredWorldAssetsDir();
     const worldAssetsDir = mirroredWorld ?? resolveWorldAssetsDir();
     if (worldAssetsDir) app.use("/world-assets", express.static(worldAssetsDir, { maxAge: process.env.NODE_ENV === "production" ? "7d" : 0, fallthrough: false }));


### PR DESCRIPTION
## Summary

Adds a private runtime pipeline for the paid GraphicRiver isometric asset pack without committing licensed PNGs into the public repository.

## Why

The purchased asset pack should stay private on the VPS. The repository should only contain importer/loader/server code, not the paid art itself.

## Changes

- Ignores private paid asset drop folders in `.gitignore`.
- Adds `scripts/client2d-graphicriver-iso-manifest.mjs` to scan the extracted private asset directory and generate a categorized client manifest.
- Adds `server/src/api/client2dAssetUploadRoute.ts` with token-protected upload/status API.
- Mounts `/api/client2d-assets/*` for upload/status.
- Serves extracted private runtime assets from `/client2d-assets/graphicriver-iso` when present on the VPS.
- Merges `/client2d-assets/graphicriver-iso/manifest.json` into the normal client 2D asset manifest.

## VPS Runtime Paths

Raw ZIP:

```text
/opt/areloria/private-assets/graphicriver-iso/raw/graphicriver-iso-pack.zip
```

Extracted runtime assets:

```text
/opt/areloria/private-assets/graphicriver-iso/public/
```

Public runtime URL after upload:

```text
/client2d-assets/graphicriver-iso/manifest.json
```

## Required Secret / Env

```text
CLIENT2D_ASSET_UPLOAD_TOKEN=<private upload token>
```

Optional:

```text
CLIENT2D_GRAPHICRIVER_ISO_ROOT=/opt/areloria/private-assets/graphicriver-iso
```

## Safety

- Does not commit paid art assets.
- Upload is token protected.
- Max upload size is capped at 900 MB.
- Client only uses the manifest if the VPS runtime asset directory exists and manifest is reachable.