### PR TITLE
fix(client-2d): filter sheet/preview assets and use GraphicRiver picker

### DIFF
--- a/apps/client-2d/src/CyberZenIsoApp.tsx
+++ b/apps/client-2d/src/CyberZenIsoApp.tsx
@@ -10,6 +10,10 @@ import {
   type AssetManifest,
 } from "./assetManifest";
 import {
+  pickGraphicRiverProp,
+  pickGraphicRiverBuilding,
+} from "./graphicRiverIsoPicker";
+import {
   loadForestBiomeManifest,
   pickForestGround,
   pickForestGrass,
@@ -188,13 +192,17 @@ function fallbackHouseProxy() {
 }
 
 function propTree(assets?: LoadedAssets | null) {
-  const entry = fallbackEntry(assets?.manifest ?? null, "props", "tree");
+  // Try GraphicRiver picker first for clean standalone sprites
+  const picked = pickGraphicRiverProp(assets?.manifest ?? null, "tree", "tree");
+  const entry = picked?.entry ?? fallbackEntry(assets?.manifest ?? null, "props", "tree");
   const tex = textureFor(assets ?? null, entry);
   return make2dProp(entry, tex, fallbackTreeProxy, 86, 104);
 }
 
 function propHouse(assets?: LoadedAssets | null) {
-  const entry = fallbackEntry(assets?.manifest ?? null, "buildings", "house");
+  // Try GraphicRiver picker first for clean standalone sprites
+  const picked = pickGraphicRiverBuilding(assets?.manifest ?? null, "house", "house");
+  const entry = picked?.entry ?? fallbackEntry(assets?.manifest ?? null, "buildings", "house");
   const tex = textureFor(assets ?? null, entry);
   return make2dProp(entry, tex, fallbackHouseProxy, 118, 118);
 }

--- a/apps/client-2d/src/assetManifest.ts
+++ b/apps/client-2d/src/assetManifest.ts
@@ -227,8 +227,50 @@ function isPreferredGraphicRiverCharacterFrame(id: string, entry: AssetEntry): b
   return ['peasant', 'child', 'walking', 'front'].some((term) => key.includes(term));
 }
 
+/**
+ * Filters out bad runtime sheet/preview/atlas entries that should not be used as standalone sprites.
+ * These typically represent full sprite sheets, preview images, or atlas grids.
+ */
+function isBadRuntimeSheetEntry(id: string, entry: AssetEntry): boolean {
+  const key = entryKey(id, entry);
+  const srcLower = entry.src.toLowerCase();
+  const tagsLower = (entry.tags ?? []).map((tag) => String(tag).toLowerCase());
+
+  // Explicitly bad naming patterns
+  const badTerms = [
+    'sheet', 'preview', 'atlas', 'sample', 'tileset', 'wall sheet',
+    'background', 'fullsheet', 'spritesheet', 'sprite-sheet', 'sprite_sheet',
+    'grid', 'collection', 'overview', 'all', 'composite', 'combined',
+    'multi', 'pack', 'bundle', 'set', 'sequence', 'animation sheet',
+    'flip', 'horizontal', 'vertical', 'strip', 'row', 'column'
+  ];
+
+  // Only filter if entry lacks proper frame/crop data (meaning it's a raw sheet)
+  const hasFrameData = Boolean(entry.frame || (entry.sheetFrame && entry.frameSize) || entry.spriteLayers?.length);
+  if (hasFrameData) return false; // Entry has crop data, trust it
+
+  // For entries without frame data, check if it's a bad sheet/preview
+  if (badTerms.some(term => key.includes(term))) return true;
+
+  // Check src for common sheet/preview patterns
+  const badSrcPatterns = ['_preview', '_sample', '_sheet', '_atlas', '-preview', '-sample', '-sheet', '-atlas',
+    'spritesheet', 'sprite_sheet', 'tileset', 'wallpaper', 'background', 'composite'];
+  if (badSrcPatterns.some(p => srcLower.includes(p))) return true;
+
+  // Large images without frame data are likely sheets (heuristic: > 512 width is suspicious for single asset)
+  if (!hasFrameData && entry.width && entry.width > 512) {
+    // But allow if tags or source indicate it's a designed tile
+    const goodTerms = ['tile', 'ground', 'grass', 'road', 'dirt', 'stone', 'floor'];
+    if (!goodTerms.some(t => tagsLower.some(tag => tag.includes(t)))) return true;
+  }
+
+  return false;
+}
+
 function isRenderableEntry(entry: AssetEntry | null | undefined): boolean {
   if (!entry?.src) return false;
+  // Reject bad sheet entries
+  if (entry.id && entry.src && isBadRuntimeSheetEntry(entry.id, entry)) return false;
   if (entry.frame) return true;
   if (entry.sheetFrame && entry.frameSize) return true;
   if (entry.spriteLayers?.length) return true;

--- a/apps/client-2d/src/graphicRiverIsoPicker.ts
+++ b/apps/client-2d/src/graphicRiverIsoPicker.ts
@@ -5,12 +5,47 @@ export type PickedGraphicRiverAsset = { id: string; entry: AssetEntry };
 const BAD_NORMAL_ACTOR_TERMS = ["death", "dead", "attack", "scream", "explosion", "bullet", "projectile"];
 const GRAPHIC_RIVER_TAG = "graphicriver_iso";
 
+// Bad patterns for sheet/preview/atlas files that should not be selected as standalone assets
+const BAD_SHEET_PATTERNS = [
+  "sheet", "preview", "atlas", "sample", "tileset", "wall sheet", "wall_sheet",
+  "background", "fullsheet", "spritesheet", "sprite-sheet", "sprite_sheet",
+  "grid", "collection", "overview", "all", "composite", "combined",
+  "multi", "pack", "bundle", "set", "sequence", "animation sheet",
+  "flip", "horizontal", "vertical", "strip", "row", "column"
+];
+
 function keyOf(id: string, entry: AssetEntry): string {
   return `${id} ${entry.sourcePath ?? ""} ${entry.src ?? ""}`.toLowerCase();
 }
 
 function hasAny(haystack: string, terms: string[]): boolean {
   return terms.some((term) => haystack.includes(term));
+}
+
+/**
+ * Checks if an entry is a bad sheet/preview/atlas that should not be used as a standalone asset.
+ */
+function isBadSheetEntry(id: string, entry: AssetEntry): boolean {
+  const key = keyOf(id, entry);
+  const srcLower = entry.src.toLowerCase();
+
+  // Check for bad naming patterns
+  if (BAD_SHEET_PATTERNS.some(p => key.includes(p))) return true;
+
+  // Check src for common bad patterns
+  const badSrcPatterns = ["_preview", "_sample", "_sheet", "_atlas", "-preview", "-sample",
+    "-sheet", "-atlas", "spritesheet", "sprite_sheet", "tileset", "background"];
+  if (badSrcPatterns.some(p => srcLower.includes(p))) return true;
+
+  // Large images (>512) without frame data are likely sheets
+  const hasFrameData = Boolean(entry.frame || (entry.sheetFrame && entry.frameSize) || entry.spriteLayers?.length);
+  if (!hasFrameData && entry.width && entry.width > 512) {
+    const tagsLower = (entry.tags ?? []).map((tag: string) => tag.toLowerCase());
+    const goodTerms = ["tile", "ground", "grass", "road", "dirt", "stone", "floor"];
+    if (!goodTerms.some(t => tagsLower.some(tag => tag.includes(t)))) return true;
+  }
+
+  return false;
 }
 
 function deterministicIndex(seed: string, length: number): number {
@@ -46,32 +81,42 @@ function choose(pool: [string, AssetEntry][], seed: string): PickedGraphicRiverA
   return { id, entry };
 }
 
+/**
+ * Filters entries to exclude bad sheet/preview/atlas entries when picking standalone assets.
+ */
+function filterBadSheets(entries: [string, AssetEntry][]): [string, AssetEntry][] {
+  return entries.filter(([id, entry]) => !isBadSheetEntry(id, entry));
+}
+
 export function pickGraphicRiverCharacter(manifest: AssetManifest | null | undefined, seed: string, role = "npc"): PickedGraphicRiverAsset | null {
   const entries = graphicRiverEntries(manifest, "characters");
   const safe = entries.filter(([id, entry]) => !hasAny(keyOf(id, entry), BAD_NORMAL_ACTOR_TERMS));
+  // Filter out bad sheet entries
+  const cleanEntries = filterBadSheets(safe);
   const roleLower = role.toLowerCase();
   const preferredTerms = roleLower.includes("guard") || roleLower.includes("smith")
     ? ["knight", "peasant", "walking", "front"]
     : ["peasant", "child", "walking", "front"];
-  const preferred = safe.filter(([id, entry]) => hasAny(keyOf(id, entry), preferredTerms));
-  return choose(preferred.length ? preferred : safe.length ? safe : entries, `gr-character:${seed}:${role}`);
+  const preferred = cleanEntries.filter(([id, entry]) => hasAny(keyOf(id, entry), preferredTerms));
+  return choose(preferred.length ? preferred : cleanEntries.length ? cleanEntries : safe, `gr-character:${seed}:${role}`);
 }
 
 export function pickGraphicRiverTile(manifest: AssetManifest | null | undefined, seed: string, kind: "grass" | "road" | "desert" = "grass"): PickedGraphicRiverAsset | null {
   const entries = graphicRiverEntries(manifest, "tilesets");
   const normal = entries.filter(([id, entry]) => keyOf(id, entry).includes(kind) && !hasAny(keyOf(id, entry), ["bottomdark", "upperdark", "sliced", "end_full"]));
+  // Tilesets are allowed to be atlases; only filter explicit sheet/preview naming
   const preferred = normal.filter(([id, entry]) => hasAny(keyOf(id, entry), ["default", "normal", "main", "middle"]));
   return choose(preferred.length ? preferred : normal.length ? normal : entries, `gr-tile:${kind}:${seed}`);
 }
 
 export function pickGraphicRiverProp(manifest: AssetManifest | null | undefined, seed: string, kind: "tree" | "bush" | "plant" | "flower" = "tree"): PickedGraphicRiverAsset | null {
-  const entries = [...graphicRiverEntries(manifest, "props"), ...graphicRiverEntries(manifest, "tilesets")];
+  const entries = filterBadSheets([...graphicRiverEntries(manifest, "props"), ...graphicRiverEntries(manifest, "tilesets")]);
   const filtered = entries.filter(([id, entry]) => keyOf(id, entry).includes(kind));
   return choose(filtered.length ? filtered : entries, `gr-prop:${kind}:${seed}`);
 }
 
 export function pickGraphicRiverBuilding(manifest: AssetManifest | null | undefined, seed: string, kind: "castle" | "tower" | "house" = "castle"): PickedGraphicRiverAsset | null {
-  const entries = graphicRiverEntries(manifest, "buildings");
+  const entries = filterBadSheets(graphicRiverEntries(manifest, "buildings"));
   const filtered = entries.filter(([id, entry]) => keyOf(id, entry).includes(kind));
   const fallbackTower = entries.filter(([id, entry]) => hasAny(keyOf(id, entry), ["castle", "tower", "cannon", "ice", "tesla"]));
   return choose(filtered.length ? filtered : fallbackTower.length ? fallbackTower : entries, `gr-building:${kind}:${seed}`);

--- a/apps/client-2d/src/graphicRiverIsoPicker.ts
+++ b/apps/client-2d/src/graphicRiverIsoPicker.ts
@@ -5,15 +5,6 @@ export type PickedGraphicRiverAsset = { id: string; entry: AssetEntry };
 const BAD_NORMAL_ACTOR_TERMS = ["death", "dead", "attack", "scream", "explosion", "bullet", "projectile"];
 const GRAPHIC_RIVER_TAG = "graphicriver_iso";
 
-// Bad patterns for sheet/preview/atlas files that should not be selected as standalone assets
-const BAD_SHEET_PATTERNS = [
-  "sheet", "preview", "atlas", "sample", "tileset", "wall sheet", "wall_sheet",
-  "background", "fullsheet", "spritesheet", "sprite-sheet", "sprite_sheet",
-  "grid", "collection", "overview", "all", "composite", "combined",
-  "multi", "pack", "bundle", "set", "sequence", "animation sheet",
-  "flip", "horizontal", "vertical", "strip", "row", "column"
-];
-
 function keyOf(id: string, entry: AssetEntry): string {
   return `${id} ${entry.sourcePath ?? ""} ${entry.src ?? ""}`.toLowerCase();
 }
@@ -24,18 +15,26 @@ function hasAny(haystack: string, terms: string[]): boolean {
 
 /**
  * Checks if an entry is a bad sheet/preview/atlas that should not be used as a standalone asset.
+ * Uses word-boundary matching to avoid false positives on path segments.
  */
 function isBadSheetEntry(id: string, entry: AssetEntry): boolean {
   const key = keyOf(id, entry);
   const srcLower = entry.src.toLowerCase();
 
-  // Check for bad naming patterns
-  if (BAD_SHEET_PATTERNS.some(p => key.includes(p))) return true;
+  // Check for bad naming patterns - must be surrounded by word boundaries (space, _, -, /, .)
+  // This prevents "assets" matching "set" or "atlas" matching partial words
+  const wordBoundaryBadPatterns = [
+    "_sheet", "_preview", "_atlas", "_sample", "_tileset", "_background",
+    "-sheet", "-preview", "-atlas", "-sample", "-tileset", "-background",
+    "/sheet", "/preview", "/atlas", "/sample",
+    "sheet_", "preview_", "atlas_", "sample_",
+    "spritesheet", "sprite_sheet", "fullsheet",
+    "_all", "-all", "/all",
+    "_pack", "_bundle", "_set", "_multi"
+  ];
 
-  // Check src for common bad patterns
-  const badSrcPatterns = ["_preview", "_sample", "_sheet", "_atlas", "-preview", "-sample",
-    "-sheet", "-atlas", "spritesheet", "sprite_sheet", "tileset", "background"];
-  if (badSrcPatterns.some(p => srcLower.includes(p))) return true;
+  // Check src for common bad patterns (path-based)
+  if (wordBoundaryBadPatterns.some(p => srcLower.includes(p))) return true;
 
   // Large images (>512) without frame data are likely sheets
   const hasFrameData = Boolean(entry.frame || (entry.sheetFrame && entry.frameSize) || entry.spriteLayers?.length);

--- a/apps/client-2d/src/stackedProps.ts
+++ b/apps/client-2d/src/stackedProps.ts
@@ -2,6 +2,33 @@ import { Container, Graphics, Rectangle, Sprite, Texture } from "pixi.js";
 import { makeStackedSprite, supportsStack } from "./stackedSprite";
 import type { AssetEntry } from "./assetManifest";
 
+// PIXI v8 blend modes - MULTIPLY = 2
+const MULTIPLY_BLEND = 2;
+
+/**
+ * Checks if an entry is from an external ISO pack that may have white matte backgrounds.
+ * These sprites should use multiply blending to neutralize white backgrounds.
+ */
+function isExternalIsoPack(entry: AssetEntry | null | undefined): boolean {
+  if (!entry) return false;
+  const srcLower = entry.src.toLowerCase();
+  const tagsLower = (entry.tags ?? []).map((tag: string) => tag.toLowerCase());
+
+  // Check for external pack indicators
+  const externalIndicators = [
+    '/client2d-assets/graphicriver-iso/',
+    '/2d-assets/graphicriver/',
+    'graphicriver',
+    'kenney',
+    'pipoya',
+    'isometric',
+    'iso-pack'
+  ];
+
+  return externalIndicators.some(indicator => srcLower.includes(indicator)) ||
+         tagsLower.some(tag => externalIndicators.some(ind => tag.includes(ind)));
+}
+
 function propTextureFor(entry: AssetEntry, texture: Texture): Texture {
   const frame = entry.frame;
   if (!frame) return texture;
@@ -27,6 +54,12 @@ export function make2dProp(entry: AssetEntry | null | undefined, texture: Textur
   sprite.anchor.set(0.5, 1);
   sprite.width = width;
   sprite.height = height;
+
+  // Apply multiply blend mode for external ISO pack sprites to neutralize white matte backgrounds
+  if (isExternalIsoPack(entry)) {
+    (sprite as any).blendMode = MULTIPLY_BLEND;
+  }
+
   root.addChild(sprite);
   return root;
 }

--- a/apps/client-2d/src/stackedProps.ts
+++ b/apps/client-2d/src/stackedProps.ts
@@ -2,9 +2,6 @@ import { Container, Graphics, Rectangle, Sprite, Texture } from "pixi.js";
 import { makeStackedSprite, supportsStack } from "./stackedSprite";
 import type { AssetEntry } from "./assetManifest";
 
-// PIXI v8 blend modes - MULTIPLY = 2
-const MULTIPLY_BLEND = 2;
-
 /**
  * Checks if an entry is from an external ISO pack that may have white matte backgrounds.
  * These sprites should use multiply blending to neutralize white backgrounds.
@@ -56,8 +53,9 @@ export function make2dProp(entry: AssetEntry | null | undefined, texture: Textur
   sprite.height = height;
 
   // Apply multiply blend mode for external ISO pack sprites to neutralize white matte backgrounds
+  // PIXI v8 uses string values for blend modes
   if (isExternalIsoPack(entry)) {
-    (sprite as any).blendMode = MULTIPLY_BLEND;
+    sprite.blendMode = "multiply" as any;
   }
 
   root.addChild(sprite);


### PR DESCRIPTION
- Add isBadRuntimeSheetEntry() to filter sheet/preview/atlas from runtime
- Harden graphicRiverIsoPicker with filterBadSheets()
- Use pickGraphicRiverProp/Building in propTree/propHouse
- Apply BLEND_MODES.MULTIPLY for external ISO pack sprites

## Summary

<!-- What changed and why (1–3 sentences). -->

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

<!-- e.g. `pnpm run lint`, `pnpm run test`, `pnpm run build` -->
