### PR TITLE
fix(pnpm): move onlyBuiltDependencies to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,17 @@
     "vitest": "^4.1.7"
   },
   "pnpm": {
-    "allowBuilds": true,
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "@google/genai",
+      "@nestjs/core",
+      "@prisma/engines",
+      "cpu-features",
+      "esbuild",
+      "prisma",
+      "protobufjs",
+      "ssh2"
+    ],
     "overrides": {
       "@types/react": "^19.2.14",
       "@types/react-dom": "^19.2.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,15 +9,4 @@ packages:
   - "server"
   - "backend"
 
-# pnpm v11: use boolean values (true/false) for allowBuilds
-# Allow builds for all packages (enables postinstall scripts for native modules like esbuild, prisma)
-onlyBuiltDependencies:
-  - "@firebase/util"
-  - "@google/genai"
-  - "@nestjs/core"
-  - "@prisma/engines"
-  - "cpu-features"
-  - "esbuild"
-  - "prisma"
-  - "protobufjs"
-  - "ssh2"
+# Note: pnpm v11 settings are now in root package.json pnpm field


### PR DESCRIPTION
## Summary

pnpm v11 no longer reads the pnpm field from workspace-level package.json files. Settings must be in the root package.json.

### Fix
- Move `onlyBuiltDependencies` from `pnpm-workspace.yaml` to root `package.json` pnpm field

### Error Fixed
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @firebase/util, @google/genai...
```