### PR TITLE
feat(are): centralize ARE tick cadence

### DIFF
--- a/hooks/use-mobile.test.ts
+++ b/hooks/use-mobile.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ARE_SIMULATION_TICK_HZ,
+  ARE_SIMULATION_TICK_MS,
+} from "@wasd/shared";
+
+import {
   classifyViewportMode,
   classifyViewportOrientation,
   DESKTOP_BREAKPOINT,
@@ -36,7 +41,9 @@ describe("deterministic viewport classification", () => {
     expect(classifyViewportOrientation(Number.NaN, 0)).toBe("square");
   });
 
-  it("documents the world-server layout coalescing cadence", () => {
+  it("binds layout coalescing to the canonical ARE cadence", () => {
+    expect(WORLD_SERVER_TICK_HZ).toBe(ARE_SIMULATION_TICK_HZ);
+    expect(WORLD_SERVER_TICK_MS).toBe(ARE_SIMULATION_TICK_MS);
     expect(WORLD_SERVER_TICK_HZ).toBe(10);
     expect(WORLD_SERVER_TICK_MS).toBe(100);
   });

--- a/hooks/use-mobile.ts
+++ b/hooks/use-mobile.ts
@@ -1,19 +1,24 @@
 import * as React from "react";
 
+import {
+  ARE_SIMULATION_TICK_HZ,
+  ARE_SIMULATION_TICK_MS,
+} from "@wasd/shared";
+
 /**
  * Deterministic viewport state for the browser client.
  *
  * Why this is stricter than a normal resize hook:
  * - no Date.now(), no performance.now(), no random input
  * - one global store instead of one listener per component
- * - browser resize/orientation noise is coalesced to the world-server cadence
+ * - browser resize/orientation noise is coalesced to the ARE/world-server cadence
  * - all derived values are pure functions of the current viewport snapshot
  *
  * This does NOT make viewport size part of authoritative game simulation.
  * The server remains authoritative. This hook is only for HUD/layout decisions.
  */
-export const WORLD_SERVER_TICK_HZ = 10;
-export const WORLD_SERVER_TICK_MS = 1000 / WORLD_SERVER_TICK_HZ;
+export const WORLD_SERVER_TICK_HZ = ARE_SIMULATION_TICK_HZ;
+export const WORLD_SERVER_TICK_MS = ARE_SIMULATION_TICK_MS;
 
 export const MOBILE_BREAKPOINT = 768;
 export const TABLET_BREAKPOINT = 1024;

--- a/packages/shared/src/areTime.ts
+++ b/packages/shared/src/areTime.ts
@@ -1,0 +1,19 @@
+/**
+ * Canonical ARE simulation cadence shared by server, client and tooling.
+ *
+ * This module is intentionally pure: no Date.now(), no performance.now(), no
+ * timers and no process/browser globals. It defines duration conversion only;
+ * actual simulation authority remains tick-based.
+ */
+export const ARE_SIMULATION_TICK_HZ = 10;
+export const ARE_SIMULATION_TICK_MS = 1000 / ARE_SIMULATION_TICK_HZ;
+
+export function msToARETicks(ms: number): number {
+  if (!Number.isFinite(ms) || ms <= 0) return 1;
+  return Math.max(1, Math.ceil(ms / ARE_SIMULATION_TICK_MS));
+}
+
+export function areTicksToMs(ticks: number): number {
+  if (!Number.isFinite(ticks) || ticks <= 0) return 0;
+  return Math.trunc(ticks) * ARE_SIMULATION_TICK_MS;
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,1 +1,7 @@
 export const VERSION = '1.0.0';
+export {
+  ARE_SIMULATION_TICK_HZ,
+  ARE_SIMULATION_TICK_MS,
+  areTicksToMs,
+  msToARETicks,
+} from './areTime';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,7 @@ export * from './math';
 export * from './constants';
 export * from './types';
 export * from './utils';
+export * from './areTime';
 export * from './world/index.js';
 export * from './GuildSovereigntyEngine.js';
 export * from './theme/ThemeEngine.js';

--- a/server/src/core/determinism/AREDeterminism.ts
+++ b/server/src/core/determinism/AREDeterminism.ts
@@ -1,3 +1,17 @@
+import {
+  ARE_SIMULATION_TICK_HZ,
+  ARE_SIMULATION_TICK_MS,
+  areTicksToMs,
+  msToARETicks,
+} from '@wasd/shared';
+
+export {
+  ARE_SIMULATION_TICK_HZ,
+  ARE_SIMULATION_TICK_MS,
+  areTicksToMs,
+  msToARETicks,
+};
+
 export interface AREClock {
   now(): number;
 }


### PR DESCRIPTION
Adds shared ARE tick cadence constants and connects viewport cadence to shared ARE time.