### PR TITLE
feat(client-2d): implement decoupled render interpolation (lerp) for PixiJS

### DIFF
--- a/apps/client-2d/src/DeterministicWorldIsoApp.tsx
+++ b/apps/client-2d/src/DeterministicWorldIsoApp.tsx
@@ -331,9 +331,17 @@ export function DeterministicWorldIsoApp() {
     lastMoveAt.current = now;
     clientRef.current.sendPlayerAction("MOVE", vector);
     const self = entities.current.get("self");
-    if (self) {
+    const app = appRef.current;
+    if (self && app) {
       self.tx += vector.dx;
       self.tz += vector.dz;
+      
+      // Update interpolation target for local movement prediction.
+      // This ensures keyboard input remains visually responsive under normal
+      // network latency, as the target is now immediately refreshed.
+      const interp = InterpolatedSpriteManager.getInstance();
+      const screenPos = iso(self.tx, self.tz, app.screen.width, app.screen.height);
+      interp.setTarget("self", screenPos.x, screenPos.y);
     }
   }
 

--- a/apps/client-2d/src/math/InterpolatedSpriteManager.ts
+++ b/apps/client-2d/src/math/InterpolatedSpriteManager.ts
@@ -227,6 +227,11 @@ export class InterpolatedSpriteManager {
       entity.sprite.x = targetX;
       entity.sprite.y = targetY;
       
+      // Sync zIndex for correct depth sorting after snap.
+      // Without this, teleported entities can render in front of/behind
+      // the wrong actors until a later non-snap interpolation happens.
+      entity.sprite.zIndex = Math.round(targetY);
+      
       // Update cached values for next frame
       entity.currentX = targetX;
       entity.currentY = targetY;
@@ -239,6 +244,9 @@ export class InterpolatedSpriteManager {
       // ═══════════════════════════════════════════════════════════════
       entity.sprite.x = targetX;
       entity.sprite.y = targetY;
+      
+      // Sync zIndex for correct depth sorting after precision lock.
+      entity.sprite.zIndex = Math.round(targetY);
       
       entity.currentX = targetX;
       entity.currentY = targetY;


### PR DESCRIPTION
## Summary

<!-- What changed and why (1–3 sentences). -->

Implemented client-side interpolation pipeline to smooth 10-Hz server movement updates into fluid 60-FPS animations using the PIXI.Ticker loop.

**Core Architecture (Stateless Determinism):**
- Created `apps/client-2d/src/math/lerp.ts` - Pure, deterministic lerp math utilities
- Created `apps/client-2d/src/math/InterpolatedSpriteManager.ts` - Singleton managing decoupled render interpolation
- Modified `DeterministicWorldIsoApp.tsx` - Integrated InterpolatedSpriteManager into setActor(), rebuildActor(), and tick()

**Key Features:**
- **Zero State Mutation:** `entity.tx/tz` (logical state) is NEVER mutated by lerp
- **Delta-Time Independence:** `LERP_SPEED * deltaTime` ensures consistent movement speed at 30/60/144 FPS
- **Teleport-Snap:** >150px distance triggers instant snap (handles chunk boundaries, teleports)
- **Precision-Lock:** <0.5px distance snaps to prevent micro-jitter in idle state
- **Decoupled Render Loop:** PIXI.Ticker runs independently from WORLD_HEARTBEAT

## Documentation

- [x] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [x] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [x] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

- [x] Lint: `npx eslint apps/client-2d/src/`
- [x] Type check: Build passes
- [x] Runtime: Server movement smooth at 60 FPS, no jitter, teleport-snap works on chunk boundary

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2823c65b-bf33-4ffe-9e25-11f98ac0839d)