### PR TITLE
feat(client-2d): StorageOverlay UI for entity item transfers

### DIFF
--- a/apps/client-2d/src/ui/StorageOverlay.tsx
+++ b/apps/client-2d/src/ui/StorageOverlay.tsx
@@ -1,0 +1,463 @@
+/**
+ * Ouroboros StorageOverlay — React UI with Server-Authoritative State
+ * 
+ * Axiom der Erhaltung: UI NEVER modifies state locally.
+ * Every item transfer is a server intent. UI blocks until
+ * server broadcasts the new snapshots.
+ * 
+ * Split-screen layout: Player Inventory (left) | Storage Container (right)
+ * Click item to transfer to opposite storage.
+ */
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useSyncExternalStore } from "react";
+import "./storageOverlay.css";
+import {
+  ModularItem,
+  InventoryIntent,
+  type ItemStats,
+  type Rarity,
+} from "@wasd/shared";
+
+// ─── Constants ────────────────────────────────────────────────
+
+const STORAGE_GRID_COLS = 6;
+
+// ─── Types ────────────────────────────────────────────────────
+
+export interface StorageSlot {
+  itemId: string;
+  quantity: number;
+  signature?: string;
+}
+
+export interface StorageInventoryState {
+  slots: ModularItem[];
+  maxSlots: number;
+  currentWeight: number;
+  maxWeight: number;
+}
+
+export interface StorageSnapshot {
+  storageId: string;
+  storageType: 'basic' | 'advanced' | 'reinforced';
+  inventory: StorageInventoryState;
+  tick: number;
+}
+
+export interface TransferIntent {
+  intent: 'transfer';
+  fromStorageId: string;
+  toStorageId: string;
+  fromSlotIndex: number;
+  toSlotIndex: number;
+}
+
+export type StorageEvent =
+  | { event: 'storage_snapshot'; snapshot: StorageSnapshot }
+  | { event: 'storage_error'; code: string; message: string }
+  | { event: 'item_transferred'; fromStorageId: string; toStorageId: string; slotIndex: number };
+
+const RARITY_COLORS: Record<Rarity, string> = {
+  common: "#9d9d9d",
+  uncommon: "#1eff00",
+  rare: "#0070dd",
+  epic: "#a335ee",
+  legendary: "#ff8000",
+  mystic: "#00ccff",
+};
+
+const STORAGE_TYPE_LABELS: Record<string, string> = {
+  basic: "Wooden Chest",
+  advanced: "Iron Chest", 
+  reinforced: "Reinforced Vault",
+};
+
+// ─── State Store ────────────────────────────────────────────────
+
+class StorageStateStore {
+  private playerSnapshot: StorageInventoryState | null = null;
+  private targetStorageSnapshot: StorageSnapshot | null = null;
+  private pendingIntent: TransferIntent | null = null;
+  private blockedFromSlot: number | null = null;
+  private blockedToSlot: number | null = null;
+  private readonly listeners = new Set<() => void>();
+
+  public getPlayerSnapshot(): StorageInventoryState | null {
+    return this.playerSnapshot;
+  }
+
+  public getStorageSnapshot(): StorageSnapshot | null {
+    return this.targetStorageSnapshot;
+  }
+
+  public subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notify(): void {
+    this.listeners.forEach((l) => l());
+  }
+
+  /** Set player inventory (synced from inventory_snapshot via parent) */
+  public setPlayerSnapshot(snapshot: StorageInventoryState | null): void {
+    this.playerSnapshot = snapshot;
+    this.notify();
+  }
+
+  /** Called when server broadcasts storage_snapshot */
+  public receiveStorageSnapshot(snapshot: StorageSnapshot): void {
+    this.targetStorageSnapshot = snapshot;
+    this.pendingIntent = null;
+    this.blockedFromSlot = null;
+    this.blockedToSlot = null;
+    this.notify();
+  }
+
+  /** Fire a transfer intent — UI immediately enters blocked state */
+  public dispatchTransfer(intent: TransferIntent): void {
+    this.pendingIntent = intent;
+    this.blockedFromSlot = intent.fromSlotIndex;
+    this.blockedToSlot = intent.toSlotIndex;
+    this.notify();
+  }
+
+  public isBlocked(slotIndex: number): boolean {
+    return this.blockedFromSlot === slotIndex || this.blockedToSlot === slotIndex;
+  }
+
+  public hasPendingIntent(): boolean {
+    return this.pendingIntent !== null;
+  }
+
+  /** Clear pending intent and blocked state */
+  public clearPending(): void {
+    this.pendingIntent = null;
+    this.blockedFromSlot = null;
+    this.blockedToSlot = null;
+    this.notify();
+  }
+
+  public closeStorage(): void {
+    this.targetStorageSnapshot = null;
+    this.clearPending();
+    this.notify();
+  }
+
+  public isOpen(): boolean {
+    return this.targetStorageSnapshot !== null;
+  }
+}
+
+export const storageStateStore = new StorageStateStore();
+
+// ─── Hook ──────────────────────────────────────────────────────
+
+export function useStoragePlayerSnapshot(): StorageInventoryState | null {
+  return useSyncExternalStore(
+    storageStateStore.subscribe,
+    () => storageStateStore.getPlayerSnapshot(),
+    () => null
+  );
+}
+
+export function useStorageSnapshot(): StorageSnapshot | null {
+  return useSyncExternalStore(
+    storageStateStore.subscribe,
+    () => storageStateStore.getStorageSnapshot(),
+    () => null
+  );
+}
+
+// ─── Helper Functions ──────────────────────────────────────────
+
+function getItemIcon(item: ModularItem): string {
+  const category = item.category ?? '';
+  const baseName = item.name ?? '';
+  
+  if (category === "weapon") {
+    if (baseName.includes("Dagger")) return "DG";
+    if (baseName.includes("Sword") || baseName.includes("Longsword")) return "SW";
+    if (baseName.includes("Greatsword") || baseName.includes("Claymore")) return "GS";
+    if (baseName.includes("Axe")) return "AX";
+    if (baseName.includes("Mace")) return "MC";
+    return "WP";
+  }
+  if (category === "armor") {
+    if (baseName.includes("Leather")) return "LT";
+    if (baseName.includes("Chain")) return "CH";
+    if (baseName.includes("Plate")) return "PL";
+    return "AR";
+  }
+  if (category === "consumable") return "PO";
+  if (category === "material") return "MT";
+  
+  return "IT";
+}
+
+// ─── Components ────────────────────────────────────────────────
+
+interface StorageSlotProps {
+  slotIndex: number;
+  item: ModularItem | null;
+  isBlocked: boolean;
+  isStorageSide: boolean;
+  onTransfer: (slotIndex: number) => void;
+}
+
+function StorageSlot({ slotIndex, item, isBlocked, isStorageSide, onTransfer }: StorageSlotProps) {
+  const handleClick = useCallback(() => {
+    if (!isBlocked) onTransfer(slotIndex);
+  }, [isBlocked, slotIndex, onTransfer]);
+
+  return (
+    <div
+      className={[
+        "storage-slot",
+        item ? "has-item" : "empty",
+        isBlocked ? "blocked" : "",
+        item ? `rarity-${item.rarity}` : "",
+      ].filter(Boolean).join(" ")}
+      onClick={handleClick}
+      role="button"
+      tabIndex={item && !isBlocked ? 0 : -1}
+      aria-label={item ? `Item in slot ${slotIndex + 1}, ${item.name}` : `Empty slot ${slotIndex + 1}`}
+    >
+      {isBlocked && <span className="slot-spinner">⟳</span>}
+      {item && (
+        <>
+          <span className="slot-icon">{getItemIcon(item)}</span>
+          {item.rarity === "legendary" && <span className="slot-glow" />}
+          <span className="slot-quantity">{slotIndex}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Storage Overlay ───────────────────────────────────
+
+interface StorageOverlayProps {
+  /** Control visibility from parent */
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+export function StorageOverlay({ isOpen = true, onClose }: StorageOverlayProps) {
+  const playerSnapshot = useStoragePlayerSnapshot();
+  const storageSnapshot = useStorageSnapshot();
+
+  // Handle WebSocket messages
+  useEffect(() => {
+    const handleNetworkPacket = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      
+      // Client-side: Player inventory snapshot (for left panel)
+      if (detail?.event === "inventory_snapshot") {
+        const invPayload = detail.payload;
+        if (invPayload?.inventory) {
+          storageStateStore.setPlayerSnapshot(invPayload.inventory);
+        }
+      }
+      
+      // Server response: Storage contents
+      if (detail?.event === "storage_snapshot") {
+        storageStateStore.receiveStorageSnapshot(detail.payload);
+      }
+      
+      // Transfer success
+      if (detail?.event === "item_transferred") {
+        storageStateStore.clearPending();
+      }
+      
+      // Transfer error
+      if (detail?.event === "storage_error") {
+        storageStateStore.clearPending();
+      }
+    };
+
+    window.addEventListener("wasd:network-packet", handleNetworkPacket);
+
+    return () => {
+      window.removeEventListener("wasd:network-packet", handleNetworkPacket);
+    };
+  }, []);
+
+  // ─── Transfer Handlers ──────────────────────────────────────────
+
+  const transferToStorage = useCallback((fromPlayerSlotIndex: number) => {
+    const playerInv = playerSnapshot;
+    if (!playerInv?.slots?.[fromPlayerSlotIndex] || !storageSnapshot) return;
+
+    const intent: TransferIntent = {
+      intent: 'transfer',
+      fromStorageId: 'player',
+      toStorageId: storageSnapshot.storageId,
+      fromSlotIndex: fromPlayerSlotIndex,
+      toSlotIndex: -1, // Server finds first empty slot
+    };
+
+    storageStateStore.dispatchTransfer(intent);
+
+    // Fire via event bus
+    window.dispatchEvent(new CustomEvent("wasd:client-action", {
+      detail: { action: "transfer_item", payload: intent },
+    }));
+  }, [playerSnapshot, storageSnapshot]);
+
+  const transferToPlayer = useCallback((fromStorageSlotIndex: number) => {
+    if (!storageSnapshot || !playerSnapshot) return;
+    const storageItems = storageSnapshot.inventory.slots;
+    if (!storageItems?.[fromStorageSlotIndex]) return;
+
+    // Find first empty player slot
+    const emptyPlayerSlot = playerSnapshot.slots.findIndex((s, i) => !s && i < playerSnapshot.maxSlots);
+    if (emptyPlayerSlot < 0) return; // No empty slots
+
+    const intent: TransferIntent = {
+      intent: 'transfer',
+      fromStorageId: storageSnapshot.storageId,
+      toStorageId: 'player',
+      fromSlotIndex: fromStorageSlotIndex,
+      toSlotIndex: emptyPlayerSlot,
+    };
+
+    storageStateStore.dispatchTransfer(intent);
+
+    window.dispatchEvent(new CustomEvent("wasd:client-action", {
+      detail: { action: "transfer_item", payload: intent },
+    }));
+  }, [playerSnapshot, storageSnapshot]);
+
+  const handleClose = useCallback(() => {
+    // Notify server to release storage lock
+    if (storageSnapshot) {
+      window.dispatchEvent(new CustomEvent("wasd:client-action", {
+        detail: { action: "close_storage", payload: { storageId: storageSnapshot.storageId } },
+      }));
+    }
+    storageStateStore.closeStorage();
+    onClose?.();
+  }, [storageSnapshot, onClose]);
+
+  // ─── Render ───────────────────────────────────────────────────
+
+  if (!isOpen || !storageSnapshot) return null;
+
+  const storageTypeLabel = STORAGE_TYPE_LABELS[storageSnapshot.storageType] ?? "Storage";
+  const playerItems = playerSnapshot?.slots ?? [];
+  const storageItems = storageSnapshot.inventory.slots;
+
+  const playerGridRows = Math.ceil((playerSnapshot?.maxSlots ?? 12) / STORAGE_GRID_COLS);
+  const storageGridRows = Math.ceil(storageSnapshot.inventory.maxSlots / STORAGE_GRID_COLS);
+
+  return (
+    <div className="storage-overlay" role="dialog" aria-label="Storage Transfer">
+      {/* Header */}
+      <div className="storage-header">
+        <h2>Storage Transfer</h2>
+        <button className="close-btn" onClick={handleClose} aria-label="Close storage">
+          ✕
+        </button>
+        <div className="storage-type">{storageTypeLabel}</div>
+      </div>
+
+      {/* Split Content */}
+      <div className="storage-content">
+        
+        {/* Left: Player Inventory */}
+        <section className="storage-panel player-panel" aria-label="Player Inventory">
+          <h3>Player Inventory</h3>
+          {playerSnapshot && (
+            <div className="storage-weight">
+              Weight: {playerSnapshot.currentWeight.toFixed(1)} / {playerSnapshot.maxWeight}
+            </div>
+          )}
+          <div
+            className="storage-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: `repeat(${STORAGE_GRID_COLS}, 1fr)`,
+              gridTemplateRows: `repeat(${playerGridRows}, 1fr)`,
+            }}
+            role="grid"
+          >
+            {(playerItems).map((item, index) => (
+              <StorageSlot
+                key={index}
+                slotIndex={index}
+                item={item}
+                isBlocked={storageStateStore.isBlocked(index)}
+                isStorageSide={false}
+                onTransfer={transferToStorage}
+              />
+            ))}
+          </div>
+          <div className="panel-hint">← Click to move to storage</div>
+        </section>
+
+        {/* Divider */}
+        <div className="storage-divider" aria-hidden="true">
+          <div className="divider-line" />
+          <div className="divider-icon">⟷</div>
+          <div className="divider-line" />
+        </div>
+
+        {/* Right: Storage Container */}
+        <section className="storage-panel container-panel" aria-label="Storage Container">
+          <h3>{storageTypeLabel}</h3>
+          <div className="storage-weight">
+            Weight: {storageSnapshot.inventory.currentWeight.toFixed(1)} / {storageSnapshot.inventory.maxWeight}
+          </div>
+          <div
+            className="storage-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: `repeat(${STORAGE_GRID_COLS}, 1fr)`,
+              gridTemplateRows: `repeat(${storageGridRows}, 1fr)`,
+            }}
+            role="grid"
+          >
+            {(storageItems).map((item, index) => (
+              <StorageSlot
+                key={index}
+                slotIndex={index}
+                item={item}
+                isBlocked={storageStateStore.isBlocked(index)}
+                isStorageSide={true}
+                onTransfer={transferToPlayer}
+              />
+            ))}
+          </div>
+          <div className="panel-hint">Click to move to inventory →</div>
+        </section>
+      </div>
+
+      {/* Pending Intent Indicator */}
+      {storageStateStore.hasPendingIntent() && (
+        <div className="pending-indicator">
+          <span>⟳</span> Transferring...
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Export for UIManager integration ─────────────────────────
+
+/**
+ * Open the storage overlay with server data.
+ * Called by UIManager when player receives open_storage action.
+ */
+export function openStorageOverlay(snapshot: StorageSnapshot): void {
+  storageStateStore.receiveStorageSnapshot(snapshot);
+}
+
+/**
+ * Close the storage overlay.
+ * Called by UIManager or on server close command.
+ */
+export function closeStorageOverlay(): void {
+  storageStateStore.closeStorage();
+}

--- a/apps/client-2d/src/ui/UIManager.tsx
+++ b/apps/client-2d/src/ui/UIManager.tsx
@@ -1,6 +1,8 @@
 import { useSyncExternalStore } from "react";
 import { InventoryOverlay } from "./InventoryOverlay.js";
 import { CharacterOverlay } from "./CharacterOverlay.js";
+import { StorageOverlay, openStorageOverlay, closeStorageOverlay } from "./StorageOverlay.js";
+import type { StorageSnapshot } from "./StorageOverlay.js";
 
 export type ActiveOverlay =
   | { readonly type: "NONE" }
@@ -8,7 +10,8 @@ export type ActiveOverlay =
   | { readonly type: "DIALOGUE"; readonly targetId: string; readonly dialogueSeed: string; readonly lockedAtTick: number }
   | { readonly type: "CRAFT"; readonly targetId: string; readonly stationManifest: string; readonly lockedAtTick: number }
   | { readonly type: "INVENTORY" }
-  | { readonly type: "CHARACTER" };
+  | { readonly type: "CHARACTER" }
+  | { readonly type: "STORAGE"; readonly storageSnapshot: StorageSnapshot };
 
 class InteractionUIManager {
   private state: ActiveOverlay = { type: "NONE" };
@@ -50,6 +53,21 @@ class InteractionUIManager {
     this.notify();
   }
 
+  public openStorage(storageSnapshot: StorageSnapshot): void {
+    this.state = { type: "STORAGE", storageSnapshot };
+    openStorageOverlay(storageSnapshot);
+    this.notify();
+  }
+
+  public closeStorage(): void {
+    if (this.state.type === "STORAGE") {
+      closeStorageOverlay();
+      this.closeUI();
+    } else {
+      this.closeUI();
+    }
+  }
+
   public toggleCharacter(): void {
     if (this.state.type === "CHARACTER") {
       this.closeUI();
@@ -60,6 +78,10 @@ class InteractionUIManager {
 
   public closeUI(): void {
     if (this.state.type === "NONE") return;
+    // Close storage overlay if open
+    if (this.state.type === "STORAGE") {
+      closeStorageOverlay();
+    }
     this.state = { type: "NONE" };
     this.notify();
   }
@@ -95,6 +117,8 @@ export function useOverlayRenderer(): {
         return () => <InventoryOverlay isOpen={true} onClose={() => interactionUI.closeUI()} />;
       case "CHARACTER":
         return () => <CharacterOverlay isOpen={true} onClose={() => interactionUI.closeUI()} />;
+      case "STORAGE":
+        return () => <StorageOverlay isOpen={true} onClose={() => interactionUI.closeStorage()} />;
       // Add other overlay types as they are implemented
       default:
         return null;

--- a/apps/client-2d/src/ui/storageOverlay.css
+++ b/apps/client-2d/src/ui/storageOverlay.css
@@ -1,0 +1,375 @@
+/**
+ * Ouroboros StorageOverlay CSS — Tank-Schrank Aesthetic
+ * 
+ * Design Philosophy:
+ * - Hard edges, no border-radius (tank armor aesthetic)
+ * - Dark metallic palette with sharp borders
+ * - Split-screen layout: Player (left) | Storage (right)
+ * - Pessimistic blocking states with visual urgency
+ * 
+ * Brutalist UI: No Tailwind, pure native CSS.
+ */
+
+/* ─── Overlay Container ───────────────────────────────────────────── */
+
+.storage-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.92);
+  backdrop-filter: blur(6px);
+  pointer-events: auto;
+}
+
+/* ─── Header ───────────────────────────────────────────────────────── */
+
+.storage-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(900px, 96vw);
+  padding: 14px 18px;
+  background: linear-gradient(180deg, #0d1017 0%, #07090d 100%);
+  border: 1px solid rgba(0, 204, 255, 0.25);
+  border-bottom: none;
+}
+
+.storage-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #00ccff;
+}
+
+.storage-header .close-btn {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(0, 204, 255, 0.4);
+  background: rgba(0, 60, 80, 0.8);
+  color: #00ccff;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.storage-header .close-btn:hover {
+  background: rgba(0, 120, 160, 0.9);
+}
+
+.storage-type {
+  font-size: 0.78rem;
+  color: #6a9aaa;
+  letter-spacing: 0.06em;
+}
+
+/* ─── Split Content Area ──────────────────────────────────────────── */
+
+.storage-content {
+  display: flex;
+  gap: 0;
+  width: min(900px, 96vw);
+  background: rgba(0, 0, 0, 0.95);
+  border: 1px solid rgba(0, 204, 255, 0.25);
+}
+
+/* ─── Panel (Left/Right) ──────────────────────────────────────────── */
+
+.storage-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  position: relative;
+}
+
+.player-panel {
+  background: linear-gradient(180deg, #0a0d12 0%, #060810 100%);
+  border-right: 1px solid rgba(0, 204, 255, 0.15);
+}
+
+.container-panel {
+  background: linear-gradient(180deg, #0d0a12 0%, #090610 100%);
+  border-left: 1px solid rgba(0, 204, 255, 0.15);
+}
+
+.storage-panel h3 {
+  margin: 0 0 8px 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #6a7a8a;
+}
+
+.player-panel h3 {
+  color: #4a9aaa;
+}
+
+.container-panel h3 {
+  color: #7a4a9a;
+}
+
+.storage-weight {
+  font-size: 0.72rem;
+  color: #5a6a7a;
+  margin-bottom: 10px;
+  letter-spacing: 0.04em;
+}
+
+/* ─── Storage Grid ────────────────────────────────────────────────── */
+
+.storage-grid {
+  display: grid;
+  gap: 4px;
+  flex: 1;
+}
+
+/* ─── Storage Slot ─────────────────────────────────────────────────── */
+
+.storage-slot {
+  position: relative;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 20, 28, 0.95);
+  border: 1px solid rgba(80, 90, 110, 0.3);
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.storage-slot.empty {
+  cursor: default;
+}
+
+.storage-slot.has-item {
+  cursor: pointer;
+}
+
+.storage-slot.has-item:hover {
+  background: rgba(30, 40, 55, 0.95);
+  border-color: rgba(0, 204, 255, 0.4);
+}
+
+/* ─── Slot Icon ───────────────────────────────────────────────────── */
+
+.slot-icon {
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: #8a9aaa;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+.storage-slot.has-item .slot-icon {
+  color: #d0d8e0;
+}
+
+/* ─── Slot Quantity ──────────────────────────────────────────────── */
+
+.slot-quantity {
+  position: absolute;
+  bottom: 2px;
+  right: 3px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: #6a7a8a;
+  font-family: ui-monospace, monospace;
+}
+
+/* ─── Rarity Borders ──────────────────────────────────────────────── */
+
+.storage-slot.rarity-common {
+  border-color: rgba(157, 157, 157, 0.35);
+}
+
+.storage-slot.rarity-uncommon {
+  border-color: rgba(30, 255, 0, 0.35);
+  box-shadow: inset 0 0 6px rgba(30, 255, 0, 0.08);
+}
+
+.storage-slot.rarity-rare {
+  border-color: rgba(0, 112, 221, 0.45);
+  box-shadow: inset 0 0 6px rgba(0, 112, 221, 0.1);
+}
+
+.storage-slot.rarity-epic {
+  border-color: rgba(163, 53, 238, 0.5);
+  box-shadow: inset 0 0 8px rgba(163, 53, 238, 0.12);
+}
+
+.storage-slot.rarity-legendary {
+  border-color: rgba(255, 128, 0, 0.6);
+  box-shadow: inset 0 0 10px rgba(255, 128, 0, 0.15);
+}
+
+.storage-slot.rarity-mystic {
+  border-color: rgba(0, 204, 255, 0.55);
+  box-shadow: inset 0 0 8px rgba(0, 204, 255, 0.12);
+}
+
+/* ─── Legendary Glow ─────────────────────────────────────────────────── */
+
+.slot-glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at center, rgba(255, 128, 0, 0.15) 0%, transparent 70%);
+  animation: legendary-pulse 2.5s ease-in-out infinite;
+}
+
+@keyframes legendary-pulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 0.9; }
+}
+
+/* ─── Blocked State (Pessimistic UI) ──────────────────────────────── */
+
+.storage-slot.blocked {
+  opacity: 0.45;
+  cursor: wait;
+  pointer-events: none;
+}
+
+.storage-slot.blocked {
+  background: rgba(30, 60, 80, 0.6);
+  border-color: rgba(0, 204, 255, 0.4);
+}
+
+.slot-spinner {
+  font-size: 1.1rem;
+  color: #00ccff;
+  animation: slot-spin 1s linear infinite;
+}
+
+@keyframes slot-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* ─── Divider ────────────────────────────────────────────────────── */
+
+.storage-divider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  background: #050508;
+  border-left: 1px solid rgba(0, 204, 255, 0.1);
+  border-right: 1px solid rgba(0, 204, 255, 0.1);
+}
+
+.divider-line {
+  flex: 1;
+  width: 2px;
+  background: linear-gradient(180deg, transparent 0%, rgba(0, 204, 255, 0.3) 50%, transparent 100%);
+}
+
+.divider-icon {
+  padding: 12px 0;
+  font-size: 1.4rem;
+  color: rgba(0, 204, 255, 0.5);
+  font-weight: 700;
+}
+
+/* ─── Panel Hint ─────────────────────────────────────────────────── */
+
+.panel-hint {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(80, 90, 110, 0.2);
+  font-size: 0.68rem;
+  color: #4a5a6a;
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+/* ─── Pending Intent Indicator ─────────────────────────────────── */
+
+.pending-indicator {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  background: rgba(0, 40, 60, 0.92);
+  border: 1px solid rgba(0, 204, 255, 0.5);
+  color: #00ccff;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  animation: pending-pulse 1.5s ease-in-out infinite;
+}
+
+.pending-indicator span {
+  font-size: 1rem;
+  animation: slot-spin 1s linear infinite;
+}
+
+@keyframes pending-pulse {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+/* ─── Empty Slot Indicator ────────────────────────────────────── */
+
+.storage-slot.empty::after {
+  content: "";
+  width: 30%;
+  height: 30%;
+  background: rgba(60, 70, 85, 0.15);
+}
+
+/* ─── Mobile Responsive ─────────────────────────────────────────── */
+
+@media (max-width: 700px) {
+  .storage-overlay {
+    padding: 0;
+  }
+
+  .storage-content {
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    border: none;
+  }
+
+  .storage-divider {
+    flex-direction: row;
+    width: 100%;
+    height: 40px;
+    border: none;
+    border-top: 1px solid rgba(0, 204, 255, 0.15);
+    border-bottom: 1px solid rgba(0, 204, 255, 0.15);
+  }
+
+  .divider-line {
+    flex: 1;
+    height: 2px;
+    width: auto;
+    background: linear-gradient(90deg, transparent 0%, rgba(0, 204, 255, 0.3) 50%, transparent 100%);
+  }
+
+  .player-panel,
+  .container-panel {
+    flex: 1;
+    border: none;
+  }
+
+  .storage-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -35,6 +35,7 @@ import { FOREST_ACTION_DISTANCE, FOREST_RESPAWN_TICKS } from "../modules/resourc
 import { AIOrchestrator } from "./AIOrchestrator.js";
 import { processRespawns } from "../modules/combat/deathRespawnSystem.js";
 import { persistenceDirector } from "../modules/persistence/PersistenceDirector.js";
+import { storageEntityManager, type StorageEntity } from "../modules/structure/StorageEntity.js";
 
 const ELECTROWEAK_LOOT_TTL_TICKS = 1200;
 
@@ -549,6 +550,230 @@ export class WorldTick {
       player.inventory = playerData.inventory;
       player.equipment = playerData.equipment;
       this.saveAll();
+    }
+    // ─── STORAGE INTERACTION HANDLERS ────────────────────────────────────────
+    else if (msg.type === "open_storage") {
+      // Player requests to open a storage entity (e.g., chest)
+      const storageId = msg.payload?.storageId as string | undefined;
+      if (!storageId) {
+        this.ws.sendToPlayer(id, { type: "storage_error", code: "MISSING_STORAGE_ID", message: "Storage ID required" });
+        return;
+      }
+      
+      const storageEntity = storageEntityManager.getStorageEntity(storageId);
+      if (!storageEntity) {
+        this.ws.sendToPlayer(id, { type: "storage_error", code: "STORAGE_NOT_FOUND", message: "Storage not found" });
+        return;
+      }
+      
+      // Check proximity - player must be near the storage
+      const dist = Math.hypot(player.position.x - storageEntity.position.x, player.position.y - storageEntity.position.y);
+      if (dist > 40) {
+        this.ws.sendToPlayer(id, { type: "storage_error", code: "TOO_FAR", message: "Too far from storage" });
+        return;
+      }
+      
+      // Lock the storage entity
+      storageEntityManager.setStorageLocked(storageId, true);
+      storageEntityManager.openStorage(storageId, this.tickCount);
+      
+      // Build storage snapshot for client
+      const storageSnapshot = {
+        storageId: storageEntity.entityId,
+        storageType: storageEntity.storageType,
+        inventory: {
+          slots: storageEntity.inventory.slots.map((slot, idx) => {
+            if (!slot) return null;
+            // Convert InventorySlot to ModularItem - simplified for now
+            return {
+              signature: slot.id,
+              name: slot.id.split(':').pop() ?? slot.id,
+              category: "material" as const,
+              rarity: "common" as const,
+              ilvl: 1,
+              stats: {},
+              visualId: slot.id,
+              quantity: slot.quantity,
+            };
+          }),
+          maxSlots: storageEntity.inventory.maxSlots,
+          currentWeight: storageEntity.inventory.currentWeight,
+          maxWeight: storageEntity.inventory.maxWeight,
+        },
+        tick: this.tickCount,
+      };
+      
+      this.ws.sendToPlayer(id, { type: "storage_snapshot", event: "storage_snapshot", payload: storageSnapshot });
+    }
+    else if (msg.type === "close_storage") {
+      // Player closes storage - release lock
+      const storageId = msg.payload?.storageId as string | undefined;
+      if (storageId) {
+        storageEntityManager.setStorageLocked(storageId, false);
+      }
+      this.ws.sendToPlayer(id, { type: "storage_closed", event: "storage_closed", storageId });
+    }
+    else if (msg.type === "transfer_item") {
+      // Handle item transfer between player inventory and storage
+      const intentPayload = msg.payload as any;
+      const { fromStorageId, toStorageId, fromSlotIndex, toSlotIndex } = intentPayload;
+      
+      // Validate source/target
+      if (!fromStorageId || !toStorageId || fromSlotIndex === undefined) {
+        this.ws.sendToPlayer(id, { type: "storage_error", code: "INVALID_TRANSFER", message: "Invalid transfer parameters" });
+        return;
+      }
+      
+      // Find source storage entity
+      let sourceStorage: StorageEntity | null = null;
+      let destStorage: StorageEntity | null = null;
+      
+      if (fromStorageId !== "player") {
+        sourceStorage = storageEntityManager.getStorageEntity(fromStorageId);
+      }
+      if (toStorageId !== "player") {
+        destStorage = storageEntityManager.getStorageEntity(toStorageId);
+      }
+      
+      // Check if source storage is locked by another player
+      if (sourceStorage && sourceStorage.locked && sourceStorage.ownerId !== playerId) {
+        this.ws.sendToPlayer(id, { type: "storage_error", code: "STORAGE_LOCKED", message: "Storage is locked by another player" });
+        return;
+      }
+      if (destStorage && destStorage.locked && destStorage.ownerId !== playerId) {
+        this.ws.sendToPlayer(id, { type: "storage_error", code: "STORAGE_LOCKED", message: "Storage is locked by another player" });
+        return;
+      }
+      
+      // Perform transfer
+      let success = false;
+      let reason = "";
+      
+      // Case 1: Player -> Storage
+      if (fromStorageId === "player" && destStorage) {
+        const playerItems = player.inventory?.slots ?? [];
+        const item = playerItems[fromSlotIndex];
+        if (item) {
+          const addResult = storageEntityManager.addItemToStorage(
+            toStorageId,
+            item.id ?? String(fromSlotIndex),
+            item.quantity ?? 1,
+            this.tickCount
+          );
+          if (addResult.success) {
+            // Remove from player
+            playerItems[fromSlotIndex] = null;
+            player.inventory.slots = playerItems;
+            storageEntityManager.openStorage(toStorageId, this.tickCount);
+            success = true;
+            
+            // Send updated player inventory snapshot
+            this.ws.sendToPlayer(id, { 
+              type: "inventory_snapshot", 
+              event: "inventory_snapshot", 
+              payload: { inventory: player.inventory, equipment: player.equipment } 
+            });
+            
+            // Send updated storage snapshot
+            const updatedStorage = storageEntityManager.getStorageEntity(toStorageId)!;
+            this.ws.sendToPlayer(id, { type: "item_transferred", event: "item_transferred", fromStorageId, toStorageId, slotIndex: toSlotIndex });
+            
+            // Send new storage snapshot
+            const storageSnapshot = {
+              storageId: updatedStorage.entityId,
+              storageType: updatedStorage.storageType,
+              inventory: {
+                slots: updatedStorage.inventory.slots.map((slot, idx) => slot ? {
+                  signature: slot.id,
+                  name: slot.id.split(':').pop() ?? slot.id,
+                  category: "material" as const,
+                  rarity: "common" as const,
+                  ilvl: 1,
+                  stats: {},
+                  visualId: slot.id,
+                  quantity: slot.quantity,
+                } : null),
+                maxSlots: updatedStorage.inventory.maxSlots,
+                currentWeight: updatedStorage.inventory.currentWeight,
+                maxWeight: updatedStorage.inventory.maxWeight,
+              },
+              tick: this.tickCount,
+            };
+            this.ws.sendToPlayer(id, { type: "storage_snapshot", event: "storage_snapshot", payload: storageSnapshot });
+          } else {
+            reason = addResult.reason ?? "TRANSFER_FAILED";
+          }
+        }
+      }
+      // Case 2: Storage -> Player
+      else if (fromStorageId !== "player" && destStorage === null) {
+        const sourceEntity = storageEntityManager.getStorageEntity(fromStorageId);
+        if (sourceEntity) {
+          const slot = sourceEntity.inventory.slots[fromSlotIndex];
+          if (slot) {
+            // Try to add to player inventory
+            const playerItems = player.inventory?.slots ?? [];
+            const emptySlot = toSlotIndex >= 0 ? toSlotIndex : playerItems.findIndex((s, i) => !s && i < (player.inventory?.maxSlots ?? 24));
+            
+            if (emptySlot >= 0) {
+              const removeResult = storageEntityManager.removeItemFromStorage(
+                fromStorageId,
+                slot.id,
+                slot.quantity,
+                this.tickCount
+              );
+              if (removeResult.success) {
+                playerItems[emptySlot] = { ...slot };
+                player.inventory.slots = playerItems;
+                storageEntityManager.openStorage(fromStorageId, this.tickCount);
+                success = true;
+                
+                // Send updated storage snapshot
+                const updatedStorage = storageEntityManager.getStorageEntity(fromStorageId)!;
+                this.ws.sendToPlayer(id, { type: "item_transferred", event: "item_transferred", fromStorageId, toStorageId, slotIndex: fromSlotIndex });
+                
+                const storageSnapshot = {
+                  storageId: updatedStorage.entityId,
+                  storageType: updatedStorage.storageType,
+                  inventory: {
+                    slots: updatedStorage.inventory.slots.map((s, idx) => s ? {
+                      signature: s.id,
+                      name: s.id.split(':').pop() ?? s.id,
+                      category: "material" as const,
+                      rarity: "common" as const,
+                      ilvl: 1,
+                      stats: {},
+                      visualId: s.id,
+                      quantity: s.quantity,
+                    } : null),
+                    maxSlots: updatedStorage.inventory.maxSlots,
+                    currentWeight: updatedStorage.inventory.currentWeight,
+                    maxWeight: updatedStorage.inventory.maxWeight,
+                  },
+                  tick: this.tickCount,
+                };
+                this.ws.sendToPlayer(id, { type: "storage_snapshot", event: "storage_snapshot", payload: storageSnapshot });
+                this.ws.sendToPlayer(id, { 
+                  type: "inventory_snapshot", 
+                  event: "inventory_snapshot", 
+                  payload: { inventory: player.inventory, equipment: player.equipment } 
+                });
+              } else {
+                reason = removeResult.reason ?? "TRANSFER_FAILED";
+              }
+            } else {
+              reason = "PLAYER_INVENTORY_FULL";
+            }
+          }
+        }
+      }
+      
+      if (!success && !reason) {
+        reason = "TRANSFER_FAILED";
+      }
+      if (!success) {
+        this.ws.sendToPlayer(id, { type: "storage_error", code: reason, message: reason });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Implements the StorageOverlay UI component for the Ouroboros 2D client with server-authoritative item transfers.

### Changes

**Client (client-2d)**
- `StorageOverlay.tsx`: New React component with split-screen layout (Player Inventory | Storage Container)
  - `StorageStateStore`: State management via `useSyncExternalStore` for server sync
  - Transfer intent dispatching with pessimistic UI blocking until server confirms
  - `openStorageOverlay()` / `closeStorageOverlay()` API for UIManager integration

- `storageOverlay.css`: Brutalist military theme (dark metallic palette, sharp borders, no border-radius)
  - Split-screen layout with vertical divider
  - Rarity-coded item borders
  - Blocked state visual indicators

- `UIManager.tsx`: Added `STORAGE` overlay type with `openStorage()` / `closeStorage()` methods

**Server (server)**
- `WorldTick.ts`: Added message handlers:
  - `open_storage`: Validates proximity, locks storage, sends `storage_snapshot`
  - `close_storage`: Releases storage lock
  - `transfer_item`: Server-authoritative item transfer with `item_transferred` / `storage_snapshot` responses

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/689e9a9c-864c-4f04-b92f-2d36362f4032)