### PR TITLE
Dockerfile.vps: copy public assets for client-2d (cozy-spring)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,12 @@ Performance/safety:
 - **Tailwind CSS v4**: The client uses `tailwindcss@4` which requires `@tailwindcss/postcss` plugin (not the legacy `tailwindcss` PostCSS plugin) and `@import "tailwindcss"` syntax instead of the old `@tailwind` directives.
 - **Vite version**: `@vitejs/plugin-react@6.x` requires Vite 8+. The client's `vite` dependency must be `^8.x`, not `^6.x`.
 - **`@wasd/shared` export**: The shared package's `src/utils/import-fixer.ts` is a Node.js build script (uses `fs`/`path`); it must NOT be re-exported from the shared package index when consumed by browser clients.
+- **Vite `public/` dir not copied to `dist/`**: When building with `pnpm --filter @wasd/client-2d build`, Vite does NOT automatically copy the `public/` directory to `dist/`. You must explicitly copy it in the Dockerfile:
+  ```dockerfile
+  RUN mkdir -p apps/client-2d/dist/assets && \
+      cp -a apps/client-2d/public/assets/. apps/client-2d/dist/assets/
+  ```
+  This caused PR #1586 (Dockerfile.vps: copy public assets for client-2d). Assets in `apps/client-2d/public/assets/` must be copied to `apps/client-2d/dist/assets/` so they end up in `/app/server/client/dist/2d/assets/` in the Docker container.
 
 ### Documentation maintenance rule
 For every non-trivial feature or architecture change:

--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -89,7 +89,10 @@ RUN if [ -f apps/client-2d/dist/index.html ]; then \
       pnpm --filter @wasd/client-2d --if-present build; \
     fi && \
     test -f apps/client-2d/dist/index.html && \
-    grep -q 'REAL_PIXI_CLIENT' apps/client-2d/dist/index.html
+    grep -q 'REAL_PIXI_CLIENT' apps/client-2d/dist/index.html && \
+    echo "Copying public assets for client-2d" && \
+    mkdir -p apps/client-2d/dist/assets && \
+    cp -a apps/client-2d/public/assets/. apps/client-2d/dist/assets/
 
 RUN VITE_BASE_PATH=/portal/ pnpm --filter @wasd/portal --if-present build || \
     (mkdir -p portal/dist && printf '%s\n' '<!doctype html><html><body><main id="application-canvas">Areloria portal unavailable</main></body></html>' > portal/dist/index.html)


### PR DESCRIPTION
## Summary

Fixes `Dockerfile.vps` to copy `apps/client-2d/public/assets/*` to `apps/client-2d/dist/assets/` after the client-2d build.

## Problem

The Dockerfile builds the client-2d app via `pnpm --filter @wasd/client-2d build`, but Vite does not automatically copy the `public/` directory to `dist/` unless explicitly configured. This means static assets like Cozy Spring (`apps/client-2d/public/assets/cozy-spring/`) were missing from the final Docker image.

## Result

After this fix:
- Cozy Spring assets land in `/app/server/client/dist/2d/assets/cozy-spring/`
- Browser URL `https://arelorian.de/2d/assets/cozy-spring/manifest.index.json` returns 200
- No 404 on static game assets

## Verification steps (post-deploy)

```bash
# Inside container
docker exec -it areloria sh -lc '
  test -f /app/server/client/dist/2d/assets/cozy-spring/manifest.index.json && echo COZY_OK || echo COZY_MISSING
'

# From outside
curl -I https://arelorian.de/2d/assets/cozy-spring/manifest.index.json
```

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9c9079b0-1540-48e5-84cc-7395afa7400d)