### PR TITLE
chore: simplify pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,14 +9,4 @@ packages:
   - "server"
   - "backend"
 
-# pnpm v11: allow build scripts for native modules
-onlyBuiltDependencies:
-  - "@firebase/util"
-  - "@google/genai"
-  - "@nestjs/core"
-  - "@prisma/engines"
-  - "cpu-features"
-  - "esbuild"
-  - "prisma"
-  - "protobufjs"
-  - "ssh2"
+# Note: onlyBuiltDependencies is now set in .npmrc


### PR DESCRIPTION
Remove redundant onlyBuiltDependencies from workspace yaml (now in .npmrc)