### PR TITLE
fix(client-2d): remove duplicate SkillWindow export causing build failure

### DIFF
--- a/apps/client-2d/src/ui/windows/SkillWindow.tsx
+++ b/apps/client-2d/src/ui/windows/SkillWindow.tsx
@@ -458,10 +458,9 @@ export function mountSkillWindow(containerId = "skill-mount"): void {
     mountedSkillRoot = createRoot(container);
   }
 
-  mountedCharacterRoot.render(<CharacterWindow />);
-  }
+  mountedSkillRoot.render(<SkillWindow />);
+}
+
 // ─── Re-export Alias ────────────────────────────────────────────────────────
 // SkillWindow is used in UIManager.tsx for the SKILLS overlay.
-// This file contains CharacterWindow but is named SkillWindow.tsx in the windows/
-// directory. We re-export CharacterWindow as SkillWindow for backwards compatibility.
-export const SkillWindow = CharacterWindow;
+// This file contains SkillWindow component already exported above.


### PR DESCRIPTION
## Summary

Fixes the duplicate `SkillWindow` export in `SkillWindow.tsx` that causes the Docker build to fail.

## Problem

```
[PARSE_ERROR] Duplicated export 'SkillWindow'
     ╭─[ src/ui/windows/SkillWindow.tsx:177:17 ]
     │
  177 │ export function SkillWindow({ isOpen = true, onClose }) {
     │                 ─────┬─────
     │                      ╰─────── Export has already been declared here
     │
  385 │ export const SkillWindow = CharacterWindow;
     │              ─────┬─────
```

This prevents `docker compose build` from succeeding, which blocks VPS deployment.

## Changes

1. Removed the duplicate `export const SkillWindow = CharacterWindow;` line (line 467)
2. Fixed `mountSkillWindow()` which was using wrong variable (`mountedCharacterRoot` instead of `mountedSkillRoot`)

## Related

- Blocks deploy of PR #1585 (Cozy Spring visible rendering)
- Related to PR #1586 (Dockerfile.vps public assets fix)

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9c9079b0-1540-48e5-84cc-7395afa7400d)