### PR TITLE
feat: Add ARE Shadow Adapter log exporter workflow and REST API

### DIFF
--- a/.github/workflows/are-shadow-log-exporter.yml
+++ b/.github/workflows/are-shadow-log-exporter.yml
@@ -1,0 +1,327 @@
+name: ARE Shadow Adapter Log Exporter
+
+on:
+  workflow_dispatch:
+    inputs:
+      log_lines:
+        description: "Number of log lines to collect from are-shadow.jsonl"
+        required: false
+        default: "500"
+        type: string
+      include_telemetry:
+        description: "Include ecosystem telemetry snapshot"
+        required: false
+        default: "true"
+        type: boolean
+      include_state:
+        description: "Include AREShadowState dump"
+        required: false
+        default: "true"
+        type: boolean
+      include_topology:
+        description: "Include topology network snapshot"
+        required: false
+        default: "true"
+        type: boolean
+  schedule:
+    - cron: "0 */4 * * *"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  collect-are-shadow-logs:
+    name: Collect ARE Shadow Adapter Logs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      EXPORT_NAME: are-shadow-adapter-export-${{ github.run_id }}
+      VPS_PATH: /opt/areloria
+
+    steps:
+      - name: Validate SSH secrets
+        run: |
+          set -euo pipefail
+          test -n "${{ secrets.SSH_HOST }}" || { echo "Missing SSH_HOST secret"; exit 1; }
+          test -n "${{ secrets.SSH_USER }}" || { echo "Missing SSH_USER secret"; exit 1; }
+          test -n "${{ secrets.SSH_PASSWORD }}" || { echo "Missing SSH_PASSWORD secret"; exit 1; }
+
+      - name: Validate log line input
+        run: |
+          LINES="${{ github.event.inputs.log_lines || '500' }}"
+          case "$LINES" in
+            ''|*[!0-9]*) echo "Invalid LINES: $LINES, using 500"; LINES=500 ;;
+          esac
+          if [ "$LINES" -lt 50 ]; then LINES=50; fi
+          if [ "$LINES" -gt 10000 ]; then LINES=10000; fi
+          echo "LINES=$LINES" >> $GITHUB_ENV
+
+      - name: Collect ARE Shadow Adapter logs on VPS
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          INCLUDE_TELEMETRY: ${{ github.event.inputs.include_telemetry || 'true' }}
+          INCLUDE_STATE: ${{ github.event.inputs.include_state || 'true' }}
+          INCLUDE_TOPOLOGY: ${{ github.event.inputs.include_topology || 'true' }}
+          EXPORT_NAME: ${{ env.EXPORT_NAME }}
+          VPS_PATH: ${{ env.VPS_PATH }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          envs: INCLUDE_TELEMETRY,INCLUDE_STATE,INCLUDE_TOPOLOGY,EXPORT_NAME,VPS_PATH
+          script: |
+            set -euo pipefail
+
+            OUT="/tmp/${EXPORT_NAME}"
+            ARCHIVE="/tmp/${EXPORT_NAME}.tar.gz"
+            rm -rf "$OUT" "$ARCHIVE"
+            mkdir -p "$OUT"
+
+            redact_file() {
+              local file="$1"
+              [ -f "$file" ] || return 0
+              sed -E -i \
+                -e 's/(token|secret|password|passwd|authorization|cookie|api[_-]?key|firebase[_-]?key|private[_-]?key)([=: ]+)[^[:space:]"'"'"'<>]+/\1\2[REDACTED]/Ig' \
+                -e 's/(Bearer )[A-Za-z0-9._~+\/-]+/\1[REDACTED]/g' \
+                -e 's/(ghp_|github_pat_)[A-Za-z0-9_]+/[GITHUB_TOKEN_REDACTED]/g' \
+                "$file" || true
+            }
+
+            write_section() {
+              local file="$1"
+              local title="$2"
+              shift 2
+              {
+                echo "### $title ###"
+                "$@"
+              } > "$OUT/$file" 2>&1 || true
+              redact_file "$OUT/$file"
+            }
+
+            # === Header ===
+            {
+              echo "=== ARE Shadow Adapter Log Export ==="
+              echo "exported_at=$(date -Iseconds)"
+              echo "host=$(hostname)"
+              echo "vps_path=$VPS_PATH"
+              echo "workflow_run=${GITHUB_RUN_ID:-unknown}"
+              echo "github_event=$GITHUB_EVENT_NAME"
+              echo
+            } > "$OUT/00-header.txt"
+            redact_file "$OUT/00-header.txt"
+
+            # === System Resources ===
+            write_section "01-system.txt" "System Resources" \
+              uptime echo "---" free -h echo "---" df -h
+
+            # === PM2 Process Status ===
+            write_section "02-pm2-status.txt" "PM2 Status" \
+              sh -lc 'pm2 jlist 2>/dev/null | head -200 || echo "PM2 not available"'
+            write_section "03-pm2-logs.txt" "PM2 Logs (Recent)" \
+              sh -lc "pm2 logs --nostream --lines 100 2>&1 | tail -100 || echo 'No PM2 logs'"
+
+            cd "$VPS_PATH" 2>/dev/null || { echo "VPS_PATH not accessible"; exit 0; }
+
+            # === ARE Shadow JSONL Logs ===
+            if [ -f "logs/are-shadow.jsonl" ]; then
+              echo "Found logs/are-shadow.jsonl ($(wc -l < logs/are-shadow.jsonl) total lines)"
+              tail -n "$LINES" logs/are-shadow.jsonl > "$OUT/10-are-shadow-tail.jsonl"
+              redact_file "$OUT/10-are-shadow-tail.jsonl"
+              
+              # Statistics
+              {
+                echo "=== ARE Shadow Log Statistics ==="
+                echo "total_lines=$(wc -l < logs/are-shadow.jsonl)"
+                echo "sampled_lines=$LINES"
+                echo
+                echo "--- Tick Range ---"
+                tail -n "$LINES" logs/are-shadow.jsonl | jq -r '.tick' 2>/dev/null | sort -n | head -5 | xargs -I{} echo "min_tick={}"
+                tail -n "$LINES" logs/are-shadow.jsonl | jq -r '.tick' 2>/dev/null | sort -n | tail -5 | xargs -I{} echo "max_tick={}"
+                echo
+                echo "--- Capacity Distribution ---"
+                tail -n "$LINES" logs/are-shadow.jsonl | jq -r '.capacity' 2>/dev/null | sort | uniq -c | tail -20
+                echo
+                echo "--- Event Count ---"
+                tail -n "$LINES" logs/are-shadow.jsonl | jq -s 'length' 2>/dev/null || echo "0 entries"
+              } > "$OUT/11-shadow-stats.txt"
+              redact_file "$OUT/11-shadow-stats.txt"
+            else
+              echo "logs/are-shadow.jsonl not found" > "$OUT/10-are-shadow-tail.jsonl"
+            fi
+
+            # === All Log Files in logs/ directory ===
+            if [ -d "logs" ]; then
+              echo "=== Log Directory Contents ===" > "$OUT/12-log-directory.txt"
+              find logs -maxdepth 2 -type f \( -name "*.log" -o -name "*.jsonl" -o -name "*.txt" \) 2>/dev/null | sort >> "$OUT/12-log-directory.txt"
+              
+              # Collect last lines from each log file
+              find logs -maxdepth 2 -type f \( -name "*.log" -o -name "*.jsonl" \) 2>/dev/null | while read -r log_file; do
+                safe_name="$(echo "$log_file" | sed 's#^logs/##; s#[^A-Za-z0-9._-]#_#g')"
+                tail -n 100 "$log_file" > "$OUT/log-$(basename "$safe_name").tail.txt" 2>&1 || true
+                redact_file "$OUT/log-$(basename "$safe_name").tail.txt"
+              done
+            fi
+
+            # === ARE Configuration ===
+            if [ -f ".env" ]; then
+              {
+                echo "=== ARE Configuration ==="
+                grep -E '^ARE_|^SHADOW_' .env 2>/dev/null | sed 's/=[^=]*$/=[REDACTED]/' || true
+              } > "$OUT/20-are-config.txt"
+            else
+              echo "No .env file found" > "$OUT/20-are-config.txt"
+            fi
+
+            # === Ecosystem Telemetry ===
+            if [ "${INCLUDE_TELEMETRY:-true}" = "true" ]; then
+              {
+                echo "=== ARE Shadow Ecosystem Telemetry ==="
+                echo "Note: Telemetry requires in-process access"
+                echo "Timestamp: $(date -Iseconds)"
+                echo
+                echo "To get telemetry, call AREShadowAdapter.getEcosystemTelemetry()"
+                echo "from the server process."
+              } > "$OUT/30-telemetry-info.txt"
+            fi
+
+            # === Server Health Endpoint ===
+            write_section "40-health-endpoint.txt" "Server Health Endpoint" \
+              sh -lc 'curl -k --max-time 10 https://arelorian.de/health 2>&1 || echo "Health check failed"'
+
+            # === ARE Shadow API Endpoints ===
+            write_section "41-are-shadow-log.txt" "ARE Shadow API: /api/are-shadow/log" \
+              sh -lc 'curl -k --max-time 15 "https://arelorian.de/api/are-shadow/log?lines=50" 2>&1 | jq . 2>/dev/null || echo "Endpoint unavailable"'
+
+            write_section "42-are-shadow-stats.txt" "ARE Shadow API: /api/are-shadow/stats" \
+              sh -lc 'curl -k --max-time 15 "https://arelorian.de/api/are-shadow/stats" 2>&1 | jq . 2>/dev/null || echo "Endpoint unavailable"'
+
+            write_section "43-are-shadow-directory.txt" "ARE Shadow API: /api/are-shadow/directory" \
+              sh -lc 'curl -k --max-time 15 "https://arelorian.de/api/are-shadow/directory" 2>&1 | jq . 2>/dev/null || echo "Endpoint unavailable"'
+
+            write_section "44-are-shadow-telemetry.txt" "ARE Shadow API: /api/are-shadow/telemetry" \
+              sh -lc 'curl -k --max-time 15 "https://arelorian.de/api/are-shadow/telemetry" 2>&1 | jq . 2>/dev/null || echo "Endpoint unavailable"'
+
+            # === Recent Server Logs ===
+            if [ -d "logs" ]; then
+              for logfile in logs/server*.log logs/*.log; do
+                if [ -f "$logfile" ]; then
+                  safe_name="$(basename "$logfile")"
+                  tail -n 200 "$logfile" > "$OUT/server-$(echo "$safe_name" | tr '.' '_').tail.txt" 2>&1 || true
+                  redact_file "$OUT/server-$(echo "$safe_name" | tr '.' '_').tail.txt"
+                fi
+              done
+            fi
+
+            # === Archive ===
+            tar -czf "$ARCHIVE" -C "$OUT" .
+            ls -lh "$ARCHIVE"
+
+      - name: Download export archive
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          source: /tmp/${{ env.EXPORT_NAME }}.tar.gz
+          target: .
+
+      - name: Extract and display ARE Shadow log summary
+        run: |
+          set -euo pipefail
+          
+          tar -xzf ./tmp/${{ env.EXPORT_NAME }}.tar.gz
+          
+          echo "=== ARE Shadow Adapter Export Summary ==="
+          echo ""
+          echo "Files collected:"
+          find . -type f -name "*.txt" -o -name "*.jsonl" -o -name "*.tail.*" 2>/dev/null | sort
+          echo ""
+          
+          if [ -f "./10-are-shadow-tail.jsonl" ]; then
+            echo "=== ARE Shadow Log Sample (last 10 entries) ==="
+            tail -n 10 ./10-are-shadow-tail.jsonl | jq -s '.' 2>/dev/null || tail -n 10 ./10-are-shadow-tail.jsonl
+            echo ""
+          fi
+
+      - name: Upload export artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}
+          path: ./tmp/${{ env.EXPORT_NAME }}.tar.gz
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload individual log files as artifact
+        uses: actions/upload-artifact/v4
+        with:
+          name: ${{ env.EXPORT_NAME }}-logs
+          path: |
+            ./10-are-shadow-tail.jsonl
+            ./11-shadow-stats.txt
+            ./12-log-directory.txt
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Cleanup remote artifacts
+        if: always()
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          EXPORT_NAME: ${{ env.EXPORT_NAME }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          envs: EXPORT_NAME
+          script: |
+            rm -rf "/tmp/${EXPORT_NAME}" "/tmp/${EXPORT_NAME}.tar.gz" || true
+
+  generate-report:
+    name: Generate ARE Shadow Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: collect-are-shadow-logs
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}-logs
+          path: ./logs
+        continue-on-error: true
+
+      - name: Create ARE Shadow Status Report
+        run: |
+          set -euo pipefail
+          
+          echo "=== ARE Shadow Adapter Status Report ==="
+          echo "Generated: $(date -Iseconds)"
+          echo "Workflow: ${{ github.workflow }}"
+          echo "Run ID: ${{ github.run_id }}"
+          echo ""
+          
+          if [ -d "./logs" ] && [ -f "./logs/11-shadow-stats.txt" ]; then
+            echo "--- Log Statistics ---"
+            cat ./logs/11-shadow-stats.txt
+            echo ""
+          fi
+          
+          echo "--- Artifact Available ---"
+          echo "Full export available as artifact: ${{ env.EXPORT_NAME }}"
+          echo "Location: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Comment on workflow run
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.actions.createWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'are-shadow-adapter-log-exporter.yml',
+              reference: 'main'
+            });

--- a/scripts/are-shadow-log-exporter.sh
+++ b/scripts/are-shadow-log-exporter.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# are-shadow-log-exporter.sh
+# Export ARE Shadow Adapter logs with full ecosystem telemetry
+# Usage: ./are-shadow-log-exporter.sh [lines]
+
+set -euo pipefail
+
+LOG_LINES="${1:-500}"
+OUTPUT_DIR="/tmp/are-shadow-export-$(date +%Y%m%d-%H%M%S)"
+ARCHIVE="${OUTPUT_DIR}.tar.gz"
+
+VPS_PATH="${VPS_PATH:-/opt/areloria}"
+
+echo "=== ARE Shadow Adapter Log Exporter ==="
+echo "Timestamp: $(date -Iseconds)"
+echo "Log lines: $LOG_LINES"
+echo "VPS Path: $VPS_PATH"
+echo ""
+
+mkdir -p "$OUTPUT_DIR"
+
+# --- System Info ---
+{
+    echo "=== System Info ==="
+    echo "exported_at=$(date -Iseconds)"
+    echo "host=$(hostname)"
+    echo "uptime=$(uptime -p 2>/dev/null || uptime)"
+    echo "kernel=$(uname -r)"
+} > "$OUTPUT_DIR/00-system.txt"
+
+# --- PM2 Status ---
+{
+    echo "=== PM2 Status ==="
+    pm2 jlist 2>/dev/null | jq -s '{
+        processes: length,
+        status: map(select(.pm2_env?.status == "online")) | length,
+        memory_mb: (map(.monit?.memory) | add // 0) / 1024 / 1024,
+        cpu_percent: (map(.monit?.cpu) | add // 0)
+    }' 2>/dev/null || echo "{error: 'PM2 not available'}"
+} > "$OUTPUT_DIR/01-pm2.json"
+
+# --- Log Directory ---
+{
+    echo "=== Log Directory ==="
+    if [ -d "$VPS_PATH/logs" ]; then
+        find "$VPS_PATH/logs" -maxdepth 3 -type f 2>/dev/null | sort
+    else
+        echo "No logs directory found at $VPS_PATH/logs"
+    fi
+} > "$OUTPUT_DIR/02-log-directory.txt"
+
+cd "$VPS_PATH" 2>/dev/null || {
+    echo "ERROR: Cannot access $VPS_PATH"
+    exit 1
+}
+
+# --- ARE Shadow JSONL (Main Log) ---
+if [ -f "logs/are-shadow.jsonl" ]; then
+    TOTAL_LINES=$(wc -l < logs/are-shadow.jsonl)
+    echo "Found logs/are-shadow.jsonl ($TOTAL_LINES total lines)"
+    
+    tail -n "$LOG_LINES" logs/are-shadow.jsonl > "$OUTPUT_DIR/10-are-shadow-tail.jsonl"
+    
+    # Statistics
+    {
+        echo "=== ARE Shadow Log Statistics ==="
+        echo "total_lines=$TOTAL_LINES"
+        echo "sampled_lines=$LOG_LINES"
+        echo "sampled_at=$(date -Iseconds)"
+        echo ""
+        
+        # Tick range
+        echo "--- Tick Range ---"
+        TICKS=$(tail -n "$LOG_LINES" logs/are-shadow.jsonl | jq -r '.tick' 2>/dev/null | sort -n)
+        echo "min_tick=$(echo "$TICKS" | head -1)"
+        echo "max_tick=$(echo "$TICKS" | tail -1)"
+        echo ""
+        
+        # Capacity distribution
+        echo "--- Capacity Distribution ---"
+        tail -n "$LOG_LINES" logs/are-shadow.jsonl | jq -r '.capacity' 2>/dev/null | sort | uniq -c | sort -rn
+        echo ""
+        
+        # Latest entries
+        echo "--- Latest 5 Entries ---"
+        tail -n 5 logs/are-shadow.jsonl | jq '.' 2>/dev/null || cat
+        echo ""
+        
+        # Ecosystem events
+        echo "--- Ecosystem Events in Sample ---"
+        tail -n "$LOG_LINES" logs/are-shadow.jsonl | jq -r '.ecosystem.capsules // empty' 2>/dev/null | wc -l | xargs -I{} echo "capsule_records={}"
+        tail -n "$LOG_LINES" logs/are-shadow.jsonl | jq -r '.ecosystem.apexNpcs // empty' 2>/dev/null | wc -l | xargs -I{} echo "apex_npcs={}"
+    } > "$OUTPUT_DIR/11-shadow-stats.txt"
+    
+    # Detailed entries with ecosystem data
+    tail -n 50 logs/are-shadow.jsonl | jq -c '.ecosystem' 2>/dev/null | head -20 | while read -r entry; do
+        echo "Entry: $entry"
+    done > "$OUTPUT_DIR/12-ecosystem-sample.jsonl" || true
+else
+    echo "WARNING: logs/are-shadow.jsonl not found" | tee "$OUTPUT_DIR/10-are-shadow-tail.jsonl"
+fi
+
+# --- Server Logs ---
+for logfile in logs/server*.log logs/*.log; do
+    if [ -f "$logfile" ]; then
+        safe_name="$(basename "$logfile" | tr '.' '_')"
+        {
+            echo "=== Server Log: $logfile ==="
+            echo "file=$logfile"
+            echo "size=$(stat -c%s "$logfile" 2>/dev/null || echo 'unknown')"
+            echo "modified=$(stat -c%y "$logfile" 2>/dev/null || echo 'unknown')"
+            echo ""
+            tail -n 200 "$logfile"
+        } > "$OUTPUT_DIR/20-server-$safe_name.txt"
+    fi
+done 2>/dev/null || true
+
+# --- PM2 Logs ---
+{
+    echo "=== PM2 Process Logs ==="
+    pm2 logs --nostream --lines 100 2>&1 | tail -100
+} > "$OUTPUT_DIR/30-pm2-logs.txt" 2>/dev/null || true
+
+# --- Configuration ---
+{
+    echo "=== ARE Configuration ==="
+    if [ -f ".env" ]; then
+        grep -E '^ARE_|^SHADOW_|^ENABLE_ARE|^ENABLE_SHADOW' .env 2>/dev/null | while read -r line; do
+            key=$(echo "$line" | cut -d= -f1)
+            echo "$key=[REDACTED]"
+        done
+    else
+        echo "No .env found"
+    fi
+} > "$OUTPUT_DIR/40-are-config.txt"
+
+# --- Health Endpoint ---
+{
+    echo "=== Server Health ==="
+    curl -k --max-time 10 https://arelorian.de/health 2>&1 || echo "Health check failed"
+} > "$OUTPUT_DIR/50-health.json"
+
+# --- Archive ---
+cd "$(dirname "$OUTPUT_DIR")"
+tar -czf "$ARCHIVE" "$(basename "$OUTPUT_DIR")"
+ls -lh "$ARCHIVE"
+
+echo ""
+echo "=== Export Complete ==="
+echo "Archive: $ARCHIVE"
+echo "Output dir: $OUTPUT_DIR"
+echo ""
+echo "To download from VPS:"
+echo "  scp user@host:$ARCHIVE ."
+echo ""
+echo "To extract:"
+echo "  tar -xzf $ARCHIVE"

--- a/server/src/api/areShadowLogRoute.ts
+++ b/server/src/api/areShadowLogRoute.ts
@@ -1,0 +1,311 @@
+import express from "express";
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const LOG_DIR = process.env.ARE_SHADOW_LOG_DIR || "logs";
+const DEFAULT_TAIL_LINES = 200;
+const MAX_TAIL_LINES = 5000;
+
+function safeInt(value: string | undefined, fallback: number, min: number, max: number): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < min) return fallback;
+  if (n > max) return max;
+  return n;
+}
+
+function parseJsonLines(lines: string[]): unknown[] {
+  const entries: unknown[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      entries.push(JSON.parse(trimmed));
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return entries;
+}
+
+function redactSecrets(obj: unknown): unknown {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== "object") return obj;
+  if (Array.isArray(obj)) return obj.map(redactSecrets);
+  
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const secretKeys = ["token", "secret", "password", "key", "authorization", "api_key", "apiKey"];
+    if (secretKeys.some(sk => key.toLowerCase().includes(sk))) {
+      result[key] = "[REDACTED]";
+    } else if (typeof value === "object") {
+      result[key] = redactSecrets(value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export function areShadowLogRouter() {
+  const router = express.Router();
+  const baseDir = resolve(process.cwd(), LOG_DIR);
+
+  // GET /api/are-shadow/log - Get ARE Shadow JSONL logs (tail)
+  router.get("/log", (req, res) => {
+    const lines = safeInt(req.query.lines as string, DEFAULT_TAIL_LINES, 10, MAX_TAIL_LINES);
+    const logPath = join(baseDir, "are-shadow.jsonl");
+
+    if (!existsSync(logPath)) {
+      res.json({ 
+        ok: true, 
+        error: "log_file_not_found", 
+        message: `${logPath} does not exist`,
+        path: logPath,
+        hint: "ARE_SHADOW_LOG_PATH may not be set, or logging is disabled"
+      });
+      return;
+    }
+
+    try {
+      const stat = statSync(logPath);
+      const content = createReadStream(logPath, { encoding: "utf8" });
+      let buffer = "";
+      let count = 0;
+      const tailLines: string[] = [];
+
+      content.on("data", (chunk: string) => {
+        buffer += chunk;
+        const parts = buffer.split("\n");
+        buffer = parts[parts.length - 1]; // keep last incomplete line
+        for (let i = 0; i < parts.length - 1; i++) {
+          tailLines.push(parts[i]);
+          if (tailLines.length > lines) tailLines.shift();
+          count++;
+        }
+      });
+
+      content.on("end", () => {
+        if (buffer.trim()) tailLines.push(buffer);
+        
+        const entries = parseJsonLines(tailLines);
+        
+        // Calculate statistics
+        const ticks = entries.map((e: any) => e.tick).filter((t: any) => typeof t === "number").sort((a, b) => a - b);
+        const capacities = entries.map((e: any) => e.capacity).filter((c: any) => typeof c === "number");
+        
+        res.json({
+          ok: true,
+          source: "are-shadow.jsonl",
+          path: logPath,
+          totalLines: count,
+          returnedLines: entries.length,
+          sampledLines: lines,
+          fileSize: stat.size,
+          modifiedAt: stat.mtime.toISOString(),
+          statistics: {
+            tickRange: ticks.length > 0 ? { min: ticks[0], max: ticks[ticks.length - 1] } : null,
+            tickCount: ticks.length,
+            capacityRange: capacities.length > 0 
+              ? { min: Math.min(...capacities), max: Math.max(...capacities) }
+              : null,
+          },
+          entries: redactSecrets(entries)
+        });
+      });
+
+      content.on("error", (err: Error) => {
+        res.status(500).json({ ok: false, error: "read_failed", message: err.message });
+      });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: "access_failed", message: String(err) });
+    }
+  });
+
+  // GET /api/are-shadow/stats - Get ARE Shadow statistics from log
+  router.get("/stats", async (req, res) => {
+    const lines = safeInt(req.query.lines as string, DEFAULT_TAIL_LINES, 10, MAX_TAIL_LINES);
+    const logPath = join(baseDir, "are-shadow.jsonl");
+
+    if (!existsSync(logPath)) {
+      res.json({ 
+        ok: true, 
+        available: false,
+        message: "Log file not found. ARE Shadow logging may be disabled."
+      });
+      return;
+    }
+
+    try {
+      const content = await readFile(logPath, "utf8");
+      const allLines = content.split("\n").filter(l => l.trim());
+      const tailLines = allLines.slice(-lines);
+      const entries = parseJsonLines(tailLines);
+
+      // Aggregate statistics
+      const ticks = entries.map((e: any) => e.tick).filter((t: any) => typeof t === "number");
+      const capacities = entries.map((e: any) => e.capacity).filter((c: any) => typeof c === "number");
+      const sizes = entries.map((e: any) => e.size).filter((s: any) => typeof s === "number");
+
+      // Count events by type
+      let capsuleEvents = 0;
+      let apexEvents = 0;
+      let fusionEvents = 0;
+      
+      for (const entry of entries) {
+        const e = entry as any;
+        if (e.ecosystem) {
+          if (e.ecosystem.capsules?.length) capsuleEvents += e.ecosystem.capsules.length;
+          if (e.ecosystem.apexNpcs?.length) apexEvents += e.ecosystem.apexNpcs.length;
+          if (e.ecosystem.fusions?.length) fusionEvents += e.ecosystem.fusions.length;
+        }
+      }
+
+      res.json({
+        ok: true,
+        logFile: logPath,
+        totalLogLines: allLines.length,
+        analyzedLines: entries.length,
+        tickRange: ticks.length > 0 
+          ? { min: Math.min(...ticks), max: Math.max(...ticks), span: Math.max(...ticks) - Math.min(...ticks) }
+          : null,
+        capacityStats: capacities.length > 0
+          ? { min: Math.min(...capacities), max: Math.max(...capacities), avg: capacities.reduce((a, b) => a + b, 0) / capacities.length }
+          : null,
+        bufferSizeStats: sizes.length > 0
+          ? { min: Math.min(...sizes), max: Math.max(...sizes), avg: sizes.reduce((a, b) => a + b, 0) / sizes.length }
+          : null,
+        ecosystemEvents: {
+          capsules: capsuleEvents,
+          apexNpcs: apexEvents,
+          fusions: fusionEvents,
+        },
+        latestEntry: entries.length > 0 ? redactSecrets(entries[entries.length - 1]) : null,
+      });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: "analysis_failed", message: String(err) });
+    }
+  });
+
+  // GET /api/are-shadow/directory - List all ARE-related log files
+  router.get("/directory", async (req, res) => {
+    try {
+      const files: { name: string; size: number; modified: string }[] = [];
+      
+      if (existsSync(baseDir)) {
+        const entries = await readdir(baseDir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isFile()) {
+            const filePath = join(baseDir, entry.name);
+            try {
+              const stat = statSync(filePath);
+              files.push({
+                name: entry.name,
+                size: stat.size,
+                modified: stat.mtime.toISOString(),
+              });
+            } catch {
+              // skip inaccessible files
+            }
+          }
+        }
+      }
+
+      res.json({
+        ok: true,
+        directory: baseDir,
+        files: files.filter(f => 
+          f.name.endsWith(".jsonl") || 
+          f.name.endsWith(".log") || 
+          f.name.includes("shadow") ||
+          f.name.includes("are")
+        ).sort((a, b) => b.modified.localeCompare(a.modified)),
+        allFiles: files.sort((a, b) => b.modified.localeCompare(a.modified)),
+      });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: "directory_failed", message: String(err) });
+    }
+  });
+
+  // GET /api/are-shadow/telemetry - Get ecosystem telemetry (requires process access)
+  router.get("/telemetry", async (_req, res) => {
+    try {
+      // Dynamically import to get runtime telemetry
+      const { AREShadowAdapter } = await import("../core/are/AREShadowAdapter.js");
+      
+      if (typeof AREShadowAdapter.getEcosystemTelemetry !== "function") {
+        res.json({
+          ok: true,
+          available: false,
+          message: "getEcosystemTelemetry not available. ARE shadow adapter may be in minimal mode."
+        });
+        return;
+      }
+
+      const telemetry = AREShadowAdapter.getEcosystemTelemetry();
+      
+      res.json({
+        ok: true,
+        timestamp: new Date().toISOString(),
+        telemetry: redactSecrets(telemetry),
+      });
+    } catch (err) {
+      res.status(500).json({
+        ok: false,
+        error: "telemetry_unavailable",
+        message: String(err),
+        hint: "Make sure ARE Shadow adapter is properly initialized"
+      });
+    }
+  });
+
+  // GET /api/are-shadow/stream - Stream log entries (SSE-like)
+  router.get("/stream", (req, res) => {
+    const lines = safeInt(req.query.lines as string, 50, 10, 500);
+    const logPath = join(baseDir, "are-shadow.jsonl");
+
+    res.setHeader("Content-Type", "application/json");
+    res.setHeader("Transfer-Encoding", "chunked");
+    res.flushHeaders();
+
+    if (!existsSync(logPath)) {
+      res.end(JSON.stringify({ error: "log_not_found", path: logPath }) + "\n");
+      return;
+    }
+
+    try {
+      const content = createReadStream(logPath, { encoding: "utf8" });
+      let buffer = "";
+      const tailLines: string[] = [];
+
+      content.on("data", (chunk: string) => {
+        buffer += chunk;
+        const parts = buffer.split("\n");
+        buffer = parts[parts.length - 1];
+        for (let i = 0; i < parts.length - 1; i++) {
+          tailLines.push(parts[i]);
+          if (tailLines.length > lines) tailLines.shift();
+        }
+      });
+
+      content.on("end", () => {
+        if (buffer.trim()) tailLines.push(buffer);
+        
+        const entries = parseJsonLines(tailLines);
+        res.end(JSON.stringify({
+          source: "are-shadow.jsonl",
+          count: entries.length,
+          entries: redactSecrets(entries)
+        }) + "\n");
+      });
+
+      content.on("error", (err: Error) => {
+        res.end(JSON.stringify({ error: err.message }) + "\n");
+      });
+    } catch (err) {
+      res.end(JSON.stringify({ error: String(err) }) + "\n");
+    }
+  });
+
+  return router;
+}

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -8,6 +8,7 @@ import { oracleRoute } from "./oracleRoute.js";
 import { authRoute } from "./authRoute.js";
 import { mailRoute } from "./mailRoute.js";
 import { auctionRoute } from "./auctionRoute.js";
+import { areShadowLogRouter } from "./areShadowLogRoute.js";
 
 import { mcpRoute } from "./mcpRoute.js";
 
@@ -22,5 +23,6 @@ export const ApiRoutes = [
   oracleRoute(),
   authRoute(),
   mailRoute(),
-  auctionRoute()
+  auctionRoute(),
+  areShadowLogRouter(),
 ];

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -22,6 +22,7 @@ import { sovereignDeployRouter } from "../api/sovereignDeployRoute.js";
 import { healthRoutes } from "../api/healthRoutes.js";
 import { agoraRouter } from "../api/agoraRoute.js";
 import { client2dAssetUploadRouter } from "../api/client2dAssetUploadRoute.js";
+import { areShadowLogRouter } from "../api/areShadowLogRoute.js";
 import { getContentDataSourceLabel, resolveContentDir } from "../modules/content/contentDataRoot.js";
 import { getSupabaseSummary, verifySupabaseToken } from "../config/supabase.js";
 import { resolveWorldAssetsDir } from "./resolveWorldAssetsDir.js";
@@ -182,6 +183,7 @@ export class ServerBootstrap {
     app.use("/api/are/validation", areValidationRouter(tick));
     app.use("/api/are/replay", areReplayRouter(tick));
     app.use("/api/finance", express.json({ limit: "1mb" }), financeRouter());
+    app.use("/api/are-shadow", areShadowLogRouter());
     app.use("/api/sovereign/deploy", sovereignDeployRouter(tick));
     const monitorStream = new PlaytesterMonitorStream(httpServer, (options) => tick.buildPlaytesterMonitorPayload(options));
     monitorStream.start();


### PR DESCRIPTION
## Summary
Add ARE Shadow Adapter log exporter workflow and REST API endpoints to make ARE Shadow logs accessible.

### Changes
- **GitHub Actions Workflow** (`.github/workflows/are-shadow-log-exporter.yml`):
  - Scheduled (every 4 hours) + manual trigger
  - Collects `are-shadow.jsonl`, ecosystem telemetry, PM2/server logs
  - Includes ARE Shadow API endpoint checks
  - Secrets auto-redacted

- **REST API Routes** (`server/src/api/areShadowLogRoute.ts`):
  - `GET /api/are-shadow/log?lines=500` - Last N entries from are-shadow.jsonl
  - `GET /api/are-shadow/stats` - Statistics from log data
  - `GET /api/are-shadow/directory` - List ARE log files
  - `GET /api/are-shadow/telemetry` - Real-time ecosystem telemetry
  - `GET /api/are-shadow/stream` - Streaming JSON output

- **Local VPS Script** (`scripts/are-shadow-log-exporter.sh`):
  - Standalone shell script for direct VPS usage

### Testing
Run workflow manually in GitHub Actions or test API:
```bash
curl https://arelorian.de/api/are-shadow/stats
curl https://arelorian.de/api/are-shadow/log?lines=100
```

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/840f6dfa-99b2-42ef-835e-8af2d5f52098)