### PR TITLE
feat(asset-tagging): add GraphicRiver fallback chains, score weights,…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,14 @@ When working on specific topics, check the skills in `docs/ai-skills/`:
 - `wasd-manifest-system.md` - Manifest system usage
 - `wasd-github-actions-repair.md` - CI/CD debugging patterns
 - `wasd-game-architecture.md` - Core architecture decisions
+- `wasd-server-player-stats-sync.md` - Player stats synchronization
+- `wasd-storage-ui-implementation.md` - Storage UI implementation
+- `wasd-resource-entity-generation.md` - Resource/entity generation
+- `wasd-modular-inventory-system.md` - Inventory system design
+- `wasd-client-2d-rendering.md` - 2D rendering patterns
 - `server-anti-ninja-loot.md` - Security patterns for loot
+- `wasd-asset-tagging.md` - Asset tagging workflow and patterns
+- `wasd-docs-best-practices.md` - Documentation standards
 
 ### Manifest System (Server Authority)
 The manifest system provides deterministic, server-authoritative state management:

--- a/apps/client-2d/src/world/AssetBindingDirector.ts
+++ b/apps/client-2d/src/world/AssetBindingDirector.ts
@@ -65,6 +65,7 @@ export interface BindingDebug {
 
 /**
  * Score weights for semantic matching.
+ * Extended with GraphicRiver-specific weights for pattern matching.
  */
 const SCORE_WEIGHTS = {
   exactKind: 100,
@@ -83,6 +84,15 @@ const SCORE_WEIGHTS = {
   deprecated: -100,
   corrupt: -100,
   missing: -100,
+  
+  // GraphicRiver-specific weights (for pattern-based matching)
+  patternMatch: 25,      // Asset ID contains requested keyword
+  sourceMatch: 20,       // Recognized source (GraphicRiver, Kenney, etc.)
+  isoMatch: 15,          // Isometric style match
+  subcategoryMatch: 12,   // Subcategory within pack matches
+  
+  // Fallback chain bonus (when using extended GraphicRiver fallbacks)
+  fallbackChain: 5,
 };
 
 /**
@@ -197,6 +207,33 @@ export class AssetBindingDirector {
     if (query.variantHint && entryTags.some(t => t.includes(query.variantHint!.toLowerCase()))) {
       score += SCORE_WEIGHTS.variantMatch;
       reasons.push(`variant:${query.variantHint}`);
+    }
+
+    // Pattern matching (for GraphicRiver-style IDs)
+    const entryId = entry.id?.toLowerCase() ?? '';
+    for (const tag of query.tags) {
+      if (entryId.includes(tag.toLowerCase())) {
+        score += SCORE_WEIGHTS.patternMatch;
+        reasons.push(`pattern:${tag}`);
+        break; // Only count once
+      }
+    }
+
+    // Source matching
+    const entrySource = (entry as any).source?.toLowerCase() ?? '';
+    const recognizedSources = ['graphicriver', 'kenney', 'pipoya', 'assetpack01'];
+    for (const source of recognizedSources) {
+      if (entrySource.includes(source)) {
+        score += SCORE_WEIGHTS.sourceMatch;
+        reasons.push(`source:${source}`);
+        break;
+      }
+    }
+
+    // Isometric style matching
+    if (entryId.includes('iso') || entryId.includes('isometric')) {
+      score += SCORE_WEIGHTS.isoMatch;
+      reasons.push('iso');
     }
 
     // Quality bonus

--- a/apps/client-2d/src/world/AssetFallbackChains.ts
+++ b/apps/client-2d/src/world/AssetFallbackChains.ts
@@ -12,7 +12,8 @@ import type { BiomeType, CultureType } from "./AssetBindingContext";
 import { deterministicIndex } from "./DeterministicAssetRng";
 
 /**
- * Fallback category and key chains for buildings.
+ * Fallback chains for buildings.
+ * Extended with GraphicRiver-specific mappings for isometric assets.
  */
 export const BUILDING_FALLBACK_CHAINS: Record<BuildingType, readonly string[]> = {
   house: ["house", "hut", "small_building", "building", "generic_building"],
@@ -30,6 +31,44 @@ export const BUILDING_FALLBACK_CHAINS: Record<BuildingType, readonly string[]> =
 };
 
 /**
+ * Extended fallback chains for GraphicRiver isometric assets.
+ * Maps GraphicRiver naming patterns to standard building types.
+ */
+export const GRAPHICRIVER_BUILDING_FALLBACKS: Record<string, readonly string[]> = {
+  // Tower variants
+  tower: ["tower", "military_tower", "defensive", "building"],
+  cannon_tower: ["cannon_tower", "tower", "military_tower", "defensive", "building"],
+  attack_tower: ["attack_tower", "tower", "military_tower", "defensive", "building"],
+  
+  // House variants
+  small_house: ["small_house", "house", "hut", "building"],
+  large_house: ["large_house", "house", "residential", "building"],
+  
+  // Military buildings
+  guard_tower: ["guard_tower", "tower", "military", "defensive", "building"],
+  military_tower: ["military_tower", "tower", "military", "defensive", "building"],
+  watch_tower: ["watch_tower", "tower", "military", "defensive", "building"],
+  
+  // Workshop variants
+  forge: ["forge", "blacksmith", "workshop", "building"],
+  workshop: ["workshop", "craft", "building"],
+  
+  // Social buildings
+  tavern: ["tavern", "inn", "pub", "building"],
+  bar: ["bar", "tavern", "inn", "building"],
+  restaurant: ["restaurant", "tavern", "inn", "building"],
+  
+  // Commercial buildings
+  shop: ["shop", "trader_shop", "store", "building"],
+  store: ["store", "shop", "trader_shop", "building"],
+  market: ["market", "trader_shop", "shop", "building"],
+  
+  // Resource buildings
+  storage: ["storage", "warehouse", "building"],
+  warehouse: ["warehouse", "storage", "building"],
+};
+
+/**
  * Fallback chains for NPCs.
  */
 export const NPC_FALLBACK_CHAINS: Record<NpcRole, readonly string[]> = {
@@ -43,6 +82,58 @@ export const NPC_FALLBACK_CHAINS: Record<NpcRole, readonly string[]> = {
   noble: ["noble", "lord", "civilian", "npc"],
   farmer: ["farmer", "worker", "civilian", "npc"],
   animal: ["animal", "creature", "npc"],
+};
+
+/**
+ * Extended fallback chains for GraphicRiver isometric NPC assets.
+ * Maps GraphicRiver naming patterns to standard NPC roles.
+ */
+export const GRAPHICRIVER_NPC_FALLBACKS: Record<string, readonly string[]> = {
+  // Guard variants
+  guard: ["guard", "soldier", "military", "npc"],
+  soldier: ["soldier", "guard", "military", "npc"],
+  warrior: ["warrior", "soldier", "guard", "npc"],
+  knight: ["knight", "soldier", "guard", "npc"],
+  
+  // Merchant variants
+  merchant: ["merchant", "trader", "shopkeeper", "npc"],
+  trader: ["trader", "merchant", "shopkeeper", "npc"],
+  shopkeeper: ["shopkeeper", "merchant", "trader", "npc"],
+  vendor: ["vendor", "trader", "merchant", "npc"],
+  
+  // Crafting NPCs
+  blacksmith: ["blacksmith", "craftsman", "worker", "npc"],
+  craftsman: ["craftsman", "worker", "civilian", "npc"],
+  artisan: ["artisan", "craftsman", "worker", "npc"],
+  
+  // Healer/Support NPCs
+  healer: ["healer", "priest", "cleric", "npc"],
+  priest: ["priest", "healer", "cleric", "npc"],
+  cleric: ["cleric", "priest", "healer", "npc"],
+  doctor: ["doctor", "healer", "priest", "npc"],
+  
+  // Noble/Royal NPCs
+  noble: ["noble", "lord", "nobleman", "npc"],
+  lord: ["lord", "noble", "nobleman", "npc"],
+  king: ["king", "noble", "lord", "npc"],
+  queen: ["queen", "noble", "lady", "npc"],
+  
+  // Commoner NPCs
+  peasant: ["peasant", "worker", "civilian", "npc"],
+  farmer: ["farmer", "worker", "peasant", "npc"],
+  villager: ["villager", "civilian", "peasant", "npc"],
+  commoner: ["commoner", "civilian", "peasant", "npc"],
+  
+  // Child NPCs
+  child: ["child", "kid", "young", "npc"],
+  kid: ["kid", "child", "young", "npc"],
+  youth: ["youth", "young", "child", "npc"],
+  
+  // Combat NPCs
+  archer: ["archer", "ranger", "soldier", "npc"],
+  mage: ["mage", "wizard", "magic", "npc"],
+  wizard: ["wizard", "mage", "magic", "npc"],
+  ranger: ["ranger", "archer", "soldier", "npc"],
 };
 
 /**
@@ -275,4 +366,36 @@ export function combineContextTags(
   if (lod) tags.push(...(LOD_TAGS[lod as keyof typeof LOD_TAGS] ?? []));
   
   return tags;
+}
+
+/**
+ * Gets GraphicRiver fallback chain for a building variant.
+ */
+export function getGraphicRiverBuildingFallback(variant: string): readonly string[] {
+  const normalized = variant.toLowerCase().replace(/[^a-z0-9_]/g, '_');
+  return GRAPHICRIVER_BUILDING_FALLBACKS[normalized] ?? ["building", "house"];
+}
+
+/**
+ * Gets GraphicRiver fallback chain for an NPC variant.
+ */
+export function getGraphicRiverNpcFallback(variant: string): readonly string[] {
+  const normalized = variant.toLowerCase().replace(/[^a-z0-9_]/g, '_');
+  return GRAPHICRIVER_NPC_FALLBACKS[normalized] ?? ["npc", "civilian", "human"];
+}
+
+/**
+ * Extracts the variant name from a GraphicRiver-style asset ID.
+ * Example: "gr_iso_2_towers_cannon_tower_png" -> "cannon_tower"
+ */
+export function extractGraphicRiverVariant(assetId: string): string | null {
+  const match = assetId.match(/gr_iso_\d+_(?:[\w]+_)*([\w]+)(?:_\w+)*/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Checks if an asset ID follows GraphicRiver naming pattern.
+ */
+export function isGraphicRiverAsset(assetId: string): boolean {
+  return /^gr_iso_\d+_/.test(assetId.toLowerCase());
 }

--- a/docs/ASSET_PACK_IMPORT_RUNBOOK.md
+++ b/docs/ASSET_PACK_IMPORT_RUNBOOK.md
@@ -1,0 +1,162 @@
+# Asset Pack Import Runbook
+
+## Overview
+
+This runbook describes the standard process for importing new asset packs into Areloria's client-2d project.
+
+## Prerequisites
+
+- Asset pack in ZIP format
+- PNG files with transparency
+- Consistent tile size with existing assets (64x64 or 128x128 recommended)
+- Commercial-use license or public domain
+
+## Import Process
+
+### Step 1: Prepare the Pack
+
+1. Download asset pack to `.asset-inbox/` directory
+2. Extract and inspect structure
+3. Verify file format (PNG preferred)
+4. Note naming convention used
+
+### Step 2: Choose Import Method
+
+**Option A: Biome Pack** (forest, desert, snow, etc.)
+```bash
+node scripts/import-forest-biome-pack.mjs <pack.zip> [destination]
+```
+
+**Option B: Custom Import Script**
+Create a new import script based on `scripts/import-forest-biome-pack.mjs`:
+```bash
+cp scripts/import-forest-biome-pack.mjs scripts/import-<pack-name>.mjs
+# Edit the script for your pack's structure
+```
+
+**Option C: Manual Import**
+1. Copy files to `apps/client-2d/public/assets/<category>/<pack>/files/`
+2. Create manifest.json with entries
+3. Add source tags
+
+### Step 3: Run Auto-Tagging
+
+```bash
+# Preview changes
+node scripts/auto-tag-manifest.mjs --dry-run
+
+# Apply changes
+node scripts/auto-tag-manifest.mjs
+```
+
+### Step 4: Validate Assets
+
+```bash
+node scripts/validate-pixi-assets.mjs
+```
+
+### Step 5: Test in Client
+
+1. Start the client: `npx tsx server/src/index.ts`
+2. Navigate to the area using the new assets
+3. Verify rendering and fallback behavior
+
+## Asset Manifest Structure
+
+Each imported pack needs a `manifest.json`:
+
+```json
+{
+  "version": 1,
+  "id": "<pack_id>",
+  "source": "<original_pack_name>",
+  "biome": "<biome_if_applicable>",
+  "generatedAt": "<ISO_DATE>",
+  "deterministic": true,
+  "entries": {
+    "<asset_id>": {
+      "id": "<asset_id>",
+      "src": "/2d/assets/<path>/file.png",
+      "kind": "<building|npc|prop|tile>",
+      "group": "<subtype>",
+      "tags": ["tag1", "tag2", "isometric"],
+      "biomeTags": ["forest"],
+      "cultureTags": ["generic"],
+      "source": "<source_name>",
+      "bytes": 1234,
+      "sha256": "<hash>"
+    }
+  }
+}
+```
+
+## Tagging Standards
+
+### Required Tags
+
+Every asset must have:
+- `kind`: `building` | `npc` | `prop` | `tile` | `ui`
+- `source`: Origin source name
+- At least one semantic tag
+
+### Tag Categories
+
+| Category | Tags |
+|----------|------|
+| **Buildings** | `house`, `tower`, `inn`, `blacksmith`, `warehouse`, `castle`, `wall` |
+| **NPCs** | `guard`, `merchant`, `healer`, `soldier`, `noble`, `farmer`, `child` |
+| **Props** | `tree`, `rock`, `bush`, `fence`, `chest`, `sign` |
+| **Biomes** | `forest`, `desert`, `snow`, `swamp`, `mountain`, `coastal` |
+| **Culture** | `nordic`, `imperial`, `tribal`, `arcane`, `generic` |
+| **Style** | `isometric`, `pixel-art`, `game-ready` |
+
+## Adding Fallback Chains
+
+If your pack introduces new types not in existing fallbacks:
+
+1. Edit `apps/client-2d/src/world/AssetFallbackChains.ts`
+2. Add to appropriate chain:
+   - `BUILDING_FALLBACK_CHAINS` for buildings
+   - `NPC_FALLBACK_CHAINS` for NPCs
+   - `PROP_FALLBACK_CHAINS` for props
+3. For source-specific patterns, add to:
+   - `GRAPHICRIVER_BUILDING_FALLBACKS`
+   - `GRAPHICRIVER_NPC_FALLBACKS`
+
+## Verification Checklist
+
+Before committing:
+
+- [ ] Manifest validates (`node scripts/validate-pixi-assets.mjs`)
+- [ ] All PNG files have entries
+- [ ] No duplicate SHA256 hashes
+- [ ] Assets render in client
+- [ ] Fallback chains cover all types
+- [ ] Tags are semantic and descriptive
+
+## Rollback
+
+If import fails:
+
+```bash
+# Remove imported files
+rm -rf apps/client-2d/public/assets/<category>/<pack>
+
+# Restore manifest
+git checkout apps/client-2d/public/assets/<category>/manifest.json
+```
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `node scripts/auto-tag-manifest.mjs --dry-run` | Preview tagging changes |
+| `node scripts/validate-pixi-assets.mjs` | Validate manifest |
+| `node scripts/import-<pack>.mjs <zip>` | Import specific pack |
+
+## Related
+
+- [Asset Tagging Skill](../ai-skills/wasd-asset-tagging.md)
+- [Asset Purchase Recommendations](./ASSET_PURCHASE_RECOMMENDATIONS.md)
+- [Asset Binding Director](../../../apps/client-2d/src/world/AssetBindingDirector.ts)
+- [Asset Fallback Chains](../../../apps/client-2d/src/world/AssetFallbackChains.ts)

--- a/docs/ASSET_PURCHASE_RECOMMENDATIONS.md
+++ b/docs/ASSET_PURCHASE_RECOMMENDATIONS.md
@@ -1,0 +1,139 @@
+# Asset Purchase Recommendations for Areloria
+
+This document outlines recommended asset packs to address current gaps in our visual coverage.
+
+## Priority Asset Categories
+
+### 1. NPC Characters
+
+| Missing Tags | Recommended Packs |
+|--------------|------------------|
+| guard, soldier | Human Pack (RPG Character Pack) |
+| merchant, trader | Merchant/Vendor Character Set |
+| healer, priest | Cleric/Healer Character Pack |
+| blacksmith | Craftsman Character Set |
+| noble, lord | Royal/Noble Character Pack |
+| child, kid | Child/Youth Character Pack |
+| archer, ranger | Ranger/Archer Character Pack |
+
+**Recommended Sources:**
+- **itch.io**: RPG Character Pack, Fantasy RPG Character Mega Pack
+- **GraphicRiver**: Isometric RPG Character Sets
+- **Kenney.nl**: Free character assets (Public Domain)
+
+### 2. Buildings & Structures
+
+| Missing Tags | Recommended Packs |
+|--------------|------------------|
+| house, hut | Isometric House Pack, Medieval Building Kit |
+| inn, tavern | Fantasy Town Kit, Medieval Buildings |
+| workshop | Crafting Building Pack |
+| warehouse | Storage Building Set |
+| guard_post, watch_tower | Defensive Structures Pack |
+| castle | Castle/Fortification Mega Pack |
+| church, temple | Religious Building Pack |
+
+**Recommended Sources:**
+- **itch.io**: Isometric City Builder, Medieval Building Kit, Fantasy Town Kit
+- **GraphicRiver**: Isometric Buildings Collection
+- **Kenney.nl**: Abstract Platformer Pack (has basic buildings)
+
+### 3. Biome Environment Tiles
+
+| Missing Tags | Recommended Packs |
+|--------------|------------------|
+| snow, frozen | Winter/Arctic Environment Pack |
+| swamp, marsh | Swamp/Wetland Tile Set |
+| desert, sand | Desert Environment Pack |
+| mountain, rocky | Mountain/Highland Tile Set |
+| coastal, beach | Beach/Coastal Tile Set |
+
+**Recommended Sources:**
+- **itch.io**: Seasonal Biome Packs, Environment Tile Sets
+- **GraphicRiver**: Isometric Nature Packs
+- **Kenney.nl**: Seasonal Tilesets (winter, desert, etc.)
+
+## Recommended Asset Sources
+
+### Free Options (Public Domain / CC0)
+
+| Source | URL | Content Types |
+|--------|-----|---------------|
+| Kenney.nl | https://kenney.nl/assets | Characters, buildings, tiles, props, UI |
+| OpenGameArt | https://opengameart.org | Community-created game assets |
+| LibreGameArt | https://libregameart.org | Historical/public domain game art |
+
+### Paid Options (Recommended)
+
+| Source | URL | Style | Price Range |
+|--------|-----|-------|-------------|
+| itch.io | https://itch.io/game-assets | Indie, RPG, Fantasy | $5-50/pack |
+| GraphicRiver | https://graphicriver.net | Isometric, Pixel Art | $10-100/pack |
+| GameDevMarket | https://gamedevmarket.net | Professional assets | $15-75/pack |
+| Unity Asset Store | https://assetstore.unity.com | 3D and 2D | Free-$100 |
+| Unreal Marketplace | https://unrealengine.com/marketplace | 3D assets | Free-$100 |
+
+## Prioritized Shopping List
+
+### High Priority (Essential for MVP)
+
+1. **RPG Character Pack** - $15-25
+   - Contains: guard, soldier, merchant, healer, blacksmith, noble
+   - Style: Isometric, consistent with existing assets
+   
+2. **Isometric Building Kit** - $20-35
+   - Contains: house, inn, workshop, warehouse, guard_post
+   - Style: Match to GraphicRiver isometric style
+   
+3. **Medieval Environment Pack** - $15-25
+   - Contains: biome tiles (grass, stone), roads, paths
+   - Style: Isometric, 2D
+
+### Medium Priority (Enhance Visuals)
+
+4. **Winter/Snow Tile Set** - $10-20
+5. **Desert/Wasteland Tile Set** - $10-20
+6. **Castle/Fortification Pack** - $20-30
+7. **Child/Youth NPC Pack** - $10-15
+
+### Low Priority (Nice to Have)
+
+8. Swamp/Wetland tiles - $10-15
+9. Mountain/Highland tiles - $10-15
+10. Coastal/Beach tiles - $10-15
+
+## Budget Estimate
+
+| Priority | Cost Range |
+|----------|------------|
+| High Priority | $50-85 |
+| All Priority | $115-175 |
+| Complete Coverage | $200-300 |
+
+## Asset Style Guidelines
+
+When purchasing assets, ensure they match:
+
+1. **Style**: Isometric, pixel art, consistent tile size (64x64 or 128x128)
+2. **Color Palette**: Warm medieval tones, avoid neon or modern styles
+3. **Consistency**: Buy from same artist/pack for visual consistency
+4. **Format**: PNG with transparency preferred
+5. **Animation**: Character sprites should have walk/idle animations
+
+## Checkout Process
+
+1. Create account on preferred source (itch.io recommended)
+2. Purchase high-priority packs first
+3. Download and extract to `.asset-inbox/` directory
+4. Run import script: `node scripts/import-forest-biome-pack.mjs <pack.zip>`
+5. Tag assets: `node scripts/auto-tag-manifest.mjs`
+6. Review in client-2d before committing
+
+## Verification Checklist
+
+Before purchasing, verify:
+- [ ] Asset style matches existing isometric assets
+- [ ] License allows commercial use
+- [ ] PNG format with transparency
+- [ ] Consistent tile size with existing assets
+- [ ] No watermarks or attribution required in-game

--- a/docs/ai-skills/wasd-asset-tagging.md
+++ b/docs/ai-skills/wasd-asset-tagging.md
@@ -1,0 +1,184 @@
+# WASD Asset Tagging Skill
+
+## Overview
+
+This skill guides AI agents through the asset tagging workflow for Areloria's isometric 2D client. It ensures consistent semantic tagging across all imported assets.
+
+## Quick Reference
+
+### Tag Categories
+
+| Category | Tags | Usage |
+|----------|------|-------|
+| **Semantic Type** | `building`, `npc`, `prop`, `tile`, `ui`, `character` | Primary classification |
+| **Building Subtype** | `house`, `tower`, `inn`, `blacksmith`, `warehouse`, `castle` | Buildings only |
+| **NPC Role** | `guard`, `merchant`, `healer`, `soldier`, `noble` | NPCs only |
+| **Prop Type** | `tree`, `rock`, `bush`, `chest`, `fence`, `sign` | Props only |
+| **Biome** | `forest`, `desert`, `snow`, `swamp`, `mountain`, `coastal` | Environment context |
+| **Culture** | `nordic`, `imperial`, `tribal`, `arcane`, `desert`, `tropical` | Visual style |
+| **Source** | `graphicriver`, `kenney`, `pipoya`, `assetpack01` | Asset origin |
+
+### Required Tags for Each Asset
+
+Every asset must have at minimum:
+- `semantic_type`: building | npc | prop | tile | ui
+- `biome`: One of the biome tags
+- `source`: Origin source
+
+## Asset Tagging Workflow
+
+### 1. Import Phase
+
+When importing new assets:
+
+```bash
+# Import from ZIP
+node scripts/import-forest-biome-pack.mjs <asset-pack.zip>
+
+# Auto-tag after import
+node scripts/auto-tag-manifest.mjs
+```
+
+### 2. Manual Tagging
+
+For manual tagging, update the asset manifest:
+
+```json
+{
+  "id": "gr_iso_2_towers_cannon_tower_png",
+  "src": "/2d/assets/buildings/tower.png",
+  "kind": "tower",
+  "group": "defensive",
+  "tags": ["building", "tower", "defensive", "military", "isometric"],
+  "biomeTags": ["forest", "plains"],
+  "cultureTags": ["generic"],
+  "source": "GraphicRiver"
+}
+```
+
+### 3. Pattern Recognition
+
+The system automatically recognizes these patterns:
+
+| Pattern | Auto-Generated Tags |
+|---------|---------------------|
+| `*_tower*` | tower, defensive, military |
+| `*_house*` | house, residential |
+| `*_guard*` | guard, soldier, military |
+| `*_merchant*` | merchant, trader, commerce |
+| `gr_iso_*` | graphicriver, isometric, pixel-art |
+| `*_snow*` | snow, winter, frozen |
+| `*_forest*` | forest, woodland, green |
+
+## Fallback Chains
+
+When exact tag match fails, the system falls back through these chains:
+
+### Buildings
+```
+tower → military_tower → defensive → building
+house → hut → residential → building
+inn → tavern → pub → social → building
+```
+
+### NPCs
+```
+guard → soldier → warrior → human → npc
+merchant → trader → shopkeeper → commerce → npc
+```
+
+## Common Tasks
+
+### Tag a new building asset
+
+1. Identify the building type from filename
+2. Add semantic tags: `building`, `<type>`, `isometric`
+3. Add biome tags based on context
+4. Verify fallback chain exists in `AssetFallbackChains.ts`
+
+### Tag a new NPC asset
+
+1. Identify NPC role from filename
+2. Add semantic tags: `npc`, `<role>`, `character`
+3. Add culture tags for visual style
+4. Verify NPC fallback chain exists
+
+### Add a new fallback chain
+
+Edit `apps/client-2d/src/world/AssetFallbackChains.ts`:
+
+```typescript
+// For buildings
+BUILDING_FALLBACK_CHAINS.myBuilding = ["my_building", "house", "building"];
+
+// For NPCs  
+NPC_FALLBACK_CHAINS.myRole = ["my_role", "civilian", "npc"];
+
+// Or for GraphicRiver-specific patterns
+GRAPHICRIVER_BUILDING_FALLBACKS.my_variant = ["my_variant", "building"];
+```
+
+## Score Weights
+
+When binding assets, the scoring system uses these weights:
+
+| Factor | Weight | Description |
+|--------|--------|-------------|
+| exactKind | 100 | Tag matches requested kind exactly |
+| exactGroup | 50 | Group matches semantic type |
+| patternMatch | 25 | Asset ID contains requested keyword |
+| matchingTag | 15 | Tags overlap with query |
+| sourceMatch | 20 | Recognized source (GraphicRiver, Kenney) |
+| biomeTag | 20 | Biome context matches |
+| isoMatch | 15 | Isometric style detected |
+
+## GraphicRiver Asset Handling
+
+GraphicRiver assets follow this naming pattern:
+```
+gr_iso_<count>_<category>_<variant>_<state>_<index>
+```
+
+Example: `gr_iso_2_towers_cannon_tower_png_lvl_1_cannon_attack_e_1`
+
+Extract tags using:
+```typescript
+import { extractGraphicRiverVariant, isGraphicRiverAsset } from './AssetFallbackChains';
+
+// Check if asset is from GraphicRiver
+isGraphicRiverAsset("gr_iso_2_towers_cannon_tower_png") // true
+
+// Extract variant name
+extractGraphicRiverVariant("gr_iso_2_towers_cannon_tower_png") // "tower"
+```
+
+## Quality Checklist
+
+Before committing tagged assets:
+- [ ] All assets have minimum 3 tags
+- [ ] Biome tags are accurate for the environment
+- [ ] Fallback chains exist for all types
+- [ ] No duplicate entries (check SHA256)
+- [ ] Manifest validates (run `node scripts/validate-pixi-assets.mjs`)
+- [ ] Assets render correctly in client-2d
+
+## Troubleshooting
+
+### Asset not binding to expected type
+
+1. Check if tag exists in manifest
+2. Verify fallback chain has the type
+3. Add `patternMatch` scoring weight in `AssetBindingDirector.ts`
+4. Run debug mode: `createAssetBindingDirector(manifest, true)`
+
+### Duplicate entries appearing
+
+1. Run deduplication: `node scripts/auto-tag-manifest.mjs`
+2. Check SHA256 hash conflicts
+3. Manually remove duplicate manifest entries
+
+### Missing fallback for new type
+
+1. Add to appropriate chain in `AssetFallbackChains.ts`
+2. Rebuild manifest: `node scripts/auto-tag-manifest.mjs`
+3. Test binding with debug mode enabled

--- a/docs/ai-skills/wasd-docs-best-practices.md
+++ b/docs/ai-skills/wasd-docs-best-practices.md
@@ -1,0 +1,304 @@
+# WASD Documentation Best Practices
+
+## Overview
+
+This skill defines standards and guidelines for creating and maintaining documentation in the Areloria/WASD repository. Following these practices ensures AI agents produce consistent, useful, and maintainable documentation.
+
+## Documentation Hierarchy
+
+The repository uses this structure:
+
+```
+docs/
+├── *.md                    # Feature/system documentation
+├── ai-skills/              # AI agent skills (this directory)
+├── diagrams/               # Visual diagrams
+├── archive/               # Deprecated documentation
+├── wiki/                  # Community wiki content
+└── research/              # Investigation notes
+```
+
+### File Naming Conventions
+
+| Type | Convention | Example |
+|------|------------|---------|
+| Feature Doc | `FEATURE_NAME.md` | `CRAFTING_SYSTEM.md` |
+| AI Skill | `wasd-<topic>.md` | `wasd-manifest-system.md` |
+| Runbook | `RUNBOOK_<name>.md` | `CI_VPS_RUNBOOK.md` |
+| Decision | `DECISION_<date>.md` | `DECISION_2026-03-19.md` |
+| Archive | Move to `archive/` | - |
+
+## Markdown Standards
+
+### Required Frontmatter
+
+Every documentation file should include:
+
+```markdown
+# Title
+
+<!--
+type: feature | runbook | decision | reference | guide
+created: 2026-06-02
+updated: 2026-06-02
+owner: team
+-->
+
+## Overview
+
+[One paragraph summary]
+
+## Details
+
+[Content]
+```
+
+### Section Structure
+
+1. **Overview** (required) - One paragraph describing the topic
+2. **Quick Reference** (recommended) - Jump table for key info
+3. **Details** (required) - Main content
+4. **Examples** (optional) - Code snippets, use cases
+5. **Troubleshooting** (optional) - Common issues and solutions
+6. **Related** (optional) - Links to related docs
+
+### Writing Style
+
+| Do | Don't |
+|----|-------|
+| Use clear, concise sentences | Use jargon without definition |
+| Include code examples | Leave complex concepts unexplained |
+| Update docs when code changes | Leave outdated information |
+| Use tables for structured data | Use walls of text |
+| Link to related documentation | Duplicate content |
+
+## Documentation Types
+
+### Feature Documentation
+
+For systems and features:
+
+```markdown
+# Feature Name
+
+## Overview
+[One paragraph]
+
+## Quick Reference
+| Key | Value |
+|-----|-------|
+| Path | /path/to/code |
+| Type | feature |
+
+## How It Works
+[Detailed explanation]
+
+## Usage Examples
+```typescript
+// Example code
+```
+
+## Edge Cases
+- Case 1
+- Case 2
+
+## Related
+- [Link to related doc](path)
+```
+
+### Runbook
+
+For operational procedures:
+
+```markdown
+# Runbook: Procedure Name
+
+## Prerequisites
+- Requirement 1
+- Requirement 2
+
+## Steps
+1. Step one
+2. Step two
+
+## Verification
+[How to verify success]
+
+## Rollback
+[How to undo]
+```
+
+### AI Skill Documentation
+
+For AI agent guidance (in `docs/ai-skills/`):
+
+```markdown
+# SKILL_NAME Skill
+
+## Overview
+[What this skill does]
+
+## Quick Reference
+[Key commands, paths]
+
+## Common Tasks
+[Task 1 with steps]
+[Task 2 with steps]
+
+## Troubleshooting
+[Common issues]
+```
+
+## File Organization
+
+### Updating Documentation
+
+When updating code:
+
+1. Check if documentation exists for the change
+2. Update the relevant doc(s)
+3. Update `DOCUMENTATION_INDEX.md` if adding new file
+4. If significant change, update `PROJECT_STATUS_2026.md`
+
+### Archiving Documentation
+
+Move deprecated docs to `archive/`:
+
+```bash
+git mv docs/old-doc.md docs/archive/old-doc.md
+```
+
+Update any references to the archived file.
+
+### Version Control
+
+- Commit documentation changes separately from code when practical
+- Use meaningful commit messages: "docs: update crafting system runbook"
+- Review docs in PRs for accuracy
+
+## Links and References
+
+### Internal Links
+
+Use relative paths:
+```markdown
+See [Building System](../BUILDING_SYSTEM.md)
+See [Manifest System](./ai-skills/wasd-manifest-system.md)
+```
+
+### External Links
+
+Verify external links still work periodically. Use:
+- Official documentation
+- Project-specific resources
+- Avoid linking to temporary content
+
+## Quality Checklist
+
+Before committing documentation:
+
+- [ ] Frontmatter complete (type, dates)
+- [ ] Overview section exists and is accurate
+- [ ] Code examples are correct and working
+- [ ] Links are valid and relative
+- [ ] No duplicate content from other docs
+- [ ] README updated if adding new top-level doc
+
+## Documentation Maintenance Rules
+
+From `AGENTS.md`:
+
+> For every non-trivial feature or architecture change:
+> 1. Update `docs/PROJECT_STATUS_2026.md`
+> 2. Update `docs/ROADMAP_TO_RELEASE.md` if release scope changed
+> 3. If core workflow changed, also update `README.md` and relevant deploy docs
+
+## Templates
+
+### New Feature Doc
+
+```markdown
+# Feature Name
+
+<!--
+type: feature
+created: YEAR-MM-DD
+updated: YEAR-MM-DD
+-->
+
+## Overview
+
+[One paragraph describing the feature]
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| Status | [planned|in-progress|complete] |
+| Path | [code path if applicable] |
+
+## Implementation
+
+[How it works]
+
+## Usage
+
+[How to use it]
+
+## Related
+- [Related doc](link)
+```
+
+### New AI Skill
+
+```markdown
+# SKILL_NAME Skill
+
+## Overview
+
+[What this skill is for]
+
+## Quick Reference
+
+### Key Files
+| Path | Purpose |
+|------|---------|
+
+### Commands
+```bash
+# Command example
+```
+
+## Common Tasks
+
+### Task 1
+
+Steps:
+1. Step one
+2. Step two
+
+### Task 2
+
+Steps...
+
+## Troubleshooting
+
+Q: Question?
+A: Answer
+
+Q: Another?
+A: Another answer
+```
+
+## Tools and Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/validate-pixi-assets.mjs` | Validate asset documentation |
+| `scripts/sync-wiki.mjs` | Sync wiki documentation |
+
+## Resources
+
+- [Markdown Guide](https://www.markdownguide.org/)
+- [Fork Awesome Icons](https://forkaweso.me/Fork-Awesome/) (for icons in docs)
+- Existing docs in `docs/` for style reference

--- a/scripts/auto-tag-manifest.mjs
+++ b/scripts/auto-tag-manifest.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+/**
+ * Auto-Tag Manifest Script
+ * 
+ * Automatically tags new assets with semantic tags, maintains fallback mappings,
+ * and cleans duplicate entries.
+ * 
+ * Usage:
+ *   node scripts/auto-tag-manifest.mjs                    # Tag all manifest files
+ *   node scripts/auto-tag-manifest.mjs --dry-run          # Preview changes without applying
+ *   node scripts/auto-tag-manifest.mjs --source=GraphicRiver  # Tag specific source
+ *   node scripts/auto-tag-manifest.mjs --pattern="tower"  # Tag assets matching pattern
+ */
+
+import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve, dirname, basename, extname } from 'node:path';
+import { createHash } from 'node:crypto';
+
+// Pattern mappings for semantic tagging
+const PATTERN_TAGGING_RULES = {
+  // Building patterns
+  tower: ['tower', 'defensive', 'military', 'tall'],
+  castle: ['castle', 'fort', 'defensive', 'royal'],
+  house: ['house', 'residential', 'home', 'dwelling'],
+  inn: ['inn', 'tavern', 'social', 'hospitality'],
+  blacksmith: ['blacksmith', 'craft', 'forge', 'workshop'],
+  workshop: ['workshop', 'craft', 'production'],
+  warehouse: ['warehouse', 'storage', 'logistics'],
+  guard_post: ['guard_post', 'military', 'security'],
+  church: ['church', 'religious', 'spiritual'],
+  
+  // NPC patterns
+  guard: ['guard', 'soldier', 'military', 'security'],
+  soldier: ['soldier', 'military', 'warrior'],
+  merchant: ['merchant', 'trader', 'commerce', 'shopkeeper'],
+  healer: ['healer', 'priest', 'medical', 'support'],
+  blacksmith_npc: ['blacksmith', 'craftsman', 'worker'],
+  noble: ['noble', 'lord', 'royal', 'aristocrat'],
+  farmer: ['farmer', 'agriculture', 'worker'],
+  child: ['child', 'young', 'civilian'],
+  
+  // Prop patterns
+  tree: ['tree', 'nature', 'vegetation', 'forest'],
+  rock: ['rock', 'stone', 'mineral', 'geology'],
+  bush: ['bush', 'shrub', 'vegetation'],
+  flower: ['flower', 'plant', 'beauty'],
+  chest: ['chest', 'container', 'treasure'],
+  well: ['well', 'water', 'resource'],
+  fence: ['fence', 'barrier', 'boundary'],
+  sign: ['sign', 'marker', 'information'],
+  
+  // Biome patterns
+  snow: ['snow', 'winter', 'frozen', 'cold'],
+  swamp: ['swamp', 'wetland', 'marsh', 'mud'],
+  desert: ['desert', 'arid', 'sand', 'dry'],
+  mountain: ['mountain', 'alpine', 'highland', 'rocky'],
+  coastal: ['coastal', 'beach', 'shore', 'ocean'],
+  forest: ['forest', 'woodland', 'green', 'nature'],
+  
+  // Style patterns
+  isometric: ['isometric', 'iso', '2d', 'pixel'],
+  lowpoly: ['lowpoly', 'low-poly', '3d'],
+  medieval: ['medieval', 'fantasy', 'historical'],
+};
+
+// Fallback chain mappings for GraphicRiver-style asset IDs
+const GRAPHICRIVER_FALLBACK_MAP = {
+  'tower': ['tower', 'military_tower', 'defensive', 'building', 'house'],
+  'cannon_tower': ['cannon_tower', 'tower', 'military_tower', 'defensive', 'building'],
+  'house': ['house', 'residential', 'hut', 'building'],
+  'inn': ['inn', 'tavern', 'social', 'house'],
+  'blacksmith': ['blacksmith', 'forge', 'workshop', 'building'],
+  'merchant': ['merchant', 'trader', 'shop', 'npc'],
+  'guard': ['guard', 'soldier', 'warrior', 'npc'],
+  'soldier': ['soldier', 'military', 'warrior', 'npc'],
+};
+
+// Source-specific tag enrichments
+const SOURCE_TAG_ENRICHMENTS = {
+  'GraphicRiver': ['isometric', 'pixel-art', 'game-ready'],
+  'Kenney': ['public-domain', 'free', 'open-source'],
+  'Pipoya': ['character', 'sprite', 'animated'],
+  'AssetPack01': ['forest', 'biome', 'nature'],
+};
+
+/**
+ * Generate semantic tags from file path
+ */
+function extractTagsFromPath(filePath) {
+  const fileName = basename(filePath, extname(filePath)).toLowerCase();
+  const parts = fileName.split(/[_\-,\s]+/);
+  const tags = new Set();
+  
+  // Add extracted pattern tags
+  for (const [pattern, patternTags] of Object.entries(PATTERN_TAGGING_RULES)) {
+    if (fileName.includes(pattern)) {
+      patternTags.forEach(t => tags.add(t));
+    }
+    // Also check individual parts
+    parts.forEach(part => {
+      if (part.includes(pattern)) {
+        patternTags.forEach(t => tags.add(t));
+      }
+    });
+  }
+  
+  // Add file name parts as tags
+  parts.forEach(part => {
+    if (part.length > 2) {
+      tags.add(part);
+    }
+  });
+  
+  // Check for GraphicRiver-style patterns
+  const grMatch = fileName.match(/gr_iso_(\d)_([\w]+)_([\w]+)/);
+  if (grMatch) {
+    tags.add('graphicriver');
+    tags.add('isometric');
+    // Extract category from filename
+    if (grMatch[2]) tags.add(grMatch[2]);
+    if (grMatch[3]) tags.add(grMatch[3]);
+  }
+  
+  return Array.from(tags);
+}
+
+/**
+ * Generate ID from file path
+ */
+function generateId(filePath) {
+  return basename(filePath, extname(filePath))
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+
+/**
+ * Calculate content hash
+ */
+function contentHash(filePath) {
+  return createHash('sha256').update(readFileSync(filePath)).digest('hex');
+}
+
+/**
+ * Check for duplicate entries in manifest
+ */
+function findDuplicates(entries) {
+  const hashMap = new Map();
+  const duplicates = [];
+  
+  for (const [id, entry] of Object.entries(entries)) {
+    if (entry.sha256) {
+      if (hashMap.has(entry.sha256)) {
+        duplicates.push({
+          original: hashMap.get(entry.sha256),
+          duplicate: id,
+          entry
+        });
+      } else {
+        hashMap.set(entry.sha256, id);
+      }
+    }
+  }
+  
+  return duplicates;
+}
+
+/**
+ * Find assets missing semantic tags
+ */
+function findUntaggedAssets(entries) {
+  const untagged = [];
+  
+  for (const [id, entry] of Object.entries(entries)) {
+    const tags = entry.tags ?? [];
+    const hasSemanticTags = tags.some(t => 
+      PATTERN_TAGGING_RULES[t] || 
+      ['building', 'npc', 'prop', 'tile'].includes(t)
+    );
+    
+    if (!hasSemanticTags && tags.length < 3) {
+      untagged.push({ id, entry });
+    }
+  }
+  
+  return untagged;
+}
+
+/**
+ * Auto-tag assets in a manifest file
+ */
+function tagManifest(manifest, options = {}) {
+  const { dryRun = false, enrichSource = null } = options;
+  const updates = [];
+  const removals = [];
+  
+  // Find duplicates
+  const duplicates = findDuplicates(manifest.entries ?? manifest);
+  if (duplicates.length > 0) {
+    console.log(`Found ${duplicates.length} duplicate entries`);
+    
+    for (const dupe of duplicates) {
+      if (!dryRun) {
+        removals.push(dupe.duplicate);
+      }
+      updates.push({
+        type: 'duplicate',
+        id: dupe.duplicate,
+        kept: dupe.original
+      });
+    }
+  }
+  
+  // Find untagged assets
+  const untagged = findUntaggedAssets(manifest.entries ?? manifest);
+  if (untagged.length > 0) {
+    console.log(`Found ${untagged.length} untagged entries`);
+    
+    for (const asset of untagged) {
+      const autoTags = extractTagsFromPath(asset.entry.sourcePath || asset.id);
+      const enrichedTags = [...new Set([...asset.entry.tags, ...autoTags])];
+      
+      // Add source-specific enrichment
+      if (asset.entry.source && SOURCE_TAG_ENRICHMENTS[asset.entry.source]) {
+        enrichedTags.push(...SOURCE_TAG_ENRICHMENTS[asset.entry.source]);
+      }
+      
+      if (!dryRun) {
+        if (manifest.entries) {
+          manifest.entries[asset.id].tags = enrichedTags;
+        } else {
+          manifest[asset.id].tags = enrichedTags;
+        }
+      }
+      
+      updates.push({
+        type: 'tagged',
+        id: asset.id,
+        newTags: enrichedTags
+      });
+    }
+  }
+  
+  return { manifest, updates, removals, duplicates, untagged };
+}
+
+/**
+ * Process all manifest files in a directory
+ */
+function processDirectory(dirPath, options = {}) {
+  const manifestFiles = [];
+  
+  function scanDir(dir) {
+    const entries = readdirSync(dir);
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+      
+      if (stat.isDirectory()) {
+        scanDir(fullPath);
+      } else if (entry === 'manifest.json') {
+        manifestFiles.push(fullPath);
+      }
+    }
+  }
+  
+  scanDir(dirPath);
+  return manifestFiles;
+}
+
+/**
+ * Main CLI
+ */
+function main() {
+  const args = process.argv.slice(2);
+  const options = {
+    dryRun: args.includes('--dry-run'),
+    source: args.find(a => a.startsWith('--source='))?.split('=')[1],
+    pattern: args.find(a => a.startsWith('--pattern='))?.split('=')[1],
+  };
+  
+  const repoRoot = resolve(process.cwd());
+  const assetDirs = [
+    join(repoRoot, 'apps/client-2d/public/assets'),
+    join(repoRoot, 'public/assets'),
+  ];
+  
+  console.log('=== Auto-Tag Manifest Script ===');
+  console.log(`Mode: ${options.dryRun ? 'DRY-RUN (no changes will be written)' : 'LIVE (changes will be applied)'}`);
+  console.log('');
+  
+  for (const assetDir of assetDirs) {
+    if (!existsSync(assetDir)) {
+      console.log(`Skipping non-existent directory: ${assetDir}`);
+      continue;
+    }
+    
+    console.log(`Scanning: ${assetDir}`);
+    const manifestFiles = processDirectory(assetDir, options);
+    
+    for (const manifestPath of manifestFiles) {
+      console.log(`\nProcessing: ${manifestPath}`);
+      
+      try {
+        const manifestStr = readFileSync(manifestPath, 'utf8');
+        const manifest = JSON.parse(manifestStr);
+        
+        const result = tagManifest(manifest, options);
+        
+        console.log(`  - Duplicates found: ${result.duplicates.length}`);
+        console.log(`  - Assets tagged: ${result.updates.filter(u => u.type === 'tagged').length}`);
+        
+        if (result.updates.length > 0) {
+          console.log('  Updates:');
+          for (const update of result.updates.slice(0, 5)) {
+            console.log(`    - [${update.type}] ${update.id}`);
+            if (update.newTags) {
+              console.log(`      Tags: ${update.newTags.join(', ')}`);
+            }
+          }
+          if (result.updates.length > 5) {
+            console.log(`    ... and ${result.updates.length - 5} more`);
+          }
+        }
+        
+        if (!options.dryRun && result.updates.length > 0) {
+          writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+          console.log(`  Written: ${manifestPath}`);
+        }
+        
+      } catch (error) {
+        console.error(`  Error processing: ${error.message}`);
+      }
+    }
+  }
+  
+  console.log('\n=== Complete ===');
+  if (options.dryRun) {
+    console.log('This was a dry run. Run without --dry-run to apply changes.');
+  }
+}
+
+// Export for programmatic use
+export { extractTagsFromPath, generateId, tagManifest, findDuplicates, findUntaggedAssets };
+
+// Run if executed directly
+main();


### PR DESCRIPTION
… and import runbook

This commit adds comprehensive support for importing and tagging GraphicRiver-style isometric assets, including:

- Auto-tagging script (scripts/auto-tag-manifest.mjs) for semantic asset tagging
- Extended fallback chains (GRAPHICRIVER_BUILDING_FALLBACKS, GRAPHICRIVER_NPC_FALLBACKS)
- New scoring weights in AssetBindingDirector for pattern/source/iso matching
- Asset purchase recommendations document with prioritized shopping list
- AI skills for asset-tagging workflow and docs best practices
- Asset pack import runbook for future integrations

## Summary

<!-- What changed and why (1–3 sentences). -->

## Documentation

- [x] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [x] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [x] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

<!-- e.g. `pnpm run lint`, `pnpm run test`, `pnpm run build` -->
