### PR TITLE
feat(client-2d): add mobile-safe NPC tap intents

### DIFF
--- a/apps/client-2d/package.json
+++ b/apps/client-2d/package.json
@@ -7,9 +7,9 @@
     "assets": "node ../../scripts/extract-biome-atlas-v2.mjs && node ../../scripts/extract-2d-weapon-pool.mjs && node ../../scripts/extract-forest-biome-pack.mjs && node ../../scripts/are-asset-forge.mjs && node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs",
     "assets:weapons": "node ../../scripts/extract-2d-weapon-pool.mjs || true",
     "dev": "vite",
-    "build": "pnpm -w --filter @wasd/shared build && vite build",
-    "build:vps": "pnpm -w --filter @wasd/shared build && vite build",
-    "build:itch": "pnpm -w --filter @wasd/shared build && vite build --config vite.config.itch.ts",
+    "build": "cd ../../packages/shared && node scripts/transpile-build.mjs && cd ../../apps/client-2d && vite build",
+    "build:vps": "cd ../../packages/shared && node scripts/transpile-build.mjs && cd ../../apps/client-2d && vite build",
+    "build:itch": "cd ../../packages/shared && node scripts/transpile-build.mjs && cd ../../apps/client-2d && vite build --config vite.config.itch.ts",
     "preview": "vite preview",
     "preview:itch": "vite preview --outDir dist-itch",
     "validate:assets": "node ../../scripts/extract-biome-atlas-v2.mjs && node ../../scripts/extract-2d-weapon-pool.mjs && node ../../scripts/extract-forest-biome-pack.mjs && node ../../scripts/are-asset-forge.mjs && node ../../scripts/enrich-stitch-atlas-frames.mjs && node ../../scripts/validate-client-2d-assets.mjs"

--- a/apps/client-2d/src/DeterministicWorldIsoApp.tsx
+++ b/apps/client-2d/src/DeterministicWorldIsoApp.tsx
@@ -43,6 +43,13 @@ type LoadedAssets = {
   textures: Map<string, Texture>;
 };
 
+type TapInteractiveContainer = Container & {
+  eventMode?: "none" | "passive" | "auto" | "static" | "dynamic";
+  cursor?: string;
+  hitArea?: Rectangle;
+  on(event: "pointertap", handler: () => void): unknown;
+};
+
 async function loadTextureInto(cache: Map<string, Texture>, src: string): Promise<Texture | null> {
   const cached = cache.get(src);
   if (cached) return cached;
@@ -197,10 +204,11 @@ function dispatchClientAction(action: string, payload: Record<string, unknown>):
 
 function installNpcTapIntent(root: Container, targetId: string, onInteract: (targetId: string) => void): void {
   let lastTapAt = 0;
-  root.eventMode = "static";
-  root.cursor = "pointer";
-  root.hitArea = new Rectangle(-44 - NPC_TOUCH_PADDING, -92 - NPC_TOUCH_PADDING, 88 + NPC_TOUCH_PADDING * 2, 126 + NPC_TOUCH_PADDING * 2);
-  root.on("pointertap", () => {
+  const interactiveRoot = root as TapInteractiveContainer;
+  interactiveRoot.eventMode = "static";
+  interactiveRoot.cursor = "pointer";
+  interactiveRoot.hitArea = new Rectangle(-44 - NPC_TOUCH_PADDING, -92 - NPC_TOUCH_PADDING, 88 + NPC_TOUCH_PADDING * 2, 126 + NPC_TOUCH_PADDING * 2);
+  interactiveRoot.on("pointertap", () => {
     const now = Date.now();
     if (now - lastTapAt < NPC_INTERACT_COOLDOWN_MS) return;
     lastTapAt = now;

--- a/apps/client-2d/src/DeterministicWorldIsoApp.tsx
+++ b/apps/client-2d/src/DeterministicWorldIsoApp.tsx
@@ -195,7 +195,7 @@ function dispatchClientAction(action: string, payload: Record<string, unknown>):
   window.dispatchEvent(new CustomEvent("wasd:client-action", { detail: { action, payload } }));
 }
 
-function installNpcTapIntent(root: Container, targetId: string): void {
+function installNpcTapIntent(root: Container, targetId: string, onInteract: (targetId: string) => void): void {
   let lastTapAt = 0;
   root.eventMode = "static";
   root.cursor = "pointer";
@@ -208,7 +208,7 @@ function installNpcTapIntent(root: Container, targetId: string): void {
     window.setTimeout(() => {
       root.alpha = 1;
     }, 180);
-    dispatchClientAction("INTERACT_ENTITY", { targetId });
+    onInteract(targetId);
   });
 }
 
@@ -230,6 +230,12 @@ export function DeterministicWorldIsoApp() {
   const [equippedWeaponId, setEquippedWeaponId] = useState<string | null>(() => localStorage.getItem(EQUIPPED_WEAPON_KEY));
   const [messages, setMessages] = useState<Msg[]>([{ from: "WorldDirector", txt: "Deterministic Millbrook plan initializing." }]);
 
+  function sendInteractIntent(targetId: string): void {
+    clientRef.current?.sendPlayerAction("interact", { targetId });
+    dispatchClientAction("INTERACT_ENTITY", { targetId });
+    setMessages((items) => [...items.slice(-12), { from: "System", txt: `Interaction intent sent: ${targetId}` }]);
+  }
+
   function setActor(id: string, x: number, z: number, name: string, player: boolean, characterVisualId: string | null, weaponVisualId: string | null) {
     const app = appRef.current;
     const layer = actorLayerRef.current;
@@ -243,7 +249,7 @@ export function DeterministicWorldIsoApp() {
       return;
     }
     const root = buildActorVisual({ name, player, assets: assetsRef.current, characterVisualId, weaponVisualId });
-    if (!player) installNpcTapIntent(root, id);
+    if (!player) installNpcTapIntent(root, id, sendInteractIntent);
     placeActor(root, x, z, app.screen.width, app.screen.height);
     layer.addChild(root);
     entities.current.set(id, { root, tx: x, tz: z, name, isPlayer: player, weaponVisualId, characterVisualId });
@@ -256,7 +262,7 @@ export function DeterministicWorldIsoApp() {
     if (!app || !layer || !existing) return;
     const oldRoot = existing.root;
     const root = buildActorVisual({ name: existing.name, player: existing.isPlayer, assets: assetsRef.current, characterVisualId: existing.characterVisualId, weaponVisualId });
-    if (!existing.isPlayer) installNpcTapIntent(root, id);
+    if (!existing.isPlayer) installNpcTapIntent(root, id, sendInteractIntent);
     placeActor(root, existing.tx, existing.tz, app.screen.width, app.screen.height);
     layer.addChild(root);
     oldRoot.destroy({ children: true });
@@ -436,8 +442,7 @@ export function DeterministicWorldIsoApp() {
   }
 
   function interact() {
-    clientRef.current?.sendPlayerAction("interact", { targetId: "npc_elder_0" });
-    setMessages((items) => [...items.slice(-12), { from: "System", txt: "Interaction ping sent." }]);
+    sendInteractIntent("npc_elder_0");
   }
 
   return (

--- a/apps/client-2d/src/DeterministicWorldIsoApp.tsx
+++ b/apps/client-2d/src/DeterministicWorldIsoApp.tsx
@@ -16,6 +16,8 @@ const TILE_W = 96;
 const TILE_H = 48;
 const EQUIPPED_WEAPON_KEY = "wasd:2d:equippedWeaponVisualId";
 const WORLD_SEED = "areloria:earth_1_1";
+const NPC_INTERACT_COOLDOWN_MS = 1000;
+const NPC_TOUCH_PADDING = 24;
 
 type MoveVector = { dx: number; dz: number };
 type Msg = { from: string; txt: string };
@@ -189,6 +191,27 @@ function payloadCoord(entity: any, axis: "x" | "z"): number {
   return Number(value ?? 0);
 }
 
+function dispatchClientAction(action: string, payload: Record<string, unknown>): void {
+  window.dispatchEvent(new CustomEvent("wasd:client-action", { detail: { action, payload } }));
+}
+
+function installNpcTapIntent(root: Container, targetId: string): void {
+  let lastTapAt = 0;
+  root.eventMode = "static";
+  root.cursor = "pointer";
+  root.hitArea = new Rectangle(-44 - NPC_TOUCH_PADDING, -92 - NPC_TOUCH_PADDING, 88 + NPC_TOUCH_PADDING * 2, 126 + NPC_TOUCH_PADDING * 2);
+  root.on("pointertap", () => {
+    const now = Date.now();
+    if (now - lastTapAt < NPC_INTERACT_COOLDOWN_MS) return;
+    lastTapAt = now;
+    root.alpha = 0.78;
+    window.setTimeout(() => {
+      root.alpha = 1;
+    }, 180);
+    dispatchClientAction("INTERACT_ENTITY", { targetId });
+  });
+}
+
 export function DeterministicWorldIsoApp() {
   const host = useRef<HTMLDivElement>(null);
   const appRef = useRef<Application | null>(null);
@@ -220,6 +243,7 @@ export function DeterministicWorldIsoApp() {
       return;
     }
     const root = buildActorVisual({ name, player, assets: assetsRef.current, characterVisualId, weaponVisualId });
+    if (!player) installNpcTapIntent(root, id);
     placeActor(root, x, z, app.screen.width, app.screen.height);
     layer.addChild(root);
     entities.current.set(id, { root, tx: x, tz: z, name, isPlayer: player, weaponVisualId, characterVisualId });
@@ -232,6 +256,7 @@ export function DeterministicWorldIsoApp() {
     if (!app || !layer || !existing) return;
     const oldRoot = existing.root;
     const root = buildActorVisual({ name: existing.name, player: existing.isPlayer, assets: assetsRef.current, characterVisualId: existing.characterVisualId, weaponVisualId });
+    if (!existing.isPlayer) installNpcTapIntent(root, id);
     placeActor(root, existing.tx, existing.tz, app.screen.width, app.screen.height);
     layer.addChild(root);
     oldRoot.destroy({ children: true });

--- a/apps/client-2d/src/theme.css
+++ b/apps/client-2d/src/theme.css
@@ -32,7 +32,7 @@ html, body, #root {
 
 button, input { font: inherit; }
 button { cursor: pointer; }
-canvas { display: block; filter: saturate(1.16) contrast(1.08); }
+canvas { display: block; filter: saturate(1.16) contrast(1.08); touch-action: none; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none; }
 
 .cz-login-root { min-height: 100%; display: grid; place-items: center; padding: 22px; background: linear-gradient(90deg, rgba(255,255,255,0.035) 1px, transparent 1px), linear-gradient(rgba(255,255,255,0.035) 1px, transparent 1px); background-size: 38px 38px; }
 .cz-login-card { width: min(520px, 94vw); border: 1px solid var(--cz-line); border-radius: 28px; padding: 28px; background: var(--cz-panel); box-shadow: 0 0 42px rgba(103, 92, 255, 0.22), inset 0 1px 0 rgba(255,255,255,0.08); backdrop-filter: blur(18px); }
@@ -51,7 +51,7 @@ canvas { display: block; filter: saturate(1.16) contrast(1.08); }
 .az-shell { position: relative; width: 100%; height: 100%; overflow: hidden; background: radial-gradient(circle at 50% 18%, rgba(0,229,255,.14), transparent 34%), linear-gradient(180deg, #121426 0%, #142318 58%, #07100b 100%); }
 .az-shell::before { content: ""; position: absolute; inset: 0; pointer-events: none; background-image: linear-gradient(rgba(255,255,255,.035) 1px, transparent 1px), linear-gradient(90deg, rgba(0,229,255,.032) 1px, transparent 1px); background-size: 44px 44px; mask-image: radial-gradient(circle at 50% 48%, black 0%, transparent 78%); }
 .az-world-glow { position: absolute; inset: 8% 0 auto; height: 70%; pointer-events: none; background: radial-gradient(ellipse at center, rgba(57,255,20,.10), transparent 62%); filter: blur(18px); }
-.az-pixi { position: absolute; inset: 0; }
+.az-pixi { position: absolute; inset: 0; touch-action: none; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none; }
 
 .pixi-module-inspector { position: absolute; right: 126px; top: 382px; z-index: 25; display: grid; gap: 6px; width: min(280px, calc(100vw - 145px)); padding: 11px 12px; border: 1px solid rgba(0,229,255,.24); border-radius: 18px; color: rgba(244,247,255,.74); background: linear-gradient(135deg, rgba(4,8,14,.68), rgba(13,18,33,.46)); box-shadow: 0 0 24px rgba(0,229,255,.08), inset 0 1px 0 rgba(255,255,255,.07); backdrop-filter: blur(12px); pointer-events: none; font: 10px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .08em; text-transform: uppercase; }
 .pixi-module-inspector strong { color: var(--st-aether); font-size: 11px; }
@@ -78,141 +78,3 @@ canvas { display: block; filter: saturate(1.16) contrast(1.08); }
 .az-touch-pad .left { grid-column: 1; grid-row: 2; }
 .az-touch-pad .right { grid-column: 3; grid-row: 2; }
 .az-touch-pad .down { grid-column: 2; grid-row: 3; }
-
-.stitch-hud { position: absolute; inset: 0; z-index: 20; pointer-events: none; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
-.stitch-hud button, .stitch-hud input { pointer-events: auto; }
-.stitch-scanlines { position: absolute; inset: 0; pointer-events: none; opacity: .22; background: repeating-linear-gradient(0deg, rgba(255,255,255,.05) 0 1px, transparent 1px 4px); mix-blend-mode: overlay; }
-.stitch-topbar { position: absolute; top: 14px; left: 14px; right: 14px; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 14px; border: 1px solid rgba(0,229,255,.28); border-radius: 20px; background: linear-gradient(135deg, rgba(3,8,16,.82), rgba(13,18,33,.58)); box-shadow: 0 0 30px rgba(0,229,255,.14), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(15px); pointer-events: auto; }
-.stitch-kicker { display: block; color: var(--st-aether); font-size: 10px; font-weight: 950; letter-spacing: .22em; }
-.stitch-brand strong { display: block; margin-top: 2px; color: #fff6d7; font-size: 16px; letter-spacing: .02em; }
-.stitch-node-status { display: grid; justify-items: end; gap: 2px; color: rgba(244,247,255,.75); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
-.stitch-node-status b { color: #d9ffd2; font-size: 12px; }
-.stitch-live-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; background: #ff3f6f; box-shadow: 0 0 14px #ff3f6f; justify-self: end; }
-.stitch-live-dot.on { background: var(--st-emerald); box-shadow: 0 0 14px var(--st-emerald); }
-.stitch-vitals { position: absolute; top: 94px; left: 14px; width: 246px; padding: 14px; border: 1px solid rgba(255,215,106,.22); border-radius: 24px; background: rgba(4,8,14,.66); box-shadow: 0 0 34px rgba(255,215,106,.08), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(12px); pointer-events: auto; }
-.stitch-portrait { width: 74px; height: 74px; border-radius: 22px; display: grid; place-items: center; color: var(--st-aether); font-weight: 950; font-size: 38px; background: radial-gradient(circle, rgba(0,229,255,.24), rgba(139,92,246,.08)); border: 1px solid rgba(0,229,255,.32); box-shadow: inset 0 0 22px rgba(0,229,255,.15); float: left; margin-right: 12px; }
-.stitch-nameplate { min-height: 74px; display: grid; align-content: center; }
-.stitch-nameplate small { color: rgba(244,247,255,.55); text-transform: uppercase; letter-spacing: .14em; font-size: 10px; }
-.stitch-nameplate strong { color: white; font-size: 18px; }
-.stitch-gauge { clear: both; margin-top: 10px; height: 24px; position: relative; border-radius: 999px; background: rgba(255,255,255,.055); border: 1px solid rgba(255,255,255,.08); overflow: hidden; }
-.stitch-gauge div { display: flex; justify-content: space-between; color: rgba(244,247,255,.72); font-size: 10px; letter-spacing: .12em; font-weight: 900; position: relative; z-index: 1; padding: 5px 9px; }
-.stitch-gauge i { position: absolute; inset: 0 auto 0 0; display: block; border-radius: inherit; transition: width .2s ease; }
-.stitch-gauge.ruby i { background: linear-gradient(90deg, #7f1028, var(--st-ruby)); }
-.stitch-gauge.aether i { background: linear-gradient(90deg, #0d4e66, var(--st-aether)); }
-.stitch-gauge.emerald i { background: linear-gradient(90deg, #156b22, var(--st-emerald)); }
-.stitch-gauge.gold i { background: linear-gradient(90deg, #725310, var(--st-gold)); }
-.stitch-side-menu { position: absolute; top: 94px; right: 14px; display: grid; gap: 8px; pointer-events: auto; }
-.stitch-side-menu button { width: 96px; min-height: 56px; border: 1px solid rgba(0,229,255,.2); border-radius: 18px; color: rgba(244,247,255,.82); background: rgba(4,8,14,.62); box-shadow: inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(10px); }
-.stitch-side-menu button.active, .stitch-side-menu button:hover { border-color: var(--st-gold); color: white; background: rgba(255,215,106,.12); }
-.stitch-side-menu span { display: block; font-size: 20px; }
-.stitch-side-menu small { display: block; margin-top: 2px; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
-.stitch-radar { position: absolute; right: 126px; top: 94px; width: 188px; min-height: 96px; display: flex; align-items: center; gap: 14px; padding: 12px; border: 1px solid rgba(57,255,20,.2); border-radius: 22px; background: rgba(4,8,14,.48); backdrop-filter: blur(10px); color: rgba(244,247,255,.7); pointer-events: auto; }
-.stitch-radar b { display: block; color: var(--st-emerald); }
-.stitch-radar small { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
-.stitch-radar-ring { width: 66px; height: 66px; border-radius: 50%; position: relative; border: 1px solid rgba(57,255,20,.38); box-shadow: 0 0 18px rgba(57,255,20,.12), inset 0 0 18px rgba(57,255,20,.08); }
-.stitch-radar-ring i { position: absolute; width: 7px; height: 7px; border-radius: 50%; background: var(--st-emerald); box-shadow: 0 0 12px var(--st-emerald); }
-.stitch-radar-ring i:nth-child(1) { left: 18px; top: 17px; }
-.stitch-radar-ring i:nth-child(2) { right: 17px; top: 30px; }
-.stitch-radar-ring i:nth-child(3) { left: 30px; bottom: 13px; }
-.stitch-chat { position: absolute; left: 14px; bottom: 18px; width: min(390px, calc(100vw - 28px)); padding: 12px; border: 1px solid rgba(0,229,255,.18); border-radius: 22px; background: rgba(4,8,14,.58); backdrop-filter: blur(12px); pointer-events: auto; }
-.stitch-panel-title { display: flex; justify-content: space-between; color: rgba(244,247,255,.58); font-size: 10px; text-transform: uppercase; letter-spacing: .12em; }
-.stitch-panel-title b { color: var(--st-aether); }
-.stitch-panel-title span { color: var(--st-emerald); }
-.stitch-chat-lines { min-height: 104px; max-height: 104px; overflow: hidden; margin: 8px 0; }
-.stitch-chat-lines p { margin: 4px 0; color: rgba(244,247,255,.76); font-size: 12px; }
-.stitch-chat-lines b { color: var(--st-gold); }
-.stitch-chat-input { display: flex; gap: 8px; }
-.stitch-chat-input input { min-width: 0; flex: 1; border: 1px solid rgba(255,255,255,.1); border-radius: 14px; padding: 10px 12px; color: white; background: rgba(0,0,0,.32); outline: none; }
-.stitch-chat-input button, .stitch-bottom-right button { border: 1px solid rgba(0,229,255,.26); border-radius: 14px; padding: 10px 12px; color: #061018; font-weight: 950; background: linear-gradient(135deg, var(--st-aether), var(--st-gold)); }
-.stitch-skillbar { position: absolute; left: 50%; bottom: 20px; transform: translateX(-50%); display: flex; gap: 10px; padding: 10px; border: 1px solid rgba(255,215,106,.22); border-radius: 24px; background: rgba(4,8,14,.64); backdrop-filter: blur(12px); pointer-events: auto; }
-.stitch-skillbar button { position: relative; width: 76px; height: 72px; border: 1px solid rgba(0,229,255,.2); border-radius: 18px; color: white; background: linear-gradient(180deg, rgba(0,229,255,.12), rgba(139,92,246,.13)); }
-.stitch-skillbar button:hover { border-color: var(--st-gold); transform: translateY(-2px); }
-.stitch-skillbar kbd { position: absolute; top: 6px; left: 7px; color: rgba(244,247,255,.5); font-size: 10px; }
-.stitch-skillbar span { display: block; font-size: 23px; }
-.stitch-skillbar b { display: block; font-size: 11px; }
-.stitch-skillbar small { display: block; color: rgba(244,247,255,.58); font-size: 8px; margin-top: 1px; }
-.stitch-bottom-right { position: absolute; right: 14px; bottom: 20px; display: flex; gap: 8px; pointer-events: auto; }
-.stitch-modal { position: absolute; inset: 0; display: grid; place-items: center; background: rgba(0,0,0,.18); pointer-events: auto; }
-.stitch-modal-card { width: min(720px, calc(100vw - 28px)); max-height: min(620px, calc(100vh - 42px)); overflow: auto; border: 1px solid rgba(0,229,255,.28); border-radius: 30px; background: linear-gradient(135deg, rgba(4,8,14,.92), rgba(19,25,45,.86)); box-shadow: 0 28px 100px rgba(0,0,0,.48), 0 0 34px rgba(0,229,255,.13); backdrop-filter: blur(18px); padding: 20px; }
-.stitch-modal-card header { display: flex; justify-content: space-between; align-items: start; gap: 14px; margin-bottom: 18px; }
-.stitch-modal-card small { color: var(--st-aether); font-size: 10px; letter-spacing: .18em; font-weight: 950; }
-.stitch-modal-card h2 { margin: 4px 0 0; font-size: clamp(28px, 5vw, 48px); letter-spacing: -.05em; }
-.stitch-modal-card header button { width: 38px; height: 38px; border-radius: 13px; border: 1px solid rgba(255,255,255,.12); background: rgba(255,255,255,.06); color: white; font-size: 24px; }
-.stitch-grid-panel { display: grid; grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); gap: 12px; }
-.stitch-info { min-height: 108px; border: 1px solid rgba(255,255,255,.1); border-radius: 22px; padding: 15px; background: rgba(255,255,255,.045); display: grid; align-content: center; gap: 8px; }
-.stitch-info small { color: rgba(244,247,255,.54); }
-.stitch-info b { color: #fff6d7; font-size: 18px; }
-.stitch-map-preview { height: 260px; position: relative; border: 1px solid rgba(57,255,20,.18); border-radius: 24px; overflow: hidden; background: radial-gradient(circle at 45% 45%, rgba(57,255,20,.18), transparent 20%), linear-gradient(135deg, rgba(0,229,255,.1), rgba(255,215,106,.06)); }
-.stitch-map-preview span { position: absolute; width: 15px; height: 15px; border-radius: 50%; background: var(--st-gold); box-shadow: 0 0 18px var(--st-gold); }
-.stitch-map-preview span:nth-child(1) { left: 18%; top: 32%; }
-.stitch-map-preview span:nth-child(2) { left: 62%; top: 45%; }
-.stitch-map-preview span:nth-child(3) { left: 42%; top: 70%; }
-.stitch-map-preview span:nth-child(4) { left: 78%; top: 22%; }
-.stitch-map-preview b { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); color: white; font-size: 24px; text-shadow: 0 0 18px black; }
-
-@media (max-width: 920px) {
-  .stitch-topbar { left: 10px; right: 10px; top: 10px; padding: 10px; }
-  .stitch-brand strong { font-size: 14px; }
-  .stitch-node-status small { display: none; }
-  .stitch-vitals { top: 78px; left: 10px; width: 210px; padding: 10px; }
-  .stitch-portrait { width: 54px; height: 54px; font-size: 28px; border-radius: 17px; }
-  .stitch-nameplate { min-height: 54px; }
-  .stitch-radar { display: none; }
-  .live-reality-bridge { right: 10px; top: 78px; width: calc(100vw - 240px); min-width: 210px; }
-  .pixi-module-inspector { right: 10px; top: 258px; width: calc(100vw - 240px); min-width: 210px; }
-  .live-reality-field { height: 132px; }
-  .az-touch-pad { display: grid; }
-  .stitch-side-menu { top: auto; bottom: 102px; right: 10px; grid-template-columns: repeat(2, 52px); }
-  .stitch-side-menu button { width: 52px; min-height: 48px; border-radius: 16px; }
-  .stitch-side-menu small { display: none; }
-  .stitch-chat { width: calc(100vw - 116px); left: 10px; bottom: 10px; padding: 10px; }
-  .stitch-chat-lines { min-height: 70px; max-height: 70px; }
-  .stitch-skillbar { left: auto; right: 10px; bottom: 10px; transform: none; flex-direction: column; gap: 7px; padding: 7px; border-radius: 20px; }
-  .stitch-skillbar button { width: 74px; height: 54px; }
-  .stitch-skillbar small { display: none; }
-  .stitch-bottom-right { display: none; }
-}
-
-@media (max-width: 520px) {
-  .stitch-vitals { width: calc(100vw - 20px); display: grid; grid-template-columns: 54px 1fr; gap: 8px; }
-  .stitch-vitals .stitch-gauge { grid-column: span 2; margin-top: 0; }
-  .stitch-chat { width: calc(100vw - 104px); }
-  .stitch-kicker { letter-spacing: .12em; }
-  .live-reality-bridge { left: 10px; right: 10px; top: 210px; width: auto; }
-  .pixi-module-inspector { left: 10px; right: 10px; top: 336px; width: auto; }
-  .live-reality-field { height: 112px; }
-  .az-touch-pad { bottom: 118px; left: 10px; grid-template-columns: repeat(3, 42px); grid-template-rows: repeat(3, 42px); }
-}
-
-/* Playability pass 1: prevent mobile HUD overlap and keep combat reachable. */
-@media (max-width: 920px) {
-  .stitch-side-menu {
-    top: 82px;
-    right: 10px;
-    bottom: auto;
-    grid-template-columns: repeat(2, 52px);
-  }
-  .stitch-skillbar {
-    right: 10px;
-    bottom: 10px;
-    max-height: calc(100vh - 210px);
-    overflow: auto;
-  }
-}
-
-@media (max-width: 520px) {
-  .stitch-side-menu {
-    top: 168px;
-    right: 10px;
-    bottom: auto;
-    grid-template-columns: repeat(2, 42px);
-  }
-  .stitch-side-menu button {
-    width: 42px;
-    min-height: 40px;
-  }
-  .stitch-skillbar button {
-    width: 64px;
-    height: 48px;
-  }
-}

--- a/apps/client-2d/src/theme.css
+++ b/apps/client-2d/src/theme.css
@@ -78,3 +78,141 @@ canvas { display: block; filter: saturate(1.16) contrast(1.08); touch-action: no
 .az-touch-pad .left { grid-column: 1; grid-row: 2; }
 .az-touch-pad .right { grid-column: 3; grid-row: 2; }
 .az-touch-pad .down { grid-column: 2; grid-row: 3; }
+
+.stitch-hud { position: absolute; inset: 0; z-index: 20; pointer-events: none; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+.stitch-hud button, .stitch-hud input { pointer-events: auto; }
+.stitch-scanlines { position: absolute; inset: 0; pointer-events: none; opacity: .22; background: repeating-linear-gradient(0deg, rgba(255,255,255,.05) 0 1px, transparent 1px 4px); mix-blend-mode: overlay; }
+.stitch-topbar { position: absolute; top: 14px; left: 14px; right: 14px; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 14px; border: 1px solid rgba(0,229,255,.28); border-radius: 20px; background: linear-gradient(135deg, rgba(3,8,16,.82), rgba(13,18,33,.58)); box-shadow: 0 0 30px rgba(0,229,255,.14), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(15px); pointer-events: auto; }
+.stitch-kicker { display: block; color: var(--st-aether); font-size: 10px; font-weight: 950; letter-spacing: .22em; }
+.stitch-brand strong { display: block; margin-top: 2px; color: #fff6d7; font-size: 16px; letter-spacing: .02em; }
+.stitch-node-status { display: grid; justify-items: end; gap: 2px; color: rgba(244,247,255,.75); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.stitch-node-status b { color: #d9ffd2; font-size: 12px; }
+.stitch-live-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; background: #ff3f6f; box-shadow: 0 0 14px #ff3f6f; justify-self: end; }
+.stitch-live-dot.on { background: var(--st-emerald); box-shadow: 0 0 14px var(--st-emerald); }
+.stitch-vitals { position: absolute; top: 94px; left: 14px; width: 246px; padding: 14px; border: 1px solid rgba(255,215,106,.22); border-radius: 24px; background: rgba(4,8,14,.66); box-shadow: 0 0 34px rgba(255,215,106,.08), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(12px); pointer-events: auto; }
+.stitch-portrait { width: 74px; height: 74px; border-radius: 22px; display: grid; place-items: center; color: var(--st-aether); font-weight: 950; font-size: 38px; background: radial-gradient(circle, rgba(0,229,255,.24), rgba(139,92,246,.08)); border: 1px solid rgba(0,229,255,.32); box-shadow: inset 0 0 22px rgba(0,229,255,.15); float: left; margin-right: 12px; }
+.stitch-nameplate { min-height: 74px; display: grid; align-content: center; }
+.stitch-nameplate small { color: rgba(244,247,255,.55); text-transform: uppercase; letter-spacing: .14em; font-size: 10px; }
+.stitch-nameplate strong { color: white; font-size: 18px; }
+.stitch-gauge { clear: both; margin-top: 10px; height: 24px; position: relative; border-radius: 999px; background: rgba(255,255,255,.055); border: 1px solid rgba(255,255,255,.08); overflow: hidden; }
+.stitch-gauge div { display: flex; justify-content: space-between; color: rgba(244,247,255,.72); font-size: 10px; letter-spacing: .12em; font-weight: 900; position: relative; z-index: 1; padding: 5px 9px; }
+.stitch-gauge i { position: absolute; inset: 0 auto 0 0; display: block; border-radius: inherit; transition: width .2s ease; }
+.stitch-gauge.ruby i { background: linear-gradient(90deg, #7f1028, var(--st-ruby)); }
+.stitch-gauge.aether i { background: linear-gradient(90deg, #0d4e66, var(--st-aether)); }
+.stitch-gauge.emerald i { background: linear-gradient(90deg, #156b22, var(--st-emerald)); }
+.stitch-gauge.gold i { background: linear-gradient(90deg, #725310, var(--st-gold)); }
+.stitch-side-menu { position: absolute; top: 94px; right: 14px; display: grid; gap: 8px; pointer-events: auto; }
+.stitch-side-menu button { width: 96px; min-height: 56px; border: 1px solid rgba(0,229,255,.2); border-radius: 18px; color: rgba(244,247,255,.82); background: rgba(4,8,14,.62); box-shadow: inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter: blur(10px); }
+.stitch-side-menu button.active, .stitch-side-menu button:hover { border-color: var(--st-gold); color: white; background: rgba(255,215,106,.12); }
+.stitch-side-menu span { display: block; font-size: 20px; }
+.stitch-side-menu small { display: block; margin-top: 2px; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+.stitch-radar { position: absolute; right: 126px; top: 94px; width: 188px; min-height: 96px; display: flex; align-items: center; gap: 14px; padding: 12px; border: 1px solid rgba(57,255,20,.2); border-radius: 22px; background: rgba(4,8,14,.48); backdrop-filter: blur(10px); color: rgba(244,247,255,.7); pointer-events: auto; }
+.stitch-radar b { display: block; color: var(--st-emerald); }
+.stitch-radar small { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+.stitch-radar-ring { width: 66px; height: 66px; border-radius: 50%; position: relative; border: 1px solid rgba(57,255,20,.38); box-shadow: 0 0 18px rgba(57,255,20,.12), inset 0 0 18px rgba(57,255,20,.08); }
+.stitch-radar-ring i { position: absolute; width: 7px; height: 7px; border-radius: 50%; background: var(--st-emerald); box-shadow: 0 0 12px var(--st-emerald); }
+.stitch-radar-ring i:nth-child(1) { left: 18px; top: 17px; }
+.stitch-radar-ring i:nth-child(2) { right: 17px; top: 30px; }
+.stitch-radar-ring i:nth-child(3) { left: 30px; bottom: 13px; }
+.stitch-chat { position: absolute; left: 14px; bottom: 18px; width: min(390px, calc(100vw - 28px)); padding: 12px; border: 1px solid rgba(0,229,255,.18); border-radius: 22px; background: rgba(4,8,14,.58); backdrop-filter: blur(12px); pointer-events: auto; }
+.stitch-panel-title { display: flex; justify-content: space-between; color: rgba(244,247,255,.58); font-size: 10px; text-transform: uppercase; letter-spacing: .12em; }
+.stitch-panel-title b { color: var(--st-aether); }
+.stitch-panel-title span { color: var(--st-emerald); }
+.stitch-chat-lines { min-height: 104px; max-height: 104px; overflow: hidden; margin: 8px 0; }
+.stitch-chat-lines p { margin: 4px 0; color: rgba(244,247,255,.76); font-size: 12px; }
+.stitch-chat-lines b { color: var(--st-gold); }
+.stitch-chat-input { display: flex; gap: 8px; }
+.stitch-chat-input input { min-width: 0; flex: 1; border: 1px solid rgba(255,255,255,.1); border-radius: 14px; padding: 10px 12px; color: white; background: rgba(0,0,0,.32); outline: none; }
+.stitch-chat-input button, .stitch-bottom-right button { border: 1px solid rgba(0,229,255,.26); border-radius: 14px; padding: 10px 12px; color: #061018; font-weight: 950; background: linear-gradient(135deg, var(--st-aether), var(--st-gold)); }
+.stitch-skillbar { position: absolute; left: 50%; bottom: 20px; transform: translateX(-50%); display: flex; gap: 10px; padding: 10px; border: 1px solid rgba(255,215,106,.22); border-radius: 24px; background: rgba(4,8,14,.64); backdrop-filter: blur(12px); pointer-events: auto; }
+.stitch-skillbar button { position: relative; width: 76px; height: 72px; border: 1px solid rgba(0,229,255,.2); border-radius: 18px; color: white; background: linear-gradient(180deg, rgba(0,229,255,.12), rgba(139,92,246,.13)); }
+.stitch-skillbar button:hover { border-color: var(--st-gold); transform: translateY(-2px); }
+.stitch-skillbar kbd { position: absolute; top: 6px; left: 7px; color: rgba(244,247,255,.5); font-size: 10px; }
+.stitch-skillbar span { display: block; font-size: 23px; }
+.stitch-skillbar b { display: block; font-size: 11px; }
+.stitch-skillbar small { display: block; color: rgba(244,247,255,.58); font-size: 8px; margin-top: 1px; }
+.stitch-bottom-right { position: absolute; right: 14px; bottom: 20px; display: flex; gap: 8px; pointer-events: auto; }
+.stitch-modal { position: absolute; inset: 0; display: grid; place-items: center; background: rgba(0,0,0,.18); pointer-events: auto; }
+.stitch-modal-card { width: min(720px, calc(100vw - 28px)); max-height: min(620px, calc(100vh - 42px)); overflow: auto; border: 1px solid rgba(0,229,255,.28); border-radius: 30px; background: linear-gradient(135deg, rgba(4,8,14,.92), rgba(19,25,45,.86)); box-shadow: 0 28px 100px rgba(0,0,0,.48), 0 0 34px rgba(0,229,255,.13); backdrop-filter: blur(18px); padding: 20px; }
+.stitch-modal-card header { display: flex; justify-content: space-between; align-items: start; gap: 14px; margin-bottom: 18px; }
+.stitch-modal-card small { color: var(--st-aether); font-size: 10px; letter-spacing: .18em; font-weight: 950; }
+.stitch-modal-card h2 { margin: 4px 0 0; font-size: clamp(28px, 5vw, 48px); letter-spacing: -.05em; }
+.stitch-modal-card header button { width: 38px; height: 38px; border-radius: 13px; border: 1px solid rgba(255,255,255,.12); background: rgba(255,255,255,.06); color: white; font-size: 24px; }
+.stitch-grid-panel { display: grid; grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); gap: 12px; }
+.stitch-info { min-height: 108px; border: 1px solid rgba(255,255,255,.1); border-radius: 22px; padding: 15px; background: rgba(255,255,255,.045); display: grid; align-content: center; gap: 8px; }
+.stitch-info small { color: rgba(244,247,255,.54); }
+.stitch-info b { color: #fff6d7; font-size: 18px; }
+.stitch-map-preview { height: 260px; position: relative; border: 1px solid rgba(57,255,20,.18); border-radius: 24px; overflow: hidden; background: radial-gradient(circle at 45% 45%, rgba(57,255,20,.18), transparent 20%), linear-gradient(135deg, rgba(0,229,255,.1), rgba(255,215,106,.06)); }
+.stitch-map-preview span { position: absolute; width: 15px; height: 15px; border-radius: 50%; background: var(--st-gold); box-shadow: 0 0 18px var(--st-gold); }
+.stitch-map-preview span:nth-child(1) { left: 18%; top: 32%; }
+.stitch-map-preview span:nth-child(2) { left: 62%; top: 45%; }
+.stitch-map-preview span:nth-child(3) { left: 42%; top: 70%; }
+.stitch-map-preview span:nth-child(4) { left: 78%; top: 22%; }
+.stitch-map-preview b { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); color: white; font-size: 24px; text-shadow: 0 0 18px black; }
+
+@media (max-width: 920px) {
+  .stitch-topbar { left: 10px; right: 10px; top: 10px; padding: 10px; }
+  .stitch-brand strong { font-size: 14px; }
+  .stitch-node-status small { display: none; }
+  .stitch-vitals { top: 78px; left: 10px; width: 210px; padding: 10px; }
+  .stitch-portrait { width: 54px; height: 54px; font-size: 28px; border-radius: 17px; }
+  .stitch-nameplate { min-height: 54px; }
+  .stitch-radar { display: none; }
+  .live-reality-bridge { right: 10px; top: 78px; width: calc(100vw - 240px); min-width: 210px; }
+  .pixi-module-inspector { right: 10px; top: 258px; width: calc(100vw - 240px); min-width: 210px; }
+  .live-reality-field { height: 132px; }
+  .az-touch-pad { display: grid; }
+  .stitch-side-menu { top: auto; bottom: 102px; right: 10px; grid-template-columns: repeat(2, 52px); }
+  .stitch-side-menu button { width: 52px; min-height: 48px; border-radius: 16px; }
+  .stitch-side-menu small { display: none; }
+  .stitch-chat { width: calc(100vw - 116px); left: 10px; bottom: 10px; padding: 10px; }
+  .stitch-chat-lines { min-height: 70px; max-height: 70px; }
+  .stitch-skillbar { left: auto; right: 10px; bottom: 10px; transform: none; flex-direction: column; gap: 7px; padding: 7px; border-radius: 20px; }
+  .stitch-skillbar button { width: 74px; height: 54px; }
+  .stitch-skillbar small { display: none; }
+  .stitch-bottom-right { display: none; }
+}
+
+@media (max-width: 520px) {
+  .stitch-vitals { width: calc(100vw - 20px); display: grid; grid-template-columns: 54px 1fr; gap: 8px; }
+  .stitch-vitals .stitch-gauge { grid-column: span 2; margin-top: 0; }
+  .stitch-chat { width: calc(100vw - 104px); }
+  .stitch-kicker { letter-spacing: .12em; }
+  .live-reality-bridge { left: 10px; right: 10px; top: 210px; width: auto; }
+  .pixi-module-inspector { left: 10px; right: 10px; top: 336px; width: auto; }
+  .live-reality-field { height: 112px; }
+  .az-touch-pad { bottom: 118px; left: 10px; grid-template-columns: repeat(3, 42px); grid-template-rows: repeat(3, 42px); }
+}
+
+/* Playability pass 1: prevent mobile HUD overlap and keep combat reachable. */
+@media (max-width: 920px) {
+  .stitch-side-menu {
+    top: 82px;
+    right: 10px;
+    bottom: auto;
+    grid-template-columns: repeat(2, 52px);
+  }
+  .stitch-skillbar {
+    right: 10px;
+    bottom: 10px;
+    max-height: calc(100vh - 210px);
+    overflow: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .stitch-side-menu {
+    top: 168px;
+    right: 10px;
+    bottom: auto;
+    grid-template-columns: repeat(2, 42px);
+  }
+  .stitch-side-menu button {
+    width: 42px;
+    min-height: 40px;
+  }
+  .stitch-skillbar button {
+    width: 64px;
+    height: 48px;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds mobile-safe NPC interaction on Pixi actor containers using `pointertap` instead of `pointerdown`.
- Adds fat-finger hit areas around non-player actors so mobile users do not need pixel-perfect taps.
- Debounces each NPC interaction intent for one second and sends only `INTERACT_ENTITY` through the existing `wasd:client-action` event bus.
- Adds small canvas touch feedback by briefly dimming the tapped actor.
- Hardens `.az-pixi` and `canvas` with `touch-action: none`, `user-select: none`, and `-webkit-touch-callout: none` so Android/iOS browsers do not steal game gestures.

## Architecture
Pixi only emits an interaction intent with `targetId`. It does not open trade/dialogue UI and does not mutate inventory. The server remains the authority; React overlays still open only after `INTERACTION_ACCEPTED`.

## Mobile guardrails
- Tap accepted only through Pixi `pointertap`, avoiding swipe/pan false positives.
- Larger invisible hit area around NPC actors for thumb input.
- Per-actor cooldown prevents tap spam.
