### PR TITLE
feat(client-2d): add combat result feedback

### DIFF
--- a/apps/client-2d/src/DeterministicWorldIsoApp.tsx
+++ b/apps/client-2d/src/DeterministicWorldIsoApp.tsx
@@ -11,6 +11,8 @@ import { initLootFeedback } from "./lootPickupFeedback";
 import { makeModularWeaponSprite } from "./modularWeaponAssembler";
 import { spawnFloatingStatus, spawnTouchRipple } from "./fxLogic";
 import { moveVisualTowards } from "./visualMotion";
+import { CombatFXManager } from "./render/CombatFXManager";
+import { initCombatFXBridge } from "./render/CombatFXEventBridge";
 
 const TILE_W = 96;
 const TILE_H = 48;
@@ -226,6 +228,7 @@ export function DeterministicWorldIsoApp() {
   const worldLayerRef = useRef<Container | null>(null);
   const actorLayerRef = useRef<Container | null>(null);
   const fxLayerRef = useRef<Container | null>(null);
+  const combatFXRef = useRef<CombatFXManager | null>(null);
   const entities = useRef<Map<string, Entity>>(new Map());
   const assetsRef = useRef<LoadedAssets | null>(null);
   const clientRef = useRef<ReturnType<typeof createClient> | null>(null);
@@ -261,6 +264,9 @@ export function DeterministicWorldIsoApp() {
     placeActor(root, x, z, app.screen.width, app.screen.height);
     layer.addChild(root);
     entities.current.set(id, { root, tx: x, tz: z, name, isPlayer: player, weaponVisualId, characterVisualId });
+    
+    // Register actor with CombatFXManager for O(1) target lookup
+    combatFXRef.current?.registerActor(id, root);
   }
 
   function rebuildActor(id: string, weaponVisualId: string | null) {
@@ -334,6 +340,12 @@ export function DeterministicWorldIsoApp() {
       worldLayerRef.current = world;
       actorLayerRef.current = actors;
       fxLayerRef.current = fx;
+      
+      // Initialize CombatFXManager for combat visual effects
+      if (fx) {
+        combatFXRef.current = new CombatFXManager(app, fx);
+      }
+      
       app.stage.sortableChildren = true;
       app.stage.eventMode = "static";
       app.stage.hitArea = app.screen;
@@ -371,6 +383,12 @@ export function DeterministicWorldIsoApp() {
     const c = createClient({ url: "https://arelorian.de", heartbeatInterval: 30000 });
     clientRef.current = c;
     initLootFeedback(app, c);
+    
+    // Initialize combat FX event bridge
+    if (combatFXRef.current) {
+      initCombatFXBridge(c, combatFXRef.current);
+    }
+    
     c.on("connect" as any, () => { setConnected(true); setMessages((items) => [...items.slice(-12), { from: "Net", txt: "World stream connected." }]); });
     c.on("disconnect" as any, () => setConnected(false));
     c.on("WORLD_HEARTBEAT", (event: any) => {

--- a/apps/client-2d/src/render/CombatFXEventBridge.ts
+++ b/apps/client-2d/src/render/CombatFXEventBridge.ts
@@ -1,0 +1,152 @@
+/**
+ * CombatFXEventBridge - Connects Server Events to CombatFXManager
+ * 
+ * ARCHITECTURE:
+ * - Server Authority: This bridge ONLY listens to server-sent events
+ * - O(1) Resolution: Uses actorSpriteMap from CombatFXManager for instant lookup
+ * - Strict Decoupling: No mutation of HP or logical entity state
+ * 
+ * EVENT FLOW:
+ * 1. Server sends COMBAT_RESULT (or similar combat event)
+ * 2. Bridge extracts targetId, amount, isMiss
+ * 3. O(1) lookup of target sprite position
+ * 4. CombatFXManager spawns visual FX
+ */
+
+import type { NetworkClient } from "../networkClient";
+import type { CombatFXManager } from "./CombatFXManager";
+
+/** Combat result payload from server */
+interface CombatResultPayload {
+  targetId?: string;
+  defenderId?: string;
+  attackerId?: string;
+  damage?: number;
+  amount?: number;
+  isMiss?: boolean;
+  kind?: string;
+}
+
+/** Generic server event wrapper */
+interface ServerEvent {
+  type?: string;
+  payload?: CombatResultPayload;
+}
+
+/**
+ * Initialize combat event listeners that trigger visual FX.
+ * 
+ * @param client - Network client (from createClient)
+ * @param fxManager - CombatFXManager instance with actorSpriteMap
+ */
+export function initCombatFXBridge(
+  client: NetworkClient,
+  fxManager: CombatFXManager
+): void {
+  /**
+   * Extract target ID from payload.
+   * Server may use different field names.
+   */
+  function extractTargetId(payload: CombatResultPayload): string | null {
+    return payload.targetId ?? payload.defenderId ?? null;
+  }
+
+  /**
+   * Extract damage amount from payload.
+   * Server may use different field names.
+   */
+  function extractDamage(payload: CombatResultPayload): number {
+    return Number(payload.damage ?? payload.amount ?? 0);
+  }
+
+  /**
+   * Handle combat result event from server.
+   * Spawns damage number and hit flash if target exists.
+   */
+  function onCombatResult(event: ServerEvent): void {
+    const payload = event?.payload;
+    if (!payload) return;
+
+    // Skip non-hit events (blocks, dodges, etc.)
+    if (payload.kind && payload.kind !== "hit" && payload.kind !== "damage") return;
+
+    const targetId = extractTargetId(payload);
+    if (!targetId) return;
+
+    // O(1) lookup - get sprite from actor map
+    const targetSprite = fxManager["actorSpriteMap"].get(targetId);
+    
+    // Only spawn FX if target is visible (sprite exists in map)
+    if (!targetSprite) return;
+
+    const damage = extractDamage(payload);
+    const isMiss = Boolean(payload.isMiss);
+
+    // Spawn at current sprite position
+    // Using current position ensures FX tracks moving targets
+    const x = targetSprite.x;
+    const y = targetSprite.y;
+
+    // Spawn floating damage number
+    fxManager.spawnDamageNumber(x, y, damage, isMiss);
+
+    // Spawn hit flash (red tint) if this was a hit, not a miss
+    if (!isMiss && damage > 0) {
+      fxManager.spawnHitFlash(targetId);
+    }
+  }
+
+  /**
+   * Handle combat feedback from server (alternative event name).
+   */
+  function onCombatFeedback(event: ServerEvent): void {
+    const payload = event?.payload;
+    if (!payload) return;
+
+    const targetId = extractTargetId(payload);
+    if (!targetId) return;
+
+    // O(1) lookup
+    const targetSprite = fxManager["actorSpriteMap"].get(targetId);
+    if (!targetSprite) return;
+
+    const damage = extractDamage(payload);
+    const isMiss = Boolean(payload.isMiss);
+
+    // Spawn FX at current position
+    fxManager.spawnDamageNumber(targetSprite.x, targetSprite.y, damage, isMiss);
+    
+    if (!isMiss && damage > 0) {
+      fxManager.spawnHitFlash(targetId);
+    }
+  }
+
+  /**
+   * Handle damage broadcast from server.
+   */
+  function onDamageBroadcast(event: ServerEvent): void {
+    onCombatResult(event);  // Delegate to main handler
+  }
+
+  // Register listeners on network client
+  // These events are sent by the server when combat occurs
+  client.on("combat_result", onCombatResult);
+  client.on("combat_feedback", onCombatFeedback);
+  client.on("COMBAT_RESULT", onCombatResult);
+  client.on("COMBAT_FEEDBACK", onCombatFeedback);
+  client.on("damage", onDamageBroadcast);
+
+  // Also listen on window events (for cross-component communication)
+  if (typeof window !== "undefined") {
+    window.addEventListener("wasd:combat-result", ((event: CustomEvent<ServerEvent>) => {
+      onCombatResult(event.detail);
+    }) as EventListener);
+
+    window.addEventListener("wasd:network-packet", ((event: CustomEvent<{ event: string; payload: any }>) => {
+      const { event: type, payload } = event.detail;
+      if (type === "COMBAT_RESULT" || type === "combat_result" || type === "combat_feedback") {
+        onCombatResult({ type, payload });
+      }
+    }) as EventListener);
+  }
+}

--- a/apps/client-2d/src/render/CombatFXManager.ts
+++ b/apps/client-2d/src/render/CombatFXManager.ts
@@ -1,0 +1,235 @@
+/**
+ * CombatFXManager - PixiJS Combat Visual Effects (Fire & Forget)
+ * 
+ * ARCHITECTURE:
+ * - Strict Decoupling: FX never mutates HP, kappaPos, or any logical entity state
+ * - O(1) Actor Lookup: actorSpriteMap enables instant targetId → Sprite resolution
+ * - Pixi Ticker Lifecycle: All animations use app.ticker (no setTimeout)
+ * - Garbage Collection: FX objects are destroyed on lifetime expiry
+ * 
+ * PILLAR: Server Authority
+ * - All FX is triggered as reaction to async server events (COMBAT_RESULT)
+ * - No preemptive FX on client-side click actions
+ */
+
+import { Application, Container, Text, Ticker } from "pixi.js";
+
+/** Floating damage number node with lifecycle metadata */
+type DamageNode = {
+  node: Text;
+  velocityY: number;  // Pixels per frame (float upward)
+  lifetime: number;   // Frames until destruction
+};
+
+/** Hit flash overlay tint */
+type FlashNode = {
+  container: Container;
+  originalTint: number;
+  flashTicks: number;
+};
+
+/**
+ * CombatFXManager
+ * Manages floating damage numbers and hit flash effects.
+ * All effects are self-contained and self-destructing.
+ */
+export class CombatFXManager {
+  /** O(1) lookup: targetId → PIXI.Container for immediate position resolution */
+  private readonly actorSpriteMap = new Map<string, Container>();
+  
+  /** Active floating damage numbers (fire & forget) */
+  private readonly damageNodes: DamageNode[] = [];
+  
+  /** Active hit flash effects */
+  private readonly flashNodes: FlashNode[] = [];
+  
+  /** Reference to FX container (Z-index above world layer) */
+  private readonly fxContainer: Container;
+  
+  /** Reference to app ticker for animation loop */
+  private readonly ticker: Ticker;
+  
+  /** Default animation parameters */
+  private readonly DAMAGE_VELOCITY_Y = -0.85;    // Float upward
+  private readonly FADE_RATE = 0.028;            // Alpha decrement per frame
+  private readonly FLASH_DURATION_TICKS = 9;     // ~150ms at 60fps
+  private readonly DAMAGE_Y_OFFSET = 54;        // Above actor anchor
+
+  constructor(app: Application, fxLayer: Container) {
+    this.fxContainer = fxLayer;
+    this.ticker = app.ticker;
+    
+    // Register the animation tick callback
+    this.ticker.add(this.update, this);
+  }
+
+  /**
+   * Register actor sprite for O(1) lookup.
+   * Called during WORLD_HEARTBEAT processing when actors are created/updated.
+   */
+  registerActor(actorId: string, sprite: Container): void {
+    this.actorSpriteMap.set(actorId, sprite);
+  }
+
+  /**
+   * Unregister actor when it leaves the visible area.
+   * Prevents memory leaks from stale entries.
+   */
+  unregisterActor(actorId: string): void {
+    this.actorSpriteMap.delete(actorId);
+  }
+
+  /**
+   * Spawn floating damage number at target position.
+   * 
+   * @param x - Screen X coordinate (falls back to actor position via targetId)
+   * @param y - Screen Y coordinate (falls back to actor position via targetId)
+   * @param amount - Damage amount (negative = healing)
+   * @param isMiss - Whether attack missed
+   */
+  spawnDamageNumber(
+    x: number,
+    y: number,
+    amount: number,
+    isMiss: boolean
+  ): void {
+    // Create damage text node
+    // Android-optimized: bold stroke, high contrast
+    const label = new Text({
+      text: this.formatDamage(amount, isMiss),
+      style: {
+        fontFamily: "monospace",
+        fontSize: isMiss ? 14 : 20,
+        fontWeight: "900",
+        fill: isMiss ? 0xaaaaaa : (amount < 0 ? 0x4eff4e : 0xff5151),
+        stroke: { 
+          color: isMiss ? 0x333333 : 0x2b0202, 
+          width: isMiss ? 3 : 5 
+        },
+      },
+    });
+
+    // Position above actor (anchor at bottom-center)
+    label.anchor.set(0.5, 1);
+    label.x = x;
+    label.y = y - this.DAMAGE_Y_OFFSET;
+    label.alpha = 1;
+    label.zIndex = 1000000;  // Above all world content
+
+    // Add to FX container
+    this.fxContainer.addChild(label);
+
+    // Register with lifecycle tracking
+    this.damageNodes.push({
+      node: label,
+      velocityY: this.DAMAGE_VELOCITY_Y * (isMiss ? 0.7 : 1),
+      lifetime: isMiss ? 30 : 45,  // Miss fades faster
+    });
+  }
+
+  /**
+   * Spawn hit flash effect on target actor.
+   * Temporarily tints the actor sprite red for visual impact.
+   */
+  spawnHitFlash(targetId: string): void {
+    const sprite = this.actorSpriteMap.get(targetId);
+    if (!sprite) return;
+
+    // Store original tint for restoration
+    const flashNode: FlashNode = {
+      container: sprite,
+      originalTint: (sprite as any).tint ?? 0xffffff,
+      flashTicks: this.FLASH_DURATION_TICKS,
+    };
+
+    // Apply red tint
+    (sprite as any).tint = 0xff0000;
+    this.flashNodes.push(flashNode);
+  }
+
+  /**
+   * Pixi Ticker callback - drives all FX animations.
+   * Called every frame (~60fps).
+   */
+  private update(ticker: Ticker): void {
+    const delta = ticker.deltaTime;
+    this.updateDamageNumbers(delta);
+    this.updateHitFlashes(delta);
+  }
+
+  /**
+   * Animate floating damage numbers: rise + fade + destroy.
+   */
+  private updateDamageNumbers(delta: number): void {
+    for (let i = this.damageNodes.length - 1; i >= 0; i--) {
+      const dn = this.damageNodes[i];
+      
+      // Float upward
+      dn.node.y += dn.velocityY * delta;
+      
+      // Fade out
+      dn.node.alpha = Math.max(0, dn.node.alpha - this.FADE_RATE * delta);
+      
+      // Decrement lifetime
+      dn.lifetime -= delta;
+
+      // Destroy when expired
+      if (dn.lifetime <= 0 || dn.node.alpha <= 0) {
+        this.fxContainer.removeChild(dn.node);
+        dn.node.destroy();
+        this.damageNodes.splice(i, 1);
+      }
+    }
+  }
+
+  /**
+   * Animate hit flash: restore original tint after duration.
+   */
+  private updateHitFlashes(delta: number): void {
+    for (let i = this.flashNodes.length - 1; i >= 0; i--) {
+      const fn = this.flashNodes[i];
+      fn.flashTicks -= delta;
+
+      if (fn.flashTicks <= 0) {
+        // Restore original tint
+        (fn.container as any).tint = fn.originalTint;
+        this.flashNodes.splice(i, 1);
+      }
+    }
+  }
+
+  /**
+   * Format damage amount for display.
+   * Positive damage = red negative text
+   * Negative amount = green positive text (healing)
+   */
+  private formatDamage(amount: number, isMiss: boolean): string {
+    if (isMiss) return "MISS";
+    const rounded = Math.round(Math.abs(amount));
+    return amount < 0 ? `+${rounded}` : `-${rounded}`;
+  }
+
+  /**
+   * Cleanup all resources.
+   * Call on app destroy or unmount.
+   */
+  destroy(): void {
+    this.ticker.remove(this.update, this);
+    
+    // Destroy all active damage nodes
+    for (const dn of this.damageNodes) {
+      this.fxContainer.removeChild(dn.node);
+      dn.node.destroy();
+    }
+    this.damageNodes.length = 0;
+
+    // Restore any tinted sprites
+    for (const fn of this.flashNodes) {
+      (fn.container as any).tint = fn.originalTint;
+    }
+    this.flashNodes.length = 0;
+
+    // Clear actor map
+    this.actorSpriteMap.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Implements a combat visual effects pipeline for the 2D client that responds to server-sent combat events.

## Architecture (Strict Decoupling)

### Core Axioms:
- **Zero Mutation**: FX never mutates HP, kappaPos, or any logical entity state
- **Fire & Forget**: FX objects manage their own lifecycle via Pixi Ticker
- **O(1) Actor Lookup**: `actorSpriteMap` enables instant `targetId` → `Container` resolution
- **Server Authority**: FX triggered only as reaction to async server events

### Components:

#### 1. `CombatFXManager.ts`
- Manages floating damage numbers and hit flash effects
- `spawnDamageNumber(x, y, amount, isMiss)`: Android-optimized text with stroke
- `spawnHitFlash(targetId)`: Red tint for 150ms on hit
- `update(ticker)`: Drives all animations via app.ticker (no setTimeout)
- `registerActor(id, sprite)` / `unregisterActor(id)`: O(1) lookup maintenance

#### 2. `CombatFXEventBridge.ts`
- Connects server events to FXManager
- Listens to: `combat_result`, `combat_feedback`, `COMBAT_RESULT`, `COMBAT_FEEDBACK`, `damage`
- Extracts `targetId`, `amount`, `isMiss` from payload
- O(1) lookup: `actorSpriteMap.get(targetId)` → current position → spawn FX

#### 3. `DeterministicWorldIsoApp.tsx`
- Initializes `CombatFXManager` with FX layer
- `setActor()` registers new actors with FX manager
- `startNetwork()` initializes combat event bridge

### Event Flow:
```
Server → COMBAT_RESULT event → Bridge extracts data → O(1) target lookup → FXManager spawns damage number + hit flash
```

### Verification:
- Build passes: `pnpm --filter @wasd/client-2d build` ✓

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ae56ee25-51f7-43b1-ab1a-906d9d3118a9)