### PR TITLE
docs: Add AI skill guides for storage UI and resource generation

### DIFF
--- a/docs/PROJECT_STATUS_2026.md
+++ b/docs/PROJECT_STATUS_2026.md
@@ -1,4 +1,4 @@
-# Project status — Areloria / Ouroboros (April 2026)
+# Project status — Areloria / Ouroboros (May 2026)
 
 This file is the practical "what is shipped now" snapshot.
 Use it before trusting older reconstruction or handover docs.
@@ -7,10 +7,12 @@ Use it before trusting older reconstruction or handover docs.
 
 | Item | Status |
 |------|--------|
-| Monorepo layout | `client/` (Vite + Babylon.js), `server/` (Express + WebSocket), `game-data/` (authoritative JSON content) |
+| Monorepo layout | `client/` (Vite + Babylon.js), `client-2d/` (Vite + React + Pixi.js), `server/` (Express + WebSocket), `game-data/` (authoritative JSON content) |
 | Main server loop | `server/src/core/WorldTick.ts` at ~100 ms sim tick |
 | Main client entry | `client/src/main.ts` |
+| 2D client entry | `apps/client-2d/src/App.tsx` |
 | Primary rendering | Babylon.js (`@babylonjs/core` + loaders + materials + addons) |
+| 2D rendering | Pixi.js + React overlays (`@pixi/react`) |
 | Networking | WebSocket (`ws`) via `server/src/networking/WebSocketServer.ts` |
 | Data content root | `game-data/` by default, optional published pack via `USE_PUBLISHED_CONTENT` / `CONTENT_PACK_DIR` |
 
@@ -36,6 +38,8 @@ Use it before trusting older reconstruction or handover docs.
 | NPC runtime | `NPCSystem` + memory cache/persistence + relationships + proactive chat are wired |
 | Ouroboros agents | `OuroborosEngine` is instantiated and ticked from `WorldTick` |
 | World systems | Chunks, observers, world objects, weather/time, terrain adapters are wired |
+| Resource entities | Deterministic RESOURCE entities with KAPPA-grid alignment via `ChunkModificationDirector` + `ResourcePopulator` |
+| Storage system | `StorageEntity` entities with inventory, `open_storage`/`transfer_item` handlers in WorldTick |
 | Warfront | `WarfrontSystem` lifecycle, status pushes, reward claims are wired |
 | World boss | `WorldBossDungeonSystem` encounter flow and ranking summaries are wired |
 | Vote system | Vote banner/session/status and reward claims are wired |

--- a/docs/ai-skills/wasd-resource-entity-generation.md
+++ b/docs/ai-skills/wasd-resource-entity-generation.md
@@ -1,0 +1,249 @@
+# WASD AI Skill: Deterministic Resource Entity Generation
+
+**Purpose**: Guide future agents implementing chunk-based resource generation with KAPPA-grid alignment.
+
+**Context**: Built in Session #2026-05-31 for the ResourcePopulator feature.
+
+---
+
+## Core Axioms
+
+1. **Absolute Determinism**: NO `Math.random()`. All placement from worldSeed via AREHash.
+2. **KAPPA-Grid Alignment**: Resources have precise `kappaX`/`kappaZ` coordinates.
+3. **Depletion Persistence**: Gathered resources don't respawn on chunk reload.
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                 ResourcePopulator                           │
+│  worldSeed + chunkX + chunkZ                              │
+│         │                                                  │
+│         ▼                                                  │
+│  AREHash.hashObject({ seed, chunkX, chunkZ })             │
+│         │                                                  │
+│         ▼                                                  │
+│  SeededARERng(seed)                                       │
+│         │                                                  │
+│         ▼                                                  │
+│  For each resource type:                                   │
+│    For attempt < density * attempts:                       │
+│      nextFloat() → position                                │
+│      nextInt() → resource type                            │
+│      generateEntityId(type, cx, cz, idx)                  │
+│         │                                                  │
+│         ▼                                                  │
+│  Check ChunkModificationDirector.isDepleted(id)           │
+│         │                                                  │
+│         ▼                                                  │
+│  GeneratedResourceEntity[]                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Entity ID Format
+
+```
+res_{type}_{chunkX}_{chunkZ}_{index}
+Examples:
+  res_wood_0_5_0
+  res_stone_0_5_1
+  res_iron_1_3_0
+```
+
+---
+
+## Implementation Checklist
+
+### 1. ChunkModificationDirector.ts
+
+**Purpose**: Track depleted resources per chunk for persistence.
+
+```typescript
+class ChunkModificationDirector {
+  private modificationMap = new Map<ChunkKey, ChunkModificationData>();
+  
+  markResourceDepleted(entityId, chunkX, chunkZ, tick, originalYield?): void
+  isResourceDepleted(entityId): boolean
+  getDepletedResourcesForChunk(chunkX, chunkZ): Set<string>
+  serialize(): SerializedChunkModifications
+  deserialize(data): void
+}
+```
+
+**Key design**:
+- Deterministic entity IDs enable O(1) lookup
+- Map by entity ID, not chunk (same resource = same ID everywhere)
+
+### 2. ResourcePopulator.ts
+
+```typescript
+interface ResourceDefinition {
+  type: string;
+  yield: number;
+  density: number;        // 0-1 probability
+  biomes: string[];      // ['forest', 'mountain']
+  footprint: { w: number; d: number };
+}
+
+const RESOURCE_DEFINITIONS: Record<string, ResourceDefinition> = {
+  wood: { type: 'wood', yield: 5, density: 0.15, biomes: ['forest'] },
+  stone: { type: 'stone', yield: 4, density: 0.12, biomes: ['mountain'] },
+  iron: { type: 'iron', yield: 2, density: 0.05, biomes: ['mountain'] },
+  // ...
+};
+
+interface GeneratedResourceEntity {
+  id: string;           // res_{type}_{cx}_{cz}_{idx}
+  type: 'RESOURCE';
+  resourceType: string;
+  kappaX: number;       // KAPPA-scale (1 unit = 1000 KAPPA)
+  kappaZ: number;
+  yield: number;
+  remainingYield: number;
+  regrowRate: number;
+  depleted: boolean;
+}
+```
+
+### 3. WorldTick.ts Integration
+
+```typescript
+class WorldTick {
+  private chunkResourceCache = new Map<string, GeneratedResourceEntity[]>();
+  
+  private getChunkResources(chunkX, chunkZ): GeneratedResourceEntity[] {
+    const key = `${chunkX}:${chunkZ}`;
+    if (!this.chunkResourceCache.has(key)) {
+      const biome = this.getChunkBiome(chunkX, chunkZ);
+      const result = resourcePopulator.generateChunkResources(chunkX, chunkZ, biome);
+      this.chunkResourceCache.set(key, result.entities);
+    }
+    return this.chunkResourceCache.get(key);
+  }
+  
+  private broadcastSpatialSnapshot(socketId, playerTileX, playerTileZ, selfId) {
+    // ... existing player/npc/loot code ...
+    
+    // Add resources from 3x3 chunks around player
+    const playerChunkX = Math.floor(playerTileX / 64);
+    const playerChunkZ = Math.floor(playerTileZ / 64);
+    
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dz = -1; dz <= 1; dz++) {
+        const resources = this.getChunkResources(playerChunkX + dx, playerChunkZ + dz);
+        for (const res of resources) {
+          resources: [{
+            id: res.id,
+            type: 'RESOURCE',
+            resourceType: res.resourceType,
+            x: res.kappaX / 1000,
+            z: res.kappaZ / 1000,
+            kappaX: res.kappaX,
+            kappaZ: res.kappaZ,
+            yield: res.remainingYield,
+            maxYield: res.yield,
+            depleted: res.depleted,
+            regrowRate: res.regrowRate,
+          }]
+        }
+      }
+    }
+    
+    this.ws.sendToPlayer(socketId, {
+      type: "world_snapshot",
+      tick: this.tickCount,
+      self: selfId,
+      other_players: otherPlayers,
+      npcs: npcs,
+      loot: loot,
+      resources: resources,  // NEW
+    });
+  }
+}
+```
+
+### 4. Gathering Handler
+
+```typescript
+private processForestResourceActions() {
+  for (const request of queue) {
+    // Handle deterministic RESOURCE entities
+    if (request.input?.resourceNodeId?.startsWith('res_')) {
+      const entityId = request.input.resourceNodeId;
+      const parts = entityId.split('_'); // ['res', type, chunkX, chunkZ, idx]
+      const chunkX = parseInt(parts[2], 10);
+      const chunkZ = parseInt(parts[3], 10);
+      
+      if (chunkModificationDirector.isResourceDepleted(entityId)) {
+        this.ws.sendToPlayer(request.socketId, {
+          type: "FOREST_RESOURCE_REJECTED",
+          reason: "depleted",
+          entityId
+        });
+        continue;
+      }
+      
+      // Add item to player
+      this.inventorySystem.addItem(player, { id: itemId, quantity: 1 });
+      
+      // Mark as permanently depleted
+      chunkModificationDirector.markResourceDepleted(entityId, chunkX, chunkZ, this.tickCount);
+      
+      this.ws.sendToPlayer(request.socketId, {
+        type: "FOREST_RESOURCE_ACCEPTED",
+        entityId,
+        depleted: true
+      });
+      continue;
+    }
+    // ... existing forest resource logic ...
+  }
+}
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `server/src/modules/world/ChunkModificationDirector.ts` | Depletion persistence |
+| `server/src/modules/world/ResourcePopulator.ts` | Deterministic generation |
+| `server/src/core/WorldTick.ts` | Snapshot integration |
+| `server/src/core/are/AREHash.ts` | Deterministic hashing |
+| `server/src/core/determinism/AREDeterminism.ts` | SeededARERng |
+
+---
+
+## Performance Notes
+
+- Chunk resources are cached in `chunkResourceCache`
+- Only 9 chunks (3x3 grid) queried per player per tick
+- Generation >10ms triggers warning log
+- Depletion checks are O(1) via Map lookup
+
+---
+
+## Testing Checklist
+
+- [ ] Same chunk generates same resources (determinism)
+- [ ] Depleted resources stay depleted after chunk reload
+- [ ] Resources appear in world_snapshot
+- [ ] Gathering marks resource as depleted
+- [ ] Multiple gathers of same resource blocked
+
+---
+
+## Commit Style
+
+```
+feat(server): Deterministic RESOURCE entity generation with KAPPA-grid placement
+```
+
+---
+
+*Created: 2026-05-31 | Session: Resource Entity Generation*

--- a/docs/ai-skills/wasd-storage-ui-implementation.md
+++ b/docs/ai-skills/wasd-storage-ui-implementation.md
@@ -1,0 +1,134 @@
+# WASD AI Skill: Storage UI & Entity Transfer System
+
+**Purpose**: Guide future agents implementing server-authoritative storage/transfer UIs following Ouroboros axioms.
+
+**Context**: Built in Session #2026-05-31 for the StorageOverlay feature.
+
+---
+
+## Core Axioms
+
+1. **Server Authority**: Client NEVER modifies state locally. Only sends intents.
+2. **Stateless Determinism**: UI blocks optimistically, updates on server snapshot.
+3. **Brutalist UI**: Pure native CSS, no Tailwind, dark military aesthetic.
+4. **KAPPA-Interaction**: Fat-finger-safe pointertap events (24px+ padding).
+
+---
+
+## Architecture Overview
+
+```
+Client Actions                    Server Processing                  Client Update
+─────────────                    ────────────────                  ────────────
+wasd:client-action ──────────► handlePlayerMessage ──────────────► ws.sendToPlayer
+  { action: "transfer_item",       open_storage handler             { type: "storage_snapshot" }
+   payload: { fromStorageId,         transfer_item handler           OR
+             toStorageId,           close_storage handler           { type: "inventory_snapshot" }
+             fromSlotIndex,                                              
+             toSlotIndex } }                                       
+```
+
+---
+
+## Implementation Checklist
+
+### 1. StorageOverlay.tsx (React UI)
+
+```tsx
+// Key patterns:
+- StorageStateStore: useSyncExternalStore for server sync
+- dispatchTransfer(): Fire intent, block UI immediately
+- receiveStorageSnapshot(): Update state from server
+- clearPending(): On error or success
+```
+
+**Required exports**:
+- `storageStateStore` (singleton)
+- `openStorageOverlay(snapshot)` 
+- `closeStorageOverlay()`
+- `StorageSnapshot` type
+
+### 2. storageOverlay.css (Brutalist Theme)
+
+```css
+/* Required patterns */
+.storage-overlay { z-index: 200; }
+.storage-header { border: 1px solid rgba(0, 204, 255, 0.25); }
+.storage-slot { border-radius: 0; } /* NO rounded corners */
+.storage-slot.blocked { opacity: 0.45; pointer-events: none; }
+```
+
+**Color palette**:
+- Primary: `#00ccff` (neon cyan)
+- Background: `#0d1017` → `#07090d`
+- Borders: `rgba(0, 204, 255, 0.25)`
+
+### 3. UIManager.tsx Integration
+
+```tsx
+type ActiveOverlay = 
+  | { type: "STORAGE"; storageSnapshot: StorageSnapshot }
+  // ...
+
+openStorage(storageSnapshot: StorageSnapshot): void {
+  this.state = { type: "STORAGE", storageSnapshot };
+  openStorageOverlay(storageSnapshot);
+  this.notify();
+}
+```
+
+### 4. WorldTick.ts Server Handlers
+
+```typescript
+// Required handlers:
+- "open_storage": Validate, lock, send storage_snapshot
+- "close_storage": Unlock storage
+- "transfer_item": Move items, send both snapshots
+```
+
+---
+
+## Transfer Intent Flow
+
+```
+1. User clicks slot in player panel
+2. Client: dispatchTransfer({ fromStorageId: 'player', toStorageId: 'chest:123', ... })
+3. Client: window.dispatchEvent(CustomEvent("wasd:client-action", { action: "transfer_item", payload: intent }))
+4. Server: handlePlayerMessage receives msg.type === "transfer_item"
+5. Server: Validates source/dest, performs transfer
+6. Server: ws.sendToPlayer(id, { type: "storage_snapshot", payload: snapshot })
+7. Client: handleNetworkPacket sees "storage_snapshot"
+8. Client: storageStateStore.receiveStorageSnapshot(snapshot)
+9. React re-renders with new state
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/client-2d/src/ui/StorageOverlay.tsx` | React UI component |
+| `apps/client-2d/src/ui/storageOverlay.css` | Brutalist styling |
+| `apps/client-2d/src/ui/UIManager.tsx` | Overlay state machine |
+| `server/src/core/WorldTick.ts` | Server handlers |
+| `server/src/modules/structure/StorageEntity.ts` | Entity definitions |
+
+---
+
+## Related Patterns
+
+- See `InventoryOverlay.tsx` for similar pessimistic UI pattern
+- See `InventoryStateStore` for server sync hookup
+
+---
+
+## Commit Style
+
+```
+feat(client-2d): Add StorageOverlay UI for entity item transfers
+```
+
+---
+
+*Created: 2026-05-31 | Session: Storage Overlay Implementation*

--- a/docs/wiki/WorldTick-and-10Hz-Simulation.md
+++ b/docs/wiki/WorldTick-and-10Hz-Simulation.md
@@ -65,6 +65,39 @@ Related pages:
 | `server/src/networking/WebSocketServer.ts` | Player message delivery |
 | `client/src/engine/renderer.ts` | Client interpolation / rendering layer |
 | `apps/client-2d/src/stackedProps.ts` | 2D prop rendering path |
+| `server/src/modules/world/ChunkModificationDirector.ts` | Depletion persistence for resources |
+| `server/src/modules/world/ResourcePopulator.ts` | Deterministic resource entity generation |
+
+## Resources Entity System
+
+As of 2026-05-31, WorldTick supports `type: 'RESOURCE'` entities in `world_snapshot`:
+
+```typescript
+// Resources broadcast to clients
+this.ws.sendToPlayer(socketId, {
+  type: "world_snapshot",
+  tick: this.tickCount,
+  self: selfId,
+  other_players: [...],
+  npcs: [...],
+  loot: [...],
+  resources: [  // NEW
+    {
+      id: 'res_wood_0_5_0',
+      type: 'RESOURCE',
+      resourceType: 'wood',
+      x, z,            // World space
+      kappaX, kappaZ,   // KAPPA space (1 unit = 1000 KAPPA)
+      yield: 5,
+      maxYield: 5,
+      depleted: false,
+      regrowRate: 600, // Ticks
+    }
+  ]
+});
+```
+
+Resource entity IDs format: `res_{type}_{chunkX}_{chunkZ}_{index}`
 
 ---
 


### PR DESCRIPTION
## Summary
Updates documentation and adds AI skill guides for future agent sessions.

### Changes

**AI Skill Guides (New)**
- `docs/ai-skills/wasd-storage-ui-implementation.md`: Guide for implementing storage overlay UIs following Ouroboros axioms
- `docs/ai-skills/wasd-resource-entity-generation.md`: Guide for deterministic chunk-based resource generation

**Documentation Updates**
- `docs/wiki/WorldTick-and-10Hz-Simulation.md`: Added Resources Entity System section with `world_snapshot` format
- `docs/PROJECT_STATUS_2026.md`: 
  - Added `client-2d` to monorepo layout
  - Added Resource entities status
  - Added Storage system status
  - Updated to May 2026

### Why These Skills Matter

These guides capture the architectural decisions made in sessions:
1. **Server Authority**: Client never modifies state, only sends intents
2. **Determinism**: All world generation from `worldSeed` via AREHash
3. **Persistence**: Depleted resources tracked via ChunkModificationDirector

Future agents can reference these to avoid re-discovering patterns.

(AI-generated pull request by OpenHands agent)

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/689e9a9c-864c-4f04-b92f-2d36362f4032)