### PR TITLE
feat(are-npc-evolution): Implement Utility-based AI with world counterparts

### DIFF
--- a/server/src/core/are/AREHash.ts
+++ b/server/src/core/are/AREHash.ts
@@ -16,6 +16,22 @@ export class AREHash {
     return hash >>> 0;
   }
 
+  /**
+   * Generate hash from any serializable object.
+   * Used for NPC intents and other non-ARE payloads.
+   */
+  static hashObject(obj: unknown): number {
+    const stateString = JSON.stringify(obj);
+    let hash = AREHash.OFFSET_BASIS;
+
+    for (let index = 0; index < stateString.length; index += 1) {
+      hash ^= stateString.charCodeAt(index);
+      hash = Math.imul(hash, AREHash.FNV_PRIME);
+    }
+
+    return hash >>> 0;
+  }
+
   static mix(baseHash: number, hashes: readonly number[] = []): number {
     let hash = baseHash >>> 0;
 

--- a/server/src/core/are/ARENpcEvolution.ts
+++ b/server/src/core/are/ARENpcEvolution.ts
@@ -77,7 +77,7 @@ export interface ActionScore {
 
 export interface UtilityIntelligence {
   drives: DriveState;
-  environment: EnvironmentalEntity[];
+  environment: ScannedEnvironment;
   actionScores: ActionScore[];
   selectedAction: NPCAction;
   targetEntity?: string;

--- a/server/src/core/are/ARENpcEvolution.ts
+++ b/server/src/core/are/ARENpcEvolution.ts
@@ -323,7 +323,7 @@ export class ARENpcEvolution {
       energy: number;
       maxEnergy: number;
     },
-    inventorySlots: readonly { id?: string }[],
+    inventorySlots: readonly { id?: string; quantity?: number }[],
     closestEnemy: EnvironmentalEntity | undefined,
     ownedStorages: number
   ): DriveState {
@@ -523,7 +523,7 @@ export class ARENpcEvolution {
       maxEnergy: number;
       position: AREVector3;
     },
-    inventorySlots: readonly { id?: string }[],
+    inventorySlots: readonly { id?: string; quantity?: number }[],
     worldEntities: readonly Readonly<IAREPayload>[],
     ownedStorageCount: number,
     tick: number

--- a/server/src/core/are/ARENpcEvolution.ts
+++ b/server/src/core/are/ARENpcEvolution.ts
@@ -3,6 +3,18 @@ import { AREHash } from './AREHash';
 import type { AREVector3, IAREPayload } from './AREPayload';
 import { assertSafeInteger, kAdd, kSub, type KappaInt } from './Kappa';
 
+/**
+ * OUROBOROS SYSTEMIC EMERGENCE: ARENpcEvolution Utility AI
+ * 
+ * The brain of NPC decision-making. Operates under the dogma of
+ * "Stateless Determinism" and ARE-Logic.
+ * 
+ * CORE AXIOMS:
+ * 1. NPCs use EXACTLY the same systems as players (Conservation Axiom)
+ * 2. Utility Scoring: ActionScore = (Drive * Reward) - Risk - Cost
+ * 3. No Phantom Systems: Every logical decision has a server counterpart
+ */
+
 export interface AREFusionResult {
   readonly fused: boolean;
   readonly apex?: Readonly<IAREPayload>;
@@ -15,7 +27,81 @@ export interface ARECapsuleScanResult {
   readonly movementCost: KappaInt;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// UTILITY AI TYPES
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type NPCAction =
+  | 'IDLE'
+  | 'GATHER_WOOD'
+  | 'GATHER_STONE'
+  | 'GATHER_IRON'
+  | 'GATHER_FIBER'
+  | 'CRAFT_WOODEN_CHEST'
+  | 'CRAFT_IRON_CHEST'
+  | 'CRAFT_EQUIPMENT'
+  | 'STORE_ITEMS'
+  | 'RETRIEVE_ITEMS'
+  | 'FLEE'
+  | 'ATTACK'
+  | 'WANDER'
+  | 'RETURN_HOME';
+
+export interface DriveState {
+  resourceNeed: KappaInt;      // 0-1000: How much NPC needs resources
+  safetyNeed: KappaInt;        // 0-1000: How unsafe NPC feels
+  wealthNeed: KappaInt;        // 0-1000: How much NPC wants to store wealth
+  socialNeed: KappaInt;        // 0-1000: Territorial/social drives
+}
+
+export interface EnvironmentalEntity {
+  entityId: string;
+  entityType: 'RESOURCE' | 'STORAGE' | 'ENEMY' | 'ALLY' | 'NEUTRAL';
+  resourceType?: 'tree' | 'rock' | 'iron' | 'fiber';
+  position: AREVector3;
+  distanceKappa: KappaInt;
+  threat?: number;            // For enemies: 0-1
+  value?: KappaInt;           // For resources/storages: value in kappa
+}
+
+export interface ActionScore {
+  action: NPCAction;
+  score: KappaInt;
+  driveStrength: KappaInt;
+  reward: KappaInt;
+  risk: KappaInt;
+  cost: KappaInt;
+  targetEntity?: string;
+  reason: string;
+}
+
+export interface UtilityIntelligence {
+  drives: DriveState;
+  environment: EnvironmentalEntity[];
+  actionScores: ActionScore[];
+  selectedAction: NPCAction;
+  targetEntity?: string;
+  tick: number;
+}
+
+export interface ScannedEnvironment {
+  npcPosition: AREVector3;
+  resources: EnvironmentalEntity[];
+  enemies: EnvironmentalEntity[];
+  allies: EnvironmentalEntity[];
+  storages: EnvironmentalEntity[];
+  neutrals: EnvironmentalEntity[];
+}
+
 const DEFAULT_CHUNK_SIZE = 64000;
+const DEFAULT_VISION_RANGE_KAPPA = 5000;  // 5 meters in kappa
+const SAFE_ENEMY_DISTANCE_KAPPA = 2000;   // 2 meters - too close = danger
+const RESOURCE_VALUES: Record<string, KappaInt> = {
+  tree: 100,
+  rock: 150,
+  iron: 300,
+  fiber: 50,
+};
 
 function readInt(payload: Readonly<IAREPayload>, key: string): KappaInt {
   const value = payload[key];
@@ -41,7 +127,64 @@ function chunkKey(position: Readonly<AREVector3>, chunkSize: KappaInt): string {
   return `${Math.trunc(position.x / chunkSize)}:${Math.trunc(position.y / chunkSize)}:${Math.trunc(position.z / chunkSize)}`;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// UTILITY FUNCTIONS
+// ─────────────────────────────────────────────────────────────────────────────
+
+function clampK(value: KappaInt, min: KappaInt, max: KappaInt): KappaInt {
+  return Math.max(min, Math.min(max, value));
+}
+
+function calculateRiskScore(
+  closestEnemy: EnvironmentalEntity | undefined,
+  enemyThreshold: KappaInt
+): KappaInt {
+  if (!closestEnemy) return 0;
+  
+  if (closestEnemy.distanceKappa <= enemyThreshold) {
+    // High risk: enemy very close
+    const severity = kDiv(enemyThreshold - closestEnemy.distanceKappa, enemyThreshold);
+    return kAdd(severity, (closestEnemy.threat ?? 0) * 500);
+  }
+  
+  return (closestEnemy.threat ?? 0) * 200;
+}
+
+function calculateDriveFromInventory(
+  inventorySlots: readonly (Readonly<{ id?: string; quantity?: number }> | null)[]
+): { resourceNeed: KappaInt; hasWood: boolean; hasStone: boolean; hasIron: boolean } {
+  let woodCount = 0;
+  let stoneCount = 0;
+  let ironCount = 0;
+  
+  for (const slot of inventorySlots) {
+    if (!slot || !slot.id) continue;
+    const id = slot.id;
+    if (id.includes('wood')) woodCount += slot.quantity ?? 1;
+    else if (id.includes('stone')) stoneCount += slot.quantity ?? 1;
+    else if (id.includes('iron')) ironCount += slot.quantity ?? 1;
+  }
+  
+  // Calculate resource need based on emptiness (inverse of abundance)
+  const totalItems = woodCount + stoneCount + ironCount;
+  const maxCapacity = 20;
+  const resourceNeed = Math.max(0, maxCapacity - totalItems) * 50; // Scale 0-1000
+  
+  return {
+    resourceNeed: clampK(resourceNeed, 0, 1000),
+    hasWood: woodCount >= 5,
+    hasStone: stoneCount >= 3,
+    hasIron: ironCount >= 2,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ARENpcEvolution - THE BRAIN
+// ─────────────────────────────────────────────────────────────────────────────
+
 export class ARENpcEvolution {
+  // ─── Legacy Methods ───────────────────────────────────────────────────
+
   static fuseOnSameKappaCell(a: Readonly<IAREPayload>, b: Readonly<IAREPayload>): AREFusionResult {
     return AREGuard.executeProtected(() => {
       AREGuard.assertNoFloats(a);
@@ -86,6 +229,397 @@ export class ARENpcEvolution {
       if (!best) return AREGuard.protectPayload({ capsule: null, direction: null, movementCost: 0 });
       const direction = AREGuard.protectPayload({ x: kSub(best.position.x, npc.position.x), y: kSub(best.position.y, npc.position.y), z: kSub(best.position.z, npc.position.z) });
       return AREGuard.protectPayload({ capsule: best, direction, movementCost: bestDistance ?? 0 });
+    });
+  }
+
+  // ─── NEW UTILITY AI METHODS ───────────────────────────────────────────
+
+  /**
+   * Scan NPC environment for entities within vision range.
+   * Returns categorized entities with KAPPA-distance precomputed.
+   */
+  static scanEnvironment(
+    npcPosition: Readonly<AREVector3>,
+    worldEntities: readonly Readonly<IAREPayload>[],
+    visionRangeKappa: KappaInt = DEFAULT_VISION_RANGE_KAPPA
+  ): ScannedEnvironment {
+    return AREGuard.executeProtected(() => {
+      AREGuard.assertNoFloats(npcPosition);
+
+      const result: ScannedEnvironment = {
+        npcPosition,
+        resources: [],
+        enemies: [],
+        allies: [],
+        storages: [],
+        neutrals: [],
+      };
+
+      for (const entity of worldEntities) {
+        AREGuard.assertNoFloats(entity);
+        
+        const entityPos = entity.position;
+        const dist = distance(npcPosition, entityPos);
+        
+        if (dist > visionRangeKappa) continue;
+
+        const scanned: EnvironmentalEntity = {
+          entityId: String(entity.entityId),
+          entityType: (entity.kind as EnvironmentalEntity['entityType']) ?? 'NEUTRAL',
+          position: entityPos,
+          distanceKappa: dist,
+          resourceType: entity.resourceType as EnvironmentalEntity['resourceType'],
+          threat: entity.threat as number | undefined,
+          value: entity.value as KappaInt | undefined,
+        };
+
+        switch (scanned.entityType) {
+          case 'RESOURCE':
+            scanned.value ??= RESOURCE_VALUES[String(entity.resourceType)] ?? 50;
+            result.resources.push(scanned);
+            break;
+          case 'ENEMY':
+            result.enemies.push(scanned);
+            break;
+          case 'ALLY':
+            result.allies.push(scanned);
+            break;
+          case 'STORAGE':
+            result.storages.push(scanned);
+            break;
+          default:
+            result.neutrals.push(scanned);
+        }
+      }
+
+      // Sort all by distance (closest first)
+      const sortByDist = (a: EnvironmentalEntity, b: EnvironmentalEntity) =>
+        a.distanceKappa - b.distanceKappa;
+
+      result.resources.sort(sortByDist);
+      result.enemies.sort(sortByDist);
+      result.allies.sort(sortByDist);
+      result.storages.sort(sortByDist);
+      result.neutrals.sort(sortByDist);
+
+      return AREGuard.protectPayload(result);
+    });
+  }
+
+  /**
+   * Calculate internal drive state from NPC circumstances.
+   * Drives represent internal motivation vectors.
+   */
+  static calculateDrives(
+    npcState: {
+      health: number;
+      maxHealth: number;
+      energy: number;
+      maxEnergy: number;
+    },
+    inventorySlots: readonly (Readonly<{ id?: string } | null)[],
+    closestEnemy: EnvironmentalEntity | undefined,
+    ownedStorages: number
+  ): DriveState {
+    return AREGuard.executeProtected(() => {
+      // Resource need from inventory
+      const inventoryAnalysis = calculateDriveFromInventory(inventorySlots);
+      
+      // Safety need: enemy proximity
+      const safetyNeed = clampK(
+        calculateRiskScore(closestEnemy, SAFE_ENEMY_DISTANCE_KAPPA),
+        0,
+        1000
+      );
+
+      // Wealth need: want more storage capacity
+      const storageCapacity = ownedStorages * 12; // Each storage = 12 slots
+      const wealthNeed = ownedStorages === 0
+        ? 800  // High need if no storage
+        : 200; // Low need if has storage
+
+      // Social/territorial need (simplified)
+      const socialNeed = 100; // Placeholder
+
+      return AREGuard.protectPayload({
+        resourceNeed: inventoryAnalysis.resourceNeed,
+        safetyNeed,
+        wealthNeed,
+        socialNeed,
+      } satisfies DriveState);
+    });
+  }
+
+  /**
+   * Evaluate all possible actions and calculate utility scores.
+   * ActionScore = (Drive * Reward) - Risk - Cost
+   */
+  static evaluateActions(
+    drives: Readonly<DriveState>,
+    environment: Readonly<ScannedEnvironment>,
+    inventoryHasIngredients: {
+      wood: boolean;
+      stone: boolean;
+      iron: boolean;
+    }
+  ): ActionScore[] {
+    return AREGuard.executeProtected(() => {
+      const scores: ActionScore[] = [];
+
+      const closestResource = environment.resources[0];
+      const closestEnemy = environment.enemies[0];
+      const closestStorage = environment.storages.find(s => s.entityId.includes('chest'));
+
+      // ── GATHER_WOOD ──
+      if (closestResource?.resourceType === 'tree') {
+        const gatherRisk = calculateRiskScore(closestEnemy, SAFE_ENEMY_DISTANCE_KAPPA);
+        const gatherCost = closestResource.distanceKappa;
+        const gatherReward = RESOURCE_VALUES.tree;
+        const driveStrength = drives.resourceNeed;
+        
+        scores.push({
+          action: 'GATHER_WOOD',
+          score: kSub(kSub(kMul(driveStrength, gatherReward), gatherRisk), gatherCost),
+          driveStrength,
+          reward: gatherReward,
+          risk: gatherRisk,
+          cost: gatherCost,
+          targetEntity: closestResource.entityId,
+          reason: closestEnemy
+            ? `Gather wood: enemy at ${closestEnemy.distanceKappa}K, risk ${gatherRisk}`
+            : `Gather wood: tree at ${closestResource.distanceKappa}K`,
+        });
+      }
+
+      // ── GATHER_STONE ──
+      if (closestResource?.resourceType === 'rock') {
+        const gatherRisk = calculateRiskScore(closestEnemy, SAFE_ENEMY_DISTANCE_KAPPA);
+        const gatherCost = closestResource.distanceKappa;
+        const gatherReward = RESOURCE_VALUES.rock;
+
+        scores.push({
+          action: 'GATHER_STONE',
+          score: kSub(kSub(kMul(drives.resourceNeed, gatherReward), gatherRisk), gatherCost),
+          driveStrength: drives.resourceNeed,
+          reward: gatherReward,
+          risk: gatherRisk,
+          cost: gatherCost,
+          targetEntity: closestResource.entityId,
+          reason: `Gather stone: rock at ${closestResource.distanceKappa}K`,
+        });
+      }
+
+      // ── CRAFT_WOODEN_CHEST ──
+      if (inventoryHasIngredients.wood) {
+        const craftRisk = calculateRiskScore(closestEnemy, SAFE_ENEMY_DISTANCE_KAPPA);
+        const craftCost = 100; // Fixed crafting cost
+        const craftReward = 500; // Value of storage
+        const driveStrength = drives.wealthNeed;
+
+        scores.push({
+          action: 'CRAFT_WOODEN_CHEST',
+          score: kSub(kSub(kMul(driveStrength, craftReward), craftRisk), craftCost),
+          driveStrength,
+          reward: craftReward,
+          risk: craftRisk,
+          cost: craftCost,
+          reason: `Craft chest: wood available, wealth need ${drives.wealthNeed}`,
+        });
+      }
+
+      // ── STORE_ITEMS ──
+      if (closestStorage) {
+        const storeRisk = calculateRiskScore(closestEnemy, SAFE_ENEMY_DISTANCE_KAPPA);
+        const storeCost = closestStorage.distanceKappa;
+        const storeReward = 200; // Value of organization
+        const driveStrength = drives.wealthNeed;
+
+        scores.push({
+          action: 'STORE_ITEMS',
+          score: kSub(kSub(kMul(driveStrength, storeReward), storeRisk), storeCost),
+          driveStrength,
+          reward: storeReward,
+          risk: storeRisk,
+          cost: storeCost,
+          targetEntity: closestStorage.entityId,
+          reason: `Store items: chest at ${closestStorage.distanceKappa}K`,
+        });
+      }
+
+      // ── FLEE ──
+      if (closestEnemy && closestEnemy.distanceKappa <= SAFE_ENEMY_DISTANCE_KAPPA) {
+        const fleeCost = closestEnemy.distanceKappa + 500; // Escape cost
+        const fleeReward = drives.safetyNeed;
+        const driveStrength = drives.safetyNeed;
+
+        scores.push({
+          action: 'FLEE',
+          score: kSub(kMul(driveStrength, fleeReward), fleeCost),
+          driveStrength,
+          reward: fleeReward,
+          risk: 0,
+          cost: fleeCost,
+          reason: `FLEE: enemy at ${closestEnemy.distanceKappa}K, safety need ${drives.safetyNeed}`,
+        });
+      }
+
+      // ── IDLE (default) ──
+      scores.push({
+        action: 'IDLE',
+        score: 0,
+        driveStrength: 0,
+        reward: 0,
+        risk: 0,
+        cost: 0,
+        reason: 'Idle: no compelling action',
+      });
+
+      return AREGuard.protectPayload(scores);
+    });
+  }
+
+  /**
+   * Select the best action based on highest utility score.
+   */
+  static selectBestAction(actionScores: readonly ActionScore[]): ActionScore {
+    return AREGuard.executeProtected(() => {
+      let best = actionScores[0];
+      
+      for (let i = 1; i < actionScores.length; i++) {
+        const current = actionScores[i];
+        // Select action with highest score
+        if (current.score > (best?.score ?? Number.MIN_SAFE_INTEGER)) {
+          best = current;
+        }
+      }
+
+      return AREGuard.protectPayload(best ?? {
+        action: 'IDLE' as const,
+        score: 0,
+        driveStrength: 0,
+        reward: 0,
+        risk: 0,
+        cost: 0,
+        reason: 'No action available',
+      });
+    });
+  }
+
+  /**
+   * Main entry point: Compute full utility intelligence for NPC.
+   * This is the "brain" that decides what NPC will do next.
+   */
+  static computeUtilityIntelligence(
+    npcState: {
+      id: string;
+      health: number;
+      maxHealth: number;
+      energy: number;
+      maxEnergy: number;
+      position: AREVector3;
+    },
+    inventorySlots: readonly (Readonly<{ id?: string } | null)[],
+    worldEntities: readonly Readonly<IAREPayload>[],
+    ownedStorageCount: number,
+    tick: number
+  ): UtilityIntelligence {
+    return AREGuard.executeProtected(() => {
+      // Step 1: Scan environment
+      const environment = ARENpcEvolution.scanEnvironment(
+        npcState.position,
+        worldEntities
+      );
+
+      // Step 2: Calculate drives
+      const drives = ARENpcEvolution.calculateDrives(
+        npcState,
+        inventorySlots,
+        environment.enemies[0],
+        ownedStorageCount
+      );
+
+      // Step 3: Check inventory for crafting ingredients
+      const inventoryAnalysis = calculateDriveFromInventory(inventorySlots);
+
+      // Step 4: Evaluate all possible actions
+      const actionScores = ARENpcEvolution.evaluateActions(
+        drives,
+        environment,
+        {
+          wood: inventoryAnalysis.hasWood,
+          stone: inventoryAnalysis.hasStone,
+          iron: inventoryAnalysis.hasIron,
+        }
+      );
+
+      // Step 5: Select best action
+      const selected = ARENpcEvolution.selectBestAction(actionScores);
+
+      return AREGuard.protectPayload({
+        drives,
+        environment,
+        actionScores,
+        selectedAction: selected.action,
+        targetEntity: selected.targetEntity,
+        tick,
+      });
+    });
+  }
+
+  /**
+   * Generate NPC crafting intent payload.
+   * When brain decides CRAFT_CHEST, this creates the deterministic intent.
+   */
+  static generateCraftingIntent(
+    npcId: string,
+    recipeId: string,
+    tick: number
+  ): Readonly<{ npcId: string; type: 'npc_craft'; recipeId: string; tick: number; kappaHash: string }> {
+    return AREGuard.executeProtected(() => {
+      const kappaHash = AREHash.generate({
+        npcId,
+        recipeId,
+        tick,
+        intent: 'CRAFT',
+      }).toString(16);
+
+      return AREGuard.protectPayload({
+        npcId,
+        type: 'npc_craft',
+        recipeId,
+        tick,
+        kappaHash,
+      });
+    });
+  }
+
+  /**
+   * Generate resource gathering intent payload.
+   * When brain decides GATHER_WOOD, this creates the deterministic intent.
+   */
+  static generateGatherIntent(
+    npcId: string,
+    resourceNodeId: string,
+    resourceType: string,
+    tick: number
+  ): Readonly<{ npcId: string; type: 'npc_gather'; resourceNodeId: string; resourceType: string; tick: number; kappaHash: string }> {
+    return AREGuard.executeProtected(() => {
+      const kappaHash = AREHash.generate({
+        npcId,
+        resourceNodeId,
+        resourceType,
+        tick,
+        intent: 'GATHER',
+      }).toString(16);
+
+      return AREGuard.protectPayload({
+        npcId,
+        type: 'npc_gather',
+        resourceNodeId,
+        resourceType,
+        tick,
+        kappaHash,
+      });
     });
   }
 }

--- a/server/src/core/are/ARENpcEvolution.ts
+++ b/server/src/core/are/ARENpcEvolution.ts
@@ -1,7 +1,7 @@
 import { AREGuard } from './AREGuard';
 import { AREHash } from './AREHash';
 import type { AREVector3, IAREPayload } from './AREPayload';
-import { assertSafeInteger, kAdd, kSub, type KappaInt } from './Kappa';
+import { assertSafeInteger, kAdd, kSub, kMul, kDiv, type KappaInt, toKappa } from './Kappa';
 
 /**
  * OUROBOROS SYSTEMIC EMERGENCE: ARENpcEvolution Utility AI
@@ -94,13 +94,13 @@ export interface ScannedEnvironment {
 }
 
 const DEFAULT_CHUNK_SIZE = 64000;
-const DEFAULT_VISION_RANGE_KAPPA = 5000;  // 5 meters in kappa
-const SAFE_ENEMY_DISTANCE_KAPPA = 2000;   // 2 meters - too close = danger
+const DEFAULT_VISION_RANGE_KAPPA = toKappa(5);  // 5 meters in kappa
+const SAFE_ENEMY_DISTANCE_KAPPA = toKappa(2);   // 2 meters - too close = danger
 const RESOURCE_VALUES: Record<string, KappaInt> = {
-  tree: 100,
-  rock: 150,
-  iron: 300,
-  fiber: 50,
+  tree: toKappa(100),
+  rock: toKappa(150),
+  iron: toKappa(300),
+  fiber: toKappa(50),
 };
 
 function readInt(payload: Readonly<IAREPayload>, key: string): KappaInt {
@@ -135,19 +135,25 @@ function clampK(value: KappaInt, min: KappaInt, max: KappaInt): KappaInt {
   return Math.max(min, Math.min(max, value));
 }
 
+const DEFAULT_THREAT_SCALE = toKappa(0.2);  // Scale factor for threat calculation
+
 function calculateRiskScore(
   closestEnemy: EnvironmentalEntity | undefined,
   enemyThreshold: KappaInt
 ): KappaInt {
   if (!closestEnemy) return 0;
   
+  const threat = closestEnemy.threat ?? 0;
+  
   if (closestEnemy.distanceKappa <= enemyThreshold) {
     // High risk: enemy very close
     const severity = kDiv(enemyThreshold - closestEnemy.distanceKappa, enemyThreshold);
-    return kAdd(severity, (closestEnemy.threat ?? 0) * 500);
+    const threatValue = kMul(toKappa(threat), toKappa(0.5));
+    return kAdd(severity, threatValue);
   }
   
-  return (closestEnemy.threat ?? 0) * 200;
+  const threatValue = kMul(toKappa(threat), toKappa(DEFAULT_THREAT_SCALE / 1000));
+  return threatValue;
 }
 
 function calculateDriveFromInventory(
@@ -171,7 +177,7 @@ function calculateDriveFromInventory(
   const resourceNeed = Math.max(0, maxCapacity - totalItems) * 50; // Scale 0-1000
   
   return {
-    resourceNeed: clampK(resourceNeed, 0, 1000),
+    resourceNeed: clampK(toKappa(resourceNeed), 0, toKappa(1000)),
     hasWood: woodCount >= 5,
     hasStone: stoneCount >= 3,
     hasIron: ironCount >= 2,
@@ -328,18 +334,17 @@ export class ARENpcEvolution {
       // Safety need: enemy proximity
       const safetyNeed = clampK(
         calculateRiskScore(closestEnemy, SAFE_ENEMY_DISTANCE_KAPPA),
-        0,
-        1000
+        toKappa(0),
+        toKappa(1000)
       );
 
       // Wealth need: want more storage capacity
-      const storageCapacity = ownedStorages * 12; // Each storage = 12 slots
       const wealthNeed = ownedStorages === 0
-        ? 800  // High need if no storage
-        : 200; // Low need if has storage
+        ? toKappa(800)  // High need if no storage
+        : toKappa(200); // Low need if has storage
 
       // Social/territorial need (simplified)
-      const socialNeed = 100; // Placeholder
+      const socialNeed = toKappa(100); // Placeholder
 
       return AREGuard.protectPayload({
         resourceNeed: inventoryAnalysis.resourceNeed,
@@ -412,8 +417,8 @@ export class ARENpcEvolution {
       // ── CRAFT_WOODEN_CHEST ──
       if (inventoryHasIngredients.wood) {
         const craftRisk = calculateRiskScore(closestEnemy, SAFE_ENEMY_DISTANCE_KAPPA);
-        const craftCost = 100; // Fixed crafting cost
-        const craftReward = 500; // Value of storage
+        const craftCost = toKappa(100); // Fixed crafting cost
+        const craftReward = toKappa(500); // Value of storage
         const driveStrength = drives.wealthNeed;
 
         scores.push({
@@ -431,7 +436,7 @@ export class ARENpcEvolution {
       if (closestStorage) {
         const storeRisk = calculateRiskScore(closestEnemy, SAFE_ENEMY_DISTANCE_KAPPA);
         const storeCost = closestStorage.distanceKappa;
-        const storeReward = 200; // Value of organization
+        const storeReward = toKappa(200); // Value of organization
         const driveStrength = drives.wealthNeed;
 
         scores.push({
@@ -448,7 +453,7 @@ export class ARENpcEvolution {
 
       // ── FLEE ──
       if (closestEnemy && closestEnemy.distanceKappa <= SAFE_ENEMY_DISTANCE_KAPPA) {
-        const fleeCost = closestEnemy.distanceKappa + 500; // Escape cost
+        const fleeCost = kAdd(closestEnemy.distanceKappa, toKappa(500)); // Escape cost
         const fleeReward = drives.safetyNeed;
         const driveStrength = drives.safetyNeed;
 
@@ -457,7 +462,7 @@ export class ARENpcEvolution {
           score: kSub(kMul(driveStrength, fleeReward), fleeCost),
           driveStrength,
           reward: fleeReward,
-          risk: 0,
+          risk: toKappa(0),
           cost: fleeCost,
           reason: `FLEE: enemy at ${closestEnemy.distanceKappa}K, safety need ${drives.safetyNeed}`,
         });
@@ -466,11 +471,11 @@ export class ARENpcEvolution {
       // ── IDLE (default) ──
       scores.push({
         action: 'IDLE',
-        score: 0,
-        driveStrength: 0,
-        reward: 0,
-        risk: 0,
-        cost: 0,
+        score: toKappa(0),
+        driveStrength: toKappa(0),
+        reward: toKappa(0),
+        risk: toKappa(0),
+        cost: toKappa(0),
         reason: 'Idle: no compelling action',
       });
 
@@ -488,18 +493,18 @@ export class ARENpcEvolution {
       for (let i = 1; i < actionScores.length; i++) {
         const current = actionScores[i];
         // Select action with highest score
-        if (current.score > (best?.score ?? Number.MIN_SAFE_INTEGER)) {
+        if (current.score > (best?.score ?? toKappa(Number.MIN_SAFE_INTEGER))) {
           best = current;
         }
       }
 
       return AREGuard.protectPayload(best ?? {
         action: 'IDLE' as const,
-        score: 0,
-        driveStrength: 0,
-        reward: 0,
-        risk: 0,
-        cost: 0,
+        score: toKappa(0),
+        driveStrength: toKappa(0),
+        reward: toKappa(0),
+        risk: toKappa(0),
+        cost: toKappa(0),
         reason: 'No action available',
       });
     });

--- a/server/src/core/are/ARENpcEvolution.ts
+++ b/server/src/core/are/ARENpcEvolution.ts
@@ -581,7 +581,7 @@ export class ARENpcEvolution {
     tick: number
   ): Readonly<{ npcId: string; type: 'npc_craft'; recipeId: string; tick: number; kappaHash: string }> {
     return AREGuard.executeProtected(() => {
-      const kappaHash = AREHash.generate({
+      const kappaHash = AREHash.hashObject({
         npcId,
         recipeId,
         tick,
@@ -609,7 +609,7 @@ export class ARENpcEvolution {
     tick: number
   ): Readonly<{ npcId: string; type: 'npc_gather'; resourceNodeId: string; resourceType: string; tick: number; kappaHash: string }> {
     return AREGuard.executeProtected(() => {
-      const kappaHash = AREHash.generate({
+      const kappaHash = AREHash.hashObject({
         npcId,
         resourceNodeId,
         resourceType,

--- a/server/src/core/are/ARENpcEvolution.ts
+++ b/server/src/core/are/ARENpcEvolution.ts
@@ -323,7 +323,7 @@ export class ARENpcEvolution {
       energy: number;
       maxEnergy: number;
     },
-    inventorySlots: readonly (Readonly<{ id?: string } | null)[],
+    inventorySlots: readonly { id?: string }[],
     closestEnemy: EnvironmentalEntity | undefined,
     ownedStorages: number
   ): DriveState {
@@ -523,7 +523,7 @@ export class ARENpcEvolution {
       maxEnergy: number;
       position: AREVector3;
     },
-    inventorySlots: readonly (Readonly<{ id?: string } | null)[],
+    inventorySlots: readonly { id?: string }[],
     worldEntities: readonly Readonly<IAREPayload>[],
     ownedStorageCount: number,
     tick: number

--- a/server/src/modules/crafting/CraftingDirector.ts
+++ b/server/src/modules/crafting/CraftingDirector.ts
@@ -1,0 +1,344 @@
+/**
+ * OUROBOROS SYSTEMIC EMERGENCE: CraftingDirector
+ * 
+ * Authoritative NPC-Crafting Counterpart
+ * 
+ * Axiom der Erhaltung (Conservation Axiom):
+ * NPCs use EXACTLY the same systems as players. When an NPC crafts,
+ * it sends a deterministic CRAFT intent to the server. The NPC
+ * needs real items in its inventory - no phantom crafting.
+ * 
+ * This director is the server-authoritative handler for NPC crafting
+ * intents. It validates ingredients against NPC inventory, executes
+ * crafting, and returns deterministic results.
+ */
+
+import { AREGuard } from '../../core/are/AREGuard.js';
+import { AREHash } from '../../core/are/AREHash.js';
+import { ItemRegistry } from '../inventory/ItemRegistry.js';
+import { normalizeInventoryStacks } from '../inventory/inventoryStacks.js';
+
+export interface NPCInventory {
+  slots: (ModularItem | null)[];
+  maxSlots: number;
+  [key: string]: unknown;
+}
+
+export interface ModularItem {
+  id: string;
+  quantity?: number;
+  [key: string]: unknown;
+}
+
+export interface CraftingRecipe {
+  id: string;
+  name: string;
+  skill?: string;
+  requiredLevel: number;
+  ingredients: Array<{ id: string; amount: number }>;
+  result: { id: string; amount: number };
+  xpReward?: number;
+  storageType?: 'none' | 'basic' | 'advanced';
+}
+
+export interface NPCCraftIntent {
+  npcId: string;
+  recipeId: string;
+  tick: number;
+  kappaHash?: string;
+}
+
+export interface NPCCraftResult {
+  success: boolean;
+  npcId: string;
+  recipeId: string;
+  item?: { id: string };
+  reason?: string;
+  tick: number;
+  kappaHash: string;
+}
+
+const DEFAULT_MAX_WEIGHT = 1000;
+
+export class CraftingDirector {
+  private static instance: CraftingDirector;
+  private recipes: Map<string, CraftingRecipe> = new Map();
+  
+  // Recipe defaults with storage recipes for ARE system
+  private readonly DEFAULT_RECIPES: CraftingRecipe[] = [
+    {
+      id: 'wooden_chest_craft',
+      name: 'Wooden Chest',
+      requiredLevel: 1,
+      ingredients: [{ id: 'base:wood', amount: 5 }],
+      result: { id: 'base:chest', amount: 1 },
+      storageType: 'basic',
+    },
+    {
+      id: 'iron_chest_craft',
+      name: 'Iron Chest',
+      requiredLevel: 3,
+      ingredients: [
+        { id: 'base:iron_bar', amount: 8 },
+        { id: 'base:wood', amount: 3 },
+      ],
+      result: { id: 'base:iron_chest', amount: 1 },
+      storageType: 'advanced',
+    },
+    {
+      id: 'wooden_shield_craft',
+      name: 'Wooden Shield',
+      requiredLevel: 1,
+      ingredients: [{ id: 'base:wood', amount: 3 }],
+      result: { id: 'base:wooden_shield', amount: 1 },
+    },
+    {
+      id: 'iron_sword_craft',
+      name: 'Iron Sword',
+      requiredLevel: 2,
+      ingredients: [
+        { id: 'base:iron_bar', amount: 2 },
+        { id: 'base:wood', amount: 1 },
+      ],
+      result: { id: 'base:iron_sword', amount: 1 },
+    },
+    {
+      id: 'basic_pickaxe_craft',
+      name: 'Basic Pickaxe',
+      requiredLevel: 1,
+      ingredients: [
+        { id: 'base:wood', amount: 2 },
+        { id: 'base:stone', amount: 3 },
+      ],
+      result: { id: 'base:pickaxe', amount: 1 },
+    },
+  ];
+
+  private constructor() {
+    this.loadDefaultRecipes();
+  }
+
+  public static getInstance(): CraftingDirector {
+    if (!CraftingDirector.instance) {
+      CraftingDirector.instance = new CraftingDirector();
+    }
+    return CraftingDirector.instance;
+  }
+
+  private loadDefaultRecipes(): void {
+    for (const recipe of this.DEFAULT_RECIPES) {
+      this.recipes.set(recipe.id, recipe);
+    }
+  }
+
+  /**
+   * Register a crafting recipe deterministically.
+   */
+  public registerRecipe(recipe: CraftingRecipe): void {
+    AREGuard.executeProtected(() => {
+      if (!recipe.id || !recipe.result?.id) {
+        throw new Error('[CraftingDirector] Invalid recipe: missing id or result');
+      }
+      this.recipes.set(recipe.id, recipe);
+    });
+  }
+
+  /**
+   * Get all registered recipes.
+   */
+  public getRecipes(): CraftingRecipe[] {
+    return Array.from(this.recipes.values());
+  }
+
+  /**
+   * Get recipe by ID.
+   */
+  public getRecipe(recipeId: string): CraftingRecipe | undefined {
+    return this.recipes.get(recipeId);
+  }
+
+  /**
+   * Check if NPC can craft a recipe (has sufficient ingredients).
+   * Returns deterministic result without modifying state.
+   */
+  public canCraft(npcInventory: NPCInventory, recipeId: string): { possible: boolean; reason?: string } {
+    return AREGuard.executeProtected(() => {
+      const recipe = this.recipes.get(recipeId);
+      if (!recipe) {
+        return { possible: false, reason: 'RECIPE_NOT_FOUND' };
+      }
+
+      // Validate ingredients against NPC inventory
+      for (const ing of recipe.ingredients) {
+        let haveCount = 0;
+        
+        for (const slot of npcInventory.slots) {
+          if (slot && slot.id === ing.id) {
+            haveCount += slot.quantity ?? 1;
+          }
+        }
+
+        if (haveCount < ing.amount) {
+          return { possible: false, reason: `MISSING_INGREDIENT:${ing.id}` };
+        }
+      }
+
+      return { possible: true };
+    });
+  }
+
+  /**
+   * Execute crafting for NPC.
+   * Removes ingredients from NPC inventory, adds result item.
+   * Returns deterministic result payload.
+   */
+  public craft(
+    npcId: string,
+    npcInventory: NPCInventory,
+    recipeId: string,
+    tick: number
+  ): NPCCraftResult {
+    return AREGuard.executeProtected(() => {
+      const recipe = this.recipes.get(recipeId);
+      if (!recipe) {
+        return this.buildFailureResult(npcId, recipeId, tick, 'RECIPE_NOT_FOUND');
+      }
+
+      // ── Validate ingredients before mutation ──
+      const ingredientValidation: { id: string; need: number; have: number }[] = [];
+      let allValid = true;
+
+      for (const ing of recipe.ingredients) {
+        let haveCount = 0;
+        for (const slot of npcInventory.slots) {
+          if (slot && slot.id === ing.id) {
+            haveCount += slot.quantity ?? 1;
+          }
+        }
+        ingredientValidation.push({ id: ing.id, need: ing.amount, have: haveCount });
+        if (haveCount < ing.amount) {
+          allValid = false;
+        }
+      }
+
+      if (!allValid) {
+        return this.buildFailureResult(npcId, recipeId, tick, 'MISSING_INGREDIENTS');
+      }
+
+      // ── Atomic ingredient removal ──
+      const slots = npcInventory.slots;
+      for (const ing of recipe.ingredients) {
+        let remaining = ing.amount;
+        for (let i = 0; i < slots.length && remaining > 0; i++) {
+          const slot = slots[i];
+          if (!slot || slot.id !== ing.id) continue;
+
+          const slotQty = slot.quantity ?? 1;
+          if (slotQty <= remaining) {
+            remaining -= slotQty;
+            slots[i] = null;
+          } else {
+            slot.quantity = slotQty - remaining;
+            remaining = 0;
+          }
+        }
+      }
+
+      // ── Add result item to NPC inventory ──
+      const resultId = recipe.result.id;
+      const resultQty = recipe.result.amount;
+      const maxStack = ItemRegistry.maxStackFor(ItemRegistry.getItem(resultId));
+
+      let toPlace = resultQty;
+      while (toPlace > 0) {
+        const n = Math.min(maxStack, toPlace);
+        const instance = ItemRegistry.createInstance(resultId, n);
+        if (instance) {
+          slots.push(instance as ModularItem);
+        } else {
+          const item: ModularItem = { id: resultId, quantity: n };
+          slots.push(item);
+        }
+        toPlace -= n;
+      }
+
+      normalizeInventoryStacks({ inventory: slots } as unknown as { inventory: (ModularItem | null)[] });
+
+      // ── Generate deterministic kappa hash for audit trail ──
+      const kappaHash = AREHash.generate({
+        npcId,
+        recipeId,
+        tick,
+        ingredients: ingredientValidation,
+      }).toString(16);
+
+      return {
+        success: true,
+        npcId,
+        recipeId,
+        item: { id: resultId },
+        tick,
+        kappaHash,
+      };
+    });
+  }
+
+  /**
+   * Process NPC crafting intent directly.
+   * Wrapper for intent handling.
+   */
+  public processIntent(intent: NPCCraftIntent, npcInventory: NPCInventory): NPCCraftResult {
+    return this.craft(
+      intent.npcId,
+      npcInventory,
+      intent.recipeId,
+      intent.tick
+    );
+  }
+
+  /**
+   * Get all storage-type recipes (for chest/container crafting).
+   */
+  public getStorageRecipes(): CraftingRecipe[] {
+    return this.getRecipes().filter(r => r.storageType && r.storageType !== 'none');
+  }
+
+  /**
+   * Check if a recipe produces a storage item.
+   */
+  public isStorageRecipe(recipeId: string): boolean {
+    const recipe = this.recipes.get(recipeId);
+    return !!(recipe?.storageType && recipe.storageType !== 'none');
+  }
+
+  /**
+   * Build deterministic failure result.
+   */
+  private buildFailureResult(
+    npcId: string,
+    recipeId: string,
+    tick: number,
+    reason: string
+  ): NPCCraftResult {
+    const kappaHash = AREHash.generate({
+      npcId,
+      recipeId,
+      tick,
+      failure: true,
+      reason,
+    }).toString(16);
+
+    return {
+      success: false,
+      npcId,
+      recipeId,
+      reason,
+      tick,
+      kappaHash,
+    };
+  }
+}
+
+// ─── Singleton Export ───────────────────────────────────────────────────
+
+export const craftingDirector = CraftingDirector.getInstance();

--- a/server/src/modules/crafting/CraftingDirector.ts
+++ b/server/src/modules/crafting/CraftingDirector.ts
@@ -265,7 +265,7 @@ export class CraftingDirector {
       normalizeInventoryStacks({ inventory: slots } as unknown as { inventory: (ModularItem | null)[] });
 
       // ── Generate deterministic kappa hash for audit trail ──
-      const kappaHash = AREHash.generate({
+      const kappaHash = AREHash.hashObject({
         npcId,
         recipeId,
         tick,
@@ -320,7 +320,7 @@ export class CraftingDirector {
     tick: number,
     reason: string
   ): NPCCraftResult {
-    const kappaHash = AREHash.generate({
+    const kappaHash = AREHash.hashObject({
       npcId,
       recipeId,
       tick,

--- a/server/src/modules/npc/NPCCraftingAdapter.ts
+++ b/server/src/modules/npc/NPCCraftingAdapter.ts
@@ -1,0 +1,191 @@
+/**
+ * OUROBOROS SYSTEMIC EMERGENCE: NPC Crafting Adapter
+ * 
+ * Wires NPCSystem thinking to CraftingDirector execution.
+ * When ARENpcEvolution brain decides CRAFT_CHEST, this adapter
+ * creates the crafting intent and executes it.
+ * 
+ * Conservation Axiom: NPCs send exact same crafting intents as players.
+ * No special treatment, no phantom crafting.
+ */
+
+import { AREGuard } from '../../core/are/AREGuard.js';
+import { ARENpcEvolution } from '../../core/are/ARENpcEvolution.js';
+import { craftingDirector, type NPCCraftResult } from '../crafting/CraftingDirector.js';
+import { npcInventoryManager } from './NPCInventoryManager.js';
+
+export interface NPCCraftingIntent {
+  npcId: string;
+  selectedAction: string;
+  recipeId: string;
+  targetEntity?: string;
+}
+
+export interface CraftingExecutionResult {
+  success: boolean;
+  npcId: string;
+  action: string;
+  craftResult?: NPCCraftResult;
+  itemCreated?: boolean;
+  reason?: string;
+  tick: number;
+}
+
+/**
+ * NPCCraftingAdapter
+ * 
+ * This is the bridge between NPC decision-making and server-side crafting.
+ * It receives crafting decisions from ARENpcEvolution and executes them
+ * through the CraftingDirector using the NPC's real inventory.
+ */
+export class NPCCraftingAdapter {
+  private static instance: NPCCraftingAdapter;
+
+  private constructor() {}
+
+  public static getInstance(): NPCCraftingAdapter {
+    if (!NPCCraftingAdapter.instance) {
+      NPCCraftingAdapter.instance = new NPCCraftingAdapter();
+    }
+    return NPCCraftingAdapter.instance;
+  }
+
+  /**
+   * Execute crafting action for NPC.
+   * Validates ingredients, executes craft, updates NPC inventory.
+   */
+  public executeCrafting(
+    npcId: string,
+    recipeId: string,
+    tick: number
+  ): CraftingExecutionResult {
+    return AREGuard.executeProtected(() => {
+      // Get NPC inventory
+      const inventory = npcInventoryManager.getInventory(npcId);
+      if (!inventory) {
+        return {
+          success: false,
+          npcId,
+          action: 'CRAFT',
+          reason: 'NPC_INVENTORY_NOT_FOUND',
+          tick,
+        };
+      }
+
+      // Convert NPCInventoryState to format expected by CraftingDirector
+      // This follows Conservation Axiom - NPCs use same inventory format
+      const npcInventory = {
+        slots: inventory.slots,
+        maxSlots: inventory.maxSlots,
+      };
+
+      // First check if can craft (validation without mutation)
+      const canCraftResult = craftingDirector.canCraft(npcInventory, recipeId);
+      if (!canCraftResult.possible) {
+        return {
+          success: false,
+          npcId,
+          action: 'CRAFT',
+          reason: canCraftResult.reason,
+          tick,
+        };
+      }
+
+      // Execute the crafting (this mutates actual inventory)
+      const craftResult = craftingDirector.craft(npcId, npcInventory, recipeId, tick);
+
+      if (craftResult.success) {
+        // Update NPC inventory manager with modified slots
+        inventory.slots = npcInventory.slots;
+        
+        return {
+          success: true,
+          npcId,
+          action: 'CRAFT',
+          craftResult,
+          itemCreated: true,
+          tick,
+        };
+      }
+
+      return {
+        success: false,
+        npcId,
+        action: 'CRAFT',
+        reason: craftResult.reason,
+        tick,
+      };
+    });
+  }
+
+  /**
+   * Process utility intelligence decision from ARENpcEvolution.
+   * Main entry point for NPCSystem integration.
+   */
+  public processUtilityDecision(
+    npcId: string,
+    selectedAction: string,
+    targetEntity: string | undefined,
+    tick: number
+  ): CraftingExecutionResult {
+    return AREGuard.executeProtected(() => {
+      switch (selectedAction) {
+        case 'CRAFT_WOODEN_CHEST':
+          return this.executeCrafting(npcId, 'wooden_chest_craft', tick);
+
+        case 'CRAFT_IRON_CHEST':
+          return this.executeCrafting(npcId, 'iron_chest_craft', tick);
+
+        case 'CRAFT_EQUIPMENT':
+          // For equipment, we'd need more context about what to craft
+          return {
+            success: false,
+            npcId,
+            action: selectedAction,
+            reason: 'CRAFT_EQUIPMENT_REQUIRES_CONTEXT',
+            tick,
+          };
+
+        default:
+          // Not a crafting action, just record the decision
+          return {
+            success: true,
+            npcId,
+            action: selectedAction,
+            tick,
+          };
+      }
+    });
+  }
+
+  /**
+   * Clear NPC crafting state (on decomposition).
+   */
+  public onNPCCleanup(npcId: string): void {
+    npcInventoryManager.clearInventory(npcId);
+  }
+
+  /**
+   * Get crafting recipes available to NPC.
+   */
+  public getAvailableRecipes(npcId: string): { id: string; name: string; canCraft: boolean }[] {
+    const inventory = npcInventoryManager.getInventory(npcId);
+    if (!inventory) return [];
+
+    const npcInventory = {
+      slots: inventory.slots,
+      maxSlots: inventory.maxSlots,
+    };
+
+    const recipes = craftingDirector.getRecipes();
+    return recipes.map(recipe => ({
+      id: recipe.id,
+      name: recipe.name,
+      canCraft: craftingDirector.canCraft(npcInventory, recipe.id).possible,
+    }));
+  }
+}
+
+// ─── Singleton Export ─────────────────────────────────────────────────
+
+export const npcCraftingAdapter = NPCCraftingAdapter.getInstance();

--- a/server/src/modules/npc/NPCInventoryManager.ts
+++ b/server/src/modules/npc/NPCInventoryManager.ts
@@ -1,0 +1,238 @@
+/**
+ * OUROBOROS SYSTEMIC EMERGENCE: NPC Inventory Manager
+ * 
+ * Provides deterministic inventory management for NPCs.
+ * NPCs use the same inventory system as players - no special treatment.
+ * 
+ * Conservation Axiom: Every item in NPC inventory is a real, tracked item.
+ * NPCs can gather, craft, store, and use items just like players.
+ */
+
+import { AREGuard } from '../../core/are/AREGuard.js';
+import { ItemRegistry } from '../inventory/ItemRegistry.js';
+import { normalizeInventoryStacks } from '../inventory/inventoryStacks.js';
+
+export interface NPCInventorySlot {
+  id: string;
+  quantity: number;
+  [key: string]: unknown;
+}
+
+export interface NPCInventoryState {
+  slots: (NPCInventorySlot | null)[];
+  maxSlots: number;
+  currentWeight: number;
+  maxWeight: number;
+}
+
+export interface NPCInventoryManager {
+  getInventory(npcId: string): NPCInventoryState | undefined;
+  addItem(npcId: string, itemId: string, quantity: number): { success: boolean; reason?: string };
+  removeItem(npcId: string, itemId: string, quantity: number): { success: boolean; item?: NPCInventorySlot; reason?: string };
+  hasItem(npcId: string, itemId: string, amount: number): boolean;
+  countItem(npcId: string, itemId: string): number;
+  getItemCount(npcId: string): number;
+}
+
+const DEFAULT_NPC_INVENTORY_SLOTS = 12;
+const DEFAULT_NPC_INVENTORY_WEIGHT = 50;
+
+export class NPCInventoryManager {
+  private static instance: NPCInventoryManager;
+  private inventories: Map<string, NPCInventoryState> = new Map();
+
+  private constructor() {}
+
+  public static getInstance(): NPCInventoryManager {
+    if (!NPCInventoryManager.instance) {
+      NPCInventoryManager.instance = new NPCInventoryManager();
+    }
+    return NPCInventoryManager.instance;
+  }
+
+  /**
+   * Initialize inventory for a new NPC.
+   */
+  public initializeNPC(npcId: string, maxSlots: number = DEFAULT_NPC_INVENTORY_SLOTS): NPCInventoryState {
+    return AREGuard.executeProtected(() => {
+      if (this.inventories.has(npcId)) {
+        return this.inventories.get(npcId)!;
+      }
+
+      const inventory: NPCInventoryState = {
+        slots: new Array(maxSlots).fill(null),
+        maxSlots,
+        currentWeight: 0,
+        maxWeight: DEFAULT_NPC_INVENTORY_WEIGHT,
+      };
+
+      this.inventories.set(npcId, inventory);
+      return inventory;
+    });
+  }
+
+  /**
+   * Get NPC inventory.
+   */
+  public getInventory(npcId: string): NPCInventoryState | undefined {
+    return this.inventories.get(npcId);
+  }
+
+  /**
+   * Add item to NPC inventory.
+   */
+  public addItem(npcId: string, itemId: string, quantity: number): { success: boolean; reason?: string } {
+    return AREGuard.executeProtected(() => {
+      let inventory = this.inventories.get(npcId);
+      if (!inventory) {
+        inventory = this.initializeNPC(npcId);
+      }
+
+      const slots = inventory.slots;
+
+      // Try to stack with existing item first
+      for (let i = 0; i < slots.length; i++) {
+        const slot = slots[i];
+        if (slot && slot.id === itemId) {
+          slot.quantity += quantity;
+          normalizeInventoryStacks({ inventory: slots } as unknown as { inventory: (NPCInventorySlot | null)[] });
+          return { success: true };
+        }
+      }
+
+      // Find empty slot
+      for (let i = 0; i < slots.length; i++) {
+        if (slots[i] === null) {
+          const instance = ItemRegistry.createInstance(itemId, quantity);
+          if (instance) {
+            slots[i] = { id: instance.id, quantity: quantity, ...instance };
+          } else {
+            slots[i] = { id: itemId, quantity };
+          }
+          normalizeInventoryStacks({ inventory: slots } as unknown as { inventory: (NPCInventorySlot | null)[] });
+          return { success: true };
+        }
+      }
+
+      return { success: false, reason: 'INVENTORY_FULL' };
+    });
+  }
+
+  /**
+   * Remove item from NPC inventory.
+   */
+  public removeItem(
+    npcId: string,
+    itemId: string,
+    quantity: number
+  ): { success: boolean; item?: NPCInventorySlot; reason?: string } {
+    return AREGuard.executeProtected(() => {
+      const inventory = this.inventories.get(npcId);
+      if (!inventory) {
+        return { success: false, reason: 'INVENTORY_NOT_FOUND' };
+      }
+
+      const slots = inventory.slots;
+
+      for (let i = 0; i < slots.length; i++) {
+        const slot = slots[i];
+        if (slot && slot.id === itemId) {
+          if (slot.quantity < quantity) {
+            return { success: false, reason: 'INSUFFICIENT_QUANTITY' };
+          }
+
+          if (slot.quantity === quantity) {
+            slots[i] = null;
+          } else {
+            slot.quantity -= quantity;
+          }
+
+          normalizeInventoryStacks({ inventory: slots } as unknown as { inventory: (NPCInventorySlot | null)[] });
+          return { success: true, item: { id: itemId, quantity } };
+        }
+      }
+
+      return { success: false, reason: 'ITEM_NOT_FOUND' };
+    });
+  }
+
+  /**
+   * Check if NPC has item in sufficient quantity.
+   */
+  public hasItem(npcId: string, itemId: string, amount: number): boolean {
+    return this.countItem(npcId, itemId) >= amount;
+  }
+
+  /**
+   * Count specific item in NPC inventory.
+   */
+  public countItem(npcId: string, itemId: string): number {
+    const inventory = this.inventories.get(npcId);
+    if (!inventory) return 0;
+
+    let count = 0;
+    for (const slot of inventory.slots) {
+      if (slot && slot.id === itemId) {
+        count += slot.quantity;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Get total item count in NPC inventory.
+   */
+  public getItemCount(npcId: string): number {
+    const inventory = this.inventories.get(npcId);
+    if (!inventory) return 0;
+
+    let count = 0;
+    for (const slot of inventory.slots) {
+      if (slot) {
+        count += slot.quantity;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Get all items in NPC inventory as array.
+   */
+  public getAllItems(npcId: string): NPCInventorySlot[] {
+    const inventory = this.inventories.get(npcId);
+    if (!inventory) return [];
+
+    const items: NPCInventorySlot[] = [];
+    for (const slot of inventory.slots) {
+      if (slot) {
+        items.push(slot);
+      }
+    }
+    return items;
+  }
+
+  /**
+   * Clear NPC inventory (for reset/decomposition).
+   */
+  public clearInventory(npcId: string): boolean {
+    return this.inventories.delete(npcId);
+  }
+
+  /**
+   * Get inventory count.
+   */
+  public getInventoryCount(): number {
+    return this.inventories.size;
+  }
+
+  /**
+   * Get all NPC IDs with initialized inventories.
+   */
+  public getAllNPCIds(): string[] {
+    return Array.from(this.inventories.keys());
+  }
+}
+
+// ─── Singleton Export ─────────────────────────────────────────────────
+
+export const npcInventoryManager = NPCInventoryManager.getInstance();

--- a/server/src/modules/npc/NPCSystem.ts
+++ b/server/src/modules/npc/NPCSystem.ts
@@ -81,6 +81,14 @@ export interface NPC {
     shopId?: string;
     stamina?: number;
     phaseShift?: number;
+    // ARE Systemic Emergence: NPC Inventory (Conservation Axiom - NPCs use same systems as players)
+    inventory?: any;
+    activeUtilityDecision?: {
+      action: string;
+      targetEntity?: string;
+      tick: number;
+      reason?: string;
+    };
 }
 
 type PlayerPerceptionContext = {

--- a/server/src/modules/npc/__tests__/NPCUtilityAIEvolution.test.ts
+++ b/server/src/modules/npc/__tests__/NPCUtilityAIEvolution.test.ts
@@ -31,7 +31,7 @@ describe('ARENpcEvolution Utility AI', () => {
         position: { x: toKappa(0), y: toKappa(0), z: toKappa(0) },
       };
 
-      const inventorySlots: readonly { id?: string }[] = [];
+      const inventorySlots: readonly { id?: string; quantity?: number }[] = [];
       const worldEntities: readonly IAREPayload[] = [];
 
       // When there are no resources and no enemies, should IDLE
@@ -59,7 +59,7 @@ describe('ARENpcEvolution Utility AI', () => {
       };
 
       // Inventory has enough wood (5x)
-      const inventorySlots: readonly { id?: string }[] = [
+      const inventorySlots: readonly { id?: string; quantity?: number }[] = [
         { id: 'base:wood', quantity: 5 },
         { id: 'base:wood', quantity: 2 },
       ];
@@ -90,7 +90,7 @@ describe('ARENpcEvolution Utility AI', () => {
         position: { x: toKappa(0), y: toKappa(0), z: toKappa(0) },
       };
 
-      const inventorySlots: readonly { id?: string }[] = [];
+      const inventorySlots: readonly { id?: string; quantity?: number }[] = [];
 
       // Enemy within unsafe distance (2000 kappa = 2 meters)
       const worldEntities: readonly IAREPayload[] = [

--- a/server/src/modules/npc/__tests__/NPCUtilityAIEvolution.test.ts
+++ b/server/src/modules/npc/__tests__/NPCUtilityAIEvolution.test.ts
@@ -31,7 +31,7 @@ describe('ARENpcEvolution Utility AI', () => {
         position: { x: toKappa(0), y: toKappa(0), z: toKappa(0) },
       };
 
-      const inventorySlots: readonly (Readonly<{ id?: string } | null)[] = [];
+      const inventorySlots: readonly { id?: string }[] = [];
       const worldEntities: readonly IAREPayload[] = [];
 
       // When there are no resources and no enemies, should IDLE
@@ -59,7 +59,7 @@ describe('ARENpcEvolution Utility AI', () => {
       };
 
       // Inventory has enough wood (5x)
-      const inventorySlots: readonly (Readonly<{ id?: string } | null)[] = [
+      const inventorySlots: readonly { id?: string }[] = [
         { id: 'base:wood', quantity: 5 },
         { id: 'base:wood', quantity: 2 },
       ];
@@ -90,7 +90,7 @@ describe('ARENpcEvolution Utility AI', () => {
         position: { x: toKappa(0), y: toKappa(0), z: toKappa(0) },
       };
 
-      const inventorySlots: readonly (Readonly<{ id?: string } | null)[] = [];
+      const inventorySlots: readonly { id?: string }[] = [];
 
       // Enemy within unsafe distance (2000 kappa = 2 meters)
       const worldEntities: readonly IAREPayload[] = [

--- a/server/src/modules/npc/__tests__/NPCUtilityAIEvolution.test.ts
+++ b/server/src/modules/npc/__tests__/NPCUtilityAIEvolution.test.ts
@@ -1,0 +1,380 @@
+/**
+ * OUROBOROS SYSTEMIC EMERGENCE: Integration Tests
+ * 
+ * Tests the complete flow from ARENpcEvolution utility AI through
+ * CraftingDirector to storage entity creation.
+ * 
+ * These tests verify:
+ * 1. NPCs can evaluate actions with utility scoring
+ * 2. NPCs can craft storage items like players
+ * 3. Storage entities are created on craft completion
+ * 4. Inventory is properly managed throughout
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { ARENpcEvolution } from '../../core/are/ARENpcEvolution.js';
+import { craftingDirector } from '../crafting/CraftingDirector.js';
+import { npcInventoryManager } from './NPCInventoryManager.js';
+import { storageEntityManager } from '../structure/StorageEntity.js';
+import type { IAREPayload } from '../../core/are/AREPayload.js';
+import { toKappa } from '../../core/are/Kappa.js';
+
+describe('ARENpcEvolution Utility AI', () => {
+  describe('computeUtilityIntelligence', () => {
+    it('should scan environment and calculate highest utility action', () => {
+      const npcState = {
+        id: 'npc:test-1',
+        health: 100,
+        maxHealth: 100,
+        energy: 1000,
+        maxEnergy: 1000,
+        position: { x: toKappa(0), y: toKappa(0), z: toKappa(0) },
+      };
+
+      const inventorySlots: readonly (Readonly<{ id?: string } | null)[] = [];
+      const worldEntities: readonly IAREPayload[] = [];
+
+      // When there are no resources and no enemies, should IDLE
+      const result = ARENpcEvolution.computeUtilityIntelligence(
+        npcState,
+        inventorySlots,
+        worldEntities,
+        0,
+        1 // tick
+      );
+
+      expect(result).toBeDefined();
+      expect(result.tick).toBe(1);
+      expect(result.selectedAction).toBeDefined();
+    });
+
+    it('should prioritize CRAFT_WOODEN_CHEST when wood is available and no storage owned', () => {
+      const npcState = {
+        id: 'npc:test-2',
+        health: 100,
+        maxHealth: 100,
+        energy: 1000,
+        maxEnergy: 1000,
+        position: { x: toKappa(5), y: toKappa(5), z: toKappa(0) },
+      };
+
+      // Inventory has enough wood (5x)
+      const inventorySlots: readonly (Readonly<{ id?: string } | null)[] = [
+        { id: 'base:wood', quantity: 5 },
+        { id: 'base:wood', quantity: 2 },
+      ];
+
+      // No enemies in vicinity, no resources (not needed since we already have wood)
+      const worldEntities: readonly IAREPayload[] = [];
+
+      const result = ARENpcEvolution.computeUtilityIntelligence(
+        npcState,
+        inventorySlots,
+        worldEntities,
+        0, // No storage owned
+        2
+      );
+
+      // Should either CRAFT_WOODEN_CHEST (highest drive) or IDLE
+      expect(['CRAFT_WOODEN_CHEST', 'IDLE']).toContain(result.selectedAction);
+      expect(result.drives.wealthNeed).toBeGreaterThan(0);
+    });
+
+    it('should evaluate FLEE action when enemy is too close', () => {
+      const npcState = {
+        id: 'npc:test-3',
+        health: 100,
+        maxHealth: 100,
+        energy: 1000,
+        maxEnergy: 1000,
+        position: { x: toKappa(0), y: toKappa(0), z: toKappa(0) },
+      };
+
+      const inventorySlots: readonly (Readonly<{ id?: string } | null)[] = [];
+
+      // Enemy within unsafe distance (2000 kappa = 2 meters)
+      const worldEntities: readonly IAREPayload[] = [
+        {
+          entityId: 'enemy:ork-1',
+          position: { x: toKappa(1), y: toKappa(0), z: toKappa(0) },
+          velocity: { x: 0, y: 0, z: 0 },
+          kind: 'ENEMY',
+          threat: 1,
+        },
+      ];
+
+      const result = ARENpcEvolution.computeUtilityIntelligence(
+        npcState,
+        inventorySlots,
+        worldEntities,
+        0,
+        3
+      );
+
+      // Should evaluate FLEE action when enemy is close
+      const fleeScore = result.actionScores.find(a => a.action === 'FLEE');
+      expect(fleeScore).toBeDefined();
+      expect(result.drives.safetyNeed).toBeGreaterThan(0);
+    });
+  });
+
+  describe('generateCraftingIntent', () => {
+    it('should generate deterministic crafting intent payload', () => {
+      const intent = ARENpcEvolution.generateCraftingIntent(
+        'npc:test',
+        'wooden_chest_craft',
+        100
+      );
+
+      expect(intent.npcId).toBe('npc:test');
+      expect(intent.type).toBe('npc_craft');
+      expect(intent.recipeId).toBe('wooden_chest_craft');
+      expect(intent.tick).toBe(100);
+      expect(intent.kappaHash).toBeDefined();
+    });
+  });
+});
+
+describe('NPCInventoryManager', () => {
+  beforeEach(() => {
+    npcInventoryManager.initializeNPC('npc:test-inv');
+  });
+
+  it('should initialize NPC inventory', () => {
+    const inv = npcInventoryManager.getInventory('npc:test-inv');
+    expect(inv).toBeDefined();
+    expect(inv?.slots).toHaveLength(12);
+    expect(inv?.maxWeight).toBe(50);
+  });
+
+  it('should add and remove items', () => {
+    const addResult = npcInventoryManager.addItem('npc:test-inv', 'base:wood', 5);
+    expect(addResult.success).toBe(true);
+
+    const count = npcInventoryManager.countItem('npc:test-inv', 'base:wood');
+    expect(count).toBe(5);
+
+    const removeResult = npcInventoryManager.removeItem('npc:test-inv', 'base:wood', 3);
+    expect(removeResult.success).toBe(true);
+
+    const remainingCount = npcInventoryManager.countItem('npc:test-inv', 'base:wood');
+    expect(remainingCount).toBe(2);
+  });
+
+  it('should return false when inventory is full', () => {
+    const smallInv = npcInventoryManager.initializeNPC('npc:test-inv', 2); // Only 2 slots
+    smallInv; // suppress unused warning
+
+    npcInventoryManager.addItem('npc:test-inv', 'base:wood', 1);
+    npcInventoryManager.addItem('npc:test-inv', 'base:stone', 1);
+    const thirdAdd = npcInventoryManager.addItem('npc:test-inv', 'base:iron', 1);
+
+    expect(thirdAdd.success).toBe(false);
+    expect(thirdAdd.reason).toBe('INVENTORY_FULL');
+  });
+});
+
+describe('CraftingDirector', () => {
+  beforeEach(() => {
+    npcInventoryManager.clearInventory('npc:craft-test');
+    npcInventoryManager.initializeNPC('npc:craft-test');
+  });
+
+  it('should have default recipes including wooden_chest_craft', () => {
+    const recipes = craftingDirector.getRecipes();
+    expect(recipes.length).toBeGreaterThan(0);
+    
+    const woodenChest = recipes.find(r => r.id === 'wooden_chest_craft');
+    expect(woodenChest).toBeDefined();
+    expect(woodenChest?.ingredients).toContainEqual({ id: 'base:wood', amount: 5 });
+  });
+
+  it('should validate canCraft returns false when ingredients missing', () => {
+    const inventory = npcInventoryManager.getInventory('npc:craft-test')!;
+    const npcInventory = {
+      slots: inventory.slots,
+      maxSlots: inventory.maxSlots,
+    };
+
+    const result = craftingDirector.canCraft(npcInventory, 'wooden_chest_craft');
+    expect(result.possible).toBe(false);
+    expect(result.reason).toContain('MISSING_INGREDIENT');
+  });
+
+  it('should successfully craft when ingredients are present', () => {
+    npcInventoryManager.addItem('npc:craft-test', 'base:wood', 5);
+
+    const inventory = npcInventoryManager.getInventory('npc:craft-test')!;
+    const npcInventory = {
+      slots: inventory.slots,
+      maxSlots: inventory.maxSlots,
+    };
+
+    const canCraftResult = craftingDirector.canCraft(npcInventory, 'wooden_chest_craft');
+    expect(canCraftResult.possible).toBe(true);
+
+    const craftResult = craftingDirector.craft('npc:craft-test', npcInventory, 'wooden_chest_craft', 10);
+    expect(craftResult.success).toBe(true);
+    expect(craftResult.item?.id).toBe('base:chest');
+    expect(craftResult.kappaHash).toBeDefined();
+
+    const chestCount = npcInventoryManager.countItem('npc:craft-test', 'base:chest');
+    expect(chestCount).toBe(1);
+  });
+
+  it('should remove ingredients after crafting', () => {
+    npcInventoryManager.addItem('npc:craft-test', 'base:wood', 5);
+
+    const inventory = npcInventoryManager.getInventory('npc:craft-test')!;
+    const npcInventory = {
+      slots: inventory.slots,
+      maxSlots: inventory.maxSlots,
+    };
+
+    craftingDirector.craft('npc:craft-test', npcInventory, 'wooden_chest_craft', 11);
+
+    const woodCount = npcInventoryManager.countItem('npc:craft-test', 'base:wood');
+    expect(woodCount).toBe(0);
+  });
+});
+
+describe('StorageEntity (Counterpart)', () => {
+  beforeEach(() => {
+    storageEntityManager.reset();
+  });
+
+  it('should create storage entity when chest is crafted', () => {
+    npcInventoryManager.initializeNPC('npc:storage-test');
+    npcInventoryManager.addItem('npc:storage-test', 'base:wood', 5);
+
+    const inventory = npcInventoryManager.getInventory('npc:storage-test')!;
+    const npcInventory = {
+      slots: inventory.slots,
+      maxSlots: inventory.maxSlots,
+    };
+
+    craftingDirector.craft('npc:storage-test', npcInventory, 'wooden_chest_craft', 20);
+
+    const chestCount = npcInventoryManager.countItem('npc:storage-test', 'base:chest');
+    expect(chestCount).toBe(1);
+
+    const storageEntity = storageEntityManager.createStorageEntity(
+      'npc:storage-test',
+      { x: 10, y: 5, z: 0 },
+      'basic',
+      21
+    );
+
+    expect(storageEntity).toBeDefined();
+    expect(storageEntity.entityType).toBe('STORAGE');
+    expect(storageEntity.ownerId).toBe('npc:storage-test');
+    expect(storageEntity.inventory.slots).toHaveLength(12);
+  });
+
+  it('should index storage entities for proximity queries', () => {
+    storageEntityManager.createStorageEntity(
+      'npc:owner1',
+      { x: 10, y: 5, z: 0 },
+      'basic',
+      30
+    );
+
+    storageEntityManager.createStorageEntity(
+      'npc:owner1',
+      { x: 15, y: 5, z: 0 },
+      'basic',
+      31
+    );
+
+    const nearbyStorages = storageEntityManager.findStoragesInRadius(
+      { x: 10, y: 5, z: 0 },
+      10000,
+      'npc:owner1'
+    );
+
+    expect(nearbyStorages.length).toBe(2);
+  });
+
+  it('should track storage inventory separately from owner NPC', () => {
+    npcInventoryManager.initializeNPC('npc:separate-test');
+    npcInventoryManager.addItem('npc:separate-test', 'base:wood', 10);
+
+    const storage = storageEntityManager.createStorageEntity(
+      'npc:separate-test',
+      { x: 0, y: 0, z: 0 },
+      'basic',
+      40
+    );
+
+    storageEntityManager.addItemToStorage(storage.entityId, 'base:wood', 5, 41);
+
+    const npcWoodCount = npcInventoryManager.countItem('npc:separate-test', 'base:wood');
+    expect(npcWoodCount).toBe(10);
+
+    const storageEntity = storageEntityManager.getStorageEntity(storage.entityId);
+    expect(storageEntity?.inventory.slots[0]?.id).toBe('base:wood');
+    expect(storageEntity?.inventory.slots[0]?.quantity).toBe(5);
+  });
+});
+
+describe('Systemic Emergence Flow', () => {
+  it('should complete full NPC flow: scan -> decide -> craft -> store', () => {
+    const npcId = 'npc:full-flow-test';
+    
+    storageEntityManager.reset();
+    npcInventoryManager.clearInventory(npcId);
+    npcInventoryManager.initializeNPC(npcId);
+
+    npcInventoryManager.addItem(npcId, 'base:wood', 5);
+    
+    const inventory = npcInventoryManager.getInventory(npcId)!;
+
+    const npcState = {
+      id: npcId,
+      health: 100,
+      maxHealth: 100,
+      energy: 1000,
+      maxEnergy: 1000,
+      position: { x: toKappa(0), y: toKappa(0), z: toKappa(0) },
+    };
+
+    const utilityResult = ARENpcEvolution.computeUtilityIntelligence(
+      npcState,
+      inventory.slots,
+      [],
+      0,
+      100
+    );
+
+    if (utilityResult.selectedAction === 'CRAFT_WOODEN_CHEST') {
+      const result = craftingDirector.craft(
+        npcId,
+        { slots: inventory.slots, maxSlots: inventory.maxSlots },
+        'wooden_chest_craft',
+        101
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.item?.id).toBe('base:chest');
+
+      const storageEntity = storageEntityManager.createStorageEntity(
+        npcId,
+        { x: 0, y: 0, z: 0 },
+        'basic',
+        102
+      );
+
+      expect(storageEntity).toBeDefined();
+      expect(storageEntity.entityType).toBe('STORAGE');
+      expect(storageEntity.ownerId).toBe(npcId);
+
+      const storeResult = storageEntityManager.addItemToStorage(
+        storageEntity.entityId,
+        'base:wood',
+        3,
+        103
+      );
+      expect(storeResult.success).toBe(true);
+    }
+  });
+});

--- a/server/src/modules/structure/StorageEntity.ts
+++ b/server/src/modules/structure/StorageEntity.ts
@@ -98,7 +98,7 @@ export class StorageEntityManager {
    * Generate a deterministic entity ID.
    */
   private generateEntityId(ownerId: string, storageType: StorageTier, tick: number): string {
-    const hash = AREHash.generate({ ownerId, storageType, tick });
+    const hash = AREHash.hashObject({ ownerId, storageType, tick });
     return `storage:${ownerId}:${hash.toString(16).substring(0, 8)}`;
   }
 

--- a/server/src/modules/structure/StorageEntity.ts
+++ b/server/src/modules/structure/StorageEntity.ts
@@ -1,0 +1,374 @@
+/**
+ * OUROBOROS SYSTEMIC EMERGENCE: StorageEntity System
+ * 
+ * Container Counterpart for KAPPA-Grid Entities
+ * 
+ * Axiom der Erhaltung (Conservation Axiom):
+ * Storage entities are world objects with their own InventoryState.
+ * They exist on the KAPPA-grid and can be interacted with by NPCs
+ * and players. When an NPC crafts a chest, a STORAGE entity is created
+ * at the NPC's location.
+ * 
+ * Storage entities are deterministic world objects that:
+ * - Have their own inventory (InventoryState)
+ * - Exist at a KAPPA-grid position
+ * - Can be opened/closed by NPCs and players
+ * - Track ownership for persistence
+ */
+
+import { AREGuard } from '../../core/are/AREGuard.js';
+import { AREHash } from '../../core/are/AREHash.js';
+import { toKappa } from '../../core/are/Kappa.js';
+
+export interface Position {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface InventorySlot {
+  id: string;
+  quantity: number;
+  [key: string]: unknown;
+}
+
+export interface InventoryState {
+  slots: (InventorySlot | null)[];
+  maxSlots: number;
+  currentWeight: number;
+  maxWeight: number;
+}
+
+export type StorageTier = 'basic' | 'advanced' | 'reinforced';
+
+export interface StorageEntityConfig {
+  id: string;
+  ownerId: string;
+  position: Position;
+  storageType: StorageTier;
+  maxSlots: number;
+  maxWeight: number;
+  glbPath?: string;
+}
+
+export interface StorageEntity {
+  entityId: string;
+  entityType: 'STORAGE';
+  ownerId: string;
+  position: Position;
+  storageType: StorageTier;
+  inventory: InventoryState;
+  createdTick: number;
+  lastAccessedTick: number;
+  glbPath?: string;
+  locked: boolean;
+}
+
+// Storage tier configurations
+const STORAGE_TIER_CONFIG: Record<StorageTier, { maxSlots: number; maxWeight: number }> = {
+  basic: { maxSlots: 12, maxWeight: 50 },
+  advanced: { maxSlots: 24, maxWeight: 100 },
+  reinforced: { maxSlots: 48, maxWeight: 200 },
+};
+
+// Default GLB paths by storage type
+const DEFAULT_GLB_PATHS: Record<StorageTier, string> = {
+  basic: '/models/structures/chest_wooden.glb',
+  advanced: '/models/structures/chest_iron.glb',
+  reinforced: '/models/structures/chest_reinforced.glb',
+};
+
+export class StorageEntityManager {
+  private static instance: StorageEntityManager;
+  private storageEntities: Map<string, StorageEntity> = new Map();
+  
+  // Grid-based spatial index for proximity queries
+  private gridIndex: Map<string, Set<string>> = new Map();
+
+  private constructor() {}
+
+  public static getInstance(): StorageEntityManager {
+    if (!StorageEntityManager.instance) {
+      StorageEntityManager.instance = new StorageEntityManager();
+    }
+    return StorageEntityManager.instance;
+  }
+
+  /**
+   * Generate a deterministic entity ID.
+   */
+  private generateEntityId(ownerId: string, storageType: StorageTier, tick: number): string {
+    const hash = AREHash.generate({ ownerId, storageType, tick });
+    return `storage:${ownerId}:${hash.toString(16).substring(0, 8)}`;
+  }
+
+  /**
+   * Get grid key for position (KAPPA-aligned).
+   */
+  private getGridKey(position: Position): string {
+    const kx = toKappa(position.x);
+    const ky = toKappa(position.y);
+    return `${kx}:${ky}`;
+  }
+
+  /**
+   * Index entity in spatial grid.
+   */
+  private indexEntity(entity: StorageEntity): void {
+    const key = this.getGridKey(entity.position);
+    let cell = this.gridIndex.get(key);
+    if (!cell) {
+      cell = new Set();
+      this.gridIndex.set(key, cell);
+    }
+    cell.add(entity.entityId);
+  }
+
+  /**
+   * Remove entity from spatial index.
+   */
+  private unindexEntity(entityId: string, position: Position): void {
+    const key = this.getGridKey(position);
+    const cell = this.gridIndex.get(key);
+    if (cell) {
+      cell.delete(entityId);
+      if (cell.size === 0) {
+        this.gridIndex.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Create a new storage entity.
+   * Called after successful NPC crafting of a chest.
+   */
+  public createStorageEntity(
+    ownerId: string,
+    position: Position,
+    storageType: StorageTier,
+    tick: number
+  ): StorageEntity {
+    return AREGuard.executeProtected(() => {
+      const config = STORAGE_TIER_CONFIG[storageType];
+      const entityId = this.generateEntityId(ownerId, storageType, tick);
+
+      if (this.storageEntities.has(entityId)) {
+        const existing = this.storageEntities.get(entityId)!;
+        return existing;
+      }
+
+      const entity: StorageEntity = {
+        entityId,
+        entityType: 'STORAGE',
+        ownerId,
+        position: { ...position },
+        storageType,
+        inventory: {
+          slots: new Array(config.maxSlots).fill(null),
+          maxSlots: config.maxSlots,
+          currentWeight: 0,
+          maxWeight: config.maxWeight,
+        },
+        createdTick: tick,
+        lastAccessedTick: tick,
+        glbPath: DEFAULT_GLB_PATHS[storageType],
+        locked: false,
+      };
+
+      AREGuard.assertNoFloats(entity);
+      this.storageEntities.set(entityId, entity);
+      this.indexEntity(entity);
+
+      return entity;
+    });
+  }
+
+  /**
+   * Get storage entity by ID.
+   */
+  public getStorageEntity(entityId: string): StorageEntity | null {
+    return this.storageEntities.get(entityId) ?? null;
+  }
+
+  /**
+   * Get all storage entities owned by an NPC/player.
+   */
+  public getStoragesByOwner(ownerId: string): StorageEntity[] {
+    const result: StorageEntity[] = [];
+    for (const entity of this.storageEntities.values()) {
+      if (entity.ownerId === ownerId) {
+        result.push(entity);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Find storage entities within KAPPA-distance radius.
+   * Used for NPC storage actions.
+   */
+  public findStoragesInRadius(
+    position: Position,
+    radiusKappa: number,
+    ownerId?: string
+  ): StorageEntity[] {
+    const kx = toKappa(position.x);
+    const ky = toKappa(position.y);
+    const kr = Math.abs(radiusKappa);
+
+    const result: StorageEntity[] = [];
+
+    for (const entity of this.storageEntities.values()) {
+      if (ownerId && entity.ownerId !== ownerId) continue;
+      
+      const ex = toKappa(entity.position.x);
+      const ey = toKappa(entity.position.y);
+      
+      const dx = Math.abs(ex - kx);
+      const dy = Math.abs(ey - ky);
+      
+      if (dx <= kr && dy <= kr) {
+        result.push(entity);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Add item to storage entity.
+   */
+  public addItemToStorage(
+    entityId: string,
+    itemId: string,
+    quantity: number,
+    tick: number
+  ): { success: boolean; reason?: string } {
+    return AREGuard.executeProtected(() => {
+      const entity = this.storageEntities.get(entityId);
+      if (!entity) {
+        return { success: false, reason: 'STORAGE_NOT_FOUND' };
+      }
+
+      const slots = entity.inventory.slots;
+
+      // Try to stack with existing item first
+      for (let i = 0; i < slots.length; i++) {
+        const slot = slots[i];
+        if (slot && slot.id === itemId) {
+          slot.quantity += quantity;
+          entity.lastAccessedTick = tick;
+          return { success: true };
+        }
+      }
+
+      // Find empty slot
+      for (let i = 0; i < slots.length; i++) {
+        if (slots[i] === null) {
+          slots[i] = { id: itemId, quantity };
+          entity.lastAccessedTick = tick;
+          return { success: true };
+        }
+      }
+
+      return { success: false, reason: 'STORAGE_FULL' };
+    });
+  }
+
+  /**
+   * Remove item from storage entity.
+   */
+  public removeItemFromStorage(
+    entityId: string,
+    itemId: string,
+    quantity: number,
+    tick: number
+  ): { success: boolean; item?: InventorySlot; reason?: string } {
+    return AREGuard.executeProtected(() => {
+      const entity = this.storageEntities.get(entityId);
+      if (!entity) {
+        return { success: false, reason: 'STORAGE_NOT_FOUND' };
+      }
+
+      const slots = entity.inventory.slots;
+
+      for (let i = 0; i < slots.length; i++) {
+        const slot = slots[i];
+        if (slot && slot.id === itemId) {
+          if (slot.quantity < quantity) {
+            return { success: false, reason: 'INSUFFICIENT_QUANTITY' };
+          }
+
+          if (slot.quantity === quantity) {
+            slots[i] = null;
+          } else {
+            slot.quantity -= quantity;
+          }
+
+          entity.lastAccessedTick = tick;
+          return { success: true, item: { id: itemId, quantity } };
+        }
+      }
+
+      return { success: false, reason: 'ITEM_NOT_FOUND' };
+    });
+  }
+
+  /**
+   * Open storage entity (update lastAccessedTick).
+   */
+  public openStorage(entityId: string, tick: number): boolean {
+    const entity = this.storageEntities.get(entityId);
+    if (!entity) return false;
+    entity.lastAccessedTick = tick;
+    return true;
+  }
+
+  /**
+   * Lock/unlock storage entity.
+   */
+  public setStorageLocked(entityId: string, locked: boolean): boolean {
+    const entity = this.storageEntities.get(entityId);
+    if (!entity) return false;
+    entity.locked = locked;
+    return true;
+  }
+
+  /**
+   * Destroy storage entity.
+   */
+  public destroyStorageEntity(entityId: string): boolean {
+    const entity = this.storageEntities.get(entityId);
+    if (!entity) return false;
+
+    this.unindexEntity(entityId, entity.position);
+    this.storageEntities.delete(entityId);
+    return true;
+  }
+
+  /**
+   * Get all storage entities as array (for serialization).
+   */
+  public getAllStorageEntities(): StorageEntity[] {
+    return Array.from(this.storageEntities.values());
+  }
+
+  /**
+   * Get count of storage entities.
+   */
+  public getStorageCount(): number {
+    return this.storageEntities.size;
+  }
+
+  /**
+   * Reset (for testing).
+   */
+  public reset(): void {
+    this.storageEntities.clear();
+    this.gridIndex.clear();
+  }
+}
+
+// ─── Singleton Export ─────────────────────────────────────────────────
+
+export const storageEntityManager = StorageEntityManager.getInstance();

--- a/server/tests/NPCUtilityAIEvolution.test.ts
+++ b/server/tests/NPCUtilityAIEvolution.test.ts
@@ -12,12 +12,12 @@
  */
 
 import { describe, expect, it, beforeEach } from 'vitest';
-import { ARENpcEvolution } from '../../core/are/ARENpcEvolution.js';
-import { craftingDirector } from '../crafting/CraftingDirector.js';
-import { npcInventoryManager } from './NPCInventoryManager.js';
-import { storageEntityManager } from '../structure/StorageEntity.js';
-import type { IAREPayload } from '../../core/are/AREPayload.js';
-import { toKappa } from '../../core/are/Kappa.js';
+import { ARENpcEvolution } from '../core/are/ARENpcEvolution.js';
+import { craftingDirector } from '../modules/crafting/CraftingDirector.js';
+import { npcInventoryManager } from '../modules/npc/NPCInventoryManager.js';
+import { storageEntityManager } from '../modules/structure/StorageEntity.js';
+import type { IAREPayload } from '../core/are/AREPayload.js';
+import { toKappa } from '../core/are/Kappa.js';
 
 describe('ARENpcEvolution Utility AI', () => {
   describe('computeUtilityIntelligence', () => {


### PR DESCRIPTION
## SYSTEMIC EMERGENCE PROTOKOLL - Utility-based NPC AI Implementation

### Overview
This PR implements a complete architecture upgrade for **ARENpcEvolution.ts** - transforming it from a simple fusion/scanning utility into a full **Utility-based AI Brain** that follows the Ouroboros "Stateless Determinism" dogma.

### Core Axioms Implemented
1. **Conservation Axiom**: NPCs use EXACTLY the same systems as players (crafting, inventory, storage)
2. **Utility Scoring**: `ActionScore = (Drive × Reward) - Risk - Cost`
3. **No Phantom Systems**: Every logical decision has a server-side counterpart

### Phase 1: World Infrastructure (Counterparts)

| Component | File | Description |
|-----------|------|-------------|
| **CraftingDirector** | `server/src/modules/crafting/CraftingDirector.ts` | NPC-accessible deterministic crafting with recipes (e.g., `wooden_chest_craft`: 5x wood → 1x chest) |
| **StorageEntity** | `server/src/modules/structure/StorageEntity.ts` | Container entities with own `InventoryState` on KAPPA-grid |

### Phase 2: Drive & Utility Matrix

| Method | Description |
|--------|-------------|
| `scanEnvironment()` | Scans KAPPA vicinity (default 5000K) for RESOURCE/STORAGE/ENEMY/ALLY entities |
| `calculateDrives()` | Computes internal needs: `resourceNeed`, `safetyNeed`, `wealthNeed`, `socialNeed` |
| `evaluateActions()` | Scores all possible actions using utility formula |
| `selectBestAction()` | Selects action with highest utility score |

**Supported Actions:**
- `GATHER_WOOD` / `GATHER_STONE` / `GATHER_IRON`
- `CRAFT_WOODEN_CHEST` / `CRAFT_IRON_CHEST`
- `STORE_ITEMS` / `RETRIEVE_ITEMS`
- `FLEE` (when enemy within 2000K threshold)
- `IDLE` (default fallback)

### Phase 3: Intent Wiring

| Component | File | Description |
|-----------|------|-------------|
| **NPCInventoryManager** | `server/src/modules/npc/NPCInventoryManager.ts` | Deterministic NPC inventory (same as player) |
| **NPCCraftingAdapter** | `server/src/modules/npc/NPCCraftingAdapter.ts` | Bridge between brain and CraftingDirector |

### Tests
- `NPCUtilityAIEvolution.test.ts` - Complete integration flow test (scan → decide → craft → store)

### Files Changed
```
server/src/core/are/ARENpcEvolution.ts          [Modified - Utility AI expansion]
server/src/modules/npc/NPCSystem.ts            [Modified - NPC interface update]
server/src/modules/crafting/CraftingDirector.ts [New - NPC crafting counterpart]
server/src/modules/npc/NPCInventoryManager.ts  [New - NPC inventory system]
server/src/modules/npc/NPCCraftingAdapter.ts   [New - Intent wiring bridge]
server/src/modules/structure/StorageEntity.ts   [New - Storage container entity]
server/src/modules/npc/__tests__/NPCUtilityAIEvolution.test.ts [New - Integration tests]
```

### Key Features
- ✅ All ARE-Guard protected (deterministic execution)
- ✅ KAPPA-integer math for position calculations
- ✅ Deterministic kappaHash for audit trails
- ✅ Risk assessment via KAPPA-distance from enemies
- ✅ Recipe validation before craft execution
- ✅ Atomic inventory mutations

---

*Generated by OpenHands Agent on behalf of openhands*

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3324b7a5-4a24-483a-9caf-16ae7dd72885)