### PR TITLE
feat(client-2d): bind GraphicRiver iso assets into live scene

### DIFF
--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -208,6 +208,25 @@ function deterministicIndex(seed: string, length: number): number {
   return Math.abs(hash) % length;
 }
 
+function entryKey(id: string, entry: AssetEntry): string {
+  return `${id} ${entry.sourcePath ?? ''} ${entry.src ?? ''}`.toLowerCase();
+}
+
+function isGraphicRiverEntry(id: string, entry: AssetEntry): boolean {
+  const tags = (entry.tags ?? []).map((tag) => String(tag).toLowerCase());
+  return tags.includes('graphicriver_iso') || entry.src.includes('/client2d-assets/graphicriver-iso/') || entryKey(id, entry).includes('graphicriver');
+}
+
+function isBadNormalActorFrame(id: string, entry: AssetEntry): boolean {
+  const key = entryKey(id, entry);
+  return ['death', 'dead', 'attack', 'scream', 'explosion', 'bullet', 'projectile'].some((term) => key.includes(term));
+}
+
+function isPreferredGraphicRiverCharacterFrame(id: string, entry: AssetEntry): boolean {
+  const key = entryKey(id, entry);
+  return ['peasant', 'child', 'walking', 'front'].some((term) => key.includes(term));
+}
+
 function isRenderableEntry(entry: AssetEntry | null | undefined): boolean {
   if (!entry?.src) return false;
   if (entry.frame) return true;
@@ -263,17 +282,27 @@ export function pickCharacterVisual(
   const wantedGroup = String(input.group || '').toLowerCase();
   const wantedKind = String(input.kind || '').toLowerCase();
   const renderablePool = Object.entries(characters).filter(([, entry]) => isRenderableEntry(entry));
-  const matches = renderablePool.filter(([, entry]) => {
+  const matches = renderablePool.filter(([id, entry]) => {
     const tags = (entry.tags ?? []).map((tag) => String(tag).toLowerCase());
     const group = String(entry.group ?? '').toLowerCase();
     const kind = String(entry.kind ?? '').toLowerCase();
     const tagsOk = wantedTags.length === 0 || wantedTags.every((tag) => tags.includes(tag));
     const groupOk = !wantedGroup || group === wantedGroup || tags.includes(wantedGroup);
     const kindOk = !wantedKind || kind === wantedKind || tags.includes(wantedKind);
-    return tagsOk && groupOk && kindOk;
+    if (!tagsOk || !groupOk || !kindOk) return false;
+    if (isGraphicRiverEntry(id, entry) && isBadNormalActorFrame(id, entry)) return false;
+    return true;
   });
 
-  const pool = matches.length > 0 ? matches : renderablePool;
+  const safeGraphicRiver = renderablePool.filter(([id, entry]) => isGraphicRiverEntry(id, entry) && !isBadNormalActorFrame(id, entry));
+  const preferredGraphicRiver = safeGraphicRiver.filter(([id, entry]) => isPreferredGraphicRiverCharacterFrame(id, entry));
+  const pool = matches.length > 0
+    ? matches
+    : preferredGraphicRiver.length > 0
+      ? preferredGraphicRiver
+      : safeGraphicRiver.length > 0
+        ? safeGraphicRiver
+        : renderablePool;
   if (pool.length === 0) return null;
 
   const seed = String(input.seed ?? `${wantedTags.join(',')}:${wantedGroup}:${wantedKind}`);

--- a/apps/client-2d/src/client2dBootstrapNpcOverlay.ts
+++ b/apps/client-2d/src/client2dBootstrapNpcOverlay.ts
@@ -1,97 +1,10 @@
-import { loadClient2DBootstrap, type Client2DBootstrapNpc } from "./client2dBootstrap";
-
-const TILE_W = 96;
-const TILE_H = 48;
-const OVERLAY_ID = "client2d-bootstrap-npc-overlay";
-const STYLE_ID = "client2d-bootstrap-npc-overlay-style";
-
-function injectStyle(): void {
-  if (document.getElementById(STYLE_ID)) return;
-  const style = document.createElement("style");
-  style.id = STYLE_ID;
-  style.textContent = [
-    `#${OVERLAY_ID}{position:absolute;inset:0;pointer-events:none;z-index:28;overflow:hidden;}`,
-    `.client2d-bootstrap-npc-marker{position:absolute;transform:translate(-50%,-100%);display:grid;place-items:center;gap:2px;min-width:88px;padding:3px 6px 5px;border:1px solid rgba(161,255,177,.48);border-radius:12px;background:linear-gradient(180deg,rgba(5,16,10,.86),rgba(2,6,4,.62));box-shadow:0 0 18px rgba(57,255,20,.16),inset 0 0 10px rgba(255,255,255,.06);color:#fff4cf;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;text-align:center;text-shadow:0 2px 4px #000;white-space:nowrap;}`,
-    `.client2d-bootstrap-npc-dot{width:16px;height:16px;border-radius:50%;background:#d4ffd7;border:2px solid #39ff14;box-shadow:0 0 10px rgba(57,255,20,.36);}`,
-    `.client2d-bootstrap-npc-marker[data-fixed="true"]{border-color:rgba(255,216,128,.7);box-shadow:0 0 20px rgba(255,184,78,.22),inset 0 0 10px rgba(255,255,255,.08);}`,
-    `.client2d-bootstrap-npc-marker[data-role="merchant"] .client2d-bootstrap-npc-dot{background:#ffe7a8;border-color:#ffbe4d;}`,
-    `.client2d-bootstrap-npc-marker[data-role="blacksmith"] .client2d-bootstrap-npc-dot{background:#d7dce2;border-color:#f6f7ff;}`,
-    `.client2d-bootstrap-npc-name{font-size:10px;font-weight:800;letter-spacing:.02em;}`,
-    `.client2d-bootstrap-npc-role{max-width:118px;overflow:hidden;text-overflow:ellipsis;font-size:8px;color:rgba(199,255,211,.82);text-transform:uppercase;}`,
-  ].join("\n");
-  document.head.appendChild(style);
-}
-
-function getWorldHost(): HTMLElement | null {
-  return document.querySelector<HTMLElement>(".az-shell") ?? document.querySelector<HTMLElement>("#root");
-}
-
-function ensureOverlay(): HTMLElement | null {
-  const host = getWorldHost();
-  if (!host) return null;
-  if (getComputedStyle(host).position === "static") host.style.position = "relative";
-  let overlay = document.getElementById(OVERLAY_ID);
-  if (!overlay) {
-    overlay = document.createElement("div");
-    overlay.id = OVERLAY_ID;
-    host.appendChild(overlay);
-  }
-  return overlay;
-}
-
-function coord(npc: Client2DBootstrapNpc, axis: "x" | "z"): number {
-  const value = axis === "x" ? npc.x ?? npc.gridX ?? 0 : npc.z ?? npc.gridZ ?? npc.y ?? 0;
-  return Number.isFinite(Number(value)) ? Number(value) : 0;
-}
-
-function projectIso(x: number, z: number, width: number, height: number): { left: number; top: number } {
-  return {
-    left: width / 2 + (x - z) * (TILE_W / 2),
-    top: height / 2 + (x + z) * (TILE_H / 2) - 28,
-  };
-}
-
-function renderNpcMarker(overlay: HTMLElement, npc: Client2DBootstrapNpc, index: number): void {
-  const p = projectIso(coord(npc, "x"), coord(npc, "z"), overlay.clientWidth || window.innerWidth, overlay.clientHeight || window.innerHeight);
-  const marker = document.createElement("div");
-  marker.className = "client2d-bootstrap-npc-marker";
-  marker.dataset.id = String(npc.id ?? `server-npc-${index}`);
-  marker.dataset.role = String(npc.role ?? "npc");
-  marker.dataset.fixed = String(Boolean(npc.fixed || npc.permanent));
-  marker.style.left = `${p.left}px`;
-  marker.style.top = `${p.top}px`;
-
-  const dot = document.createElement("span");
-  dot.className = "client2d-bootstrap-npc-dot";
-  const name = document.createElement("span");
-  name.className = "client2d-bootstrap-npc-name";
-  name.textContent = String(npc.displayName || npc.name || "NPC");
-  const role = document.createElement("span");
-  role.className = "client2d-bootstrap-npc-role";
-  role.textContent = String(npc.currentAction || npc.role || "server npc");
-
-  marker.append(dot, name, role);
-  overlay.appendChild(marker);
-}
-
-async function renderBootstrapNpcOverlay(): Promise<void> {
-  injectStyle();
-  const overlay = ensureOverlay();
-  if (!overlay) return;
-  const bootstrap = await loadClient2DBootstrap();
-  if (!bootstrap?.ok || bootstrap.contract !== "client2d-bootstrap-v1" || !Array.isArray(bootstrap.npcs)) return;
-  overlay.replaceChildren();
-  bootstrap.npcs.forEach((npc, index) => renderNpcMarker(overlay, npc, index));
-  window.dispatchEvent(new CustomEvent("areloria:client2d-bootstrap-npcs", { detail: bootstrap }));
-}
-
-function scheduleRender(): void {
-  window.setTimeout(() => void renderBootstrapNpcOverlay(), 800);
-  window.setTimeout(() => void renderBootstrapNpcOverlay(), 2400);
-}
-
+// The old DOM marker overlay is intentionally disabled.
+// Bootstrap NPCs are rendered through the Pixi scene / asset binding layer instead.
 if (typeof window !== "undefined") {
-  window.addEventListener("DOMContentLoaded", scheduleRender, { once: true });
-  window.addEventListener("resize", () => void renderBootstrapNpcOverlay());
-  scheduleRender();
+  window.addEventListener("DOMContentLoaded", () => {
+    document.getElementById("client2d-bootstrap-npc-overlay")?.remove();
+    document.getElementById("client2d-bootstrap-npc-overlay-style")?.remove();
+  }, { once: true });
 }
+
+export {};

--- a/apps/client-2d/src/graphicRiverIsoPicker.ts
+++ b/apps/client-2d/src/graphicRiverIsoPicker.ts
@@ -1,0 +1,78 @@
+import type { AssetCategory, AssetEntry, AssetManifest } from "./assetManifest";
+
+export type PickedGraphicRiverAsset = { id: string; entry: AssetEntry };
+
+const BAD_NORMAL_ACTOR_TERMS = ["death", "dead", "attack", "scream", "explosion", "bullet", "projectile"];
+const GRAPHIC_RIVER_TAG = "graphicriver_iso";
+
+function keyOf(id: string, entry: AssetEntry): string {
+  return `${id} ${entry.sourcePath ?? ""} ${entry.src ?? ""}`.toLowerCase();
+}
+
+function hasAny(haystack: string, terms: string[]): boolean {
+  return terms.some((term) => haystack.includes(term));
+}
+
+function deterministicIndex(seed: string, length: number): number {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash) % length;
+}
+
+function isRenderable(entry: AssetEntry | null | undefined): boolean {
+  if (!entry?.src) return false;
+  if (entry.src.toLowerCase().endsWith(".json")) return false;
+  return true;
+}
+
+function categoryEntries(manifest: AssetManifest | null | undefined, category: AssetCategory): [string, AssetEntry][] {
+  const group = manifest?.[category] ?? {};
+  return Object.entries(group).filter(([, entry]) => isRenderable(entry));
+}
+
+function graphicRiverEntries(manifest: AssetManifest | null | undefined, category: AssetCategory): [string, AssetEntry][] {
+  return categoryEntries(manifest, category).filter(([id, entry]) => {
+    const tags = (entry.tags ?? []).map((tag) => String(tag).toLowerCase());
+    return tags.includes(GRAPHIC_RIVER_TAG) || keyOf(id, entry).includes("graphicriver") || entry.src.includes("/client2d-assets/graphicriver-iso/");
+  });
+}
+
+function choose(pool: [string, AssetEntry][], seed: string): PickedGraphicRiverAsset | null {
+  if (pool.length === 0) return null;
+  const [id, entry] = pool[deterministicIndex(seed, pool.length)];
+  return { id, entry };
+}
+
+export function pickGraphicRiverCharacter(manifest: AssetManifest | null | undefined, seed: string, role = "npc"): PickedGraphicRiverAsset | null {
+  const entries = graphicRiverEntries(manifest, "characters");
+  const safe = entries.filter(([id, entry]) => !hasAny(keyOf(id, entry), BAD_NORMAL_ACTOR_TERMS));
+  const roleLower = role.toLowerCase();
+  const preferredTerms = roleLower.includes("guard") || roleLower.includes("smith")
+    ? ["knight", "peasant", "walking", "front"]
+    : ["peasant", "child", "walking", "front"];
+  const preferred = safe.filter(([id, entry]) => hasAny(keyOf(id, entry), preferredTerms));
+  return choose(preferred.length ? preferred : safe.length ? safe : entries, `gr-character:${seed}:${role}`);
+}
+
+export function pickGraphicRiverTile(manifest: AssetManifest | null | undefined, seed: string, kind: "grass" | "road" | "desert" = "grass"): PickedGraphicRiverAsset | null {
+  const entries = graphicRiverEntries(manifest, "tilesets");
+  const normal = entries.filter(([id, entry]) => keyOf(id, entry).includes(kind) && !hasAny(keyOf(id, entry), ["bottomdark", "upperdark", "sliced", "end_full"]));
+  const preferred = normal.filter(([id, entry]) => hasAny(keyOf(id, entry), ["default", "normal", "main", "middle"]));
+  return choose(preferred.length ? preferred : normal.length ? normal : entries, `gr-tile:${kind}:${seed}`);
+}
+
+export function pickGraphicRiverProp(manifest: AssetManifest | null | undefined, seed: string, kind: "tree" | "bush" | "plant" | "flower" = "tree"): PickedGraphicRiverAsset | null {
+  const entries = [...graphicRiverEntries(manifest, "props"), ...graphicRiverEntries(manifest, "tilesets")];
+  const filtered = entries.filter(([id, entry]) => keyOf(id, entry).includes(kind));
+  return choose(filtered.length ? filtered : entries, `gr-prop:${kind}:${seed}`);
+}
+
+export function pickGraphicRiverBuilding(manifest: AssetManifest | null | undefined, seed: string, kind: "castle" | "tower" | "house" = "castle"): PickedGraphicRiverAsset | null {
+  const entries = graphicRiverEntries(manifest, "buildings");
+  const filtered = entries.filter(([id, entry]) => keyOf(id, entry).includes(kind));
+  const fallbackTower = entries.filter(([id, entry]) => hasAny(keyOf(id, entry), ["castle", "tower", "cannon", "ice", "tesla"]));
+  return choose(filtered.length ? filtered : fallbackTower.length ? fallbackTower : entries, `gr-building:${kind}:${seed}`);
+}


### PR DESCRIPTION
## Summary
- add a deterministic GraphicRiver isometric asset picker for terrain, props, buildings, and characters
- disable the old DOM-based bootstrap NPC overlay so it no longer duplicates or covers the Pixi scene
- harden character selection so normal NPCs do not pick death, attack, scream, explosion, bullet, or projectile frames from the large runtime manifest
- prefer GraphicRiver peasant/child/walking/front frames for live NPC visuals

## Notes
- no paid GraphicRiver assets are committed to the repository
- runtime assets continue to load from `/client2d-assets/graphicriver-iso/manifest.json`
- fallback proxy graphics remain available if the runtime manifest is missing

## Test plan
- deploy branch build
- open `/2d?assetRefresh=1`
- verify no DOM NPC overlay appears
- verify NPCs choose safe runtime character frames instead of death/attack frames
- verify GraphicRiver manifest remains runtime-only