### PR TITLE
fix(pnpm): use onlyBuiltDependencies for native modules

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,15 @@ packages:
   - "server"
   - "backend"
 
-# pnpm v11: use boolean values (true/false) for allowBuilds, not strings
-# Setting allowBuilds to true allows all packages to be built during install
-allowBuilds: true
+# pnpm v11: use boolean values (true/false) for allowBuilds
+# Allow builds for all packages (enables postinstall scripts for native modules like esbuild, prisma)
+onlyBuiltDependencies:
+  - "@firebase/util"
+  - "@google/genai"
+  - "@nestjs/core"
+  - "@prisma/engines"
+  - "cpu-features"
+  - "esbuild"
+  - "prisma"
+  - "protobufjs"
+  - "ssh2"


### PR DESCRIPTION
## Summary

pnpm v11 requires explicit listing of packages that need build scripts.

### Fix
- Replace deprecated `allowBuilds` with `onlyBuiltDependencies`
- Explicitly list native modules: esbuild, prisma, protobufjs, ssh2, etc.

### Error Fixed
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @firebase/util, @google/genai, @nestjs/core, @prisma/engines, cpu-features, esbuild, prisma, protobufjs, ssh2
```