### PR TITLE
fix(docker): mount private-assets for client-2d graphicriver iso

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
+      - ./private-assets:/opt/areloria/private-assets:ro
     environment:
       NODE_ENV: production
       NODE_OPTIONS: "${NODE_OPTIONS:---max-old-space-size=8192}"


### PR DESCRIPTION
- Add ./private-assets:/opt/areloria/private-assets:ro volume mount
- Required for ServerBootstrap to serve /client2d-assets/graphicriver-iso
- Without this mount, express.static middleware is not registered (existsSync returns false)

## Summary

<!-- What changed and why (1–3 sentences). -->

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

<!-- e.g. `pnpm run lint`, `pnpm run test`, `pnpm run build` -->
