### PR TITLE
fix(ci): refresh lockfile before client-2d frozen install

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -63,7 +63,9 @@ jobs:
           pnpm config set verify-deps-before-run false
 
       - name: Install client-2d dependencies
-        run: pnpm --filter @wasd/client-2d... install --frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
+        run: |
+          pnpm --filter @wasd/client-2d... install --lockfile-only --no-frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
+          pnpm --filter @wasd/client-2d... install --frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
 
       - name: Build client-2d on GitHub runner
         run: |


### PR DESCRIPTION
## Summary
- fixes VPS Docker Deploy failing before build on `ERR_PNPM_OUTDATED_LOCKFILE`
- runs a lockfile-only `--no-frozen-lockfile` install for the filtered deploy workspace before the frozen install
- keeps the second install frozen, so the actual dependency install still validates the generated lock state

## Why
`portal/package.json` was bumped to Vite `^6.4.2` while the lockfile still had the old portal Vite specifier. The Dockerfile already has a lockfile sync step, but the GitHub runner prebuild step failed earlier.

## Test
- rerun VPS Docker Deploy
- expect the Install client-2d dependencies step to pass