### PR TITLE
fix(client-2d): resolve shared world source for Vite build

### DIFF
--- a/apps/client-2d/package.json
+++ b/apps/client-2d/package.json
@@ -7,9 +7,9 @@
     "assets": "node ../../scripts/extract-biome-atlas-v2.mjs && node ../../scripts/extract-2d-weapon-pool.mjs && node ../../scripts/extract-forest-biome-pack.mjs && node ../../scripts/are-asset-forge.mjs && node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs",
     "assets:weapons": "node ../../scripts/extract-2d-weapon-pool.mjs || true",
     "dev": "vite",
-    "build": "vite build",
-    "build:vps": "vite build",
-    "build:itch": "vite build --config vite.config.itch.ts",
+    "build": "pnpm -w --filter @wasd/shared build && vite build",
+    "build:vps": "pnpm -w --filter @wasd/shared build && vite build",
+    "build:itch": "pnpm -w --filter @wasd/shared build && vite build --config vite.config.itch.ts",
     "preview": "vite preview",
     "preview:itch": "vite preview --outDir dist-itch",
     "validate:assets": "node ../../scripts/extract-biome-atlas-v2.mjs && node ../../scripts/extract-2d-weapon-pool.mjs && node ../../scripts/extract-forest-biome-pack.mjs && node ../../scripts/are-asset-forge.mjs && node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs"

--- a/apps/client-2d/src/world/WorldPlanAssetBinder.ts
+++ b/apps/client-2d/src/world/WorldPlanAssetBinder.ts
@@ -1,7 +1,7 @@
 import type { AssetManifest } from "../assetManifest";
 import { fallbackEntry, pickCharacterVisual } from "../assetManifest";
 import { pickGraphicRiverBuilding, pickGraphicRiverCharacter, pickGraphicRiverProp, pickGraphicRiverTile } from "../graphicRiverIsoPicker";
-import type { BuildingType, NpcRole, PropType, RoadType } from "@wasd/shared";
+import type { BuildingType, NpcRole, PropType, RoadType } from "@wasd/shared/world";
 import type { BoundAsset, WorldPlanAssetBinder } from "./WorldPlanRenderTypes";
 
 function roleToCharacterQuery(role: NpcRole): { readonly group?: string; readonly kind?: string; readonly tags: readonly string[] } {

--- a/apps/client-2d/src/world/WorldPlanRenderTypes.ts
+++ b/apps/client-2d/src/world/WorldPlanRenderTypes.ts
@@ -1,6 +1,6 @@
 import type { Container, Texture } from "pixi.js";
 import type { AssetEntry } from "../assetManifest";
-import type { BuildingType, NpcRole, PropType, RoadType } from "@wasd/shared";
+import type { BuildingType, NpcRole, PropType, RoadType } from "@wasd/shared/world";
 
 export type RenderLayerName = "terrain" | "roads" | "buildings" | "props" | "actors";
 

--- a/apps/client-2d/vite.config.mjs
+++ b/apps/client-2d/vite.config.mjs
@@ -8,9 +8,11 @@ const root = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      '@wasd/core-network': path.resolve(root, './src/networkClient.ts')
-    }
+    alias: [
+      { find: '@wasd/core-network', replacement: path.resolve(root, './src/networkClient.ts') },
+      { find: '@wasd/shared/world', replacement: path.resolve(root, '../../packages/shared/src/world/index.ts') },
+      { find: '@wasd/shared', replacement: path.resolve(root, '../../packages/shared/src/index.ts') }
+    ]
   },
   server: {
     port: 5173,

--- a/apps/client-2d/vite.config.ts
+++ b/apps/client-2d/vite.config.ts
@@ -8,10 +8,11 @@ const root = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@wasd/core-network": path.resolve(root, "./src/networkClient.ts"),
-      "@wasd/shared": path.resolve(root, "../../packages/shared/src/index.ts")
-    }
+    alias: [
+      { find: "@wasd/core-network", replacement: path.resolve(root, "./src/networkClient.ts") },
+      { find: "@wasd/shared/world", replacement: path.resolve(root, "../../packages/shared/src/world/index.ts") },
+      { find: "@wasd/shared", replacement: path.resolve(root, "../../packages/shared/src/index.ts") }
+    ]
   },
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- Fixes the failing `pnpm --filter @wasd/client-2d build` where Vite tries to resolve `@wasd/shared` through the package `dist/index.js` entry before shared is built.
- Converts the 2D Vite alias config from object form to ordered alias entries.
- Adds a specific `@wasd/shared/world` alias to `packages/shared/src/world/index.ts` before the generic `@wasd/shared` alias.

## Why
The client-only build runs before `@wasd/shared` has guaranteed emitted `dist/index.js`, so resolving through the workspace package entry can fail. The client should consume shared source during Vite builds.

## Expected result
`pnpm --filter @wasd/client-2d --if-present build` should no longer fail with:

```text
Failed to resolve entry for package "@wasd/shared"
```
