### PR TITLE
fix: Correct upload-artifact version syntax in workflow

### DIFF
--- a/.github/workflows/are-shadow-log-exporter.yml
+++ b/.github/workflows/are-shadow-log-exporter.yml
@@ -257,7 +257,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload individual log files as artifact
-        uses: actions/upload-artifact/v4
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}-logs
           path: |


### PR DESCRIPTION
Fix upload-artifact version syntax in workflow (line 260: `/v4` -> `@v4`)

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/840f6dfa-99b2-42ef-835e-8af2d5f52098)