### PR TITLE
fix(nginx): allow large client2d asset uploads

### DIFF
--- a/scripts/install-nginx-host-gateway.sh
+++ b/scripts/install-nginx-host-gateway.sh
@@ -53,7 +53,9 @@ server {
   listen [::]:80;
   server_name $DOMAIN $WWW_DOMAIN;
 
-  client_max_body_size 64m;
+  # GraphicRiver/Client2D private asset packs can be several hundred MB.
+  client_max_body_size 1024m;
+  client_body_timeout 600s;
 
   location / {
     proxy_pass http://$ENGINE_HOST:$ENGINE_PORT;
@@ -64,6 +66,18 @@ server {
     proxy_set_header X-Forwarded-Proto \$scheme;
     proxy_read_timeout 120s;
     proxy_send_timeout 120s;
+  }
+
+  location /api/client2d-assets/upload {
+    proxy_pass http://$ENGINE_HOST:$ENGINE_PORT;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_request_buffering off;
+    proxy_read_timeout 900s;
+    proxy_send_timeout 900s;
   }
 
   location /ws {


### PR DESCRIPTION
## Summary

Raises the host-level nginx upload limit for private Client2D asset pack uploads.

## Why

The browser upload currently fails with:

```html
413 Request Entity Too Large
nginx
```

That means nginx rejects the ZIP before the Node upload API receives it. The Node route already allows up to 900 MB, but nginx was capped at 64 MB.

## Changes

- Raises `client_max_body_size` from `64m` to `1024m`.
- Adds `client_body_timeout 600s`.
- Adds a dedicated `/api/client2d-assets/upload` proxy location.
- Disables proxy request buffering for that upload route.
- Extends upload route proxy read/send timeouts to 900s.

## After merge/deploy

The VPS nginx installer must run again so `/etc/nginx/sites-available/arelorian-game` receives the new limit.