### PR TITLE
fix(deploy): remove stray else from Cozy workflow

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -190,8 +190,6 @@ print(f'  tilesets={len(m.get(\"tilesets\",{}))}')
               echo "ERROR: no .asset-inbox/cozy-spring and no committed fallback — cannot proceed"
               exit 1
             fi
-          else
-            echo "No .asset-inbox/cozy-spring on runner."
           fi
 
           if [ -f apps/client-2d/public/assets/cozy-spring/manifest.json ]; then


### PR DESCRIPTION
Fixes the VPS Docker Deploy workflow shell syntax error around the Cozy Spring import step.

The workflow had two consecutive `else` branches in the same shell `if`, causing the deploy to fail around line 181 before the VPS deploy could run.

Change is intentionally minimal:
- remove the stray second `else`
- keep the existing fallback check and VPS-side import path intact

After merge, the push to `main` should trigger the deploy workflow again.