### PR TITLE
fix(pnpm): enable all build scripts in npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,7 +2,7 @@ node-linker=isolated
 
 # pnpm v11 configuration
 # Allow builds for all packages (enables postinstall scripts for native modules)
-allow-builds=true
+onlyBuiltDependencies=true
 
 # Performance settings
 side-effects-cache=false


### PR DESCRIPTION
## Summary

Set `onlyBuiltDependencies=true` in `.npmrc` to allow all native module build scripts.

### Fix
Replace `allow-builds=true` with `onlyBuiltDependencies=true` in `.npmrc`.