### PR TITLE
fix: Use github.event_name instead of GITHUB_EVENT_NAME

### DIFF
--- a/.github/workflows/are-shadow-log-exporter.yml
+++ b/.github/workflows/are-shadow-log-exporter.yml
@@ -110,7 +110,7 @@ jobs:
               echo "host=$(hostname)"
               echo "vps_path=$VPS_PATH"
               echo "workflow_run=${GITHUB_RUN_ID:-unknown}"
-              echo "github_event=$GITHUB_EVENT_NAME"
+              echo "github_event=${{ github.event_name }}"
               echo
             } > "$OUT/00-header.txt"
             redact_file "$OUT/00-header.txt"


### PR DESCRIPTION
Fix GITHUB_EVENT_NAME unbound variable error in SSH script

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/840f6dfa-99b2-42ef-835e-8af2d5f52098)