### PR TITLE
feat(core): connect watchdog determinism across core files

### DIFF
--- a/backend/src/core/axiomatic-event-bus.ts
+++ b/backend/src/core/axiomatic-event-bus.ts
@@ -1,4 +1,12 @@
-import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS, normalizePositiveInteger, sanitizeText } from './watchdog-determinism';
+import {
+    WATCHDOG_TICK_HZ,
+    WATCHDOG_TICK_MS,
+    deterministicPayloadHash,
+    fnv1a32,
+    normalizePositiveInteger,
+    sanitizeText,
+    stableStringify,
+} from './watchdog-determinism';
 
 export const AXIOMATIC_EVENT_SCHEMA_VERSION = 2 as const;
 export const AXIOMATIC_TICK_HZ = WATCHDOG_TICK_HZ;
@@ -77,10 +85,7 @@ export interface AxiomaticLedgerStats {
     deterministic: true;
 }
 
-/**
- * Deterministic helpers used by the bus and replay/debug systems.
- * The implementation intentionally avoids Math.random(), Date.now(), locale sorting and object insertion-order hashes.
- */
+/** Deterministic ARE helpers shared by replay/debug systems. */
 export class AREStateCompiler {
     private static readonly RESONANCE_PRIME = 16807;
     private static readonly RESONANCE_MAX = 2147483647;
@@ -105,26 +110,18 @@ export class AREStateCompiler {
     }
 
     public static calculateEventResonance(event: Pick<IAxiomaticEvent, 'sequenceId' | 'tick' | 'tickSequence' | 'type' | 'payload'>): number {
-        const canonicalPayload = stableStringify(event.payload);
-        const dataString = `${event.tick}:${event.tickSequence}:${event.sequenceId}:${event.type}:${canonicalPayload}`;
+        const dataString = `${event.tick}:${event.tickSequence}:${event.sequenceId}:${event.type}:${stableStringify(event.payload)}`;
         return this.computeResonance(fnv1a32(dataString));
     }
 
     public static payloadHash(payload: unknown): string {
-        return fnv1a32Hex(stableStringify(payload));
+        return deterministicPayloadHash(payload);
     }
 }
 
 /**
  * AxiomaticEventBus
- *
- * Strict deterministic event hub for the 10Hz world server:
- * - assigns global sequence ids in publish order
- * - assigns per-tick sequence ids
- * - derives timestamp from tick * 100ms, never from wall-clock time
- * - emits listeners in priority/id order
- * - stores a ring-buffer ledger for replay and watchdog inspection
- * - rejects backwards tick drift by default
+ * Strict deterministic event hub for the 10Hz world server and watchdog stack.
  */
 export class AxiomaticEventBus {
     private static instance: AxiomaticEventBus | null = null;
@@ -172,29 +169,19 @@ export class AxiomaticEventBus {
         return this.getLedgerStats();
     }
 
-    public subscribe<TPayload = AxiomaticPayload>(
-        type: string,
-        listener: AxiomaticListener<TPayload>,
-        priority = 0,
-    ): () => void {
+    public subscribe<TPayload = AxiomaticPayload>(type: string, listener: AxiomaticListener<TPayload>, priority = 0): () => void {
         return this.addListener(type, listener as AxiomaticListener, false, priority);
     }
 
-    public once<TPayload = AxiomaticPayload>(
-        type: string,
-        listener: AxiomaticListener<TPayload>,
-        priority = 0,
-    ): () => void {
+    public once<TPayload = AxiomaticPayload>(type: string, listener: AxiomaticListener<TPayload>, priority = 0): () => void {
         return this.addListener(type, listener as AxiomaticListener, true, priority);
     }
 
-    /** EventEmitter-compatible alias. */
     public on<TPayload = AxiomaticPayload>(type: string, listener: AxiomaticListener<TPayload>): this {
         this.subscribe(type, listener);
         return this;
     }
 
-    /** EventEmitter-compatible alias. */
     public off<TPayload = AxiomaticPayload>(type: string, listener: AxiomaticListener<TPayload>): this {
         const list = this.listeners.get(type) ?? [];
         const next = list.filter((entry) => entry.listener !== listener);
@@ -210,12 +197,8 @@ export class AxiomaticEventBus {
         payloadOrOptions?: TPayload | AxiomaticPublishOptions,
         maybeOptions: AxiomaticPublishOptions = {},
     ): IAxiomaticEvent<TPayload> {
-        const draft = typeof input === 'string'
-            ? { type: input, payload: payloadOrOptions as TPayload }
-            : input;
-        const options = typeof input === 'string'
-            ? maybeOptions
-            : ((payloadOrOptions as AxiomaticPublishOptions | undefined) ?? {});
+        const draft = typeof input === 'string' ? { type: input, payload: payloadOrOptions as TPayload } : input;
+        const options = typeof input === 'string' ? maybeOptions : ((payloadOrOptions as AxiomaticPublishOptions | undefined) ?? {});
 
         const type = sanitizeText(draft.type, 'axiomatic.event');
         const requestedTick = options.tick ?? draft.tick ?? readNumericField(draft.payload, 'tick') ?? this.currentTick;
@@ -427,35 +410,6 @@ function readStringField(value: unknown, key: string): string | undefined {
     if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
     const raw = (value as Record<string, unknown>)[key];
     return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : undefined;
-}
-
-function stableStringify(value: unknown): string {
-    if (value === null) return 'null';
-    if (value === undefined) return 'undefined';
-    if (typeof value === 'bigint') return `"${value.toString()}n"`;
-    if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '0';
-    if (typeof value === 'boolean') return value ? 'true' : 'false';
-    if (typeof value === 'string') return JSON.stringify(value);
-    if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
-    if (typeof value === 'object') {
-        const record = value as Record<string, unknown>;
-        const keys = Object.keys(record).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-        return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`;
-    }
-    return JSON.stringify(String(value));
-}
-
-function fnv1a32(input: string): number {
-    let hash = 0x811c9dc5;
-    for (let i = 0; i < input.length; i += 1) {
-        hash ^= input.charCodeAt(i);
-        hash = Math.imul(hash, 0x01000193) >>> 0;
-    }
-    return hash >>> 0;
-}
-
-function fnv1a32Hex(input: string): string {
-    return fnv1a32(input).toString(16).padStart(8, '0');
 }
 
 export const eventBus = AxiomaticEventBus.getInstance();

--- a/backend/src/core/watchdog-determinism.ts
+++ b/backend/src/core/watchdog-determinism.ts
@@ -1,5 +1,6 @@
 export const WATCHDOG_TICK_HZ = 10 as const;
 export const WATCHDOG_TICK_MS = 100 as const;
+export const WATCHDOG_DETERMINISM_VERSION = 2 as const;
 
 export type WatchdogSeverity =
     | 'LOW'
@@ -92,6 +93,8 @@ export function normalizeWatchdogEvent(
     const origin = sanitizeText(input.origin || input.source || fallbackOrigin, fallbackOrigin);
     const message = sanitizeText(input.message, input.type || 'watchdog.event');
     const channel = sanitizeText(input.channel, 'watchdog');
+    const payload = normalizeRecord(input.payload);
+    const metadata = normalizeRecord(input.metadata);
 
     return {
         ...input,
@@ -100,8 +103,14 @@ export function normalizeWatchdogEvent(
         source: origin,
         origin,
         message,
-        payload: normalizeRecord(input.payload),
-        metadata: normalizeRecord(input.metadata),
+        payload,
+        metadata: {
+            ...metadata,
+            determinismVersion: WATCHDOG_DETERMINISM_VERSION,
+            tickHz: WATCHDOG_TICK_HZ,
+            tickMs: WATCHDOG_TICK_MS,
+            payloadHash: deterministicPayloadHash(payload),
+        },
         channel,
         tick: stamp.tick,
         seq: stamp.seq,
@@ -146,6 +155,25 @@ export function validateWatchdogEventCandidate(input: unknown):
         return { ok: false, reason: 'Watchdog event metadata must be a plain object when provided.' };
     }
 
+    if (candidate.tick !== undefined && normalizePositiveInteger(candidate.tick, -1) < 0) {
+        return { ok: false, reason: 'Watchdog event tick must be a non-negative integer when provided.' };
+    }
+
+    if (candidate.seq !== undefined && normalizePositiveInteger(candidate.seq, -1) < 0) {
+        return { ok: false, reason: 'Watchdog event seq must be a non-negative integer when provided.' };
+    }
+
+    if (candidate.timestamp !== undefined) {
+        const normalizedTick = normalizePositiveInteger(candidate.tick, 0);
+        const expectedTimestamp = normalizedTick * WATCHDOG_TICK_MS;
+        if (typeof candidate.timestamp !== 'number' || !Number.isFinite(candidate.timestamp) || candidate.timestamp < 0) {
+            return { ok: false, reason: 'Watchdog event timestamp must be a non-negative finite number when provided.' };
+        }
+        if (candidate.tick !== undefined && Math.floor(candidate.timestamp) !== expectedTimestamp) {
+            return { ok: false, reason: 'Watchdog event timestamp must equal tick * 100ms in strict deterministic mode.' };
+        }
+    }
+
     return {
         ok: true,
         event: candidate as WatchdogEvent,
@@ -167,6 +195,47 @@ export function sanitizeText(value: unknown, fallback: string): string {
 export function normalizeRecord(value: unknown): Record<string, unknown> {
     if (!isPlainRecord(value)) return {};
     return value;
+}
+
+export function stableStringify(value: unknown): string {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'bigint') return `"${value.toString()}n"`;
+    if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '0';
+    if (typeof value === 'boolean') return value ? 'true' : 'false';
+    if (typeof value === 'string') return JSON.stringify(value);
+    if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+    if (typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+        const keys = Object.keys(record).sort(compareStableText);
+        return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`;
+    }
+    return JSON.stringify(String(value));
+}
+
+export function fnv1a32(input: string): number {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < input.length; i += 1) {
+        hash ^= input.charCodeAt(i);
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash >>> 0;
+}
+
+export function fnv1a32Hex(input: string): string {
+    return fnv1a32(input).toString(16).padStart(8, '0');
+}
+
+export function deterministicPayloadHash(payload: unknown): string {
+    return fnv1a32Hex(stableStringify(payload));
+}
+
+export function createDeterministicEventFingerprint(event: Pick<DeterministicWatchdogEvent, 'tick' | 'seq' | 'type' | 'origin' | 'payload'>): string {
+    return fnv1a32Hex(`${event.tick}:${event.seq}:${event.type}:${event.origin}:${stableStringify(event.payload)}`);
+}
+
+export function compareStableText(a: string, b: string): number {
+    return a < b ? -1 : a > b ? 1 : 0;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/backend/src/watchdog-server.ts
+++ b/backend/src/watchdog-server.ts
@@ -1,7 +1,9 @@
 import { RawData, WebSocket, WebSocketServer } from 'ws';
+import { AxiomaticEventBus } from './core/axiomatic-event-bus';
 import {
     WATCHDOG_TICK_HZ,
     WATCHDOG_TICK_MS,
+    createDeterministicEventFingerprint,
     createWatchdogTickStamp,
     normalizePositiveInteger,
     normalizeWatchdogEvent,
@@ -49,6 +51,8 @@ let totalRejected = 0;
 let shuttingDown = false;
 
 const clients = new Map<WebSocket, WatchdogClientMeta>();
+const axiomaticBus = AxiomaticEventBus.getInstance();
+axiomaticBus.beginTick(relayTick);
 
 const wss = new WebSocketServer({
     host: HOST,
@@ -220,10 +224,12 @@ function handleMessage(sender: WebSocket, data: RawData): void {
 
     relayTick = Math.max(relayTick, incomingTick);
     senderMeta.lastAcceptedTick = incomingTick;
+    axiomaticBus.beginTick(relayTick);
 
     const stamp = createWatchdogTickStamp(relayTick, ++relaySeq);
     const event = normalizeWatchdogEvent(validation.event, stamp, `client#${senderMeta.id}:${senderMeta.role}`);
 
+    mirrorToAxiomaticLedger(event, senderMeta, 'watchdog.relay.accepted');
     logEvent(event, senderMeta);
 
     const delivered = broadcast(sender, JSON.stringify(event));
@@ -291,10 +297,48 @@ function sendSystemEvent(ws: WebSocket, partial: Omit<DeterministicWatchdogEvent
         timestamp: stamp.timestamp,
     };
 
+    mirrorToAxiomaticLedger(event, undefined, 'watchdog.relay.system');
+
     try {
         ws.send(JSON.stringify(event));
     } catch (err) {
         console.error(`[Watchdog Server] Failed to send system event: ${toErrorMessage(err)}`);
+    }
+}
+
+function mirrorToAxiomaticLedger(event: DeterministicWatchdogEvent, sender: WatchdogClientMeta | undefined, relayKind: string): void {
+    try {
+        axiomaticBus.beginTick(event.tick);
+        axiomaticBus.publish(
+            event.type,
+            {
+                ...event.payload,
+                severity: event.severity,
+                source: event.origin,
+                origin: event.origin,
+                tick: event.tick,
+                seq: event.seq,
+                timestamp: event.timestamp,
+                channel: event.channel,
+                message: event.message,
+            },
+            {
+                tick: event.tick,
+                tickSequence: event.seq,
+                source: 'watchdog-server',
+                metadata: {
+                    ...event.metadata,
+                    relayKind,
+                    senderClientId: sender?.id ?? null,
+                    senderRole: sender?.role ?? null,
+                    eventFingerprint: createDeterministicEventFingerprint(event),
+                },
+                violationPolicy: 'reject',
+                silent: true,
+            },
+        );
+    } catch (err) {
+        console.error(`[Watchdog Server] Failed to mirror event into AxiomaticEventBus: ${toErrorMessage(err)}`);
     }
 }
 
@@ -380,7 +424,8 @@ function readBool(value: string | undefined, fallback: boolean): boolean {
 }
 
 function printStats(): void {
-    console.log(`[Watchdog Stats] clients=${clients.size} received=${totalReceived} relayed=${totalRelayed} rejected=${totalRejected} relayTick=${relayTick} relaySeq=${relaySeq}`);
+    const ledgerStats = axiomaticBus.getLedgerStats();
+    console.log(`[Watchdog Stats] clients=${clients.size} received=${totalReceived} relayed=${totalRelayed} rejected=${totalRejected} relayTick=${relayTick} relaySeq=${relaySeq} ledgerSize=${ledgerStats.size} ledgerResonance=${ledgerStats.currentResonance}`);
 
     for (const meta of clients.values()) {
         console.log(


### PR DESCRIPTION
## Was wurde gemacht

- `backend/src/core/watchdog-determinism.ts` zum gemeinsamen Determinismus-Toolkit erweitert
  - stable stringify
  - FNV-1a Hashing
  - payload hash
  - event fingerprint
  - strengere tick/seq/timestamp Validierung
  - Determinismus-Metadaten auf normalisierten Watchdog-Events
- `backend/src/core/axiomatic-event-bus.ts` auf die gemeinsamen Determinismus-Helfer umgestellt
  - keine doppelte Hash/Stringify-Implementierung mehr
  - gleiche Payload-Hash-Quelle wie Watchdog
- `backend/src/watchdog-server.ts` mit dem `AxiomaticEventBus` verbunden
  - akzeptierte Relay-Events werden ins axiomatische Ledger gespiegelt
  - System-/Reject-Events werden ebenfalls gespiegelt
  - Ledger-Stats erscheinen in Watchdog-Stats
  - Event-Fingerprints werden deterministisch aus tick/seq/type/origin/payload erzeugt

## Regeln

- 10Hz bleibt Quelle der Wahrheit
- Timestamp bleibt `tick * 100ms`
- Kein `Date.now()` / kein `Math.random()` in diesen Änderungen
- `WorldTick.ts` wurde nicht angefasst

## Hinweis

Über den GitHub Connector konnte kein lokaler TypeScript-Build ausgeführt werden.