### PR TITLE
fix(client-2d): filter Cozy artifacts and bind tiles/props correctly

### DIFF
--- a/apps/client-2d/src/world/AssetBindingDirector.ts
+++ b/apps/client-2d/src/world/AssetBindingDirector.ts
@@ -4,6 +4,18 @@
  * Core scoring and deterministic selection engine for asset binding.
  * Uses weighted scoring, candidate ranking, and deterministic random.
  * NEVER uses Date.now(), Math.random(), or any time-based seeds.
+ * 
+ * Asset Type Policy:
+ * - props: usableAsProp=true, usableAsTile=false, category=props
+ * - tilesets: usableAsTile=true, usableAsProp=false, category=tilesets
+ * - Buildings: category=buildings, NOT props
+ * 
+ * Cozy Spring exclusion rules:
+ * - Exclude props with kind="deco" (decor and homey items, extra cozy details)
+ * - Exclude props with sourceName/group containing: petals, petal, ground-details, 
+ *   ground_detail, label, text, ui, font, sheet, preview, NC
+ * - Exclude tilesets from prop binding
+ * - Exclude props from road/building binding
  */
 
 import type { AssetEntry, AssetManifest } from "../assetManifest";
@@ -30,6 +42,126 @@ import {
   findFallbackEntry,
 } from "./AssetFallbackChains";
 import type { BuildingType, NpcRole, PropType, RoadType } from "@wasd/shared/world";
+
+/**
+ * Hard runtime filter: is this entry a valid prop for world rendering?
+ * Returns false for tilesets, sheet fragments, text artifacts, deco crops.
+ */
+function isValidPropCandidate(id: string, entry: AssetEntry | null | undefined): boolean {
+  if (!entry) return false;
+  
+  // Must have source
+  if (!entry.src) return false;
+  
+  // Tilesets are NOT props
+  if (entry.category === 'tilesets') return false;
+  
+  // Cannot be marked as tile
+  if ((entry.meta as any)?.usableAsTile === true) return false;
+  
+  // Must be explicitly usable as prop (or not explicitly forbidden)
+  if ((entry.meta as any)?.usableAsProp === false) return false;
+  
+  const idLower = id.toLowerCase();
+  const srcLower = (entry.src || '').toLowerCase();
+  const groupLower = (entry.group || '').toLowerCase();
+  const sourceNameLower = (entry.sourceName || '').toLowerCase();
+  const kindLower = (entry.kind || '').toLowerCase();
+  
+  // Reject artifact patterns in ID/src/group/sourceName
+  // Use exact patterns that won't accidentally match real prop names
+  const artifactPatterns = [
+    'petals', 'petal', 'ground-details', 'ground_detail', 'ground detail',
+    'label', 'text', 'ui', 'font', 'sheet', 'preview',
+    'petals_and',
+    'decor-and-homey', 'extra-cozy-details', 'homey'
+  ];
+  
+  for (const pattern of artifactPatterns) {
+    if (idLower.includes(pattern) || srcLower.includes(pattern) || 
+        groupLower.includes(pattern) || sourceNameLower.includes(pattern)) {
+      return false;
+    }
+  }
+  
+  // Reject NC_ prefix patterns specifically (label artifacts like "NC_01.png")
+  // Only match at start of sourceName or as exact filename, not as substring in middle
+  const sourceName = entry.sourceName || '';
+  const srcFilename = entry.src?.split('/').pop() || '';
+  const combinedName = (entry.id || '') + ' ' + sourceName + ' ' + srcFilename;
+  const combinedLower = combinedName.toLowerCase();
+  
+  // Check for NC_ prefix pattern (artifact filenames like "NC_01", "NC_plant")
+  if (/\bnc_\d/.test(combinedLower) || /\bnc_[a-z]/.test(combinedLower) || 
+      (sourceName.toLowerCase().startsWith('nc_')) || (srcFilename.toLowerCase().startsWith('nc_'))) {
+    return false;
+  }
+  
+  // Reject kind="deco" (decor and homey items, extra cozy details are not proper props)
+  if (kindLower === 'deco' || kindLower === 'petal') {
+    return false;
+  }
+  
+  // Size validation: props should not be absurdly large
+  // Standard props: max 256x256
+  // Trees: max 384x384
+  const width = entry.width ?? 0;
+  const height = entry.height ?? 0;
+  const isTree = kindLower === 'tree';
+  
+  if (isTree) {
+    if (width > 384 || height > 384) return false;
+  } else {
+    if (width > 256 || height > 256) return false;
+    // Also reject very small crops (likely sheet fragments)
+    if (width < 16 || height < 16) return false;
+  }
+  
+  return true;
+}
+
+/**
+ * Hard runtime filter: is this entry a valid tileset for terrain/road rendering?
+ */
+function isValidTilesetCandidate(entry: AssetEntry | null | undefined): boolean {
+  if (!entry) return false;
+  
+  // Must have source
+  if (!entry.src) return false;
+  
+  // Must be tileset category
+  if (entry.category !== 'tilesets') return false;
+  
+  // Cannot be usable as prop (exclusive tileset)
+  if ((entry.meta as any)?.usableAsProp === true) return false;
+  
+  return true;
+}
+
+/**
+ * Hard runtime filter: is this entry suitable for building rendering?
+ * Buildings should come from buildings category or GraphicRiver fallbacks,
+ * NOT from props or tilesets.
+ */
+function isValidBuildingCandidate(entry: AssetEntry | null | undefined): boolean {
+  if (!entry) return false;
+  
+  // Must have source
+  if (!entry.src) return false;
+  
+  // Buildings should come from buildings category
+  if (entry.category === 'buildings') return true;
+  
+  // Reject props and tilesets for building binding
+  if (entry.category === 'props' || entry.category === 'tilesets') return false;
+  
+  // Reject if it looks like a prop
+  const srcLower = (entry.src || '').toLowerCase();
+  if (srcLower.includes('cozy-spring')) return false;
+  if (srcLower.includes('/props/')) return false;
+  
+  return true;
+}
 
 /**
  * Asset scoring result with debug info.
@@ -335,13 +467,18 @@ export class AssetBindingDirector {
 
   /**
    * Binds a building deterministically.
+   * Only uses entries from buildings category (NOT props or tilesets).
+   * Falls back to GraphicRiver if no buildings category available.
    */
   bindBuilding(
     buildingType: BuildingType,
     context: AssetBindingContext,
   ): BindingResult {
     const seed = combineSeed('building', String(buildingType), String(context.seed));
-    const candidates = this.collectCandidates('buildings');
+    const rawCandidates = this.collectCandidates('buildings');
+    
+    // CRITICAL: Filter out any cozy-spring props or tilesets that leaked into manifest
+    const candidates = rawCandidates.filter(([, entry]) => isValidBuildingCandidate(entry));
     
     if (candidates.length === 0) {
       return this.createEmptyResult(seed, buildingType, true, 'no buildings in manifest');
@@ -511,19 +648,23 @@ export class AssetBindingDirector {
 
   /**
    * Binds a prop deterministically.
+   * Only binds entries from props category that pass isValidPropCandidate filter.
+   * Tilesets are never used as props (they're for terrain/roads only).
    */
   bindProp(
     propType: PropType,
     context: AssetBindingContext,
   ): BindingResult {
     const seed = combineSeed('prop', String(propType), String(context.seed));
-    const candidates = [
-      ...this.collectCandidates('props'),
-      ...this.collectCandidates('tilesets'),
-    ];
+    
+    // CRITICAL: Only use props category, not tilesets
+    const rawCandidates = this.collectCandidates('props');
+    
+    // Apply hard filter to reject tilesets, artifacts, deco, small fragments
+    const candidates = rawCandidates.filter(([id, entry]) => isValidPropCandidate(id, entry));
     
     if (candidates.length === 0) {
-      return this.createEmptyResult(seed, propType, true, 'no props in manifest');
+      return this.createEmptyResult(seed, propType, true, 'no valid props in manifest after filtering');
     }
 
     // Create semantic query with biome-specific tree tags
@@ -574,6 +715,7 @@ export class AssetBindingDirector {
 
   /**
    * Handles prop binding fallback.
+   * Only searches props category (not tilesets).
    */
   private bindPropFallback(
     seed: string,
@@ -582,24 +724,23 @@ export class AssetBindingDirector {
   ): BindingResult {
     const chain = getPropFallbackChain(propType);
     
-    for (const category of ['props', 'tilesets']) {
-      for (const key of chain) {
-        const entry = findFallbackEntry(this.manifest, category, [key], seed);
-        if (entry) {
-          return {
-            id: entry.id ?? key,
-            entry,
-            debug: {
-              seed,
-              semanticType: propType,
-              candidates: 0,
-              scores: [],
-              fallbackUsed: true,
-              fallbackReason: `used chain key: ${key} in ${category}`,
-              finalScore: 0,
-            },
-          };
-        }
+    // CRITICAL: Only search props category for fallbacks, not tilesets
+    for (const key of chain) {
+      const entry = findFallbackEntry(this.manifest, 'props', [key], seed);
+      if (entry && isValidPropCandidate(entry.id ?? key, entry)) {
+        return {
+          id: entry.id ?? key,
+          entry,
+          debug: {
+            seed,
+            semanticType: propType,
+            candidates: 0,
+            scores: [],
+            fallbackUsed: true,
+            fallbackReason: `used chain key: ${key} in props`,
+            finalScore: 0,
+          },
+        };
       }
     }
 
@@ -608,16 +749,22 @@ export class AssetBindingDirector {
 
   /**
    * Binds a road deterministically.
+   * Only uses tilesets that pass isValidTilesetCandidate filter.
    */
   bindRoad(
     roadType: RoadType,
     context: AssetBindingContext,
   ): BindingResult {
     const seed = combineSeed('road', String(roadType), String(context.seed));
-    const candidates = this.collectCandidates('tilesets');
+    
+    // CRITICAL: Only use tilesets category for road binding
+    const rawCandidates = this.collectCandidates('tilesets');
+    
+    // Apply hard filter to ensure only valid tilesets
+    const candidates = rawCandidates.filter(([, entry]) => isValidTilesetCandidate(entry));
     
     if (candidates.length === 0) {
-      return this.createEmptyResult(seed, roadType, true, 'no tilesets in manifest');
+      return this.createEmptyResult(seed, roadType, true, 'no valid tilesets in manifest');
     }
 
     // Create semantic query with biome-specific road tags

--- a/scripts/extract-cozy-spring-objects.py
+++ b/scripts/extract-cozy-spring-objects.py
@@ -86,6 +86,22 @@ GROUP_KIND_MAP = {
 
 CATEGORY_TILESET_PATTERNS = ['tile', 'path', 'water', 'soil', 'grass', 'stone', 'pond']
 
+# Categories that should NOT be exported as visible world props.
+# These sheets may contain text labels, UI elements, or decorative fragments
+# that would render incorrectly as world objects.
+SKIP_RUNTIME_PROP_EXPORT = {
+    'petal', 'petals', 'ground detail', 'ground-details', 'ground detail',
+    'extra cozy details', 'decor and homey items', 'deco', 'homey',
+}
+
+def should_skip_prop_export(category: str) -> bool:
+    """Return True if this category should NOT be exported as runtime props."""
+    cat_lower = category.lower()
+    for skip in SKIP_RUNTIME_PROP_EXPORT:
+        if skip in cat_lower:
+            return True
+    return False
+
 def slug(value: str) -> str:
     """Convert string to stable slug."""
     return "".join(c if c.isalnum() or c in ("-", "_") else "-" for c in value.lower()).strip("-")
@@ -342,7 +358,36 @@ def extract_object_sprites(
     mask = build_alpha_mask(img)
     boxes, small_rej, giant_rej = extract_components(mask, img.size[0], img.size[1])
     results = []
+    
+    # Size constraints for valid props
+    MIN_DIM = 16   # minimum width or height
+    MAX_DIM = 256  # maximum width or height for non-trees
+    MAX_TREE_DIM = 384  # maximum for trees
+    MAX_ASPECT_RATIO = 5.0  # reject extreme aspect ratios
+    
     for x0, y0, x1, y1 in boxes:
+        # Compute crop dimensions BEFORE padding
+        crop_w = x1 - x0 + 1
+        crop_h = y1 - y0 + 1
+        crop_area = crop_w * crop_h
+        
+        # Reject crops that are too small (likely artifacts)
+        if crop_w < MIN_DIM or crop_h < MIN_DIM or crop_area < 96:
+            small_rej += 1
+            continue
+        
+        # Reject extreme aspect ratios (likely sheet artifacts or text)
+        aspect_ratio = max(crop_w / crop_h if crop_h > 0 else 0, crop_h / crop_w if crop_w > 0 else 0)
+        if aspect_ratio > MAX_ASPECT_RATIO:
+            small_rej += 1
+            continue
+        
+        # Check max dimensions
+        # For now, don't enforce max dim on non-trees since some sheets might be larger
+        # but still valid
+        if crop_w > MAX_TREE_DIM or crop_h > MAX_TREE_DIM:
+            continue
+        
         pad_x0 = max(0, x0 - CROP_PAD_X)
         pad_y0 = max(0, y0 - CROP_PAD_Y)
         pad_x1 = min(img.size[0] - 1, x1 + CROP_PAD_X)
@@ -595,6 +640,11 @@ def main():
             continue
 
         # Prop sheet → extract individual objects
+        # SKIP deco/petal/ground-details sheets - these contain artifacts, not real props
+        if should_skip_prop_export(category_raw):
+            print(f"  [SKIP] Category '{category_raw}': skipping runtime prop export (artifact category)")
+            continue
+
         stats['prop_sheets_processed'] += 1
         img = Image.open(png_path).convert('RGBA')
         extracted, small_rej, giant_rej = extract_object_sprites(img, png_path.stem, category_raw)

--- a/tests/asset-binding-filters.test.ts
+++ b/tests/asset-binding-filters.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for AssetBindingDirector prop/tileset/building filtering.
+ * 
+ * These tests verify that:
+ * 1. bindProp only uses props category (not tilesets)
+ * 2. tilesets are not returned as prop candidates
+ * 3. artifact entries (petals, ground-details, deco) are filtered out
+ * 4. bindRoad only uses tilesets (not props)
+ * 5. bindBuilding doesn't use cozy-spring props
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AssetBindingDirector } from '../apps/client-2d/src/world/AssetBindingDirector';
+import type { AssetManifest, AssetEntry } from '../apps/client-2d/src/assetManifest';
+
+// Mock manifest with various asset types
+const createMockManifest = (): AssetManifest => ({
+  version: 3,
+  tilesets: {
+    'cozy_grass_001': {
+      id: 'cozy_grass_001',
+      src: '/assets/cozy-spring/tilesets/grass-tiles/files/grass_01.png',
+      category: 'tilesets',
+      kind: 'grass',
+      width: 256,
+      height: 256,
+      meta: { usableAsTile: true, usableAsProp: false, runtimeRole: 'tileSource' },
+    } as AssetEntry,
+    'cozy_road_001': {
+      id: 'cozy_road_001',
+      src: '/assets/cozy-spring/tilesets/stone-paths/files/stone_01.png',
+      category: 'tilesets',
+      kind: 'road',
+      width: 512,
+      height: 512,
+      meta: { usableAsTile: true, usableAsProp: false, runtimeRole: 'tileSource' },
+    } as AssetEntry,
+    'graphic_river_grass': {
+      id: 'graphic_river_grass',
+      src: '/client2d-assets/graphicriver-iso/tiles/grass.png',
+      category: 'tilesets',
+      kind: 'grass',
+      width: 64,
+      height: 64,
+      meta: { usableAsTile: true, usableAsProp: false, runtimeRole: 'tileSource' },
+    } as AssetEntry,
+  },
+  props: {
+    'cozy_tree_001': {
+      id: 'cozy_tree_001',
+      src: '/assets/cozy-spring/props/cherry-blossom-trees/files/tree_01.png',
+      category: 'props',
+      kind: 'tree',
+      group: 'cherry blossom trees',
+      width: 96,
+      height: 128,
+      meta: { usableAsProp: true, usableAsTile: false, runtimeRole: 'propObject' },
+    } as AssetEntry,
+    'cozy_bush_001': {
+      id: 'cozy_bush_001',
+      src: '/assets/cozy-spring/props/bushes-and-shrubs/files/bush_01.png',
+      category: 'props',
+      kind: 'bush',
+      group: 'bushes and shrubs',
+      width: 48,
+      height: 48,
+      meta: { usableAsProp: true, usableAsTile: false, runtimeRole: 'propObject' },
+    } as AssetEntry,
+    'cozy_flower_001': {
+      id: 'cozy_flower_001',
+      src: '/assets/cozy-spring/props/flowers-and-plants/files/flower_01.png',
+      category: 'props',
+      kind: 'flower',
+      group: 'flowers and plants',
+      width: 32,
+      height: 32,
+      meta: { usableAsProp: true, usableAsTile: false, runtimeRole: 'propObject' },
+    } as AssetEntry,
+    // ARTIFACT: These should be filtered out
+    'cozy_petal_001': {
+      id: 'cozy_petal_001',
+      src: '/assets/cozy-spring/props/petals-and-ground-details/files/petal_01.png',
+      category: 'props',
+      kind: 'deco',
+      group: 'petals and ground details',
+      sourceName: '10._Petals_and_ground_details.png',
+      width: 16,
+      height: 16,
+      meta: { usableAsProp: true, usableAsTile: false, runtimeRole: 'propObject' },
+    } as AssetEntry,
+    'cozy_deco_001': {
+      id: 'cozy_deco_001',
+      src: '/assets/cozy-spring/props/decor-and-homey-items/files/deco_01.png',
+      category: 'props',
+      kind: 'deco',
+      group: 'decor and homey items',
+      width: 32,
+      height: 32,
+      meta: { usableAsProp: true, usableAsTile: false, runtimeRole: 'propObject' },
+    } as AssetEntry,
+    'cozy_extra_001': {
+      id: 'cozy_extra_001',
+      src: '/assets/cozy-spring/props/extra-cozy-details/files/extra_01.png',
+      category: 'props',
+      kind: 'deco',
+      group: 'extra cozy details',
+      width: 24,
+      height: 24,
+      meta: { usableAsProp: true, usableAsTile: false, runtimeRole: 'propObject' },
+    } as AssetEntry,
+    // Valid prop but from wrong path patterns
+    'cozy_artifact_nc': {
+      id: 'cozy_artifact_nc',
+      src: '/assets/cozy-spring/props/flowers-and-plants/files/NC_01.png',
+      category: 'props',
+      kind: 'flower',
+      group: 'flowers and plants',
+      sourceName: 'NC_01.png',
+      width: 32,
+      height: 32,
+      meta: { usableAsProp: true, usableAsTile: false, runtimeRole: 'propObject' },
+    } as AssetEntry,
+    'graphic_river_tree': {
+      id: 'graphic_river_tree',
+      src: '/client2d-assets/graphicriver-iso/props/tree_01.png',
+      category: 'props',
+      kind: 'tree',
+      group: 'Trees',
+      width: 64,
+      height: 96,
+      meta: { usableAsProp: true, usableAsTile: false, runtimeRole: 'propObject' },
+    } as AssetEntry,
+  },
+  buildings: {
+    'gr_house_01': {
+      id: 'gr_house_01',
+      src: '/client2d-assets/graphicriver-iso/buildings/house_01.png',
+      category: 'buildings',
+      kind: 'house',
+      width: 128,
+      height: 128,
+      meta: { usableAsProp: false, usableAsTile: false, runtimeRole: 'building' },
+    } as AssetEntry,
+  },
+});
+
+describe('AssetBindingDirector', () => {
+  let director: AssetBindingDirector;
+  let manifest: AssetManifest;
+
+  beforeEach(() => {
+    manifest = createMockManifest();
+    director = new AssetBindingDirector(manifest, false);
+  });
+
+  describe('bindProp', () => {
+    it('should NOT return tilesets as prop candidates', () => {
+      const result = director.bindProp('tree', { seed: 'test-seed', biome: 'plains' });
+      
+      // The bound prop should NOT have a tileset category
+      if (result.entry) {
+        expect(result.entry.category).not.toBe('tilesets');
+      }
+    });
+
+    it('should filter out artifacts with petals in sourceName', () => {
+      const result = director.bindProp('flower', { seed: 'artifact-filter', biome: 'plains' });
+      
+      // Should not bind to anything with 'petal' in sourceName
+      if (result.entry) {
+        const sourceName = (result.entry as any).sourceName || '';
+        expect(sourceName.toLowerCase()).not.toContain('petal');
+      }
+    });
+
+    it('should filter out entries with kind=deco', () => {
+      const result = director.bindProp('flower', { seed: 'deco-filter', biome: 'plains' });
+      
+      // Should not bind to kind='deco'
+      if (result.entry) {
+        expect(result.entry.kind?.toLowerCase()).not.toBe('deco');
+      }
+    });
+
+    it('should filter out NC/label artifacts in filename', () => {
+      const result = director.bindProp('flower', { seed: 'nc-filter', biome: 'plains' });
+      
+      // Should not bind to NC artifacts
+      if (result.entry) {
+        const src = result.entry.src || '';
+        const id = result.entry.id || '';
+        const combined = (src + id).toLowerCase();
+        expect(combined).not.toContain('nc_');
+        expect(combined).not.toContain('label');
+      }
+    });
+
+    it('should return valid props like trees, bushes, flowers', () => {
+      const result = director.bindProp('tree', { seed: 'valid-tree', biome: 'plains' });
+      
+      // Should find a tree prop
+      expect(result.entry).toBeDefined();
+      expect(result.entry?.kind?.toLowerCase()).toBe('tree');
+    });
+
+    it('should filter out entries with width/height < 16 for non-trees', () => {
+      // The petal entries have width=16 or less, they should be filtered
+      const result = director.bindProp('flower', { seed: 'tiny-filter', biome: 'plains' });
+      
+      if (result.entry) {
+        const width = result.entry.width ?? 0;
+        // If it's a flower prop, it should be at least 16x16
+        if (result.entry.kind?.toLowerCase() !== 'tree') {
+          expect(width).toBeGreaterThanOrEqual(16);
+        }
+      }
+    });
+  });
+
+  describe('bindRoad', () => {
+    it('should ONLY use tilesets for road binding', () => {
+      const result = director.bindRoad('grass', { seed: 'road-test', biome: 'plains' });
+      
+      // Road binding should return tileset entries
+      expect(result.entry).toBeDefined();
+      expect(result.entry?.category).toBe('tilesets');
+    });
+
+    it('should not return props for road binding', () => {
+      const result = director.bindRoad('grass', { seed: 'road-no-props', biome: 'plains' });
+      
+      // Should not use props for roads
+      if (result.entry) {
+        expect(result.entry.category).not.toBe('props');
+      }
+    });
+
+    it('should filter tilesets that are marked usableAsProp=true', () => {
+      // Create a manifest with a tileset incorrectly marked as usableAsProp
+      const badManifest: AssetManifest = {
+        ...manifest,
+        tilesets: {
+          'bad_tileset': {
+            id: 'bad_tileset',
+            src: '/test/bad-tileset.png',
+            category: 'tilesets',
+            kind: 'grass',
+            meta: { usableAsTile: true, usableAsProp: true } as any,
+          } as AssetEntry,
+        },
+      };
+      const badDirector = new AssetBindingDirector(badManifest, false);
+      const result = badDirector.bindRoad('grass', { seed: 'filter-bad', biome: 'plains' });
+      
+      // Should not bind to the bad tileset
+      if (result.entry) {
+        expect(result.entry.id).not.toBe('bad_tileset');
+      }
+    });
+  });
+
+  describe('bindBuilding', () => {
+    it('should only use buildings category (not props or tilesets)', () => {
+      const result = director.bindBuilding('house', { seed: 'building-test' });
+      
+      // Building binding should use buildings category
+      expect(result.entry).toBeDefined();
+      // It should either use buildings category or fall back gracefully
+      // but NOT use cozy-spring props
+      if (result.entry) {
+        expect(result.entry.category).not.toBe('props');
+        expect(result.entry.src?.toLowerCase()).not.toContain('/props/');
+      }
+    });
+
+    it('should not use cozy-spring props for buildings', () => {
+      const result = director.bindBuilding('house', { seed: 'no-cozy-buildings' });
+      
+      if (result.entry) {
+        // Should not use cozy-spring props as buildings
+        expect(result.entry.src?.toLowerCase()).not.toContain('cozy-spring');
+        expect(result.entry.src?.toLowerCase()).not.toContain('/props/');
+      }
+    });
+  });
+});
+
+describe('Asset category policies', () => {
+  it('props should have usableAsProp=true and usableAsTile=false', () => {
+    const manifest = createMockManifest();
+    for (const [id, entry] of Object.entries(manifest.props || {})) {
+      const meta = entry.meta as any;
+      if (meta?.runtimeRole === 'propObject') {
+        expect(meta.usableAsProp).toBe(true);
+        expect(meta.usableAsTile).toBe(false);
+      }
+    }
+  });
+
+  it('tilesets should have usableAsTile=true and usableAsProp=false', () => {
+    const manifest = createMockManifest();
+    for (const [id, entry] of Object.entries(manifest.tilesets || {})) {
+      const meta = entry.meta as any;
+      if (meta?.runtimeRole === 'tileSource') {
+        expect(meta.usableAsTile).toBe(true);
+        expect(meta.usableAsProp).toBe(false);
+      }
+    }
+  });
+
+  it('buildings should NOT be in props or tilesets category', () => {
+    const manifest = createMockManifest();
+    // Buildings should be in their own category
+    expect(manifest.buildings).toBeDefined();
+    
+    // Ensure no buildings leaked into props
+    for (const [id, entry] of Object.entries(manifest.props || {})) {
+      expect(entry.category).not.toBe('buildings');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes the rendering of Cozy Spring assets in the 2D client by filtering out text artifacts and ensuring proper asset binding.

## Changes

### AUFGABE A — BINDER FIX (`apps/client-2d/src/world/AssetBindingDirector.ts`)

1. **`bindProp`**: Now only uses `props` category (not tilesets)
2. **`bindPropFallback`**: Only searches `props` category
3. **Added `isValidPropCandidate()` filter** that rejects:
   - Tilesets (category=`tilesets`)
   - Props with kind=`deco` or kind=`petal`
   - Entries with sourceName/group containing: petals, petal, ground-details, label, text, ui, font, sheet, preview, NC, decor-and-homey, extra-cozy-details
   - Props smaller than 16x16 (likely sheet fragments)
   - Props larger than 256x256 (or 384x384 for trees)
4. **`bindRoad`**: Only uses tilesets that pass `isValidTilesetCandidate()`
5. **`bindBuilding`**: Filters out cozy-spring props with `isValidBuildingCandidate()`

### AUFGABE B — EXTRACTOR FIX (`scripts/extract-cozy-spring-objects.py`)

1. Added `SKIP_RUNTIME_PROP_EXPORT` set for artifact categories
2. `should_skip_prop_export()` skips entire sheets in these categories
3. Added dimension filtering in `extract_object_sprites()`

### AUFGABE D — TESTS (`tests/asset-binding-filters.test.ts`)

- bindProp should NOT return tilesets
- bindProp should filter artifacts (petals, deco, NC, etc.)
- bindRoad should ONLY use tilesets (not props)
- bindBuilding should only use buildings category

## Expected Result After Deploy

- No "NC", "PETALS" or text artifacts in game view
- Ground/roads use Cozy tileset textures
- Flowers/bushes/trees appear cleanly
- Houses/buildings come from building category/fallbacks
- Cozy manifest remains version 3

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*