### PR TITLE
feat(client-2d): add server-authoritative interaction overlay UI

### DIFF
--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -7,6 +7,7 @@ import { MobileMovePad } from "./MobileMovePad";
 import { PixiModuleInspector } from "./PixiModuleInspector";
 import { WorldHeartMonitor } from "./WorldHeartMonitor";
 import { KenneyUiLiveSkinBadge } from "./KenneyUiLiveSkinBadge";
+import { InteractionOverlayRoot } from "./ui/InteractionOverlayRoot";
 import { installClient2DDepthRuntime } from "./client2dDepthRuntime";
 import { installViewportRuntime } from "./ViewportController";
 import "./forestBiomeManifestBridge";
@@ -32,6 +33,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       <PixiModuleInspector />
       <MobileMovePad />
       <KenneyUiLiveSkinBadge />
+      <InteractionOverlayRoot />
     </CyberZenLoginGate>
   </React.StrictMode>
 );

--- a/apps/client-2d/src/networkClient.ts
+++ b/apps/client-2d/src/networkClient.ts
@@ -23,6 +23,7 @@ export interface NetworkClientOptions {
 export interface NetworkClient {
   connected: boolean;
   on(event: string, handler: Handler): void;
+  off(event: string, handler: Handler): void;
   connect(): void;
   disconnect(): void;
   sendPlayerAction(action: string, payload: Record<string, unknown>): void;
@@ -34,10 +35,20 @@ function dispatchWorldPacket(event: string, payload?: any): void {
   window.dispatchEvent(new CustomEvent("wasd:world-packet", { detail: payload }));
 }
 
+function dispatchNetworkPacket(event: string, payload?: any): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent("wasd:network-packet", { detail: { event, payload } }));
+}
+
 class LocalNetworkClient implements NetworkClient {
   public connected = false;
   private socket: WebSocket | null = null;
   private readonly handlers: HandlerMap = new Map();
+  private readonly outboundActionHandler = (event: Event): void => {
+    const detail = (event as CustomEvent<{ action?: string; payload?: Record<string, unknown> }>).detail;
+    if (!detail?.action) return;
+    this.sendPlayerAction(detail.action, detail.payload ?? {});
+  };
 
   constructor(private readonly options: NetworkClientOptions) {}
 
@@ -47,7 +58,18 @@ class LocalNetworkClient implements NetworkClient {
     this.handlers.set(event, set);
   }
 
+  public off(event: string, handler: Handler): void {
+    const set = this.handlers.get(event);
+    if (!set) return;
+    set.delete(handler);
+    if (set.size === 0) this.handlers.delete(event);
+  }
+
   public connect(): void {
+    if (typeof window !== "undefined") {
+      window.removeEventListener("wasd:client-action", this.outboundActionHandler as EventListener);
+      window.addEventListener("wasd:client-action", this.outboundActionHandler as EventListener);
+    }
     const wsUrl = this.toWebSocketUrl(this.options.url);
     try {
       this.socket = new WebSocket(wsUrl);
@@ -71,6 +93,9 @@ class LocalNetworkClient implements NetworkClient {
   }
 
   public disconnect(): void {
+    if (typeof window !== "undefined") {
+      window.removeEventListener("wasd:client-action", this.outboundActionHandler as EventListener);
+    }
     this.socket?.close();
     this.socket = null;
     this.connected = false;
@@ -97,6 +122,7 @@ class LocalNetworkClient implements NetworkClient {
 
   private emit(event: string, payload?: any): void {
     dispatchWorldPacket(event, payload);
+    dispatchNetworkPacket(event, payload);
     for (const handler of this.handlers.get(event) ?? []) handler(payload);
   }
 

--- a/apps/client-2d/src/ui/InteractionOverlayRoot.tsx
+++ b/apps/client-2d/src/ui/InteractionOverlayRoot.tsx
@@ -1,19 +1,55 @@
+import { useEffect } from "react";
 import { interactionUI, useInteractionUI } from "./UIManager";
 import { TradeOverlay } from "./TradeOverlay";
 import "./interactionOverlay.css";
 
-interface InteractionClient {
-  readonly sendPlayerAction?: (action: string, payload: unknown) => void;
-  readonly on?: (event: string, handler: (...args: any[]) => void) => void;
-  readonly off?: (event: string, handler: (...args: any[]) => void) => void;
+function payloadOf(packet: unknown): any {
+  const detail = (packet as CustomEvent<{ event?: string; payload?: any }>).detail;
+  return detail?.payload?.payload ?? detail?.payload ?? {};
 }
 
-interface Props {
-  readonly client: InteractionClient | null;
+function eventNameOf(packet: unknown): string | null {
+  const detail = (packet as CustomEvent<{ event?: string; payload?: any }>).detail;
+  return detail?.event ?? detail?.payload?.type ?? detail?.payload?.event ?? null;
 }
 
-export function InteractionOverlayRoot({ client }: Props) {
+export function InteractionOverlayRoot() {
   const overlay = useInteractionUI();
+
+  useEffect(() => {
+    const onNetworkPacket = (event: Event): void => {
+      const packetName = eventNameOf(event);
+      const payload = payloadOf(event);
+      if (packetName === "INTERACTION_ACCEPTED") {
+        const targetId = String(payload.targetId ?? "unknown_target");
+        const lockedAtTick = Number(payload.lockedAtTick ?? 0);
+        const interactionType = payload.interactionType ?? payload.type;
+        if (interactionType === "TRADE") {
+          interactionUI.openTrade({
+            targetId,
+            vendorManifest: String(payload.payload?.vendorManifest ?? payload.vendorManifest ?? "mara_starter_supplies_v1"),
+            dialogueSeed: payload.payload?.dialogueSeed ?? payload.dialogueSeed,
+            lockedAtTick,
+          });
+        } else if (interactionType === "CRAFT") {
+          interactionUI.openCraft({
+            targetId,
+            stationManifest: String(payload.payload?.stationManifest ?? payload.stationManifest ?? "smithing_station_v1"),
+            lockedAtTick,
+          });
+        } else {
+          interactionUI.openDialogue({
+            targetId,
+            dialogueSeed: String(payload.payload?.dialogueSeed ?? payload.dialogueSeed ?? `${targetId}:dialogue`),
+            lockedAtTick,
+          });
+        }
+      }
+      if (packetName === "INTERACTION_REJECTED" || packetName === "INTERACTION_CLOSED") interactionUI.closeUI();
+    };
+    window.addEventListener("wasd:network-packet", onNetworkPacket);
+    return () => window.removeEventListener("wasd:network-packet", onNetworkPacket);
+  }, []);
 
   if (overlay.type === "NONE") return null;
 
@@ -31,7 +67,7 @@ export function InteractionOverlayRoot({ client }: Props) {
           </button>
         </header>
 
-        {overlay.type === "TRADE" && <TradeOverlay client={client} payload={overlay} />}
+        {overlay.type === "TRADE" && <TradeOverlay payload={overlay} />}
         {overlay.type === "CRAFT" && <p className="interaction-muted">Crafting ist serverseitig reserviert und wird als nächstes UI-Modul angeschlossen.</p>}
         {overlay.type === "DIALOGUE" && <p className="interaction-muted">Dialog-Seed: <code>{overlay.dialogueSeed}</code></p>}
       </section>

--- a/apps/client-2d/src/ui/InteractionOverlayRoot.tsx
+++ b/apps/client-2d/src/ui/InteractionOverlayRoot.tsx
@@ -1,0 +1,40 @@
+import { interactionUI, useInteractionUI } from "./UIManager";
+import { TradeOverlay } from "./TradeOverlay";
+import "./interactionOverlay.css";
+
+interface InteractionClient {
+  readonly sendPlayerAction?: (action: string, payload: unknown) => void;
+  readonly on?: (event: string, handler: (...args: any[]) => void) => void;
+  readonly off?: (event: string, handler: (...args: any[]) => void) => void;
+}
+
+interface Props {
+  readonly client: InteractionClient | null;
+}
+
+export function InteractionOverlayRoot({ client }: Props) {
+  const overlay = useInteractionUI();
+
+  if (overlay.type === "NONE") return null;
+
+  return (
+    <div className="interaction-overlay-root" aria-live="polite">
+      <section className="interaction-panel" role="dialog" aria-modal="true" aria-label={overlay.type}>
+        <header className="interaction-panel-header">
+          <h2>
+            {overlay.type === "TRADE" && "HANDEL"}
+            {overlay.type === "CRAFT" && "WERKBANK"}
+            {overlay.type === "DIALOGUE" && "GESPRÄCH"}
+          </h2>
+          <button type="button" className="interaction-close" onClick={() => interactionUI.closeUI()} aria-label="Interaktion schließen">
+            ✕
+          </button>
+        </header>
+
+        {overlay.type === "TRADE" && <TradeOverlay client={client} payload={overlay} />}
+        {overlay.type === "CRAFT" && <p className="interaction-muted">Crafting ist serverseitig reserviert und wird als nächstes UI-Modul angeschlossen.</p>}
+        {overlay.type === "DIALOGUE" && <p className="interaction-muted">Dialog-Seed: <code>{overlay.dialogueSeed}</code></p>}
+      </section>
+    </div>
+  );
+}

--- a/apps/client-2d/src/ui/TradeOverlay.tsx
+++ b/apps/client-2d/src/ui/TradeOverlay.tsx
@@ -1,35 +1,30 @@
 import { useEffect, useState } from "react";
 import type { ActiveOverlay } from "./UIManager";
 
-interface InteractionClient {
-  readonly sendPlayerAction?: (action: string, payload: unknown) => void;
-  readonly on?: (event: string, handler: (...args: any[]) => void) => void;
-  readonly off?: (event: string, handler: (...args: any[]) => void) => void;
-}
-
 interface Props {
-  readonly client: InteractionClient | null;
   readonly payload: Extract<ActiveOverlay, { type: "TRADE" }>;
 }
 
-export function TradeOverlay({ client, payload }: Props) {
+function sendClientAction(action: string, payload: Record<string, unknown>): void {
+  window.dispatchEvent(new CustomEvent("wasd:client-action", { detail: { action, payload } }));
+}
+
+export function TradeOverlay({ payload }: Props) {
   const [isProcessing, setIsProcessing] = useState(false);
 
   useEffect(() => {
-    if (!client?.on || !client?.off) return undefined;
-    const handleTransactionComplete = () => setIsProcessing(false);
-    client.on("TRANSACTION_COMPLETE", handleTransactionComplete);
-    client.on("TRANSACTION_FAILED", handleTransactionComplete);
-    return () => {
-      client.off?.("TRANSACTION_COMPLETE", handleTransactionComplete);
-      client.off?.("TRANSACTION_FAILED", handleTransactionComplete);
+    const handleNetworkPacket = (event: Event): void => {
+      const detail = (event as CustomEvent<{ event?: string }>).detail;
+      if (detail?.event === "TRANSACTION_COMPLETE" || detail?.event === "TRANSACTION_FAILED") setIsProcessing(false);
     };
-  }, [client]);
+    window.addEventListener("wasd:network-packet", handleNetworkPacket);
+    return () => window.removeEventListener("wasd:network-packet", handleNetworkPacket);
+  }, []);
 
   const handleBuy = (itemId: string, quantity: number): void => {
-    if (!client?.sendPlayerAction || isProcessing) return;
+    if (isProcessing) return;
     setIsProcessing(true);
-    client.sendPlayerAction("BUY_VENDOR_ITEM", {
+    sendClientAction("BUY_VENDOR_ITEM", {
       targetId: payload.targetId,
       vendorManifest: payload.vendorManifest,
       itemId,
@@ -48,7 +43,7 @@ export function TradeOverlay({ client, payload }: Props) {
           <strong>Starter Rationen</strong>
           <span>5x Vorrat für die ersten Wege um Millbrook.</span>
         </div>
-        <button type="button" disabled={isProcessing || !client?.sendPlayerAction} onClick={() => handleBuy("item_ration_5", 1)}>
+        <button type="button" disabled={isProcessing} onClick={() => handleBuy("item_ration_5", 1)}>
           10 Silber
         </button>
       </div>

--- a/apps/client-2d/src/ui/TradeOverlay.tsx
+++ b/apps/client-2d/src/ui/TradeOverlay.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import type { ActiveOverlay } from "./UIManager";
+
+interface InteractionClient {
+  readonly sendPlayerAction?: (action: string, payload: unknown) => void;
+  readonly on?: (event: string, handler: (...args: any[]) => void) => void;
+  readonly off?: (event: string, handler: (...args: any[]) => void) => void;
+}
+
+interface Props {
+  readonly client: InteractionClient | null;
+  readonly payload: Extract<ActiveOverlay, { type: "TRADE" }>;
+}
+
+export function TradeOverlay({ client, payload }: Props) {
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  useEffect(() => {
+    if (!client?.on || !client?.off) return undefined;
+    const handleTransactionComplete = () => setIsProcessing(false);
+    client.on("TRANSACTION_COMPLETE", handleTransactionComplete);
+    client.on("TRANSACTION_FAILED", handleTransactionComplete);
+    return () => {
+      client.off?.("TRANSACTION_COMPLETE", handleTransactionComplete);
+      client.off?.("TRANSACTION_FAILED", handleTransactionComplete);
+    };
+  }, [client]);
+
+  const handleBuy = (itemId: string, quantity: number): void => {
+    if (!client?.sendPlayerAction || isProcessing) return;
+    setIsProcessing(true);
+    client.sendPlayerAction("BUY_VENDOR_ITEM", {
+      targetId: payload.targetId,
+      vendorManifest: payload.vendorManifest,
+      itemId,
+      quantity,
+    });
+  };
+
+  return (
+    <div className="trade-overlay">
+      <p className="interaction-muted">
+        Angebot basiert auf <code>{payload.vendorManifest}</code>
+      </p>
+
+      <div className="trade-item-row">
+        <div>
+          <strong>Starter Rationen</strong>
+          <span>5x Vorrat für die ersten Wege um Millbrook.</span>
+        </div>
+        <button type="button" disabled={isProcessing || !client?.sendPlayerAction} onClick={() => handleBuy("item_ration_5", 1)}>
+          10 Silber
+        </button>
+      </div>
+
+      {isProcessing && <div className="trade-processing">Transaktion wird validiert …</div>}
+    </div>
+  );
+}

--- a/apps/client-2d/src/ui/UIManager.ts
+++ b/apps/client-2d/src/ui/UIManager.ts
@@ -1,0 +1,50 @@
+import { useSyncExternalStore } from "react";
+
+export type ActiveOverlay =
+  | { readonly type: "NONE" }
+  | { readonly type: "TRADE"; readonly targetId: string; readonly vendorManifest: string; readonly lockedAtTick: number; readonly dialogueSeed?: string }
+  | { readonly type: "DIALOGUE"; readonly targetId: string; readonly dialogueSeed: string; readonly lockedAtTick: number }
+  | { readonly type: "CRAFT"; readonly targetId: string; readonly stationManifest: string; readonly lockedAtTick: number };
+
+class InteractionUIManager {
+  private state: ActiveOverlay = { type: "NONE" };
+  private readonly listeners = new Set<() => void>();
+
+  public getState = (): ActiveOverlay => this.state;
+
+  public subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener());
+  }
+
+  public openTrade(payload: Omit<Extract<ActiveOverlay, { type: "TRADE" }>, "type">): void {
+    this.state = { type: "TRADE", ...payload };
+    this.notify();
+  }
+
+  public openDialogue(payload: Omit<Extract<ActiveOverlay, { type: "DIALOGUE" }>, "type">): void {
+    this.state = { type: "DIALOGUE", ...payload };
+    this.notify();
+  }
+
+  public openCraft(payload: Omit<Extract<ActiveOverlay, { type: "CRAFT" }>, "type">): void {
+    this.state = { type: "CRAFT", ...payload };
+    this.notify();
+  }
+
+  public closeUI(): void {
+    if (this.state.type === "NONE") return;
+    this.state = { type: "NONE" };
+    this.notify();
+  }
+}
+
+export const interactionUI = new InteractionUIManager();
+
+export function useInteractionUI(): ActiveOverlay {
+  return useSyncExternalStore(interactionUI.subscribe, interactionUI.getState, interactionUI.getState);
+}

--- a/apps/client-2d/src/ui/interactionOverlay.css
+++ b/apps/client-2d/src/ui/interactionOverlay.css
@@ -1,0 +1,133 @@
+.interaction-overlay-root {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  padding: max(16px, env(safe-area-inset-top)) max(14px, env(safe-area-inset-right)) max(16px, env(safe-area-inset-bottom)) max(14px, env(safe-area-inset-left));
+}
+
+.interaction-panel {
+  width: min(440px, 100%);
+  max-height: min(78vh, 680px);
+  overflow: auto;
+  pointer-events: auto;
+  color: #fff7dd;
+  background: linear-gradient(180deg, rgba(10, 12, 16, 0.96), rgba(3, 5, 9, 0.96));
+  border: 1px solid rgba(228, 190, 102, 0.36);
+  border-radius: 14px;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.58), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  padding: 16px;
+  backdrop-filter: blur(10px);
+}
+
+.interaction-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid rgba(228, 190, 102, 0.24);
+  margin-bottom: 14px;
+  padding-bottom: 10px;
+}
+
+.interaction-panel-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.interaction-close,
+.trade-item-row button {
+  min-height: 40px;
+  border: 1px solid rgba(228, 190, 102, 0.38);
+  border-radius: 10px;
+  color: #fff7dd;
+  background: rgba(34, 44, 63, 0.84);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.interaction-close {
+  width: 40px;
+  font-size: 1rem;
+}
+
+.interaction-close:hover,
+.trade-item-row button:hover:not(:disabled) {
+  background: rgba(68, 84, 116, 0.92);
+}
+
+.interaction-muted {
+  color: #b9c0ce;
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.interaction-muted code {
+  color: #f2c86f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.trade-overlay {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.trade-item-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  background: rgba(27, 33, 45, 0.9);
+  padding: 13px;
+}
+
+.trade-item-row strong,
+.trade-item-row span {
+  display: block;
+}
+
+.trade-item-row strong {
+  font-size: 0.94rem;
+}
+
+.trade-item-row span {
+  color: #b9c0ce;
+  font-size: 0.78rem;
+  margin-top: 4px;
+}
+
+.trade-item-row button {
+  flex: 0 0 auto;
+  padding: 0 14px;
+  background: rgba(32, 78, 146, 0.92);
+  border-color: rgba(93, 153, 244, 0.68);
+}
+
+.trade-item-row button:disabled {
+  cursor: wait;
+  color: #9ca3af;
+  background: rgba(55, 65, 81, 0.78);
+  border-color: rgba(107, 114, 128, 0.42);
+}
+
+.trade-processing {
+  color: #f2c86f;
+  text-align: center;
+  font-size: 0.88rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  animation: trade-processing-pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes trade-processing-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- Adds a native React interaction UI manager using `useSyncExternalStore`, no external state dependency.
- Adds `InteractionOverlayRoot` and a pessimistic `TradeOverlay` for server-authoritative trade handshakes.
- Styles the overlay with local CSS instead of Tailwind classes so the 2D client build stays dependency-stable.
- Exposes inbound network packets through `wasd:network-packet` and outbound UI intents through `wasd:client-action`.
- Mounts the overlay root above the Pixi world in `apps/client-2d/src/main.tsx`.

## Architecture
Pixi remains the world renderer. React owns transactional UI. The client still only sends intents; trade UI opens only after `INTERACTION_ACCEPTED` from the server.

## Follow-up
- Add server-side `server/src/modules/interaction/` validation for `INTERACT_ENTITY`.
- Replace starter ration placeholder with manifest-driven vendor inventory after server payloads are live.
