### PR TITLE
fix: SCP target to ./tmp to match extraction path

### DIFF
--- a/.github/workflows/are-shadow-log-exporter.yml
+++ b/.github/workflows/are-shadow-log-exporter.yml
@@ -246,7 +246,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
           source: /tmp/${{ env.EXPORT_NAME }}.tar.gz
-          target: .
+          target: ./tmp
 
       - name: Extract and display ARE Shadow log summary
         run: |


### PR DESCRIPTION
Fix SCP target to ./tmp to match extraction path

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/840f6dfa-99b2-42ef-835e-8af2d5f52098)