### PR TITLE
fix(client-2d): add browser upload page for private assets

### DIFF
--- a/client/public/client2d-asset-upload.html
+++ b/client/public/client2d-asset-upload.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Areloria Asset Upload</title>
+  <style>
+    body{margin:0;min-height:100vh;display:grid;place-items:center;padding:20px;background:#061009;color:#f7ffe1;font-family:system-ui,sans-serif}main{width:min(760px,100%);border:1px solid rgba(142,255,166,.34);border-radius:24px;padding:22px;background:#020804;box-shadow:0 0 38px rgba(57,255,20,.12)}h1{margin:0 0 8px;font-size:24px}p{color:#c9ffd2;line-height:1.45}label{display:block;margin:18px 0 8px;font-weight:800}input,button{width:100%;box-sizing:border-box;border-radius:14px;border:1px solid rgba(178,255,193,.3);padding:14px;background:#061009;color:#fff;font:inherit}button{margin-top:16px;background:#16813c;font-weight:900;cursor:pointer}button:disabled{opacity:.55;cursor:wait}.hint{font-size:13px;color:#9fe9ad}pre{white-space:pre-wrap;overflow:auto;max-height:310px;min-height:120px;padding:14px;border-radius:14px;background:#010501;border:1px solid rgba(142,255,166,.18);color:#d9ffd9}
+  </style>
+</head>
+<body>
+<main>
+  <h1>Areloria GraphicRiver Iso Upload</h1>
+  <p>Wähle das gekaufte ZIP aus. Es wird auf dem VPS gespeichert, entpackt und als Client2D-Manifest bereitgestellt. Die Datei wird nicht ins öffentliche GitHub-Repo geladen.</p>
+  <label for="file">ZIP-Datei</label>
+  <input id="file" type="file" accept=".zip,application/zip" />
+  <button id="upload">Upload starten</button>
+  <button id="status" type="button">Status prüfen</button>
+  <p class="hint">Ziel: /opt/areloria/private-assets/graphicriver-iso/</p>
+  <pre id="out">Bereit.</pre>
+</main>
+<script>
+const fileInput=document.getElementById('file');
+const uploadButton=document.getElementById('upload');
+const statusButton=document.getElementById('status');
+const out=document.getElementById('out');
+function show(value){out.textContent=typeof value==='string'?value:JSON.stringify(value,null,2)}
+async function readJsonResponse(response){const text=await response.text();try{return JSON.parse(text)}catch{return text}}
+async function checkStatus(){const response=await fetch('/api/client2d-assets/status',{cache:'no-store'});show(await readJsonResponse(response))}
+statusButton.addEventListener('click',async()=>{statusButton.disabled=true;try{await checkStatus()}catch(error){show(String(error))}finally{statusButton.disabled=false}});
+uploadButton.addEventListener('click',async()=>{const file=fileInput.files&&fileInput.files[0];if(!file){show('Bitte zuerst eine ZIP-Datei auswählen.');return}uploadButton.disabled=true;statusButton.disabled=true;show('Upload läuft. Bei großem ZIP bitte warten und den Tab offen lassen...');try{const response=await fetch('/api/client2d-assets/upload',{method:'POST',headers:{'content-type':'application/zip'},body:file});show(await readJsonResponse(response))}catch(error){show(String(error))}finally{uploadButton.disabled=false;statusButton.disabled=false}});
+checkStatus().catch(()=>{});
+</script>
+</body>
+</html>

--- a/server/src/api/client2dAssetUploadRoute.ts
+++ b/server/src/api/client2dAssetUploadRoute.ts
@@ -43,6 +43,7 @@ function statusPayload() {
     publicDirExists: existsSync(publicDir),
     manifestExists: existsSync(manifest),
     manifestUrl: "/client2d-assets/graphicriver-iso/manifest.json",
+    uploadPage: "/client2d-asset-upload.html",
     uploadUrl: "/api/client2d-assets/upload",
     maxUploadBytes: MAX_UPLOAD_BYTES,
   };
@@ -53,6 +54,10 @@ export function client2dAssetUploadRouter(): Router {
 
   r.get("/status", (_req: Request, res: Response) => {
     res.json(statusPayload());
+  });
+
+  r.get("/upload", (_req: Request, res: Response) => {
+    res.redirect(302, "/client2d-asset-upload.html");
   });
 
   r.post("/upload", async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary

Adds a real browser upload page for the private GraphicRiver Iso asset pack and fixes `GET /api/client2d-assets/upload` by redirecting it to that page.

## Why

Opening `/api/client2d-assets/upload` in a browser previously showed `Cannot GET` because only the POST upload endpoint existed. This adds an Android-friendly page so the ZIP can be selected and uploaded from the browser.

## Changes

- Adds `client/public/client2d-asset-upload.html`.
- Adds `GET /api/client2d-assets/upload` redirect to `/client2d-asset-upload.html`.
- Adds `uploadPage` to the status payload.
- Keeps direct POST upload at `/api/client2d-assets/upload`.
- Keeps no-token behavior.

## Use after deploy

Open:

```text
https://www.arelorian.de/client2d-asset-upload.html
```

or:

```text
https://www.arelorian.de/api/client2d-assets/upload
```

Then select the paid ZIP and upload.