### PR TITLE
chore(client-2d): sync lockfile for shared workspace dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@pixi/tilemap':
         specifier: ^5.0.2
         version: 5.0.2(pixi.js@8.18.1)
+      '@wasd/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       pixi-filters:
         specifier: ^6.1.4
         version: 6.1.5(pixi.js@8.18.1)


### PR DESCRIPTION
chore(client-2d): sync lockfile for shared workspace dependency

Update pnpm-lock.yaml to ensure the lockfile is in sync with the shared workspace dependencies.

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ae56ee25-51f7-43b1-ab1a-906d9d3118a9)