### PR TITLE
feat: Monster AI, RuneScape XP System, and KAPPA Loot

### DIFF
--- a/apps/client-2d/src/loot/LootRenderer.ts
+++ b/apps/client-2d/src/loot/LootRenderer.ts
@@ -1,0 +1,420 @@
+/**
+ * Ouroboros LootRenderer — 2D Client Loot System
+ * 
+ * ARCHITECTURE (Server Authority + Stateless Determinism):
+ * - Loot entities rendered from world_tick broadcast (server authorative)
+ * - Interaction: pointertap with FAT-FINGER PADDING prevents mis-clicks
+ * - Intent: wasd:client-action { type: "pickup_loot", entityId }
+ * - Server validates distance + inventory, atomically removes loot
+ * 
+ * FAT-FINGER PROTECTION:
+ * - Loot sprites have larger hit area than visual (1.5x radius padding)
+ * - Minimum tap distance from character enforced
+ * - Tap cooldown prevents rapid double-taps
+ * 
+ * SECURITY:
+ * - All visuals derived from ItemSignature (no client-side item creation)
+ * - Sprite selection uses same deterministic mapping as server
+ * - Client cannot spawn, move, or duplicate loot
+ */
+
+import { Container, Text, Graphics } from "pixi.js";
+import type { Application } from "pixi.js";
+import { fromKappaInt } from "@wasd/shared";
+import { iso3 } from "../isometricProjection";
+
+const TILE_W = 96;
+const TILE_H = 48;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface LootEntity {
+  id: string;
+  type: "LOOT";
+  x: number;       // Kappa-int
+  y: number;       // Kappa-int
+  z?: number;
+  itemSignature?: string;
+  itemName?: string;
+  rarity?: string;
+  ilvl?: number;
+  visualId?: string;
+  gold?: number;
+}
+
+export interface LootRenderContext {
+  width: number;
+  height: number;
+  playerKappaX: number;
+  playerKappaY: number;
+}
+
+// ─── Loot Renderer ────────────────────────────────────────────────────────────
+
+export class LootRenderer {
+  private readonly root: Container;
+  private readonly lootSprites: Map<string, Container> = new Map();
+  private readonly app: Application;
+  
+  // Fat-finger padding (pixels beyond sprite bounds)
+  private readonly HIT_PADDING = 24;
+  
+  // Tap cooldown to prevent accidental double-taps
+  private readonly TAP_COOLDOWN_MS = 300;
+  private lastTapTime = 0;
+  private lastTapLootId: string | null = null;
+  
+  // Rarity colors
+  private readonly RARITY_COLORS: Record<string, number> = {
+    common: 0xaaaaaa,
+    uncommon: 0x4eff4e,
+    rare: 0x4e9eff,
+    epic: 0x9e4eff,
+    legendary: 0xffa500,
+    mystic: 0xff4eff,
+  };
+  
+  // Visual ID to sprite path mapping (deterministic from ItemSignature)
+  private readonly VISUAL_SPRITES: Record<string, string> = {
+    weapon_base_0: "loot_dagger",
+    weapon_base_1: "loot_shortsword",
+    weapon_base_2: "loot_longsword",
+    weapon_base_3: "loot_broadsword",
+    weapon_base_4: "loot_greatsword",
+    weapon_base_5: "loot_claymore",
+    weapon_base_6: "loot_flamberge",
+    weapon_base_7: "loot_zweihander",
+    armor_base_0: "loot_leather",
+    armor_base_1: "loot_chain",
+    armor_base_2: "loot_scale",
+    armor_base_3: "loot_plate",
+    armor_base_4: "loot_reinforced",
+    armor_base_5: "loot_dragon",
+    armor_base_6: "loot_mythril",
+    armor_base_7: "loot_adamantine",
+    gold_pile: "loot_gold",
+    default: "loot_generic",
+  };
+  
+  constructor(app: Application, parent: Container) {
+    this.app = app;
+    this.root = new Container();
+    this.root.zIndex = 500;
+    parent.addChild(this.root);
+  }
+  
+  /**
+   * Render loot entities from world tick data.
+   * Called during WORLD_HEARTBEAT processing.
+   */
+  public renderLoot(
+    lootEntities: LootEntity[],
+    ctx: LootRenderContext,
+    onPickupIntent: (lootId: string) => void
+  ): void {
+    // Track which loot IDs are still active
+    const activeIds = new Set<string>();
+    
+    for (const loot of lootEntities) {
+      activeIds.add(loot.id);
+      
+      // Create or update sprite
+      let sprite = this.lootSprites.get(loot.id);
+      
+      if (!sprite) {
+        sprite = this.createLootSprite(loot);
+        this.lootSprites.set(loot.id, sprite);
+        this.root.addChild(sprite);
+        
+        // Setup fat-finger tap handler
+        this.setupTapHandler(sprite, loot.id, onPickupIntent);
+      }
+      
+      // Update position
+      this.positionSprite(sprite, loot, ctx);
+    }
+    
+    // Remove sprites for loot that no longer exists
+    for (const [id, sprite] of this.lootSprites) {
+      if (!activeIds.has(id)) {
+        this.root.removeChild(sprite);
+        sprite.destroy({ children: true });
+        this.lootSprites.delete(id);
+      }
+    }
+  }
+  
+  /**
+   * Create a loot sprite container with visual + rarity indicator.
+   */
+  private createLootSprite(loot: LootEntity): Container {
+    const container = new Container();
+    
+    // Base sprite (determined by visualId from signature)
+    const visualKey = loot.visualId ?? "default";
+    const spriteName = this.VISUAL_SPRITES[visualKey] ?? this.VISUAL_SPRITES.default;
+    
+    // Create placeholder graphic (actual sprite loaded from atlas)
+    const baseGraphic = this.createLootGraphic(spriteName, loot);
+    container.addChild(baseGraphic);
+    
+    // Rarity glow ring
+    const rarityColor = this.RARITY_COLORS[loot.rarity ?? "common"] ?? 0xaaaaaa;
+    const glowRing = new Graphics();
+    glowRing.circle(0, -12, 18);
+    glowRing.stroke({ width: 2, color: rarityColor, alpha: 0.6 });
+    container.addChild(glowRing);
+    
+    // Rarity label (optional, for legendary+)
+    if (loot.rarity === "legendary" || loot.rarity === "mystic") {
+      const label = new Text({
+        text: loot.rarity?.toUpperCase(),
+        style: {
+          fontFamily: "monospace",
+          fontSize: 10,
+          fontWeight: "900",
+          fill: rarityColor,
+          stroke: { color: 0x000000, width: 2 },
+        },
+      });
+      label.anchor.set(0.5, 1);
+      label.y = -36;
+      label.alpha = 0.8;
+      container.addChild(label);
+    }
+    
+    // Gold indicator
+    if (loot.gold && loot.gold > 0) {
+      const goldLabel = new Text({
+        text: `+${loot.gold}`,
+        style: {
+          fontFamily: "monospace",
+          fontSize: 12,
+          fontWeight: "900",
+          fill: 0xffd700,
+          stroke: { color: 0x8b6914, width: 2 },
+        },
+      });
+      goldLabel.anchor.set(0.5, 0);
+      goldLabel.y = -8;
+      goldLabel.alpha = 0.9;
+      container.addChild(goldLabel);
+    }
+    
+    // Hover state (scale up slightly)
+    container.eventMode = "static";
+    container.cursor = "pointer";
+    
+    return container;
+  }
+  
+  /**
+   * Create the base loot graphic (placeholder until atlas loaded).
+   */
+  private createLootGraphic(spriteName: string, loot: LootEntity): Graphics {
+    const g = new Graphics();
+    
+    if (spriteName === "loot_gold" || loot.gold) {
+      // Gold pile
+      g.circle(0, 0, 12);
+      g.fill({ color: 0xffd700, alpha: 0.9 });
+      g.circle(-4, -4, 8);
+      g.fill({ color: 0xffe066, alpha: 0.8 });
+    } else {
+      // Item sprite — diamond shape with rarity color
+      const rarityColor = this.RARITY_COLORS[loot.rarity ?? "common"] ?? 0xaaaaaa;
+      
+      // Diamond item shape
+      g.moveTo(0, -20);
+      g.lineTo(14, 0);
+      g.lineTo(0, 20);
+      g.lineTo(-14, 0);
+      g.closePath();
+      g.fill({ color: 0x2a2a3a, alpha: 0.95 });
+      g.stroke({ width: 2, color: rarityColor, alpha: 0.8 });
+      
+      // Inner highlight
+      g.moveTo(0, -14);
+      g.lineTo(10, 0);
+      g.lineTo(0, 14);
+      g.lineTo(-10, 0);
+      g.closePath();
+      g.fill({ color: 0x3a3a4a, alpha: 0.6 });
+    }
+    
+    g.zIndex = 0;
+    return g;
+  }
+  
+  /**
+   * Position loot sprite using isometric projection.
+   */
+  private positionSprite(sprite: Container, loot: LootEntity, ctx: LootRenderContext): void {
+    const screenPos = iso3({
+      gridX: fromKappaInt(loot.x),
+      gridZ: fromKappaInt(loot.y),
+      screenWidth: ctx.width,
+      screenHeight: ctx.height,
+      tileWidth: TILE_W,
+      tileHeight: TILE_H,
+      height: 0,
+    });
+    
+    sprite.x = screenPos.x;
+    sprite.y = screenPos.y - 20; // Slightly above ground
+    sprite.zIndex = screenPos.zIndex + 500; // Above terrain, below actors
+  }
+  
+  /**
+   * Setup fat-finger-safe tap handler with padding.
+   */
+  private setupTapHandler(
+    sprite: Container,
+    lootId: string,
+    onPickupIntent: (lootId: string) => void
+  ): void {
+    // Create expanded hit area for fat-finger protection
+    const hitArea = new Graphics();
+    hitArea.circle(0, -12, 24 + this.HIT_PADDING); // 24 base + 24 padding = 48px radius
+    hitArea.fill({ color: 0xffffff, alpha: 0 }); // Invisible
+    hitArea.zIndex = -1;
+    sprite.addChild(hitArea);
+    
+    sprite.on("pointertap", () => {
+      // Fat-finger protection: prevent rapid double-taps
+      const now = Date.now();
+      if (now - this.lastTapTime < this.TAP_COOLDOWN_MS && this.lastTapLootId === lootId) {
+        return; // Ignore tap
+      }
+      
+      this.lastTapTime = now;
+      this.lastTapLootId = lootId;
+      
+      // Visual feedback: scale bounce
+      this.bounceSprite(sprite);
+      
+      // Emit pickup intent to server
+      onPickupIntent(lootId);
+    });
+    
+    // Hover state
+    sprite.on("pointerover", () => {
+      sprite.scale.set(1.1);
+    });
+    
+    sprite.on("pointerout", () => {
+      sprite.scale.set(1.0);
+    });
+  }
+  
+  /**
+   * Bounce animation on tap.
+   */
+  private bounceSprite(sprite: Container): void {
+    const originalScale = sprite.scale.x;
+    sprite.scale.set(originalScale * 1.2);
+    
+    // Quick scale back
+    const ticker = this.app.ticker;
+    let frame = 0;
+    
+    const animate = () => {
+      frame++;
+      const progress = frame / 4;
+      
+      if (progress >= 1) {
+        sprite.scale.set(1.0);
+        ticker.remove(animate);
+        return;
+      }
+      
+      // Ease back to 1.0
+      const easeOut = 1 - Math.pow(1 - progress, 3);
+      sprite.scale.set(1.0 + (0.2 * (1 - easeOut)));
+    };
+    
+    ticker.add(animate);
+  }
+  
+  /**
+   * Highlight loot at given position (for targeted pickup).
+   */
+  public highlightLoot(lootId: string, durationMs: number = 500): void {
+    const sprite = this.lootSprites.get(lootId);
+    if (!sprite) return;
+    
+    const originalAlpha = sprite.alpha;
+    sprite.alpha = 1.0;
+    
+    setTimeout(() => {
+      sprite.alpha = originalAlpha;
+    }, durationMs);
+  }
+  
+  /**
+   * Clear all loot sprites.
+   */
+  public clear(): void {
+    for (const sprite of this.lootSprites.values()) {
+      this.root.removeChild(sprite);
+      sprite.destroy({ children: true });
+    }
+    this.lootSprites.clear();
+  }
+  
+  /**
+   * Get loot at screen position (for debugging/testing).
+   */
+  public getLootAtPosition(screenX: number, screenY: number): string | null {
+    for (const [id, sprite] of this.lootSprites) {
+      const dx = screenX - sprite.x;
+      const dy = screenY - sprite.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      
+      if (distance <= 48) { // Fat-finger radius
+        return id;
+      }
+    }
+    return null;
+  }
+}
+
+// ─── Loot Icon Derivation ──────────────────────────────────────────────────────
+
+/**
+ * Derive loot icon key from ItemSignature for atlas lookup.
+ * This matches the server-side Visual ID derivation in itemSignature.ts
+ */
+export function deriveLootIconKey(itemSignature?: string): string {
+  if (!itemSignature) return "default";
+  
+  try {
+    // Parse signature: base:blade_3|hilt_12|material_iron|...
+    const parts = itemSignature.split("|");
+    
+    for (const part of parts) {
+      const [key, value] = part.split(":");
+      if (key === "base") {
+        // Map blade_3 -> weapon_base_2 (0-indexed)
+        if (value.startsWith("blade_")) {
+          const idx = parseInt(value.replace("blade_", ""), 10) - 1;
+          return `weapon_base_${idx}`;
+        }
+        if (value.startsWith("chest_")) {
+          const idx = parseInt(value.replace("chest_", ""), 10) - 1;
+          return `armor_base_${idx}`;
+        }
+        if (value.startsWith("axe_")) {
+          return "weapon_base_0"; // Axe fallback to dagger
+        }
+        if (value.startsWith("mace_")) {
+          return "weapon_base_1"; // Mace fallback
+        }
+      }
+    }
+  } catch {
+    // Invalid signature, use default
+  }
+  
+  return "default";
+}

--- a/server/src/modules/ai/MonsterDirector.ts
+++ b/server/src/modules/ai/MonsterDirector.ts
@@ -1,0 +1,468 @@
+/**
+ * Ouroboros MonsterDirector — Server-Authoritative AI State Machine
+ * 
+ * ARCHITECTURE (Stateless Determinism):
+ * - All AI logic runs server-side in 10-Hz WorldHeartbeat
+ * - Client receives rendered result only — zero client-side AI
+ * - State Machine: IDLE → WANDER → PURSUE → ATTACK → DEAD
+ * 
+ * HABITAT-KAPPA-DISTANCE (KAPPA Math):
+ * - Monsters spawn at a seed position (spawnSeed)
+ * - Maximum distance from spawn = habitatRadius (in Kappa-Meters)
+ * - Aggro triggers when player enters detectionRadius
+ * - Prevents rubber-banding: NPC snaps back to habitat if player retreats
+ * 
+ * SECURITY (Exploit Prevention):
+ * - Aggro state is server-determined — client cannot force aggro
+ * - Kappa-distance enforced on every tick — no teleporting out of range
+ * - Despawn timer prevents infinite corpse farming
+ */
+
+import { KappaPosGrid } from "@wasd/shared";
+import { createARESeed, SeededARERng, type ARERng } from "../../core/determinism/AREDeterminism.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export enum MonsterState {
+  IDLE = "IDLE",
+  WANDER = "WANDER",
+  PURSUE = "PURSUE",
+  ATTACK = "ATTACK",
+  DEAD = "DEAD",
+}
+
+export interface KappaCoord {
+  x: number; // Kappa-int (1 unit = 1 meter)
+  y: number;
+  z: number;
+}
+
+export interface MonsterEntity {
+  id: string;
+  name: string;
+  position: KappaCoord;
+  rotation: number;
+  health: number;
+  maxHealth: number;
+  
+  // Habitat configuration
+  spawnSeed: KappaCoord;     // Original spawn center
+  habitatRadius: number;    // Max distance from spawn (kappa meters)
+  
+  // AI state
+  state: MonsterState;
+  stateTimer: number;       // Ticks in current state
+  targetId: string | null;  // Player/NPC being chased
+  
+  // Perception parameters
+  detectionRadius: number;  // Aggro range (kappa-meters)
+  attackRange: number;      // Combat range (kappa-meters)
+  wanderSpeed: number;      // Tiles per tick when wandering
+  
+  // Combat stats
+  damage: number;
+  attackSpeed: number;      // Attacks per second
+  stamina: number;
+  maxStamina: number;
+  
+  // Drop table seed
+  dropTableSeed: number;
+  
+  // Passive skills
+  skills?: {
+    combat?: { level: number };
+    heavy_armor?: { level: number };
+    evasion?: { level: number };
+    sword_mastery?: { level: number };
+    blunt_force?: { level: number };
+    archery?: { level: number };
+  };
+}
+
+// ─── MonsterDirector ───────────────────────────────────────────────────────────
+
+export class MonsterDirector {
+  private monsters: Map<string, MonsterEntity> = new Map();
+  private worldTick = 0;
+  
+  // Kappa-distance constants
+  private readonly DEFAULT_HABITAT_RADIUS = 8000;  // 8 kappa-meters from spawn
+  private readonly DEFAULT_DETECTION_RADIUS = 4000;  // 4 kappa-meters aggro range
+  private readonly DEFAULT_ATTACK_RANGE = 1500;      // 1.5 kappa-meters (melee)
+  private readonly WANDER_SPEED = 50;               // 0.05 kappa-meters per tick
+  
+  // Despawn timer for dead monsters
+  private readonly DESPAWN_TICKS = 300;             // 30 seconds at 10Hz
+  
+  constructor() {}
+  
+  /**
+   * Sync world tick for deterministic behavior.
+   * Called from WorldTick.tick() each heartbeat.
+   */
+  public setTick(tick: number): void {
+    this.worldTick = tick;
+  }
+  
+  /**
+   * Register a new monster entity.
+   */
+  public addMonster(monster: MonsterEntity): void {
+    // Initialize spawn seed if not set
+    monster.spawnSeed ??= { ...monster.position };
+    monster.habitatRadius ??= this.DEFAULT_HABITAT_RADIUS;
+    monster.detectionRadius ??= this.DEFAULT_DETECTION_RADIUS;
+    monster.attackRange ??= this.DEFAULT_ATTACK_RANGE;
+    monster.state ??= MonsterState.IDLE;
+    monster.stateTimer ??= 0;
+    monster.dropTableSeed ??= this.hashEntityId(monster.id);
+    
+    this.monsters.set(monster.id, monster);
+  }
+  
+  /**
+   * Remove a monster (GM command or cleanup).
+   */
+  public removeMonster(id: string): boolean {
+    return this.monsters.delete(id);
+  }
+  
+  /**
+   * Get all active monsters.
+   */
+  public getAllMonsters(): MonsterEntity[] {
+    return Array.from(this.monsters.values());
+  }
+  
+  /**
+   * Main AI tick — called every 100ms from WorldTick.
+   * Iterates all monsters and processes their state machine.
+   */
+  public tick(onlinePlayers: { id: string; position: KappaCoord; stealthLevel?: number }[]): MonsterTickResult[] {
+    const results: MonsterTickResult[] = [];
+    
+    for (const monster of this.monsters.values()) {
+      // Skip dead monsters (they're despawning)
+      if (monster.state === MonsterState.DEAD) {
+        monster.stateTimer++;
+        if (monster.stateTimer >= this.DESPAWN_TICKS) {
+          this.monsters.delete(monster.id);
+          results.push({ type: "despawn", monsterId: monster.id });
+        }
+        continue;
+      }
+      
+      // Find nearest detectable player
+      const nearestPlayer = this.findNearestPlayer(monster, onlinePlayers);
+      
+      // State machine transition
+      const previousState = monster.state;
+      this.transitionState(monster, nearestPlayer);
+      
+      // Execute current state behavior
+      const tickResult = this.executeState(monster, nearestPlayer);
+      
+      if (tickResult) {
+        results.push(tickResult);
+      }
+      
+      // Increment state timer
+      monster.stateTimer++;
+    }
+    
+    return results;
+  }
+  
+  /**
+   * Get monster by ID.
+   */
+  public getMonster(id: string): MonsterEntity | undefined {
+    return this.monsters.get(id);
+  }
+  
+  /**
+   * Force a monster to take damage.
+   * Returns true if monster died.
+   */
+  public applyDamage(monsterId: string, damage: number): { health: number; died: boolean } {
+    const monster = this.monsters.get(monsterId);
+    if (!monster) return { health: 0, died: false };
+    
+    monster.health = Math.max(0, monster.health - damage);
+    const died = monster.health <= 0;
+    
+    if (died) {
+      monster.state = MonsterState.DEAD;
+      monster.stateTimer = 0;
+    }
+    
+    return { health: monster.health, died };
+  }
+  
+  /**
+   * Check if monster is alive.
+   */
+  public isAlive(monsterId: string): boolean {
+    const monster = this.monsters.get(monsterId);
+    return monster !== undefined && monster.state !== MonsterState.DEAD;
+  }
+  
+  // ─── Private Methods ─────────────────────────────────────────────────────────
+  
+  /**
+   * Find nearest detectable player within aggro radius.
+   * Uses stealth check for hidden players.
+   */
+  private findNearestPlayer(
+    monster: MonsterEntity,
+    players: { id: string; position: KappaCoord; stealthLevel?: number }[]
+  ): { id: string; position: KappaCoord } | null {
+    let nearest: { id: string; position: KappaCoord; distance: number } | null = null;
+    
+    for (const player of players) {
+      const distance = this.kappaDistance(monster.position, player.position);
+      
+      // Skip if out of detection range
+      if (distance > monster.detectionRadius) continue;
+      
+      // Stealth check: high stealth = harder to detect
+      const stealthPenalty = (player.stealthLevel ?? 0) * 500;
+      const effectiveRange = monster.detectionRadius - stealthPenalty;
+      
+      if (distance > effectiveRange) continue;
+      
+      // Update nearest if closer
+      if (!nearest || distance < nearest.distance) {
+        nearest = { id: player.id, position: player.position, distance };
+      }
+    }
+    
+    return nearest ? { id: nearest.id, position: nearest.position } : null;
+  }
+  
+  /**
+   * Calculate KAPPA-distance between two positions.
+   * Uses Euclidean distance in Kappa-coordinates (1 unit = 1 meter).
+   */
+  private kappaDistance(a: KappaCoord, b: KappaCoord): number {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    const dz = (a.z ?? 0) - (b.z ?? 0);
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  }
+  
+  /**
+   * State machine transition logic.
+   */
+  private transitionState(
+    monster: MonsterEntity,
+    nearestPlayer: { id: string; position: KappaCoord } | null
+  ): void {
+    const previousState = monster.state;
+    
+    switch (monster.state) {
+      case MonsterState.IDLE:
+        // Transition to PURSUE if player in range
+        if (nearestPlayer) {
+          monster.state = MonsterState.PURSUE;
+          monster.targetId = nearestPlayer.id;
+          monster.stateTimer = 0;
+        } else {
+          // Random chance to start wandering
+          const rng = this.createMonsterRng(monster, "idle");
+          if (rng.nextFloat() < 0.01) { // 1% chance per tick
+            monster.state = MonsterState.WANDER;
+            monster.stateTimer = 0;
+          }
+        }
+        break;
+        
+      case MonsterState.WANDER:
+        // Transition to PURSUE if player detected
+        if (nearestPlayer) {
+          monster.state = MonsterState.PURSUE;
+          monster.targetId = nearestPlayer.id;
+          monster.stateTimer = 0;
+        } else if (monster.stateTimer > 600) { // Wander for ~60 seconds
+          monster.state = MonsterState.IDLE;
+          monster.stateTimer = 0;
+        }
+        break;
+        
+      case MonsterState.PURSUE:
+        if (!nearestPlayer) {
+          // Lost target — return to idle
+          monster.state = MonsterState.IDLE;
+          monster.targetId = null;
+          monster.stateTimer = 0;
+        } else {
+          const distance = this.kappaDistance(monster.position, nearestPlayer.position);
+          if (distance <= monster.attackRange) {
+            // In attack range — transition to ATTACK
+            monster.state = MonsterState.ATTACK;
+            monster.stateTimer = 0;
+          }
+        }
+        break;
+        
+      case MonsterState.ATTACK:
+        if (!nearestPlayer) {
+          monster.state = MonsterState.IDLE;
+          monster.targetId = null;
+          monster.stateTimer = 0;
+        } else {
+          const distance = this.kappaDistance(monster.position, nearestPlayer.position);
+          if (distance > monster.attackRange) {
+            // Target moved out of range — pursue again
+            monster.state = MonsterState.PURSUE;
+            monster.stateTimer = 0;
+          }
+        }
+        break;
+    }
+  }
+  
+  /**
+   * Execute behavior for current state.
+   */
+  private executeState(
+    monster: MonsterEntity,
+    nearestPlayer: { id: string; position: KappaCoord } | null
+  ): MonsterTickResult | null {
+    switch (monster.state) {
+      case MonsterState.IDLE:
+        // Idle: regenerate stamina slowly
+        monster.stamina = Math.min(monster.maxStamina, monster.stamina + 1);
+        return null;
+        
+      case MonsterState.WANDER:
+        // Move randomly within habitat
+        const wanderDir = this.createWanderDirection(monster);
+        const newPos = this.applyMovement(monster.position, wanderDir, monster.wanderSpeed ?? this.WANDER_SPEED);
+        
+        // Check habitat boundary — snap back if exceeded
+        if (this.isOutOfHabitat(newPos, monster.spawnSeed, monster.habitatRadius)) {
+          // Return to spawn
+          monster.position = { ...monster.spawnSeed };
+        } else {
+          monster.position = newPos;
+        }
+        
+        // Face movement direction
+        monster.rotation = Math.atan2(wanderDir.y, wanderDir.x);
+        return { type: "move", monsterId: monster.id, position: monster.position };
+        
+      case MonsterState.PURSUE:
+        if (nearestPlayer) {
+          // Move toward target
+          const direction = this.normalizeDirection(monster.position, nearestPlayer.position);
+          const pursueSpeed = (monster.wanderSpeed ?? this.WANDER_SPEED) * 1.5; // Faster than wander
+          const newPos = this.applyMovement(monster.position, direction, pursueSpeed);
+          
+          // Check habitat — don't pursue outside
+          if (!this.isOutOfHabitat(newPos, monster.spawnSeed, monster.habitatRadius)) {
+            monster.position = newPos;
+          }
+          
+          // Face target
+          monster.rotation = Math.atan2(direction.y, direction.x);
+          return { type: "move", monsterId: monster.id, position: monster.position };
+        }
+        return null;
+        
+      case MonsterState.ATTACK:
+        // ATTACK state handled by CombatDirector
+        // Just ensure we're facing the target
+        if (nearestPlayer) {
+          const direction = this.normalizeDirection(monster.position, nearestPlayer.position);
+          monster.rotation = Math.atan2(direction.y, direction.x);
+        }
+        return null;
+        
+      default:
+        return null;
+    }
+  }
+  
+  /**
+   * Check if position exceeds habitat radius from spawn seed.
+   */
+  private isOutOfHabitat(pos: KappaCoord, spawnSeed: KappaCoord, radius: number): boolean {
+    return this.kappaDistance(pos, spawnSeed) > radius;
+  }
+  
+  /**
+   * Create deterministic wander direction.
+   */
+  private createWanderDirection(monster: MonsterEntity): { x: number; y: number } {
+    const rng = this.createMonsterRng(monster, `wander:${this.worldTick}`);
+    const angle = rng.nextFloat() * Math.PI * 2;
+    return {
+      x: Math.cos(angle),
+      y: Math.sin(angle),
+    };
+  }
+  
+  /**
+   * Apply movement delta to position.
+   */
+  private applyMovement(pos: KappaCoord, dir: { x: number; y: number }, speed: number): KappaCoord {
+    return {
+      x: pos.x + Math.round(dir.x * speed),
+      y: pos.y + Math.round(dir.y * speed),
+      z: pos.z ?? 0,
+    };
+  }
+  
+  /**
+   * Normalize direction vector.
+   */
+  private normalizeDirection(from: KappaCoord, to: KappaCoord): { x: number; y: number } {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    
+    if (len === 0) return { x: 0, y: 0 };
+    
+    return {
+      x: dx / len,
+      y: dy / len,
+    };
+  }
+  
+  /**
+   * Create deterministic RNG for monster behavior.
+   */
+  private createMonsterRng(monster: MonsterEntity, salt: string): SeededARERng {
+    return new SeededARERng(createARESeed([
+      "monster",
+      monster.id,
+      this.worldTick,
+      salt,
+      monster.dropTableSeed,
+    ]));
+  }
+  
+  /**
+   * Hash entity ID to number for seeding.
+   */
+  private hashEntityId(id: string): number {
+    let hash = 0;
+    for (let i = 0; i < id.length; i++) {
+      hash = ((hash << 5) - hash) + id.charCodeAt(i);
+      hash = hash & hash;
+    }
+    return Math.abs(hash);
+  }
+}
+
+// ─── Result Types ──────────────────────────────────────────────────────────────
+
+export type MonsterTickResult =
+  | { type: "move"; monsterId: string; position: KappaCoord }
+  | { type: "despawn"; monsterId: string }
+  | { type: "death"; monsterId: string; position: KappaCoord; dropTableSeed: number };
+
+// ─── Singleton Export ──────────────────────────────────────────────────────────
+
+export const monsterDirector = new MonsterDirector();

--- a/server/src/modules/combat/CombatDirector.ts
+++ b/server/src/modules/combat/CombatDirector.ts
@@ -1,0 +1,452 @@
+/**
+ * Ouroboros CombatDirector — RuneScape-Style Combat XP System
+ * 
+ * ARCHITECTURE (Server Authority):
+ * - All combat calculations are server-authoritative
+ * - XP is granted per combat tick (Hit/Miss/Defend), NOT on kill
+ * - XP type derived deterministically from equipped ItemSignature
+ * - Async `xp_gained` events sent to client for visual feedback
+ * 
+ * RUNESCAPE XP LOGIC:
+ * - Attack XP: Based on weapon base (sword_mastery, blunt_force, archery)
+ * - Defense XP: Based on armor piece (heavy_armor, evasion)
+ * - XP formula: hitDamage * skillMultiplier * tierBonus
+ * 
+ * SECURITY (Exploit Prevention):
+ * - Equipment validated server-side — client cannot spoof weapon stats
+ * - XP amounts are deterministic — verifiable by ARE invariant guard
+ * - No client-side XP calculation or manipulation possible
+ */
+
+import { parseItemSignature, type ParsedSignature, type ModularItem } from "@wasd/shared/items/itemSignature.js";
+import { type EquipmentState } from "@wasd/shared/items/types.js";
+import { type FxKind } from "./types.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface XPGainEvent {
+  playerId: string;
+  skillId: string;
+  amount: number;
+  source: "attack" | "defend" | "kill" | "quest";
+  itemSignature?: string;
+  tick: number;
+}
+
+export interface CombatXPResult {
+  attackXP: number;
+  defendXP: number;
+  attackSkill: string;
+  defendSkill: string;
+  xpEvents: XPGainEvent[];
+}
+
+export interface CombatTickInput {
+  attackerId: string;
+  defenderId: string;
+  attackerEquipment: EquipmentState;
+  defenderEquipment: EquipmentState;
+  hit: boolean;
+  damage: number;
+  crit: boolean;
+  isDefender: boolean;  // true if this player is being attacked
+}
+
+// ─── XP Constants ─────────────────────────────────────────────────────────────
+
+const XP_MULTIPLIER = 0.5;      // Base XP per damage point
+const CRIT_BONUS = 1.5;          // 50% bonus XP on crits
+const MISS_PENALTY = 0.1;       // Small XP for attempting (encourages learning)
+
+const SKILL_XP_MULTIPLIERS: Record<string, number> = {
+  // Attack skills
+  sword_mastery: 1.0,   // Standard swords
+  blunt_force: 1.1,      // Axes and maces hit harder
+  archery: 0.9,          // Ranged is slightly safer
+  
+  // Defense skills
+  heavy_armor: 1.0,      // Standard armor
+  evasion: 1.05,         // Dodge-based defense (slightly more XP for timing)
+  shield_wall: 1.2,      // Shield blocking is very effective
+  
+  // Generic fallback
+  combat: 0.8,
+};
+
+// ─── Weapon Base → Skill Mapping ──────────────────────────────────────────────
+
+const BLADE_TO_SKILL: Record<string, string> = {
+  blade_1: "sword_mastery",  // Dagger
+  blade_2: "sword_mastery",  // Shortsword
+  blade_3: "sword_mastery",  // Longsword
+  blade_4: "sword_mastery",   // Broadsword
+  blade_5: "sword_mastery",   // Greatsword
+  blade_6: "sword_mastery",   // Claymore
+  blade_7: "sword_mastery",   // Flamberge
+  blade_8: "sword_mastery",   // Zweihander
+  
+  axe_1: "blunt_force",
+  axe_2: "blunt_force",
+  axe_3: "blunt_force",
+  axe_4: "blunt_force",
+  axe_5: "blunt_force",
+  axe_6: "blunt_force",
+  axe_7: "blunt_force",
+  axe_8: "blunt_force",
+  
+  mace_1: "blunt_force",
+  mace_2: "blunt_force",
+  mace_3: "blunt_force",
+  mace_4: "blunt_force",
+  mace_5: "blunt_force",
+  mace_6: "blunt_force",
+  mace_7: "blunt_force",
+  mace_8: "blunt_force",
+  
+  spear_1: "sword_mastery",
+  spear_2: "sword_mastery",
+  spear_3: "sword_mastery",
+  spear_4: "sword_mastery",
+  spear_5: "sword_mastery",
+  spear_6: "sword_mastery",
+  spear_7: "sword_mastery",
+  spear_8: "sword_mastery",
+  
+  bow_1: "archery",
+  bow_2: "archery",
+  bow_3: "archery",
+  bow_4: "archery",
+  bow_5: "archery",
+  bow_6: "archery",
+  bow_7: "archery",
+  bow_8: "archery",
+};
+
+// ─── Armor Base → Skill Mapping ───────────────────────────────────────────────
+
+const CHEST_TO_SKILL: Record<string, string> = {
+  chest_1: "evasion",        // Leather Vest — light armor
+  chest_2: "evasion",         // Chain Mail — medium
+  chest_3: "evasion",         // Scale Mail — medium
+  chest_4: "heavy_armor",     // Plate Armor — heavy
+  chest_5: "heavy_armor",     // Reinforced Plate — heavy
+  chest_6: "heavy_armor",     // Dragon Scale — heavy
+  chest_7: "heavy_armor",     // Mythril Plate — heavy
+  chest_8: "heavy_armor",     // Adamantine Guard — heavy
+};
+
+// ─── Material Tier Bonus ───────────────────────────────────────────────────────
+
+const MATERIAL_TIER_BONUS: Record<string, number> = {
+  material_iron: 1.0,
+  material_steel: 1.1,
+  material_silver: 1.15,
+  material_mithril: 1.25,
+  material_adamantine: 1.35,
+  material_orichalcum: 1.5,
+  material_dragon_scale: 1.6,
+  material_star_metal: 1.75,
+};
+
+// ─── CombatDirector ────────────────────────────────────────────────────────────
+
+export class CombatDirector {
+  private worldTick = 0;
+  private pendingXPevents: XPGainEvent[] = [];
+  
+  constructor() {}
+  
+  /**
+   * Sync world tick for deterministic XP calculation.
+   */
+  public setTick(tick: number): void {
+    this.worldTick = tick;
+  }
+  
+  /**
+   * Drain all pending XP events (called by WorldTick to broadcast).
+   */
+  public drainXPevents(): XPGainEvent[] {
+    const events = this.pendingXPevents;
+    this.pendingXPevents = [];
+    return events;
+  }
+  
+  /**
+   * Calculate XP gain for an attack action.
+   * Called by CombatService when resolving combat.
+   */
+  public calculateAttackXP(
+    playerId: string,
+    equipment: EquipmentState,
+    hit: boolean,
+    damage: number,
+    crit: boolean
+  ): XPGainEvent[] {
+    const events: XPGainEvent[] = [];
+    
+    // Get weapon from MAIN_HAND slot
+    const weapon = equipment.MAIN_HAND;
+    
+    if (!weapon) {
+      // Bare-handed — generic combat XP
+      events.push(this.createXPEvent(
+        playerId,
+        "combat",
+        hit ? damage * XP_MULTIPLIER : damage * MISS_PENALTY,
+        "attack"
+      ));
+      return events;
+    }
+    
+    // Parse weapon signature
+    const parsed = parseItemSignature(weapon.signature);
+    const weaponSkill = this.deriveWeaponSkill(parsed);
+    const tierBonus = this.deriveMaterialTierBonus(parsed);
+    
+    // Calculate attack XP
+    let xpAmount = damage * XP_MULTIPLIER;
+    
+    if (crit) {
+      xpAmount *= CRIT_BONUS;
+    } else if (!hit) {
+      xpAmount *= MISS_PENALTY;
+    }
+    
+    // Apply skill and tier bonuses
+    const skillMultiplier = SKILL_XP_MULTIPLIERS[weaponSkill] ?? 1.0;
+    xpAmount *= skillMultiplier * tierBonus;
+    
+    events.push(this.createXPEvent(
+      playerId,
+      weaponSkill,
+      Math.floor(xpAmount),
+      "attack",
+      weapon.signature
+    ));
+    
+    return events;
+  }
+  
+  /**
+   * Calculate XP gain for defending against an attack.
+   * Called when a player takes damage (successfully blocked or got hit).
+   */
+  public calculateDefendXP(
+    playerId: string,
+    equipment: EquipmentState,
+    hit: boolean,
+    damage: number
+  ): XPGainEvent[] {
+    const events: XPGainEvent[] = [];
+    
+    // Get chest armor for defense skill
+    const armor = equipment.CHEST;
+    
+    if (!armor) {
+      // No armor — generic evasion
+      events.push(this.createXPEvent(
+        playerId,
+        "evasion",
+        hit ? damage * XP_MULTIPLIER * 0.5 : damage * XP_MULTIPLIER * 0.3,
+        "defend"
+      ));
+      return events;
+    }
+    
+    // Parse armor signature
+    const parsed = parseItemSignature(armor.signature);
+    const defendSkill = this.deriveArmorSkill(parsed);
+    const tierBonus = this.deriveMaterialTierBonus(parsed);
+    
+    // Defense XP is lower than attack XP (surviving vs winning)
+    // But successful blocks (miss = hit for player) get bonus
+    let xpAmount = damage * XP_MULTIPLIER * 0.7;
+    
+    if (!hit) {
+      // Successfully dodged/blocked — bonus XP
+      xpAmount *= 1.5;
+    }
+    
+    // Apply skill and tier bonuses
+    const skillMultiplier = SKILL_XP_MULTIPLIERS[defendSkill] ?? 1.0;
+    xpAmount *= skillMultiplier * tierBonus;
+    
+    events.push(this.createXPEvent(
+      playerId,
+      defendSkill,
+      Math.floor(xpAmount),
+      "defend",
+      armor.signature
+    ));
+    
+    return events;
+  }
+  
+  /**
+   * Process a combat tick and return XP results.
+   * This is the main entry point called by CombatService.
+   */
+  public processCombatTick(input: CombatTickInput): CombatXPResult {
+    const attackXP = input.isDefender ? 0 : this.calculateAttackXP(
+      input.attackerId,
+      input.attackerEquipment,
+      input.hit,
+      input.damage,
+      input.crit
+    );
+    
+    const defendXP = this.calculateDefendXP(
+      input.defenderId,
+      input.defenderEquipment,
+      input.hit,
+      input.damage
+    );
+    
+    // Merge all events
+    const allEvents = [...attackXP, ...defendXP];
+    
+    // Queue for broadcast
+    this.pendingXPevents.push(...allEvents);
+    
+    // Return structured result for FX manager
+    const attackEvent = attackXP[0];
+    const defendEvent = defendXP[0];
+    
+    return {
+      attackXP: attackEvent?.amount ?? 0,
+      defendXP: defendEvent?.amount ?? 0,
+      attackSkill: attackEvent?.skillId ?? "combat",
+      defendSkill: defendEvent?.skillId ?? "evasion",
+      xpEvents: allEvents,
+    };
+  }
+  
+  /**
+   * Grant bonus XP for a kill (quest, achievement, etc.)
+   */
+  public grantKillXP(playerId: string, baseXP: number, source: "quest" | "achievement" = "quest"): XPGainEvent[] {
+    const events: XPGainEvent[] = [];
+    
+    // Kill XP goes to primary combat skill
+    events.push(this.createXPEvent(
+      playerId,
+      "sword_mastery",
+      Math.floor(baseXP),
+      "kill"
+    ));
+    
+    this.pendingXPevents.push(...events);
+    return events;
+  }
+  
+  // ─── Private Helper Methods ──────────────────────────────────────────────────
+  
+  /**
+   * Derive the attack skill from weapon base component.
+   */
+  private deriveWeaponSkill(parsed: ParsedSignature): string {
+    const baseId = parsed.base.id;
+    
+    // Try exact match first
+    if (BLADE_TO_SKILL[baseId]) {
+      return BLADE_TO_SKILL[baseId];
+    }
+    
+    // Fallback: check prefix for weapon type hints
+    // e.g., "prefix_shadow" might imply dagger
+    if (baseId.startsWith("blade_")) {
+      return "sword_mastery";
+    }
+    if (baseId.startsWith("axe_")) {
+      return "blunt_force";
+    }
+    if (baseId.startsWith("mace_")) {
+      return "blunt_force";
+    }
+    if (baseId.startsWith("spear_")) {
+      return "sword_mastery";
+    }
+    if (baseId.startsWith("bow_")) {
+      return "archery";
+    }
+    
+    // Default fallback
+    return "combat";
+  }
+  
+  /**
+   * Derive the defense skill from armor base component.
+   */
+  private deriveArmorSkill(parsed: ParsedSignature): string {
+    const baseId = parsed.base.id;
+    
+    // Try exact match first
+    if (CHEST_TO_SKILL[baseId]) {
+      return CHEST_TO_SKILL[baseId];
+    }
+    
+    // Fallback based on material tier (higher tier = heavier armor)
+    const tier = this.deriveMaterialTier(parsed);
+    if (tier >= 5) {
+      return "heavy_armor";
+    }
+    
+    return "evasion";
+  }
+  
+  /**
+   * Derive material tier (1-8) from parsed signature.
+   */
+  private deriveMaterialTier(parsed: ParsedSignature): number {
+    const matId = parsed.material;
+    const tierMatch = matId.match(/material_(?:iron|steel|silver|mithril|adamantine|orichalcum|dragon_scale|star_metal)/);
+    
+    if (!tierMatch) return 1;
+    
+    const tierMap: Record<string, number> = {
+      material_iron: 1,
+      material_steel: 2,
+      material_silver: 3,
+      material_mithril: 4,
+      material_adamantine: 5,
+      material_orichalcum: 6,
+      material_dragon_scale: 7,
+      material_star_metal: 8,
+    };
+    
+    return tierMap[tierMatch[0]] ?? 1;
+  }
+  
+  /**
+   * Calculate material tier bonus multiplier.
+   */
+  private deriveMaterialTierBonus(parsed: ParsedSignature): number {
+    const tier = this.deriveMaterialTier(parsed);
+    return MATERIAL_TIER_BONUS[`material_tier_${tier}`] ?? (tier * 0.1 + 0.9);
+  }
+  
+  /**
+   * Create an XP gain event.
+   */
+  private createXPEvent(
+    playerId: string,
+    skillId: string,
+    amount: number,
+    source: "attack" | "defend" | "kill" | "quest",
+    itemSignature?: string
+  ): XPGainEvent {
+    return {
+      playerId,
+      skillId,
+      amount: Math.max(0, Math.floor(amount)),
+      source,
+      itemSignature,
+      tick: this.worldTick,
+    };
+  }
+}
+
+// ─── Singleton Export ──────────────────────────────────────────────────────────
+
+export const combatDirector = new CombatDirector();

--- a/server/src/modules/combat/CombatDirector.ts
+++ b/server/src/modules/combat/CombatDirector.ts
@@ -18,9 +18,9 @@
  * - No client-side XP calculation or manipulation possible
  */
 
-import { parseItemSignature, type ParsedSignature, type ModularItem } from "@wasd/shared/items/itemSignature.js";
-import { type EquipmentState } from "@wasd/shared/items/types.js";
-import { type FxKind } from "./types.js";
+import { parseItemSignature, type ParsedSignature, buildModularItem, type EquipmentState } from "@wasd/shared";
+import { MODULAR_COMPONENT_POOLS, type ItemSignature } from "@wasd/shared";
+import { type FxKind } from "./CombatSystem.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -288,7 +288,7 @@ export class CombatDirector {
    * This is the main entry point called by CombatService.
    */
   public processCombatTick(input: CombatTickInput): CombatXPResult {
-    const attackXP = input.isDefender ? 0 : this.calculateAttackXP(
+    const attackXP = this.calculateAttackXP(
       input.attackerId,
       input.attackerEquipment,
       input.hit,
@@ -304,7 +304,7 @@ export class CombatDirector {
     );
     
     // Merge all events
-    const allEvents = [...attackXP, ...defendXP];
+    const allEvents: XPGainEvent[] = [...attackXP, ...defendXP];
     
     // Queue for broadcast
     this.pendingXPevents.push(...allEvents);

--- a/server/src/modules/world/LootDirector.ts
+++ b/server/src/modules/world/LootDirector.ts
@@ -21,8 +21,7 @@
  */
 
 import { createARESeed, SeededARERng } from "../../core/determinism/AREDeterminism.js";
-import { MODULAR_COMPONENT_POOLS, type ItemSignature } from "@wasd/shared/items/types.js";
-import { forgeSignature, buildModularItem, type ModularItem } from "@wasd/shared/items/itemSignature.js";
+import { MODULAR_COMPONENT_POOLS, type ItemSignature, forgeSignature, buildModularItem } from "@wasd/shared";
 import { inventoryDirector } from "../inventory/InventoryDirector.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -461,21 +460,21 @@ export class LootDirector {
     let hiltIdx: number, materialIdx: number, prefixIdx: number, suffixIdx: number, runeIdx: number;
     
     if (isWeapon) {
-      hiltIdx = Math.abs(rng.nextInt()) % MODULAR_COMPONENT_POOLS.hilts.length;
-      materialIdx = Math.abs(rng.nextInt() >> 4) % MODULAR_COMPONENT_POOLS.materials.length;
+      hiltIdx = Math.abs(rng.nextInt(1000000)) % MODULAR_COMPONENT_POOLS.hilts.length;
+      materialIdx = Math.abs(rng.nextInt(1000000) >> 4) % MODULAR_COMPONENT_POOLS.materials.length;
       
       // Prefix/suffix/rune are rarer
-      prefixIdx = Math.abs(rng.nextInt() >> 8) % MODULAR_COMPONENT_POOLS.prefixes.length;
-      suffixIdx = Math.abs(rng.nextInt() >> 12) % MODULAR_COMPONENT_POOLS.suffixes.length;
-      runeIdx = Math.abs(rng.nextInt() >> 16) % MODULAR_COMPONENT_POOLS.runes.length;
+      prefixIdx = Math.abs(rng.nextInt(1000000) >> 8) % MODULAR_COMPONENT_POOLS.prefixes.length;
+      suffixIdx = Math.abs(rng.nextInt(1000000) >> 12) % MODULAR_COMPONENT_POOLS.suffixes.length;
+      runeIdx = Math.abs(rng.nextInt(1000000) >> 16) % MODULAR_COMPONENT_POOLS.runes.length;
     } else {
       // Armor — no hilt
       hiltIdx = -1;
-      materialIdx = Math.abs(rng.nextInt()) % MODULAR_COMPONENT_POOLS.materials.length;
+      materialIdx = Math.abs(rng.nextInt(1000000)) % MODULAR_COMPONENT_POOLS.materials.length;
       
-      prefixIdx = Math.abs(rng.nextInt() >> 8) % MODULAR_COMPONENT_POOLS.prefixes.length;
-      suffixIdx = Math.abs(rng.nextInt() >> 12) % MODULAR_COMPONENT_POOLS.suffixes.length;
-      runeIdx = Math.abs(rng.nextInt() >> 16) % MODULAR_COMPONENT_POOLS.runes.length;
+      prefixIdx = Math.abs(rng.nextInt(1000000) >> 8) % MODULAR_COMPONENT_POOLS.prefixes.length;
+      suffixIdx = Math.abs(rng.nextInt(1000000) >> 12) % MODULAR_COMPONENT_POOLS.suffixes.length;
+      runeIdx = Math.abs(rng.nextInt(1000000) >> 16) % MODULAR_COMPONENT_POOLS.runes.length;
     }
     
     // 20% chance for prefix, 15% for suffix, 10% for rune

--- a/server/src/modules/world/LootDirector.ts
+++ b/server/src/modules/world/LootDirector.ts
@@ -1,0 +1,533 @@
+/**
+ * Ouroboros LootDirector — KAPPA Grid Loot System
+ * 
+ * ARCHITECTURE (Stateless Determinism + Conservation Axiom):
+ * - Loot is a physical world entity (type: 'LOOT')
+ * - Loot generated deterministically from monster's SeededARERng
+ * - 0-3 items per monster death based on monster tier
+ * - Loot persists for ELECTROWEAK_LOOT_TTL_TICKS then decays
+ * 
+ * KAPPA GRID CONSERVATION (Anti-Exploit):
+ * - Loot position = monster's current KAPPA position at death
+ * - LootEntity stored in WorldTick.lootEntities Map
+ * - Simultaneous pickup: first-click-wins, second gets REJECT
+ * - No duplication possible — loot is removed atomically on pickup
+ * 
+ * SECURITY (Server Authority):
+ * - Drop tables are server-side only
+ * - Loot generation uses deterministic signature from world tick + monster seed
+ * - Client cannot spawn, move, or duplicate loot entities
+ * - Distance check enforced before pickup (prevents teleporting loot)
+ */
+
+import { createARESeed, SeededARERng } from "../../core/determinism/AREDeterminism.js";
+import { MODULAR_COMPONENT_POOLS, type ItemSignature } from "@wasd/shared/items/types.js";
+import { forgeSignature, buildModularItem, type ModularItem } from "@wasd/shared/items/itemSignature.js";
+import { inventoryDirector } from "../inventory/InventoryDirector.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface KappaCoord {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface LootEntity {
+  id: string;
+  type: "LOOT";
+  position: KappaCoord;
+  itemSignature: ItemSignature;
+  itemName: string;
+  rarity: string;
+  ilvl: number;
+  visualId: string;
+  gold: number;
+  ownerId?: string;      // Player who killed the monster
+  spawnedAtTick: number;
+  despawnAtTick: number;
+}
+
+export interface DropTableEntry {
+  itemId: string;        // e.g., "blade_3" or "chest_5"
+  weight: number;        // Higher = more likely
+  minTier: number;       // Minimum monster tier to drop this
+  unique?: boolean;       // Guaranteed drop (if tier met)
+}
+
+export interface MonsterDropConfig {
+  minDrops: number;      // Minimum items (0-3 typical)
+  maxDrops: number;      // Maximum items
+  goldMin: number;       // Minimum gold drop
+  goldMax: number;       // Maximum gold drop
+  dropTable: DropTableEntry[];
+}
+
+// ─── Drop Tables ──────────────────────────────────────────────────────────────
+
+const COMMON_MONSTER_DROPS: MonsterDropConfig = {
+  minDrops: 0,
+  maxDrops: 2,
+  goldMin: 5,
+  goldMax: 25,
+  dropTable: [
+    // Common weapons
+    { itemId: "blade_1", weight: 30, minTier: 0 },
+    { itemId: "blade_2", weight: 25, minTier: 0 },
+    { itemId: "hilt_1", weight: 40, minTier: 0 },
+    { itemId: "hilt_2", weight: 35, minTier: 0 },
+    // Common materials
+    { itemId: "material_iron", weight: 50, minTier: 0 },
+    { itemId: "material_steel", weight: 20, minTier: 1 },
+    { itemId: "material_silver", weight: 10, minTier: 2 },
+    // Prefix/suffix (rare common drops)
+    { itemId: "prefix_vorpal", weight: 5, minTier: 1 },
+    { itemId: "suffix_bane", weight: 5, minTier: 1 },
+  ],
+};
+
+const RARE_MONSTER_DROPS: MonsterDropConfig = {
+  minDrops: 1,
+  maxDrops: 3,
+  goldMin: 20,
+  goldMax: 75,
+  dropTable: [
+    // Better weapons
+    { itemId: "blade_3", weight: 25, minTier: 0 },
+    { itemId: "blade_4", weight: 20, minTier: 1 },
+    { itemId: "blade_5", weight: 15, minTier: 2 },
+    { itemId: "blade_6", weight: 10, minTier: 3 },
+    // Armor
+    { itemId: "chest_1", weight: 30, minTier: 0 },
+    { itemId: "chest_2", weight: 25, minTier: 1 },
+    { itemId: "chest_3", weight: 20, minTier: 2 },
+    // Better materials
+    { itemId: "material_steel", weight: 40, minTier: 0 },
+    { itemId: "material_silver", weight: 30, minTier: 1 },
+    { itemId: "material_mithril", weight: 15, minTier: 2 },
+    // Prefixes/suffixes
+    { itemId: "prefix_swift", weight: 10, minTier: 1 },
+    { itemId: "prefix_brutal", weight: 10, minTier: 1 },
+    { itemId: "suffix_wrath", weight: 8, minTier: 2 },
+    { itemId: "suffix_doom", weight: 5, minTier: 3 },
+    // Runes
+    { itemId: "rune_fire", weight: 5, minTier: 2 },
+    { itemId: "rune_ice", weight: 5, minTier: 2 },
+  ],
+};
+
+const ELITE_MONSTER_DROPS: MonsterDropConfig = {
+  minDrops: 2,
+  maxDrops: 4,
+  goldMin: 50,
+  goldMax: 150,
+  dropTable: [
+    // High-tier weapons
+    { itemId: "blade_5", weight: 25, minTier: 0 },
+    { itemId: "blade_6", weight: 20, minTier: 1 },
+    { itemId: "blade_7", weight: 15, minTier: 2 },
+    { itemId: "blade_8", weight: 10, minTier: 3 },
+    // High-tier armor
+    { itemId: "chest_4", weight: 25, minTier: 0 },
+    { itemId: "chest_5", weight: 20, minTier: 1 },
+    { itemId: "chest_6", weight: 15, minTier: 2 },
+    { itemId: "chest_7", weight: 10, minTier: 3 },
+    // Rare materials
+    { itemId: "material_mithril", weight: 40, minTier: 0 },
+    { itemId: "material_adamantine", weight: 25, minTier: 1 },
+    { itemId: "material_orichalcum", weight: 10, minTier: 2 },
+    { itemId: "material_dragon_scale", weight: 5, minTier: 3 },
+    // Rare prefixes
+    { itemId: "prefix_cursed", weight: 10, minTier: 1 },
+    { itemId: "prefix_holy", weight: 10, minTier: 1 },
+    { itemId: "prefix_arcane", weight: 8, minTier: 2 },
+    { itemId: "prefix_shadow", weight: 8, minTier: 2 },
+    { itemId: "prefix_frost", weight: 8, minTier: 2 },
+    // Rare suffixes
+    { itemId: "suffix_fury", weight: 10, minTier: 1 },
+    { itemId: "suffix_destr", weight: 8, minTier: 2 },
+    { itemId: "suffix_judgment", weight: 5, minTier: 3 },
+    { itemId: "suffix_ruin", weight: 5, minTier: 3 },
+    // Runes (more common for elites)
+    { itemId: "rune_fire", weight: 15, minTier: 0 },
+    { itemId: "rune_ice", weight: 15, minTier: 0 },
+    { itemId: "rune_lightning", weight: 10, minTier: 1 },
+    { itemId: "rune_poison", weight: 10, minTier: 1 },
+    { itemId: "rune_void", weight: 5, minTier: 2 },
+    { itemId: "rune_holy", weight: 5, minTier: 2 },
+    { itemId: "rune_shadow", weight: 5, minTier: 2 },
+    { itemId: "rune_nature", weight: 5, minTier: 2 },
+  ],
+};
+
+// ─── LootDirector ─────────────────────────────────────────────────────────────
+
+export class LootDirector {
+  private lootEntities: Map<string, LootEntity> = new Map();
+  private worldTick = 0;
+  private lootIdCounter = 0;
+  
+  // Loot TTL — matches electroweak pruning
+  private readonly LOOT_TTL_TICKS = 1200;  // 2 minutes at 10Hz
+  
+  // Drop table tier thresholds
+  private readonly ELITE_TIER_THRESHOLD = 10;  // monster level >= 10 = elite drops
+  private readonly RARE_TIER_THRESHOLD = 5;    // monster level >= 5 = rare drops
+  
+  constructor() {}
+  
+  /**
+   * Sync world tick for deterministic loot generation.
+   */
+  public setTick(tick: number): void {
+    this.worldTick = tick;
+  }
+  
+  /**
+   * Get all active loot entities.
+   */
+  public getAllLoot(): LootEntity[] {
+    return Array.from(this.lootEntities.values());
+  }
+  
+  /**
+   * Get loot entity by ID.
+   */
+  public getLoot(id: string): LootEntity | undefined {
+    return this.lootEntities.get(id);
+  }
+  
+  /**
+   * Check if loot exists.
+   */
+  public hasLoot(id: string): boolean {
+    return this.lootEntities.has(id);
+  }
+  
+  /**
+   * Generate loot drops for a dead monster.
+   * Returns array of LootEntity to be added to world.
+   * 
+   * SECURITY: Deterministic — same monster/tick = same loot.
+   */
+  public generateDeathDrops(
+    monsterId: string,
+    monsterLevel: number,
+    position: KappaCoord,
+    ownerId?: string,
+    dropTableSeed?: number
+  ): LootEntity[] {
+    // Select appropriate drop table based on monster level
+    let dropConfig: MonsterDropConfig;
+    if (monsterLevel >= this.ELITE_TIER_THRESHOLD) {
+      dropConfig = ELITE_MONSTER_DROPS;
+    } else if (monsterLevel >= this.RARE_TIER_THRESHOLD) {
+      dropConfig = RARE_MONSTER_DROPS;
+    } else {
+      dropConfig = COMMON_MONSTER_DROPS;
+    }
+    
+    // Create deterministic RNG from monster identity + world tick
+    const rng = this.createLootRng(monsterId, dropTableSeed ?? 0);
+    
+    // Determine number of drops
+    const numDrops = dropConfig.minDrops + Math.floor(rng.nextFloat() * (dropConfig.maxDrops - dropConfig.minDrops + 1));
+    
+    // Generate drops
+    const lootItems: LootEntity[] = [];
+    
+    for (let i = 0; i < numDrops; i++) {
+      // Select random item from weighted drop table
+      const selectedEntry = this.selectWeightedDrop(dropConfig.dropTable, monsterLevel, rng);
+      
+      if (selectedEntry) {
+        // Build the item signature
+        const signature = this.buildItemSignature(selectedEntry.itemId, rng, i);
+        const item = buildModularItem(signature, this.deriveIlvl(monsterLevel, selectedEntry.minTier));
+        
+        const lootId = `loot:${monsterId}:${this.worldTick}:${i}:${this.lootIdCounter++}`;
+        
+        const lootEntity: LootEntity = {
+          id: lootId,
+          type: "LOOT",
+          position: { ...position },
+          itemSignature: signature,
+          itemName: item.name,
+          rarity: item.rarity,
+          ilvl: item.ilvl,
+          visualId: item.visualId,
+          gold: 0,  // Gold handled separately
+          ownerId,
+          spawnedAtTick: this.worldTick,
+          despawnAtTick: this.worldTick + this.LOOT_TTL_TICKS,
+        };
+        
+        lootItems.push(lootEntity);
+        this.lootEntities.set(lootId, lootEntity);
+      }
+    }
+    
+    // Generate gold
+    if (dropConfig.goldMin > 0 || dropConfig.goldMax > 0) {
+      const goldAmount = Math.floor(dropConfig.goldMin + rng.nextFloat() * (dropConfig.goldMax - dropConfig.goldMin));
+      
+      if (goldAmount > 0) {
+        const goldLootId = `gold:${monsterId}:${this.worldTick}:${this.lootIdCounter++}`;
+        
+        const goldLoot: LootEntity = {
+          id: goldLootId,
+          type: "LOOT",
+          position: { ...position },
+          itemSignature: "gold:currency",
+          itemName: `${goldAmount} Gold`,
+          rarity: "common",
+          ilvl: 0,
+          visualId: "gold_pile",
+          gold: goldAmount,
+          ownerId,
+          spawnedAtTick: this.worldTick,
+          despawnAtTick: this.worldTick + this.LOOT_TTL_TICKS,
+        };
+        
+        lootItems.push(goldLoot);
+        this.lootEntities.set(goldLootId, goldLoot);
+      }
+    }
+    
+    return lootItems;
+  }
+  
+  /**
+   * Attempt to pick up loot for a player.
+   * Returns success/failure with details.
+   * 
+   * KAPPA GRID CONSERVATION: First-click wins, second gets REJECT.
+   */
+  public attemptPickup(
+    lootId: string,
+    playerId: string,
+    playerPosition: KappaCoord,
+    inventoryCapacity: number,
+    maxWeight: number,
+    currentWeight: number
+  ): PickupResult {
+    const loot = this.lootEntities.get(lootId);
+    
+    if (!loot) {
+      return {
+        success: false,
+        code: "LOOT_NOT_FOUND",
+        message: "Loot entity does not exist or has already been picked up.",
+      };
+    }
+    
+    // Check if loot has expired
+    if (this.worldTick > loot.despawnAtTick) {
+      this.lootEntities.delete(lootId);
+      return {
+        success: false,
+        code: "LOOT_EXPIRED",
+        message: "Loot has expired and despawned.",
+      };
+    }
+    
+    // Check distance (must be within pickup range)
+    const distance = this.kappaDistance(playerPosition, loot.position);
+    const PICKUP_RANGE = 2000;  // 2 kappa-meters
+    
+    if (distance > PICKUP_RANGE) {
+      return {
+        success: false,
+        code: "TOO_FAR",
+        message: `Too far from loot (${Math.round(distance)} kappa-meters). Move closer.`,
+      };
+    }
+    
+    // Check inventory weight
+    const itemWeight = Math.max(1, loot.ilvl * 0.5);
+    if (currentWeight + itemWeight > maxWeight) {
+      return {
+        success: false,
+        code: "OVER_WEIGHT",
+        message: "Cannot carry more weight. Free inventory space or unequip items.",
+      };
+    }
+    
+    // Check inventory slots
+    if (inventoryCapacity <= 0) {
+      return {
+        success: false,
+        code: "INVENTORY_FULL",
+        message: "Inventory is full. Free a slot or drop an item.",
+      };
+    }
+    
+    // ATOMIC PICKUP — remove from world, add to inventory
+    this.lootEntities.delete(lootId);
+    
+    return {
+      success: true,
+      lootId,
+      itemSignature: loot.itemSignature,
+      itemName: loot.itemName,
+      rarity: loot.rarity,
+      ilvl: loot.ilvl,
+      gold: loot.gold,
+    };
+  }
+  
+  /**
+   * Remove loot entity manually (admin, etc.)
+   */
+  public removeLoot(lootId: string): boolean {
+    return this.lootEntities.delete(lootId);
+  }
+  
+  /**
+   * Clean up expired loot entities.
+   * Called by WorldTick during electroweak pruning.
+   */
+  public pruneExpiredLoot(): LootEntity[] {
+    const expired: LootEntity[] = [];
+    
+    for (const [id, loot] of this.lootEntities) {
+      if (this.worldTick > loot.despawnAtTick) {
+        expired.push(loot);
+        this.lootEntities.delete(id);
+      }
+    }
+    
+    return expired;
+  }
+  
+  // ─── Private Helper Methods ──────────────────────────────────────────────────
+  
+  /**
+   * Create deterministic RNG for loot generation.
+   */
+  private createLootRng(monsterId: string, dropTableSeed: number): SeededARERng {
+    return new SeededARERng(createARESeed([
+      "loot",
+      monsterId,
+      this.worldTick,
+      dropTableSeed,
+    ]));
+  }
+  
+  /**
+   * Select item from weighted drop table.
+   */
+  private selectWeightedDrop(
+    dropTable: DropTableEntry[],
+    monsterLevel: number,
+    rng: SeededARERng
+  ): DropTableEntry | null {
+    // Filter eligible drops (tier requirement met)
+    const eligible = dropTable.filter(entry => entry.minTier <= monsterLevel);
+    
+    if (eligible.length === 0) return null;
+    
+    // Calculate total weight
+    let totalWeight = 0;
+    for (const entry of eligible) {
+      totalWeight += entry.weight;
+    }
+    
+    // Random selection
+    const roll = rng.nextFloat() * totalWeight;
+    
+    let cumulative = 0;
+    for (const entry of eligible) {
+      cumulative += entry.weight;
+      if (roll <= cumulative) {
+        return entry;
+      }
+    }
+    
+    // Fallback (shouldn't happen)
+    return eligible[eligible.length - 1];
+  }
+  
+  /**
+   * Build item signature from base component ID.
+   */
+  private buildItemSignature(baseId: string, rng: SeededARERng, slotIndex: number): ItemSignature {
+    // Determine component type
+    const isWeapon = baseId.startsWith("blade_") || baseId.startsWith("axe_") || 
+                     baseId.startsWith("mace_") || baseId.startsWith("spear_") ||
+                     baseId.startsWith("bow_");
+    
+    // Select other components deterministically
+    let hiltIdx: number, materialIdx: number, prefixIdx: number, suffixIdx: number, runeIdx: number;
+    
+    if (isWeapon) {
+      hiltIdx = Math.abs(rng.nextInt()) % MODULAR_COMPONENT_POOLS.hilts.length;
+      materialIdx = Math.abs(rng.nextInt() >> 4) % MODULAR_COMPONENT_POOLS.materials.length;
+      
+      // Prefix/suffix/rune are rarer
+      prefixIdx = Math.abs(rng.nextInt() >> 8) % MODULAR_COMPONENT_POOLS.prefixes.length;
+      suffixIdx = Math.abs(rng.nextInt() >> 12) % MODULAR_COMPONENT_POOLS.suffixes.length;
+      runeIdx = Math.abs(rng.nextInt() >> 16) % MODULAR_COMPONENT_POOLS.runes.length;
+    } else {
+      // Armor — no hilt
+      hiltIdx = -1;
+      materialIdx = Math.abs(rng.nextInt()) % MODULAR_COMPONENT_POOLS.materials.length;
+      
+      prefixIdx = Math.abs(rng.nextInt() >> 8) % MODULAR_COMPONENT_POOLS.prefixes.length;
+      suffixIdx = Math.abs(rng.nextInt() >> 12) % MODULAR_COMPONENT_POOLS.suffixes.length;
+      runeIdx = Math.abs(rng.nextInt() >> 16) % MODULAR_COMPONENT_POOLS.runes.length;
+    }
+    
+    // 20% chance for prefix, 15% for suffix, 10% for rune
+    const hasPrefix = rng.nextFloat() < 0.2;
+    const hasSuffix = rng.nextFloat() < 0.15;
+    const hasRune = rng.nextFloat() < 0.1;
+    
+    const components = [
+      `base:${baseId}`,
+      isWeapon ? `hilt:${MODULAR_COMPONENT_POOLS.hilts[hiltIdx]}` : null,
+      `material:${MODULAR_COMPONENT_POOLS.materials[materialIdx]}`,
+      hasPrefix ? `prefix:${MODULAR_COMPONENT_POOLS.prefixes[prefixIdx]}` : null,
+      hasSuffix ? `suffix:${MODULAR_COMPONENT_POOLS.suffixes[suffixIdx]}` : null,
+      hasRune ? `rune:${MODULAR_COMPONENT_POOLS.runes[runeIdx]}` : null,
+    ].filter(Boolean);
+    
+    return components.join("|") as ItemSignature;
+  }
+  
+  /**
+   * Derive item level from monster level and tier requirement.
+   */
+  private deriveIlvl(monsterLevel: number, tierReq: number): number {
+    const base = Math.max(1, monsterLevel - tierReq);
+    return Math.min(60, base * 2 + tierReq);
+  }
+  
+  /**
+   * Calculate KAPPA-distance between two positions.
+   */
+  private kappaDistance(a: KappaCoord, b: KappaCoord): number {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    const dz = (a.z ?? 0) - (b.z ?? 0);
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  }
+}
+
+// ─── Result Types ──────────────────────────────────────────────────────────────
+
+export interface PickupResult {
+  success: boolean;
+  code?: "LOOT_NOT_FOUND" | "LOOT_EXPIRED" | "TOO_FAR" | "OVER_WEIGHT" | "INVENTORY_FULL";
+  message?: string;
+  lootId?: string;
+  itemSignature?: string;
+  itemName?: string;
+  rarity?: string;
+  ilvl?: number;
+  gold?: number;
+}
+
+// ─── Singleton Export ──────────────────────────────────────────────────────────
+
+export const lootDirector = new LootDirector();


### PR DESCRIPTION
## Summary

Implements the core monster AI, RuneScape-style XP system, and KAPPA Grid loot system for the Ouroboros Areloria game engine.

### Architecture: Stateless Determinism

All logic runs server-side in 10-Hz WorldHeartbeat. Client sends Intents only.

### Changes

1. **MonsterDirector** (`server/src/modules/ai/MonsterDirector.ts`)
   - State machine: `IDLE → WANDER → PURSUE → ATTACK → DEAD`
   - Habitat-KAPPA-Mathematik for movement bounds (max distance from spawn)
   - Deterministic aggro detection with stealth penalties
   - Secure: No client-side AI possible

2. **CombatDirector** (`server/src/modules/combat/CombatDirector.ts`)
   - RuneScape-style XP gain per combat tick (not on kill)
   - Attack XP: Derived from `ItemSignature` of equipped weapon
   - Defense XP: Derived from `CHEST` armor piece
   - Async `xp_gained` events for client FX feedback

3. **LootDirector** (`server/src/modules/world/LootDirector.ts`)
   - Deterministic drop generation via `SeededARERng`
   - 0-3 items per monster death based on tier
   - KAPPA Grid Conservation: No dupes on simultaneous pickup
   - First-click-wins atomic pickup logic

4. **LootRenderer** (`apps/client-2d/src/loot/LootRenderer.ts`)
   - Renders loot entities from server broadcast
   - Fat-Finger-Padding (48px hit area) for touch safety
   - Item icon derived from `ItemSignature`

### Exploit Prevention

| Threat | Mitigation |
|--------|------------|
| Aggro hacking | Server-determined state, client cannot force targets |
| XP duplication | Deterministic, ARE-guard verifiable |
| Loot duplication | Atomic pickup with Map.delete |
| Teleport loot | Distance check (2000 kappa-meters) before pickup |

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1b9a99d4-43c3-49f8-892d-6d2a046b1a05)