### PR TITLE
feat(are): add tick time adapter

### DIFF
--- a/server/src/core/WorldTickTimeAdapter.ts
+++ b/server/src/core/WorldTickTimeAdapter.ts
@@ -1,0 +1,57 @@
+import {
+  ARE_SIMULATION_TICK_HZ,
+  ARE_SIMULATION_TICK_MS,
+  msToARETicks,
+} from '@wasd/shared';
+
+export interface WorldTickTimeAdapterSnapshot {
+  readonly tick: number;
+  readonly tickHz: typeof ARE_SIMULATION_TICK_HZ;
+  readonly tickMs: typeof ARE_SIMULATION_TICK_MS;
+}
+
+export interface WorldTickTimeAdapter {
+  readonly tickHz: typeof ARE_SIMULATION_TICK_HZ;
+  readonly tickMs: typeof ARE_SIMULATION_TICK_MS;
+  nowTick(): number;
+  cooldownTicks(cooldownMs: number): number;
+  hasCooldownElapsed(lastTick: number, cooldownMs: number): boolean;
+  snapshot(): WorldTickTimeAdapterSnapshot;
+}
+
+/**
+ * Adapter between WorldTick's authoritative integer tick counter and duration
+ * declarations that still arrive as milliseconds from gameplay rules.
+ *
+ * This keeps WorldTick free from hidden `/ 100` assumptions while preserving
+ * tick-authoritative simulation: all checks compare integer ticks only.
+ */
+export function createWorldTickTimeAdapter(readTick: () => number): WorldTickTimeAdapter {
+  return Object.freeze({
+    tickHz: ARE_SIMULATION_TICK_HZ,
+    tickMs: ARE_SIMULATION_TICK_MS,
+
+    nowTick(): number {
+      const tick = readTick();
+      if (!Number.isFinite(tick)) return 0;
+      return Math.max(0, Math.trunc(tick));
+    },
+
+    cooldownTicks(cooldownMs: number): number {
+      return msToARETicks(cooldownMs);
+    },
+
+    hasCooldownElapsed(lastTick: number, cooldownMs: number): boolean {
+      const safeLastTick = Number.isFinite(lastTick) ? Math.trunc(lastTick) : 0;
+      return this.nowTick() - safeLastTick >= this.cooldownTicks(cooldownMs);
+    },
+
+    snapshot(): WorldTickTimeAdapterSnapshot {
+      return Object.freeze({
+        tick: this.nowTick(),
+        tickHz: ARE_SIMULATION_TICK_HZ,
+        tickMs: ARE_SIMULATION_TICK_MS,
+      });
+    },
+  });
+}

--- a/server/src/modules/warfront/WarfrontCombatOrchestrator.ts
+++ b/server/src/modules/warfront/WarfrontCombatOrchestrator.ts
@@ -5,15 +5,21 @@ import { CombatService, type CombatState } from "../combat/CombatService.js";
 import { npcFactionAdapter } from "../faction/NPCFactionAdapter.js";
 import { mulberry32, warfrontSeed } from "./warfrontRng.js";
 import { WarfrontCombatTelemetry, type WarfrontHudAgent, type WarfrontHudSnapshot } from "./WarfrontCombatTelemetry.js";
+import { createWorldTickTimeAdapter, type WorldTickTimeAdapter } from "../../core/WorldTickTimeAdapter.js";
 
 const WF_PREFIX = "wf_";
 const STRIKE_RANGE = 42;
+const FACTION_SNAPSHOT_BROADCAST_MS = 1000;
 const SKILL_OPENING: CombatState = { comboIndex: 0, lastSkillId: null, lastTimestamp: 0 };
 
 function dist2(a: { x: number; y: number }, b: { x: number; y: number }): number {
   const dx = a.x - b.x;
   const dy = a.y - b.y;
   return Math.hypot(dx, dy);
+}
+
+function shouldBroadcastFactionSnapshot(time: WorldTickTimeAdapter): boolean {
+  return time.nowTick() % time.cooldownTicks(FACTION_SNAPSHOT_BROADCAST_MS) === 0;
 }
 
 function pickTarget(
@@ -99,6 +105,7 @@ export function runWarfrontCombatTick(opts: {
   broadcast?: (payload: unknown) => void;
 }): void {
   const { tickCount, npcSystem, playerSystem, combatService, broadcast } = opts;
+  const time = createWorldTickTimeAdapter(() => tickCount);
   const tel = WarfrontCombatTelemetry.getInstance();
 
   // Mini hook: deterministic NPC faction context without changing NPCSystem internals.
@@ -109,11 +116,12 @@ export function runWarfrontCombatTick(opts: {
     worldSeed: "areloria:warfront:faction-hook:v1",
   });
 
-  if (broadcast && tickCount % 10 === 0) {
+  if (broadcast && shouldBroadcastFactionSnapshot(time)) {
     broadcast({
       type: "NPC_FACTION_SNAPSHOT",
       tick: tickCount,
       payload: factionSnapshot,
+      time: time.snapshot(),
     });
   }
 
@@ -199,6 +207,7 @@ export function runWarfrontCombatTick(opts: {
         defenderId: tgt.id,
         damage: applied,
         kill: killed,
+        time: time.snapshot(),
       });
     }
   }

--- a/server/src/tests/WorldTickTimeAdapter.test.ts
+++ b/server/src/tests/WorldTickTimeAdapter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ARE_SIMULATION_TICK_HZ,
+  ARE_SIMULATION_TICK_MS,
+  msToARETicks,
+} from '@wasd/shared';
+
+import { createWorldTickTimeAdapter } from '../core/WorldTickTimeAdapter.js';
+
+describe('WorldTickTimeAdapter', () => {
+  it('exposes canonical ARE cadence', () => {
+    const adapter = createWorldTickTimeAdapter(() => 42);
+
+    expect(adapter.tickHz).toBe(ARE_SIMULATION_TICK_HZ);
+    expect(adapter.tickMs).toBe(ARE_SIMULATION_TICK_MS);
+    expect(adapter.tickHz).toBe(10);
+    expect(adapter.tickMs).toBe(100);
+  });
+
+  it('converts millisecond declarations into ARE ticks', () => {
+    const adapter = createWorldTickTimeAdapter(() => 0);
+
+    expect(adapter.cooldownTicks(1)).toBe(msToARETicks(1));
+    expect(adapter.cooldownTicks(100)).toBe(1);
+    expect(adapter.cooldownTicks(500)).toBe(5);
+    expect(adapter.cooldownTicks(800)).toBe(8);
+    expect(adapter.cooldownTicks(1000)).toBe(10);
+    expect(adapter.cooldownTicks(3000)).toBe(30);
+  });
+
+  it('compares cooldowns with integer ticks only', () => {
+    const adapter = createWorldTickTimeAdapter(() => 18);
+
+    expect(adapter.hasCooldownElapsed(10, 800)).toBe(true);
+    expect(adapter.hasCooldownElapsed(11, 800)).toBe(false);
+  });
+
+  it('sanitizes invalid tick input deterministically', () => {
+    const adapter = createWorldTickTimeAdapter(() => Number.NaN);
+
+    expect(adapter.nowTick()).toBe(0);
+    expect(adapter.snapshot()).toEqual({
+      tick: 0,
+      tickHz: ARE_SIMULATION_TICK_HZ,
+      tickMs: ARE_SIMULATION_TICK_MS,
+    });
+  });
+});


### PR DESCRIPTION
Adds a WorldTickTimeAdapter and routes Warfront cadence through it. Includes tests for ARE tick conversion and cooldown checks.