### PR TITLE
feat(client-2d): implement decoupled render interpolation + Anti-Ninja Loot + Character UI

### DIFF
--- a/apps/client-2d/src/ui/CharacterOverlay.tsx
+++ b/apps/client-2d/src/ui/CharacterOverlay.tsx
@@ -1,0 +1,313 @@
+/**
+ * Ouroboros CharacterOverlay — RuneScape-Style Character Sheet
+ * 
+ * ARCHITECTURE (Read-Only Stats Axiom):
+ * - This UI NEVER calculates XP or levels locally
+ * - All stats are received from server via player_stats_snapshot
+ * - Uses useSyncExternalStore for reactive server-driven updates
+ * 
+ * Keyboard: Press 'C' to toggle character sheet
+ */
+
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { useSyncExternalStore } from "react";
+import "./characterOverlay.css";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SkillSnapshot {
+  xp: number;
+  level: number;
+  nextLevelXP: number;
+  progressPercent: number;
+}
+
+export interface PlayerStatsSnapshot {
+  playerId: string;
+  skills: Record<string, SkillSnapshot>;
+  totalLevel: number;
+  hp: number;
+  maxHp: number;
+  mana: number;
+  maxMana: number;
+  stamina: number;
+  maxStamina: number;
+  gold: number;
+  level: number;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SKILL_DISPLAY_ORDER = [
+  "sword_mastery",
+  "blunt_force", 
+  "archery",
+  "heavy_armor",
+  "evasion",
+  "shield_wall",
+  "combat",
+] as const;
+
+const SKILL_LABELS: Record<string, string> = {
+  sword_mastery: "Sword Mastery",
+  blunt_force: "Blunt Force",
+  archery: "Archery",
+  heavy_armor: "Heavy Armor",
+  evasion: "Evasion",
+  shield_wall: "Shield Wall",
+  combat: "Combat",
+};
+
+// ─── State Store ──────────────────────────────────────────────────────────────
+
+class CharacterStateStore {
+  private state: PlayerStatsSnapshot | null = null;
+  private readonly listeners = new Set<() => void>();
+
+  public getSnapshot(): PlayerStatsSnapshot | null {
+    return this.state;
+  }
+
+  public subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notify(): void {
+    this.listeners.forEach((l) => l());
+  }
+
+  /** Called by network handler when server broadcasts player_stats_snapshot */
+  public receiveSnapshot(snapshot: PlayerStatsSnapshot): void {
+    this.state = snapshot;
+    this.notify();
+  }
+
+  /** Clear state on disconnect */
+  public clear(): void {
+    this.state = null;
+    this.notify();
+  }
+}
+
+export const characterStateStore = new CharacterStateStore();
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useCharacterStats(): PlayerStatsSnapshot | null {
+  return useSyncExternalStore(
+    characterStateStore.subscribe,
+    () => characterStateStore.getSnapshot(),
+    () => null
+  );
+}
+
+// ─── Components ────────────────────────────────────────────────────────────────
+
+interface StatBarProps {
+  label: string;
+  current: number;
+  max: number;
+  color: string;
+  showText?: boolean;
+}
+
+function StatBar({ label, current, max, color, showText = true }: StatBarProps) {
+  const percent = max > 0 ? Math.min(100, (current / max) * 100) : 0;
+  
+  return (
+    <div className="char-stat-bar">
+      <div className="char-stat-label">{label}</div>
+      <div className="char-stat-bar-container">
+        <div 
+          className="char-stat-bar-fill" 
+          style={{ width: `${percent}%`, backgroundColor: color }}
+        />
+      </div>
+      {showText && (
+        <div className="char-stat-value">{current} / {max}</div>
+      )}
+    </div>
+  );
+}
+
+interface SkillRowProps {
+  skillId: string;
+  skill: SkillSnapshot;
+}
+
+function SkillRow({ skillId, skill }: SkillRowProps) {
+  const label = SKILL_LABELS[skillId] ?? skillId.replace(/_/g, " ");
+  const formattedXP = skill.xp.toLocaleString();
+  const nextXP = skill.nextLevelXP.toLocaleString();
+  
+  return (
+    <div className="char-skill-row">
+      <div className="char-skill-info">
+        <span className="char-skill-name">{label}</span>
+        <span className="char-skill-level">Lv. {skill.level}</span>
+      </div>
+      <div className="char-skill-xp">
+        <div className="char-skill-progress-container">
+          <div 
+            className="char-skill-progress-fill" 
+            style={{ width: `${skill.progressPercent}%` }}
+          />
+        </div>
+        <span className="char-skill-xp-text">
+          {formattedXP} / {nextXP}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Character Overlay ────────────────────────────────────────────────────
+
+interface CharacterOverlayProps {
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+export function CharacterOverlay({ isOpen = true, onClose }: CharacterOverlayProps) {
+  const snapshot = useCharacterStats();
+
+  // Listen for WebSocket stats updates
+  useEffect(() => {
+    const handleNetworkPacket = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      if (detail?.event === "player_stats_snapshot") {
+        characterStateStore.receiveSnapshot(detail.payload);
+      }
+    };
+
+    window.addEventListener("wasd:network-packet", handleNetworkPacket);
+
+    return () => {
+      window.removeEventListener("wasd:network-packet", handleNetworkPacket);
+    };
+  }, []);
+
+  // Calculate derived stats
+  const hpPercent = useMemo(() => {
+    if (!snapshot) return 0;
+    return snapshot.maxHp > 0 ? (snapshot.hp / snapshot.maxHp) * 100 : 0;
+  }, [snapshot?.hp, snapshot?.maxHp]);
+
+  const manaPercent = useMemo(() => {
+    if (!snapshot) return 0;
+    return snapshot.maxMana > 0 ? (snapshot.mana / snapshot.maxMana) * 100 : 0;
+  }, [snapshot?.mana, snapshot?.maxMana]);
+
+  const staminaPercent = useMemo(() => {
+    if (!snapshot) return 0;
+    return snapshot.maxStamina > 0 ? (snapshot.stamina / snapshot.maxStamina) * 100 : 0;
+  }, [snapshot?.stamina, snapshot?.maxStamina]);
+
+  // Sort skills by display order, then alphabetically
+  const sortedSkills = useMemo(() => {
+    if (!snapshot?.skills) return [];
+    
+    const skills = Object.entries(snapshot.skills);
+    return skills.sort(([aId], [bId]) => {
+      const aIdx = SKILL_DISPLAY_ORDER.indexOf(aId as typeof SKILL_DISPLAY_ORDER[number]);
+      const bIdx = SKILL_DISPLAY_ORDER.indexOf(bId as typeof SKILL_DISPLAY_ORDER[number]);
+      
+      if (aIdx >= 0 && bIdx >= 0) return aIdx - bIdx;
+      if (aIdx >= 0) return -1;
+      if (bIdx >= 0) return 1;
+      return aId.localeCompare(bId);
+    });
+  }, [snapshot?.skills]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="character-overlay" role="dialog" aria-label="Character Sheet">
+      {/* Header */}
+      <div className="char-header">
+        <h2>Character</h2>
+        {onClose && (
+          <button className="char-close-btn" onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* Player Info */}
+      <div className="char-player-info">
+        <div className="char-player-name">
+          {snapshot?.playerId ?? "Unknown"}
+        </div>
+        <div className="char-player-level">
+          <span className="char-level-badge">Lv. {snapshot?.level ?? 1}</span>
+          <span className="char-total-level">Total: {snapshot?.totalLevel ?? 0}</span>
+        </div>
+        <div className="char-gold">
+          <span className="char-gold-icon">◆</span>
+          <span className="char-gold-value">{snapshot?.gold?.toLocaleString() ?? 0} Gold</span>
+        </div>
+      </div>
+
+      {/* Vital Stats */}
+      <section className="char-section" aria-label="Vitals">
+        <h3>Vitals</h3>
+        <StatBar 
+          label="HP" 
+          current={snapshot?.hp ?? 0} 
+          max={snapshot?.maxHp ?? 100} 
+          color="#e03030"
+        />
+        <StatBar 
+          label="Mana" 
+          current={snapshot?.mana ?? 0} 
+          max={snapshot?.maxMana ?? 25} 
+          color="#3080e0"
+        />
+        <StatBar 
+          label="Stamina" 
+          current={snapshot?.stamina ?? 0} 
+          max={snapshot?.maxStamina ?? 100} 
+          color="#30c030"
+        />
+      </section>
+
+      {/* Skills */}
+      <section className="char-section char-skills-section" aria-label="Skills">
+        <h3>Skills</h3>
+        <div className="char-skills-list">
+          {sortedSkills.map(([skillId, skill]) => (
+            <SkillRow 
+              key={skillId} 
+              skillId={skillId} 
+              skill={skill} 
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Empty State */}
+      {!snapshot && (
+        <div className="char-empty-state">
+          <p>No character data received.</p>
+          <p className="char-empty-hint">Start combat to earn XP!</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Mount Helper ─────────────────────────────────────────────────────────────
+
+export function mountCharacterOverlay(containerId = "character-mount"): void {
+  const container = document.getElementById(containerId);
+  if (!container) {
+    console.warn(`Character mount point #${containerId} not found`);
+    return;
+  }
+  
+  import("react").then(({ createRoot }) => {
+    const root = createRoot(container);
+    root.render(<CharacterOverlay />);
+  });
+}

--- a/apps/client-2d/src/ui/UIManager.tsx
+++ b/apps/client-2d/src/ui/UIManager.tsx
@@ -1,12 +1,14 @@
 import { useSyncExternalStore } from "react";
 import { InventoryOverlay } from "./InventoryOverlay.js";
+import { CharacterOverlay } from "./CharacterOverlay.js";
 
 export type ActiveOverlay =
   | { readonly type: "NONE" }
   | { readonly type: "TRADE"; readonly targetId: string; readonly vendorManifest: string; readonly lockedAtTick: number; readonly dialogueSeed?: string }
   | { readonly type: "DIALOGUE"; readonly targetId: string; readonly dialogueSeed: string; readonly lockedAtTick: number }
   | { readonly type: "CRAFT"; readonly targetId: string; readonly stationManifest: string; readonly lockedAtTick: number }
-  | { readonly type: "INVENTORY" };
+  | { readonly type: "INVENTORY" }
+  | { readonly type: "CHARACTER" };
 
 class InteractionUIManager {
   private state: ActiveOverlay = { type: "NONE" };
@@ -41,6 +43,19 @@ class InteractionUIManager {
   public openInventory(): void {
     this.state = { type: "INVENTORY" };
     this.notify();
+  }
+
+  public openCharacter(): void {
+    this.state = { type: "CHARACTER" };
+    this.notify();
+  }
+
+  public toggleCharacter(): void {
+    if (this.state.type === "CHARACTER") {
+      this.closeUI();
+    } else {
+      this.openCharacter();
+    }
   }
 
   public closeUI(): void {
@@ -78,6 +93,8 @@ export function useOverlayRenderer(): {
     switch (overlay.type) {
       case "INVENTORY":
         return () => <InventoryOverlay isOpen={true} onClose={() => interactionUI.closeUI()} />;
+      case "CHARACTER":
+        return () => <CharacterOverlay isOpen={true} onClose={() => interactionUI.closeUI()} />;
       // Add other overlay types as they are implemented
       default:
         return null;
@@ -87,7 +104,7 @@ export function useOverlayRenderer(): {
   return { overlay, OverlayComponent };
 }
 
-// Register keyboard shortcut for inventory toggle
+// Register keyboard shortcuts
 if (typeof window !== "undefined") {
   window.addEventListener("keydown", (e) => {
     if (e.key === "i" || e.key === "I" || e.key === "Tab") {
@@ -97,6 +114,15 @@ if (typeof window !== "undefined") {
           !document.activeElement?.hasAttribute("contenteditable")) {
         e.preventDefault();
         interactionUI.toggleInventory();
+      }
+    }
+    if (e.key === "c" || e.key === "C") {
+      // Character sheet toggle
+      if (document.activeElement?.tagName !== "INPUT" && 
+          document.activeElement?.tagName !== "TEXTAREA" &&
+          !document.activeElement?.hasAttribute("contenteditable")) {
+        e.preventDefault();
+        interactionUI.toggleCharacter();
       }
     }
     if (e.key === "Escape") {

--- a/apps/client-2d/src/ui/characterOverlay.css
+++ b/apps/client-2d/src/ui/characterOverlay.css
@@ -1,0 +1,292 @@
+/**
+ * Ouroboros CharacterOverlay — Tank-Style CSS
+ * 
+ * Aesthetic: Dark military theme, sharp corners (no border-radius).
+ * Inspired by RuneScape's classic interface with a darker, more
+ * brutalist edge. No rounded corners, no soft shadows.
+ */
+
+.character-overlay {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 380px;
+  max-height: 85vh;
+  background: #0a0c10;
+  border: 2px solid #3a4050;
+  color: #e0e4f0;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 12px;
+  z-index: 1000;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 
+    0 0 0 1px #000,
+    0 4px 20px rgba(0, 0, 0, 0.8),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* ─── Header ──────────────────────────────────────────── */
+
+.char-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  background: #12151c;
+  border-bottom: 2px solid #2a3040;
+}
+
+.char-header h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #b0b8d0;
+}
+
+.char-close-btn {
+  background: none;
+  border: 1px solid #4a5060;
+  color: #8090a0;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  transition: background 0.1s, color 0.1s;
+}
+
+.char-close-btn:hover {
+  background: #2a3040;
+  color: #e0e4f0;
+  border-color: #6a7080;
+}
+
+/* ─── Player Info ─────────────────────────────────────── */
+
+.char-player-info {
+  padding: 12px;
+  background: #0e1118;
+  border-bottom: 2px solid #2a3040;
+}
+
+.char-player-name {
+  font-size: 16px;
+  font-weight: bold;
+  color: #d0d8f0;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.char-player-level {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.char-level-badge {
+  background: #1a2030;
+  border: 1px solid #4a5870;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: #80a0c0;
+}
+
+.char-total-level {
+  font-size: 11px;
+  color: #6080a0;
+}
+
+.char-gold {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #d4a030;
+}
+
+.char-gold-icon {
+  color: #ffd700;
+}
+
+.char-gold-value {
+  font-weight: bold;
+}
+
+/* ─── Sections ────────────────────────────────────────── */
+
+.char-section {
+  padding: 12px;
+  border-bottom: 1px solid #1a1e28;
+}
+
+.char-section h3 {
+  margin: 0 0 10px 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #607080;
+  border-bottom: 1px solid #2a3040;
+  padding-bottom: 4px;
+}
+
+/* ─── Stat Bars ───────────────────────────────────────── */
+
+.char-stat-bar {
+  margin-bottom: 8px;
+}
+
+.char-stat-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #8090a0;
+  margin-bottom: 3px;
+}
+
+.char-stat-bar-container {
+  height: 14px;
+  background: #0a0c10;
+  border: 1px solid #2a3040;
+  position: relative;
+  overflow: hidden;
+}
+
+.char-stat-bar-fill {
+  height: 100%;
+  transition: width 0.2s ease-out;
+}
+
+.char-stat-value {
+  font-size: 10px;
+  color: #607080;
+  margin-top: 2px;
+  text-align: right;
+}
+
+/* ─── Skills Section ──────────────────────────────────── */
+
+.char-skills-section {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 320px;
+}
+
+.char-skills-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.char-skill-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  background: #0e1118;
+  border: 1px solid #1a1e28;
+}
+
+.char-skill-row:hover {
+  background: #12151c;
+  border-color: #2a3040;
+}
+
+.char-skill-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 100px;
+}
+
+.char-skill-name {
+  font-size: 11px;
+  color: #b0b8d0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.char-skill-level {
+  font-size: 10px;
+  color: #6080a0;
+}
+
+.char-skill-xp {
+  flex: 1;
+  max-width: 160px;
+  margin-left: 12px;
+}
+
+.char-skill-progress-container {
+  height: 10px;
+  background: #0a0c10;
+  border: 1px solid #2a3040;
+  position: relative;
+  overflow: hidden;
+}
+
+.char-skill-progress-fill {
+  height: 100%;
+  background: linear-gradient(
+    to bottom,
+    #4060a0 0%,
+    #3050a0 50%,
+    #2040a0 100%
+  );
+  transition: width 0.15s ease-out;
+}
+
+.char-skill-xp-text {
+  display: block;
+  font-size: 9px;
+  color: #506070;
+  margin-top: 2px;
+  text-align: right;
+  font-family: monospace;
+}
+
+/* ─── Empty State ────────────────────────────────────── */
+
+.char-empty-state {
+  padding: 24px;
+  text-align: center;
+  color: #506070;
+}
+
+.char-empty-state p {
+  margin: 4px 0;
+}
+
+.char-empty-hint {
+  font-size: 10px;
+  color: #406060;
+  margin-top: 8px !important;
+}
+
+/* ─── Scrollbar ──────────────────────────────────────── */
+
+.char-skills-section::-webkit-scrollbar {
+  width: 8px;
+}
+
+.char-skills-section::-webkit-scrollbar-track {
+  background: #0a0c10;
+  border-left: 1px solid #1a1e28;
+}
+
+.char-skills-section::-webkit-scrollbar-thumb {
+  background: #2a3040;
+  border: 1px solid #3a4050;
+}
+
+.char-skills-section::-webkit-scrollbar-thumb:hover {
+  background: #3a4050;
+}

--- a/server/src/modules/player/PlayerStatsDirector.ts
+++ b/server/src/modules/player/PlayerStatsDirector.ts
@@ -1,0 +1,295 @@
+/**
+ * PlayerStatsDirector — Server-Authoritative Skill/XP State
+ * 
+ * ARCHITECTURE (Server Authority + Stateless Determinism):
+ * - All XP calculations are server-side only
+ * - Player skill state is maintained per-player
+ * - Broadcasts player_stats_snapshot to individual clients via WebSocket
+ * - Client NEVER calculates XP or levels locally
+ * 
+ * RUNEscape XP System:
+ * - XP formula: 50 * level^1.4 (server-side only)
+ * - Levels 1-99
+ * - Skills tracked: sword_mastery, blunt_force, archery, heavy_armor, evasion, etc.
+ */
+
+import { combatDirector, type XPGainEvent } from "../combat/CombatDirector.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SkillSnapshot {
+  xp: number;
+  level: number;
+  nextLevelXP: number;
+  progressPercent: number; // 0-100 for UI progress bar
+}
+
+export interface PlayerStatsSnapshot {
+  playerId: string;
+  skills: Record<string, SkillSnapshot>;
+  totalLevel: number;
+  hp: number;
+  maxHp: number;
+  mana: number;
+  maxMana: number;
+  stamina: number;
+  maxStamina: number;
+  gold: number;
+  level: number; // Overall player level
+}
+
+// ─── XP Constants ─────────────────────────────────────────────────────────────
+
+const MAX_LEVEL = 99;
+
+/**
+ * RuneScape-style XP curve.
+ * XP needed for level L+1 = floor(50 * (L+1)^1.4)
+ */
+export function xpForLevel(level: number): number {
+  if (level <= 1) return 0;
+  return Math.floor(50 * Math.pow(level, 1.4));
+}
+
+/**
+ * Total XP required to reach a specific level.
+ */
+export function totalXpForLevel(level: number): number {
+  let total = 0;
+  for (let l = 2; l <= level; l++) {
+    total += xpForLevel(l - 1);
+  }
+  return total;
+}
+
+/**
+ * Calculate level from total XP.
+ */
+export function levelFromXp(totalXp: number): number {
+  let level = 1;
+  let xpRemaining = totalXp;
+  while (level < MAX_LEVEL && xpRemaining >= xpForLevel(level)) {
+    xpRemaining -= xpForLevel(level);
+    level++;
+  }
+  return level;
+}
+
+// ─── PlayerStatsDirector ──────────────────────────────────────────────────────
+
+export class PlayerStatsDirector {
+  // Per-player skill state: playerId → skills map
+  private playerSkills: Map<string, Record<string, { xp: number; level: number }>> = new Map();
+  
+  // WebSocket broadcast function (set by integration)
+  private broadcastToPlayer: ((playerId: string, event: string, payload: PlayerStatsSnapshot) => void) | null = null;
+  
+  // Pending XP events from CombatDirector
+  private pendingXPevents: XPGainEvent[] = [];
+  
+  /**
+   * Set the broadcast function for WebSocket integration.
+   * Called during system wiring.
+   */
+  public setBroadcastFn(fn: (playerId: string, event: string, payload: PlayerStatsSnapshot) => void): void {
+    this.broadcastToPlayer = fn;
+  }
+  
+  /**
+   * Drain XP events from CombatDirector.
+   * Called by WorldTick to process accumulated XP.
+   */
+  public drainXPevents(): XPGainEvent[] {
+    const events = this.pendingXPevents;
+    this.pendingXPevents = [];
+    return events;
+  }
+  
+  /**
+   * Queue XP events from CombatDirector.
+   */
+  public queueXPevents(events: XPGainEvent[]): void {
+    this.pendingXPevents.push(...events);
+  }
+  
+  /**
+   * Process accumulated XP events and broadcast updates to clients.
+   */
+  public processXPevents(events: XPGainEvent[]): void {
+    // Group events by player
+    const playerXPGains = new Map<string, Map<string, number>>();
+    
+    for (const event of events) {
+      if (!playerXPGains.has(event.playerId)) {
+        playerXPGains.set(event.playerId, new Map());
+      }
+      const skillGains = playerXPGains.get(event.playerId)!;
+      skillGains.set(event.skillId, (skillGains.get(event.skillId) ?? 0) + event.amount);
+    }
+    
+    // Apply XP gains to each player
+    for (const [playerId, skillGains] of playerXPGains) {
+      for (const [skillId, amount] of skillGains) {
+        this.applyXP(playerId, skillId, amount);
+      }
+      
+      // Broadcast updated stats to this player
+      this.broadcastSnapshot(playerId);
+    }
+  }
+  
+  /**
+   * Apply XP to a specific skill for a player.
+   */
+  public applyXP(playerId: string, skillId: string, amount: number): { leveledUp: boolean; newLevel: number } {
+    const skills = this.getOrCreateSkills(playerId);
+    
+    if (!skills[skillId]) {
+      skills[skillId] = { xp: 0, level: 1 };
+    }
+    
+    const skill = skills[skillId];
+    const oldLevel = skill.level;
+    
+    skill.xp += amount;
+    
+    // Level up while possible
+    while (skill.level < MAX_LEVEL && skill.xp >= xpForLevel(skill.level)) {
+      skill.level++;
+    }
+    
+    return {
+      leveledUp: skill.level > oldLevel,
+      newLevel: skill.level,
+    };
+  }
+  
+  /**
+   * Get or create skills map for a player.
+   */
+  public getOrCreateSkills(playerId: string): Record<string, { xp: number; level: number }> {
+    if (!this.playerSkills.has(playerId)) {
+      // Initialize with default combat skills
+      this.playerSkills.set(playerId, {
+        sword_mastery: { xp: 0, level: 1 },
+        blunt_force: { xp: 0, level: 1 },
+        archery: { xp: 0, level: 1 },
+        heavy_armor: { xp: 0, level: 1 },
+        evasion: { xp: 0, level: 1 },
+        shield_wall: { xp: 0, level: 1 },
+        combat: { xp: 0, level: 1 },
+      });
+    }
+    return this.playerSkills.get(playerId)!;
+  }
+  
+  /**
+   * Get skill snapshot for a player.
+   */
+  public getSkillSnapshot(playerId: string, skillId: string): SkillSnapshot | null {
+    const skills = this.playerSkills.get(playerId);
+    if (!skills || !skills[skillId]) return null;
+    
+    const skill = skills[skillId];
+    const nextXP = xpForLevel(skill.level);
+    const prevXP = skill.level > 1 ? totalXpForLevel(skill.level) : 0;
+    const currentLevelXP = skill.xp - prevXP;
+    const progressPercent = Math.min(100, (currentLevelXP / nextXP) * 100);
+    
+    return {
+      xp: skill.xp,
+      level: skill.level,
+      nextLevelXP: nextXP,
+      progressPercent,
+    };
+  }
+  
+  /**
+   * Get full stats snapshot for a player.
+   * Used for initial sync and periodic broadcasts.
+   */
+  public getFullSnapshot(playerId: string, playerState: any): PlayerStatsSnapshot {
+    const skills = this.getOrCreateSkills(playerId);
+    const skillSnapshots: Record<string, SkillSnapshot> = {};
+    
+    let totalLevel = 0;
+    for (const [skillId, skill] of Object.entries(skills)) {
+      totalLevel += skill.level;
+      const nextXP = xpForLevel(skill.level);
+      const prevXP = skill.level > 1 ? totalXpForLevel(skill.level) : 0;
+      const currentLevelXP = skill.xp - prevXP;
+      const progressPercent = Math.min(100, (currentLevelXP / nextXP) * 100);
+      
+      skillSnapshots[skillId] = {
+        xp: skill.xp,
+        level: skill.level,
+        nextLevelXP: nextXP,
+        progressPercent,
+      };
+    }
+    
+    return {
+      playerId,
+      skills: skillSnapshots,
+      totalLevel,
+      hp: playerState?.health ?? 0,
+      maxHp: playerState?.maxHealth ?? 100,
+      mana: playerState?.mana ?? 0,
+      maxMana: playerState?.maxMana ?? 25,
+      stamina: playerState?.stamina ?? 0,
+      maxStamina: playerState?.maxStamina ?? 100,
+      gold: playerState?.gold ?? 0,
+      level: playerState?.level ?? 1,
+    };
+  }
+  
+  /**
+   * Broadcast stats snapshot to a specific player.
+   */
+  private broadcastSnapshot(playerId: string): void {
+    if (!this.broadcastToPlayer) return;
+    
+    // Get player state from PlayerSystem
+    const { playerSystem } = this;
+    const playerState = playerSystem?.getPlayer(playerId);
+    
+    const snapshot = this.getFullSnapshot(playerId, playerState);
+    this.broadcastToPlayer(playerId, "player_stats_snapshot", snapshot);
+  }
+  
+  /**
+   * Remove player data (on disconnect/cleanup).
+   */
+  public removePlayer(playerId: string): void {
+    this.playerSkills.delete(playerId);
+  }
+  
+  /**
+   * Load player skills from persisted state.
+   */
+  public loadSkills(playerId: string, skills: Record<string, { xp: number; level: number }>): void {
+    this.playerSkills.set(playerId, skills);
+  }
+  
+  /**
+   * Get skills for persistence.
+   */
+  public getSkillsForSave(playerId: string): Record<string, { xp: number; level: number }> | undefined {
+    return this.playerSkills.get(playerId);
+  }
+  
+  // Lazy reference to PlayerSystem (set during wiring)
+  private get playerSystem() {
+    // Dynamic import to avoid circular dependency
+    try {
+      const { playerSystem } = require("./PlayerSystem.js");
+      return playerSystem;
+    } catch {
+      return null;
+    }
+  }
+}
+
+// ─── Singleton Export ──────────────────────────────────────────────────────────
+
+export const playerStatsDirector = new PlayerStatsDirector();

--- a/server/src/modules/world/LootDirector.ts
+++ b/server/src/modules/world/LootDirector.ts
@@ -42,7 +42,8 @@ export interface LootEntity {
   ilvl: number;
   visualId: string;
   gold: number;
-  ownerId?: string;      // Player who killed the monster
+  ownerId: string | null;  // Player who killed/caused most damage — null = public loot
+  lockedUntilTick: number; // Anti-Ninja Lock: until this tick, only ownerId can pickup
   spawnedAtTick: number;
   despawnAtTick: number;
 }
@@ -169,6 +170,10 @@ export class LootDirector {
   // Loot TTL — matches electroweak pruning
   private readonly LOOT_TTL_TICKS = 1200;  // 2 minutes at 10Hz
   
+  // ANTI-NINJA LOCK: Loot is bound to killer for first 60 seconds
+  // At 10Hz, 60 seconds = 600 ticks
+  private readonly LOOT_LOCK_DURATION_TICKS = 600;
+  
   // Drop table tier thresholds
   private readonly ELITE_TIER_THRESHOLD = 10;  // monster level >= 10 = elite drops
   private readonly RARE_TIER_THRESHOLD = 5;    // monster level >= 5 = rare drops
@@ -213,7 +218,7 @@ export class LootDirector {
     monsterId: string,
     monsterLevel: number,
     position: KappaCoord,
-    ownerId?: string,
+    killerId: string | null,
     dropTableSeed?: number
   ): LootEntity[] {
     // Select appropriate drop table based on monster level
@@ -246,6 +251,8 @@ export class LootDirector {
         
         const lootId = `loot:${monsterId}:${this.worldTick}:${i}:${this.lootIdCounter++}`;
         
+        // ANTI-NINJA LOCK: Set owner and lock duration
+        // If killerId is null, loot is public (e.g., from world nodes)
         const lootEntity: LootEntity = {
           id: lootId,
           type: "LOOT",
@@ -256,7 +263,8 @@ export class LootDirector {
           ilvl: item.ilvl,
           visualId: item.visualId,
           gold: 0,  // Gold handled separately
-          ownerId,
+          ownerId: killerId,
+          lockedUntilTick: this.worldTick + this.LOOT_LOCK_DURATION_TICKS,
           spawnedAtTick: this.worldTick,
           despawnAtTick: this.worldTick + this.LOOT_TTL_TICKS,
         };
@@ -273,6 +281,7 @@ export class LootDirector {
       if (goldAmount > 0) {
         const goldLootId = `gold:${monsterId}:${this.worldTick}:${this.lootIdCounter++}`;
         
+        // Gold loot also respects anti-ninja lock
         const goldLoot: LootEntity = {
           id: goldLootId,
           type: "LOOT",
@@ -283,7 +292,8 @@ export class LootDirector {
           ilvl: 0,
           visualId: "gold_pile",
           gold: goldAmount,
-          ownerId,
+          ownerId: killerId,
+          lockedUntilTick: this.worldTick + this.LOOT_LOCK_DURATION_TICKS,
           spawnedAtTick: this.worldTick,
           despawnAtTick: this.worldTick + this.LOOT_TTL_TICKS,
         };
@@ -328,6 +338,26 @@ export class LootDirector {
         code: "LOOT_EXPIRED",
         message: "Loot has expired and despawned.",
       };
+    }
+    
+    // ═══════════════════════════════════════════════════════════════════
+    // ANTI-NINJA LOCK CHECK (Causality Guard)
+    //
+    // For the first 60 seconds (600 ticks at 10Hz), loot belongs to the killer.
+    // If lockedUntilTick > currentTick, only the owner can pick up.
+    // If ownerId is null, loot is public (e.g., from world gathering nodes).
+    //
+    // This prevents ninja-looting: a player who shows up after the kill
+    // cannot steal the drops from the player who did the work.
+    // ═══════════════════════════════════════════════════════════════════
+    if (this.worldTick < loot.lockedUntilTick && loot.ownerId !== null) {
+      if (playerId !== loot.ownerId) {
+        return {
+          success: false,
+          code: "LOOT_LOCKED",
+          message: `This loot is locked to ${loot.ownerId} for ${Math.ceil((loot.lockedUntilTick - this.worldTick) / 10)} more seconds.`,
+        };
+      }
     }
     
     // Check distance (must be within pickup range)
@@ -517,7 +547,7 @@ export class LootDirector {
 
 export interface PickupResult {
   success: boolean;
-  code?: "LOOT_NOT_FOUND" | "LOOT_EXPIRED" | "TOO_FAR" | "OVER_WEIGHT" | "INVENTORY_FULL";
+  code?: "LOOT_NOT_FOUND" | "LOOT_EXPIRED" | "LOOT_LOCKED" | "TOO_FAR" | "OVER_WEIGHT" | "INVENTORY_FULL";
   message?: string;
   lootId?: string;
   itemSignature?: string;


### PR DESCRIPTION
## Summary

Full-featured client-side interpolation pipeline with anti-ninja loot system and RuneScape-style character UI.

## Commits on this PR

1. **feat(client-2d): implement decoupled render interpolation (lerp) for PixiJS**
   - Pure lerp math in `apps/client-2d/src/math/lerp.ts`
   - `InterpolatedSpriteManager` singleton for decoupled 60-FPS render loop
   - Teleport-Snap (>150px), Precision-Lock (<0.5px), Delta-Time independence

2. **fix(client-2d): address PR review comments**  
   - `sendMove()`: update interpolation target immediately for local prediction
   - `InterpolatedSpriteManager`: sync zIndex after snap/precision-lock

3. **feat: Anti-Ninja Loot Lock + RuneScape Character UI**
   - `LootDirector`: ownerId + lockedUntilTick (60s kill lock)
   - `PlayerStatsDirector`: Server-authoritative XP/level tracking
   - `CharacterOverlay.tsx`: React UI with useSyncExternalStore
   - `characterOverlay.css`: Tank-style dark military aesthetic

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

- [ ] Lint: `npx eslint apps/client-2d/src/`
- [ ] Type check: Build passes
- [ ] Runtime: Server movement smooth at 60 FPS, no jitter, teleport-snap works on chunk boundary
- [ ] Loot: Kill lock prevents ninja-looting for 60 seconds
- [ ] Character UI: Press 'C' to open, displays XP bars correctly

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2823c65b-bf33-4ffe-9e25-11f98ac0839d)