### PR TITLE
fix(deploy): require exact client-2d build stamp

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -44,6 +44,7 @@ jobs:
       SSH_PORT: ${{ inputs.ssh_port || secrets.SSH_PORT || '22' }}
       CLIENT_2D_ARCHIVE: wasd-client-2d-dist-${{ github.sha }}.tgz
       CLIENT_2D_MARKER: REAL_PIXI_CLIENT
+      CLIENT_2D_BUILD_SHA: ${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -72,6 +73,19 @@ jobs:
           pnpm --filter @wasd/client-2d --if-present build
           test -f apps/client-2d/dist/index.html
           grep -q "${CLIENT_2D_MARKER}" apps/client-2d/dist/index.html
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const sha = process.env.CLIENT_2D_BUILD_SHA;
+          if (!sha) throw new Error('CLIENT_2D_BUILD_SHA missing');
+          fs.writeFileSync('apps/client-2d/dist/build-stamp.json', JSON.stringify({
+            ok: true,
+            app: 'client-2d',
+            commit: sha,
+            marker: process.env.CLIENT_2D_MARKER || 'REAL_PIXI_CLIENT',
+            generatedBy: 'vps-docker-deploy.yml'
+          }, null, 2));
+          NODE
+          grep -q "${CLIENT_2D_BUILD_SHA}" apps/client-2d/dist/build-stamp.json
           tar -C apps/client-2d -czf "${CLIENT_2D_ARCHIVE}" dist
           ls -lh "${CLIENT_2D_ARCHIVE}"
 
@@ -108,18 +122,20 @@ jobs:
             -o ServerAliveInterval=30 \
             -o ServerAliveCountMax=10 \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            "DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_BRANCH='${DEPLOY_BRANCH}' ARELORIAN_PORT='${ARELORIAN_PORT}' ARELORIAN_DOCKER_NETWORK='${ARELORIAN_DOCKER_NETWORK}' CLIENT_2D_ARCHIVE='${CLIENT_2D_ARCHIVE}' CLIENT_2D_MARKER='${CLIENT_2D_MARKER}' bash -s" << 'EOF'
+            "DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_BRANCH='${DEPLOY_BRANCH}' ARELORIAN_PORT='${ARELORIAN_PORT}' ARELORIAN_DOCKER_NETWORK='${ARELORIAN_DOCKER_NETWORK}' CLIENT_2D_ARCHIVE='${CLIENT_2D_ARCHIVE}' CLIENT_2D_MARKER='${CLIENT_2D_MARKER}' CLIENT_2D_BUILD_SHA='${CLIENT_2D_BUILD_SHA}' bash -s" << 'EOF'
           set -Eeuo pipefail
           APP_DIR="${DEPLOY_PATH:-/opt/areloria}"
           BRANCH="${DEPLOY_BRANCH:-main}"
           REPO_URL="https://github.com/${{ github.repository }}.git"
           CLIENT_2D_ARCHIVE="${CLIENT_2D_ARCHIVE:-}"
           CLIENT_2D_MARKER="${CLIENT_2D_MARKER:-REAL_PIXI_CLIENT}"
+          CLIENT_2D_BUILD_SHA="${CLIENT_2D_BUILD_SHA:-}"
 
           echo "=== VPS Docker deploy entry ==="
           echo "App dir: $APP_DIR"
           echo "Branch: $BRANCH"
           echo "Client-2D archive: ${CLIENT_2D_ARCHIVE:-none}"
+          echo "Client-2D build sha: ${CLIENT_2D_BUILD_SHA:-none}"
 
           mkdir -p "$APP_DIR"
           cd "$APP_DIR"
@@ -144,6 +160,10 @@ jobs:
             tar -xzf "$APP_DIR/$CLIENT_2D_ARCHIVE" -C apps/client-2d
             test -f apps/client-2d/dist/index.html
             grep -q "$CLIENT_2D_MARKER" apps/client-2d/dist/index.html
+            test -f apps/client-2d/dist/build-stamp.json
+            if [ -n "$CLIENT_2D_BUILD_SHA" ]; then
+              grep -q "$CLIENT_2D_BUILD_SHA" apps/client-2d/dist/build-stamp.json
+            fi
           else
             echo "WARN: No prebuilt client-2d artifact found; Dockerfile must build and verify client-2d."
           fi
@@ -155,6 +175,7 @@ jobs:
           ARELORIAN_ENV_FILE=".env.docker" \
           CLIENT_2D_ARCHIVE="$CLIENT_2D_ARCHIVE" \
           CLIENT_2D_MARKER="$CLIENT_2D_MARKER" \
+          CLIENT_2D_BUILD_SHA="$CLIENT_2D_BUILD_SHA" \
           DEPLOY_BRANCH="$BRANCH" \
           bash scripts/deploy-vps-docker.sh
           EOF
@@ -179,6 +200,23 @@ jobs:
             exit 1
           fi
           echo "2D client marker OK: ${CLIENT_2D_MARKER}"
+
+          echo "Checking https://arelorian.de/2d/build-stamp.json for exact commit"
+          STAMP="$(curl -k -sS -L --max-time 20 "https://arelorian.de/2d/build-stamp.json" || true)"
+          STAMP="$STAMP" CLIENT_2D_BUILD_SHA="$CLIENT_2D_BUILD_SHA" node -e '
+            const raw = process.env.STAMP || "";
+            let data;
+            try { data = JSON.parse(raw); } catch (error) {
+              console.error("ERROR: /2d/build-stamp.json did not return JSON");
+              console.error(raw.slice(0, 800));
+              process.exit(1);
+            }
+            if (data.commit !== process.env.CLIENT_2D_BUILD_SHA) {
+              console.error(`ERROR: stale 2D bundle. expected=${process.env.CLIENT_2D_BUILD_SHA} got=${data.commit}`);
+              process.exit(1);
+            }
+            console.log(`2D build stamp OK: ${data.commit}`);
+          '
 
           echo "Checking https://arelorian.de/api/v1/client2d/bootstrap for server-authoritative starter state"
           BOOTSTRAP="$(curl -k -sS -L --max-time 20 "https://arelorian.de/api/v1/client2d/bootstrap" || true)"

--- a/scripts/deploy-vps-docker.sh
+++ b/scripts/deploy-vps-docker.sh
@@ -11,8 +11,9 @@ ARELORIAN_ENABLE_DOCKER_INGRESS="${ARELORIAN_ENABLE_DOCKER_INGRESS:-false}"
 ARELORIAN_INGRESS_HTTP_BIND="${ARELORIAN_INGRESS_HTTP_BIND:-0.0.0.0}"
 ARELORIAN_INGRESS_HTTP_PORT="${ARELORIAN_INGRESS_HTTP_PORT:-80}"
 CLIENT_2D_MARKER="${CLIENT_2D_MARKER:-REAL_PIXI_CLIENT}"
+CLIENT_2D_BUILD_SHA="${CLIENT_2D_BUILD_SHA:-}"
 NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}"
-export ARELORIAN_PORT ARELORIAN_DOCKER_NETWORK ARELORIAN_ENABLE_DOCKER_INGRESS ARELORIAN_INGRESS_HTTP_BIND ARELORIAN_INGRESS_HTTP_PORT CLIENT_2D_MARKER NODE_OPTIONS
+export ARELORIAN_PORT ARELORIAN_DOCKER_NETWORK ARELORIAN_ENABLE_DOCKER_INGRESS ARELORIAN_INGRESS_HTTP_BIND ARELORIAN_INGRESS_HTTP_PORT CLIENT_2D_MARKER CLIENT_2D_BUILD_SHA NODE_OPTIONS
 cd "$REPO_ROOT"
 
 LOCK_PATH="${DEPLOY_LOCK_PATH:-/tmp/wasd-vps-docker-deploy.lock}"
@@ -83,7 +84,7 @@ validate_required_runtime_env() {
 validate_client_2d_dockerfile_gate() {
   echo "=== Client-2D Dockerfile gate preflight ==="
   echo "Deploy HEAD: $(git rev-parse --short HEAD)"
-  git status --short Dockerfile.vps docker-compose.yml apps/client-2d/index.html || true
+  git status --short Dockerfile.vps docker-compose.yml apps/client-2d/index.html apps/client-2d/dist/build-stamp.json || true
 
   if [ ! -f Dockerfile.vps ]; then
     echo "ERROR: Dockerfile.vps is missing; VPS compose cannot prove the real 2D client build gate."
@@ -107,6 +108,14 @@ validate_client_2d_dockerfile_gate() {
   if ! grep -q "$CLIENT_2D_MARKER" apps/client-2d/index.html; then
     echo "ERROR: apps/client-2d/index.html is missing ${CLIENT_2D_MARKER}."
     exit 1
+  fi
+
+  if [ -n "$CLIENT_2D_BUILD_SHA" ]; then
+    test -f apps/client-2d/dist/build-stamp.json || { echo "ERROR: prebuilt client-2d build-stamp.json missing before Docker build."; exit 1; }
+    grep -q "$CLIENT_2D_BUILD_SHA" apps/client-2d/dist/build-stamp.json || { echo "ERROR: prebuilt client-2d build stamp does not match ${CLIENT_2D_BUILD_SHA}."; cat apps/client-2d/dist/build-stamp.json || true; exit 1; }
+    echo "Client-2D build stamp preflight OK: ${CLIENT_2D_BUILD_SHA}"
+  else
+    echo "WARN: CLIENT_2D_BUILD_SHA is empty; deploy can only prove marker, not exact client bundle freshness."
   fi
 
   echo "Client-2D Dockerfile gate OK: ${CLIENT_2D_MARKER} enforced."
@@ -236,7 +245,7 @@ fetch_and_reset() {
   local temp_ref="refs/wasd-deploy/${DEPLOY_BRANCH}"
   echo "[1/4] git fetch + hard reset via temporary deploy ref"
   git reset --hard >/dev/null 2>&1 || true
-  git clean -fd -e .env -e .env.local -e .env.docker -e data/ -e logs/ >/dev/null 2>&1 || true
+  git clean -fd -e .env -e .env.local -e .env.docker -e data/ -e logs/ -e apps/client-2d/dist/ >/dev/null 2>&1 || true
   git update-ref -d "$temp_ref" >/dev/null 2>&1 || true
   if ! git -c remote.origin.fetch= fetch --no-tags origin "+refs/heads/${DEPLOY_BRANCH}:${temp_ref}"; then
     echo "WARN: fetch failed; healing stale origin ref and retrying once."
@@ -260,6 +269,12 @@ client_shell_ready() {
 
 client_2d_shell_ready() {
   docker exec arelorian-engine node -e "fetch('http://127.0.0.1:${CONTAINER_PORT}/2d/').then(async r=>{const body=await r.text();process.exit(r.ok&&body.includes(process.env.CLIENT_2D_MARKER||'REAL_PIXI_CLIENT')?0:1)}).catch(()=>process.exit(1))" >/dev/null 2>&1
+}
+
+client_2d_build_stamp_ready() {
+  [ -n "$CLIENT_2D_BUILD_SHA" ] || return 0
+  docker exec arelorian-engine sh -lc "test -f /app/server/client/dist/2d/build-stamp.json && grep -q '$CLIENT_2D_BUILD_SHA' /app/server/client/dist/2d/build-stamp.json" >/dev/null 2>&1 && return 0
+  docker exec arelorian-engine node -e "fetch('http://127.0.0.1:${CONTAINER_PORT}/2d/build-stamp.json').then(async r=>{const data=await r.json();process.exit(r.ok&&data.commit===process.env.CLIENT_2D_BUILD_SHA?0:1)}).catch(()=>process.exit(1))" >/dev/null 2>&1
 }
 
 portal_shell_ready() {
@@ -298,6 +313,7 @@ echo "Runtime env file: $ARELORIAN_ENV_FILE"
 echo "Docker ingress enabled: $ARELORIAN_ENABLE_DOCKER_INGRESS"
 echo "NODE_OPTIONS: $NODE_OPTIONS"
 echo "Client-2D marker: $CLIENT_2D_MARKER"
+echo "Client-2D build sha: ${CLIENT_2D_BUILD_SHA:-none}"
 if [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ]; then
   echo "Ingress bind: ${ARELORIAN_INGRESS_HTTP_BIND}:${ARELORIAN_INGRESS_HTTP_PORT}"
 fi
@@ -319,7 +335,6 @@ docker builder prune -f --filter 'until=24h' >/dev/null 2>&1 || true
 docker image prune -f >/dev/null 2>&1 || true
 
 echo "[2/4] Build images (monorepo context, sequential to avoid OOM)"
-# Use --progress plain (global flag must come before subcommand) for compatibility with Docker Compose v2
 compose_cmd --progress plain build arelorian-engine
 compose_cmd --progress plain build monitor-bridge
 
@@ -338,28 +353,30 @@ ok=0
 for i in $(seq 1 36); do
   if container_http_ready; then
     echo "  container HTTP ready ($i/36)"
-    if client_shell_ready && client_2d_shell_ready && portal_shell_ready; then
+    if client_shell_ready && client_2d_shell_ready && client_2d_build_stamp_ready && portal_shell_ready; then
       echo "  client shell ready"
       echo "  client-2d shell ready (${CLIENT_2D_MARKER})"
+      echo "  client-2d build stamp ready (${CLIENT_2D_BUILD_SHA:-not-required})"
       echo "  portal shell ready"
       if host_http_ready; then echo "  host HTTP mapping ready"; else echo "  WARN: host mapping not responding yet"; fi
       if ingress_http_ready; then echo "  ingress HTTP ready"; else echo "  WARN: ingress HTTP not responding yet"; fi
       ok=1
       break
     fi
-    echo "  waiting for client/2d/portal shell... ($i/36)"
+    echo "  waiting for client/2d/portal shell/build stamp... ($i/36)"
   fi
   if [ "$i" -ge 12 ] && runtime_activity_ready; then
     echo "  runtime activity ready ($i/36): node process and world events detected"
-    if client_shell_ready && client_2d_shell_ready && portal_shell_ready; then
+    if client_shell_ready && client_2d_shell_ready && client_2d_build_stamp_ready && portal_shell_ready; then
       echo "  client shell ready"
       echo "  client-2d shell ready (${CLIENT_2D_MARKER})"
+      echo "  client-2d build stamp ready (${CLIENT_2D_BUILD_SHA:-not-required})"
       echo "  portal shell ready"
       if ingress_http_ready; then echo "  ingress HTTP ready"; else echo "  WARN: ingress HTTP not responding yet"; fi
       ok=1
       break
     fi
-    echo "  waiting for client/2d/portal shell... ($i/36)"
+    echo "  waiting for client/2d/portal shell/build stamp... ($i/36)"
   fi
   echo "  waiting... ($i/36)"
   sleep 5
@@ -372,7 +389,7 @@ if [[ "$ok" != "1" ]]; then
   if [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ]; then
     docker inspect arelorian-ingress-router --format 'Ingress={{.State.Status}} Health={{if .State.Health}}{{else}}n/a{{end}} ExitCode={{.State.ExitCode}} Ports={{json .NetworkSettings.Ports}}' || true
   fi
-  docker exec arelorian-engine sh -lc "node -v; printenv PORT GAME_PORT HOST NODE_ENV NODE_OPTIONS CLIENT_2D_MARKER; ps aux | head -20" || true
+  docker exec arelorian-engine sh -lc "node -v; printenv PORT GAME_PORT HOST NODE_ENV NODE_OPTIONS CLIENT_2D_MARKER CLIENT_2D_BUILD_SHA; ps aux | head -20; ls -lah /app/server/client/dist/2d; cat /app/server/client/dist/2d/build-stamp.json 2>/dev/null || true" || true
   docker exec arelorian-engine node -e "fetch('http://127.0.0.1:${CONTAINER_PORT}/2d/').then(async r=>{console.log('2d status',r.status); console.log((await r.text()).slice(0,800));}).catch(e=>{console.error(e); process.exit(1)})" || true
   ss -ltnp "sport = :${ARELORIAN_PORT}" || true
   compose_cmd logs --tail=160 arelorian-engine || true


### PR DESCRIPTION
Adds a client-2d build-stamp.json containing the workflow commit SHA and makes the VPS deploy fail unless the running /2d/build-stamp.json matches that exact SHA. This prevents stale 2D bundles from passing deploy checks only because the static REAL_PIXI_CLIENT marker exists.