### PR TITLE
fix(client-2d): Force initial chunk visibility update + add debug HUD

### DIFF
--- a/apps/client-2d/src/ArelorianStitchHud.tsx
+++ b/apps/client-2d/src/ArelorianStitchHud.tsx
@@ -20,6 +20,12 @@ export interface ArelorianStitchHudProps {
   onEquipWeapon?: (item: InventoryItem) => void;
   onCycleWeapon?: () => void;
   onToggleAutoMove?: () => void;
+  // DEBUG: Player position & chunk visibility tracking
+  debugPlayerPos?: { x: number; z: number };
+  debugChunkCoords?: { chunkX: number; chunkZ: number };
+  debugVisibleChunks?: number;
+  debugHeartbeatReceived?: boolean;
+  debugInitialized?: boolean;
 }
 
 const skills = [
@@ -73,6 +79,12 @@ export function ArelorianStitchHud({
   onEquipWeapon,
   onCycleWeapon,
   onToggleAutoMove,
+  // DEBUG props
+  debugPlayerPos,
+  debugChunkCoords,
+  debugVisibleChunks,
+  debugHeartbeatReceived,
+  debugInitialized,
 }: ArelorianStitchHudProps) {
   const [activePanel, setActivePanel] = useState<HudPanel>(null);
   const [isInventoryOpen, setIsInventoryOpen] = useState(false);
@@ -215,6 +227,31 @@ export function ArelorianStitchHud({
         <Gauge label="MP" value={mana} tone="aether" />
         <Gauge label="STA" value={stamina} tone="emerald" />
         <Gauge label="XP" value={xp} tone="gold" />
+      </aside>
+
+      {/* DEBUG HUD: Player Position & Chunk Visibility */}
+      <aside className="stitch-debug" aria-label="Debug: Player Position & Chunk Tracking">
+        <div className="stitch-debug-title">POSITION DEBUG</div>
+        <div className="stitch-debug-row">
+          <span>Heartbeat:</span>
+          <span className={debugHeartbeatReceived ? "ok" : "warn"}>{debugHeartbeatReceived ? "✓" : "✗"}</span>
+        </div>
+        <div className="stitch-debug-row">
+          <span>Initialized:</span>
+          <span className={debugInitialized ? "ok" : "warn"}>{debugInitialized ? "✓" : "✗"}</span>
+        </div>
+        <div className="stitch-debug-row">
+          <span>Player Pos:</span>
+          <span>{debugPlayerPos ? `${debugPlayerPos.x.toFixed(0)}, ${debugPlayerPos.z.toFixed(0)}` : "---"}</span>
+        </div>
+        <div className="stitch-debug-row">
+          <span>Chunk Coords:</span>
+          <span>{debugChunkCoords ? `${debugChunkCoords.chunkX}, ${debugChunkCoords.chunkZ}` : "---"}</span>
+        </div>
+        <div className="stitch-debug-row">
+          <span>Visible Chunks:</span>
+          <span>{debugVisibleChunks ?? "---"}</span>
+        </div>
       </aside>
 
       <aside className="stitch-side-menu" aria-label="Game Menus">

--- a/apps/client-2d/src/DeterministicWorldIsoApp.tsx
+++ b/apps/client-2d/src/DeterministicWorldIsoApp.tsx
@@ -241,6 +241,8 @@ export function DeterministicWorldIsoApp() {
   const keys = useRef(new Set<string>());
   const lastMoveAt = useRef(0);
   const lastPlayerKappa = useRef({ x: 0, z: 0 });
+  // FIX: Force initial chunk visibility update on first heartbeat
+  const hasInitializedVisibility = useRef(false);
   const playerName = localStorage.getItem("wasd:2d:name") || "Architect";
   
   /**
@@ -263,6 +265,12 @@ export function DeterministicWorldIsoApp() {
   const [weaponCount, setWeaponCount] = useState(0);
   const [equippedWeaponId, setEquippedWeaponId] = useState<string | null>(() => localStorage.getItem(EQUIPPED_WEAPON_KEY));
   const [messages, setMessages] = useState<Msg[]>([{ from: "WorldDirector", txt: "Deterministic Millbrook plan initializing." }]);
+  
+  // DEBUG: Player position & chunk visibility state
+  const [debugHeartbeatReceived, setDebugHeartbeatReceived] = useState(false);
+  const [debugPlayerPos, setDebugPlayerPos] = useState<{ x: number; z: number } | null>(null);
+  const [debugChunkCoords, setDebugChunkCoords] = useState<{ chunkX: number; chunkZ: number } | null>(null);
+  const [debugVisibleChunks, setDebugVisibleChunks] = useState<number | null>(null);
 
   // ─────────────────────────────────────────────────────────────────
   // ZERO-TRUST MANIFEST SYSTEM - Input Lockdown
@@ -685,6 +693,8 @@ chunkManager.init({
       }
       
       // Update chunk visibility based on player kappa position
+      // FIX: Force initial visibility update - without this, if player starts near (0,0),
+      // the dx/dz >= 500 check prevents updateVisibility from ever being called
       if (event.payload?.self) {
         const self = event.payload.self;
         const playerKappa = {
@@ -692,13 +702,37 @@ chunkManager.init({
           z: payloadCoord(self, "z") * 1000,
         };
         
-        // Only update if player moved significantly (reduce CPU)
         const dx = Math.abs(playerKappa.x - lastPlayerKappa.current.x);
         const dz = Math.abs(playerKappa.z - lastPlayerKappa.current.z);
-        if (dx >= 500 || dz >= 500) {
+        // FIX: Also update on first heartbeat to ensure initial chunk loading
+        if (!hasInitializedVisibility.current || dx >= 500 || dz >= 500) {
+          hasInitializedVisibility.current = true;
           lastPlayerKappa.current = playerKappa;
           chunkManagerRef.current?.updateVisibility(playerKappa);
         }
+        
+        // DEBUG: Update debug state for HUD display
+        setDebugHeartbeatReceived(true);
+        setDebugPlayerPos({ x: playerKappa.x, z: playerKappa.z });
+        // Calculate chunk coords (kappa / (chunkTiles * 1000))
+        const chunkX = Math.floor(playerKappa.x / (16 * 1000));
+        const chunkZ = Math.floor(playerKappa.z / (16 * 1000));
+        setDebugChunkCoords({ chunkX, chunkZ });
+        // Get active chunk count from ChunkManager
+        if (chunkManagerRef.current) {
+          setDebugVisibleChunks(chunkManagerRef.current.getActiveChunkCount());
+        }
+        
+        // Console debug log for deep debugging
+        console.log("[PlayerPosDebug]", {
+          heartbeatSelf: event.payload?.self,
+          selfX: payloadCoord(event.payload?.self, "x"),
+          selfZ: payloadCoord(event.payload?.self, "z"),
+          playerKappa,
+          lastPlayerKappa: lastPlayerKappa.current,
+          chunkX,
+          chunkZ,
+        });
       }
       
       payloadEntries(event.payload?.agents ?? event.payload?.npcs, "agent").forEach(([id, npc]: any) => {
@@ -1114,6 +1148,12 @@ chunkManager.init({
         onStrike={strikeAction}
         onCycleWeapon={cycleEquippedWeapon}
         onToggleAutoMove={() => setMessages((items) => [...items.slice(-12), { from: "Navigator", txt: "WorldDirector routes are generated; auto-route execution follows server validation." }])}
+        // DEBUG: Player position & chunk tracking
+        debugPlayerPos={debugPlayerPos ?? undefined}
+        debugChunkCoords={debugChunkCoords ?? undefined}
+        debugVisibleChunks={debugVisibleChunks ?? undefined}
+        debugHeartbeatReceived={debugHeartbeatReceived}
+        debugInitialized={hasInitializedVisibility.current}
       />
     </div>
   );

--- a/apps/client-2d/src/kenneyUiLiveSkin.css
+++ b/apps/client-2d/src/kenneyUiLiveSkin.css
@@ -159,3 +159,51 @@
     transform-origin: right bottom;
   }
 }
+
+/* DEBUG HUD: Position & Chunk Tracking */
+.stitch-debug {
+  position: fixed;
+  bottom: 120px;
+  right: 20px;
+  background: rgba(0, 8, 20, 0.92);
+  border: 1px solid #0af;
+  padding: 12px 16px;
+  font-family: "Courier New", monospace;
+  font-size: 11px;
+  color: #0ef;
+  min-width: 180px;
+  z-index: 9999;
+  box-shadow: 0 0 12px rgba(0, 170, 255, 0.3);
+}
+
+.stitch-debug-title {
+  font-weight: bold;
+  color: #0ff;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #0af;
+  padding-bottom: 4px;
+  font-size: 12px;
+  letter-spacing: 1px;
+}
+
+.stitch-debug-row {
+  display: flex;
+  justify-content: space-between;
+  margin: 4px 0;
+}
+
+.stitch-debug-row span:first-child {
+  color: #7af;
+}
+
+.stitch-debug-row span:last-child {
+  color: #0ff;
+}
+
+.stitch-debug-row .ok {
+  color: #0f0;
+}
+
+.stitch-debug-row .warn {
+  color: #f80;
+}


### PR DESCRIPTION
## Summary

This PR fixes a critical issue in the client-2d chunk visibility system where `updateVisibility()` was never called for players starting near position (0,0), causing the world to appear as only the initial static start village.

### Problem

The original code used this logic:
```typescript
if (dx >= 500 || dz >= 500) {
  chunkManagerRef.current?.updateVisibility(playerKappa);
}
```

When `lastPlayerKappa` is `{ x: 0, z: 0 }` and the server reports the player at a position near (0,0), `dx` and `dz` would be less than 500, and `updateVisibility()` would never be called. This left the ChunkManager stuck at the local initial state.

### Solution

1. **Added `hasInitializedVisibility` ref** - Forces the first visibility update regardless of movement distance:
   ```typescript
   if (!hasInitializedVisibility.current || dx >= 500 || dz >= 500) {
     hasInitializedVisibility.current = true;
     chunkManagerRef.current?.updateVisibility(playerKappa);
   }
   ```

2. **Added Debug HUD Panel** - Shows real-time tracking data for debugging:
   - Heartbeat received status
   - Visibility initialized status  
   - Player position (kappa coordinates)
   - Current chunk coordinates
   - Visible chunks count

3. **Added Console Debug Logging** - Logs `[PlayerPosDebug]` to console on each heartbeat for remote debugging.

### Files Changed

- `apps/client-2d/src/DeterministicWorldIsoApp.tsx` - Core fix + debug state
- `apps/client-2d/src/ArelorianStitchHud.tsx` - Debug HUD panel UI
- `apps/client-2d/src/kenneyUiLiveSkin.css` - Debug HUD styling

### Testing

After this fix, the debug panel should show:
- ✅ Heartbeat: ✓ (received)
- ✅ Initialized: ✓ (after first heartbeat)
- Player position should update
- Visible chunks should be > 0 (3x3 grid = 9 chunks)

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/08c28d92-65ca-47f6-9598-12db48c1df73)