### PR TITLE
feat(server): move deterministic watchdog into server runtime

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -76,6 +76,13 @@ RUN pnpm --filter @wasd/core-logic --if-present run build:runtime && \
     pnpm --filter @wasd/shared --if-present build && \
     pnpm --filter @wasd/server --if-present build
 
+RUN test -f server/dist/core/watchdog-determinism.js && \
+    test -f server/dist/core/axiomatic-event-bus.js && \
+    test -f server/dist/core/watchdog-emitter.js && \
+    test -f server/dist/core/installDeterministicWatchdog.js && \
+    grep -q 'installDeterministicWatchdogRuntime' server/dist/index.js && \
+    grep -q 'WATCHDOG_TICK_HZ' server/dist/core/watchdog-determinism.js
+
 RUN node scripts/sync-world-assets.mjs || true
 
 RUN pnpm --filter @wasd/client --if-present build || \
@@ -140,6 +147,12 @@ COPY --from=builder /app/packages/core-logic ./packages/core-logic
 COPY --from=builder /app/packages/shared ./packages/shared
 COPY --from=builder /app/client/dist ./client/dist
 COPY --from=builder /app/client/dist ./server/client/dist
+
+RUN test -f /app/server/dist/core/watchdog-determinism.js && \
+    test -f /app/server/dist/core/axiomatic-event-bus.js && \
+    test -f /app/server/dist/core/watchdog-emitter.js && \
+    test -f /app/server/dist/core/installDeterministicWatchdog.js && \
+    grep -q 'installDeterministicWatchdogRuntime' /app/server/dist/index.js
 
 RUN test -f /app/client/dist/2d/index.html && \
     test -f /app/server/client/dist/2d/index.html && \

--- a/server/src/core/axiomatic-event-bus.ts
+++ b/server/src/core/axiomatic-event-bus.ts
@@ -1,0 +1,259 @@
+import {
+  WATCHDOG_TICK_HZ,
+  WATCHDOG_TICK_MS,
+  deterministicPayloadHash,
+  fnv1a32,
+  normalizePositiveInteger,
+  sanitizeText,
+  stableStringify,
+} from './watchdog-determinism';
+
+export const AXIOMATIC_EVENT_SCHEMA_VERSION = 2 as const;
+export const KAPPA_INVARIANT = 1000 as const;
+export const AXIOMATIC_WILDCARD_EVENT = '*' as const;
+
+export type AxiomaticListener<TPayload = unknown> = (event: IAxiomaticEvent<TPayload>) => void;
+export type DeterminismViolationPolicy = 'reject' | 'coerce';
+
+export interface IAxiomaticEvent<TPayload = unknown> {
+  id: string;
+  sequenceId: number;
+  tickSequence: number;
+  tick: number;
+  type: string;
+  timestamp: number;
+  payload: TPayload;
+  actorId?: string;
+  source?: string;
+  metadata: Record<string, unknown> & {
+    resonance: number;
+    kappa: number[];
+    payloadHash: string;
+    canonicalSize: number;
+    tickHz: typeof WATCHDOG_TICK_HZ;
+    tickMs: typeof WATCHDOG_TICK_MS;
+    deterministic: true;
+  };
+  version: typeof AXIOMATIC_EVENT_SCHEMA_VERSION;
+}
+
+export interface AxiomaticPublishOptions {
+  tick?: number;
+  tickSequence?: number;
+  actorId?: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+  violationPolicy?: DeterminismViolationPolicy;
+  silent?: boolean;
+}
+
+interface ListenerEntry {
+  id: number;
+  type: string;
+  listener: AxiomaticListener;
+  once: boolean;
+  priority: number;
+}
+
+export interface AxiomaticLedgerStats {
+  size: number;
+  max: number;
+  full: boolean;
+  currentTick: number;
+  currentTickSequence: number;
+  currentResonance: number;
+  lastSequenceId: number;
+  tickHz: typeof WATCHDOG_TICK_HZ;
+  tickMs: typeof WATCHDOG_TICK_MS;
+  deterministic: true;
+}
+
+export class AREStateCompiler {
+  private static readonly RESONANCE_PRIME = 16807;
+  private static readonly RESONANCE_MAX = 2147483647;
+
+  public static computeResonance(value: number): number {
+    const seed = normalizePositiveInteger(Math.abs(value), 1) || 1;
+    return (seed * this.RESONANCE_PRIME) % this.RESONANCE_MAX;
+  }
+
+  public static computeKappa(seed: number): number[] {
+    const safeSeed = normalizePositiveInteger(seed, 1) || 1;
+    const x = this.computeResonance(safeSeed);
+    const y = this.computeResonance(x);
+    return [Math.trunc(safeSeed * KAPPA_INVARIANT), x % KAPPA_INVARIANT, y % KAPPA_INVARIANT];
+  }
+
+  public static calculateEventResonance(event: Pick<IAxiomaticEvent, 'sequenceId' | 'tick' | 'tickSequence' | 'type' | 'payload'>): number {
+    return this.computeResonance(fnv1a32(`${event.tick}:${event.tickSequence}:${event.sequenceId}:${event.type}:${stableStringify(event.payload)}`));
+  }
+}
+
+export class AxiomaticEventBus {
+  private static instance: AxiomaticEventBus | null = null;
+  private readonly maxLedgerSize = 50000;
+  private readonly eventLedger: IAxiomaticEvent[] = [];
+  private readonly listeners = new Map<string, ListenerEntry[]>();
+  private globalSequenceId = 0;
+  private listenerSequenceId = 0;
+  private currentTick = 0;
+  private currentTickSequence = 0;
+  private globalResonanceState = 0;
+
+  private constructor() {}
+
+  public static getInstance(): AxiomaticEventBus {
+    if (!AxiomaticEventBus.instance) AxiomaticEventBus.instance = new AxiomaticEventBus();
+    return AxiomaticEventBus.instance;
+  }
+
+  public beginTick(tick: number): void {
+    const nextTick = normalizePositiveInteger(tick, this.currentTick);
+    if (nextTick < this.currentTick) throw new Error(`[AxiomaticEventBus] Refused backwards world tick: ${nextTick} < ${this.currentTick}.`);
+    if (nextTick !== this.currentTick) {
+      this.currentTick = nextTick;
+      this.currentTickSequence = 0;
+    }
+  }
+
+  public publish<TPayload = unknown>(type: string, payload?: TPayload, options: AxiomaticPublishOptions = {}): IAxiomaticEvent<TPayload> {
+    const eventType = sanitizeText(type, 'axiomatic.event');
+    const requestedTick = options.tick ?? readNumericField(payload, 'tick') ?? this.currentTick;
+    let tick = normalizePositiveInteger(requestedTick, this.currentTick);
+    let violation: string | undefined;
+
+    if (tick < this.currentTick) {
+      violation = `backwards_tick:${tick}<${this.currentTick}`;
+      if ((options.violationPolicy ?? 'reject') === 'reject') throw new Error(`[AxiomaticEventBus] Refused non-monotonic event "${eventType}".`);
+      tick = this.currentTick;
+    }
+
+    this.beginTick(tick);
+
+    const tickSequence = options.tickSequence ?? ++this.currentTickSequence;
+    this.currentTickSequence = Math.max(this.currentTickSequence, tickSequence);
+
+    const sequenceId = this.globalSequenceId++;
+    const canonicalPayload = stableStringify(payload ?? {});
+    const payloadHash = deterministicPayloadHash(payload ?? {});
+    const timestamp = tick * WATCHDOG_TICK_MS;
+
+    const event: IAxiomaticEvent<TPayload> = {
+      id: '',
+      sequenceId,
+      tickSequence,
+      tick,
+      type: eventType,
+      timestamp,
+      payload: (payload ?? {}) as TPayload,
+      actorId: options.actorId ?? readStringField(payload, 'actorId'),
+      source: options.source ?? readStringField(payload, 'source') ?? readStringField(payload, 'origin'),
+      metadata: {
+        ...(options.metadata ?? {}),
+        resonance: 0,
+        kappa: [],
+        payloadHash,
+        canonicalSize: canonicalPayload.length,
+        tickHz: WATCHDOG_TICK_HZ,
+        tickMs: WATCHDOG_TICK_MS,
+        deterministic: true,
+        ...(violation ? { violation } : {}),
+      },
+      version: AXIOMATIC_EVENT_SCHEMA_VERSION,
+    };
+
+    const resonance = AREStateCompiler.calculateEventResonance(event);
+    event.metadata.resonance = resonance;
+    event.metadata.kappa = AREStateCompiler.computeKappa(sequenceId + tick + tickSequence + resonance);
+    event.id = `evt_${tick}_${tickSequence}_${sequenceId}_${payloadHash}`;
+
+    this.globalResonanceState = (this.globalResonanceState + resonance) % 2147483647;
+    this.eventLedger.push(event);
+    if (this.eventLedger.length > this.maxLedgerSize) this.eventLedger.shift();
+
+    if (!options.silent) console.log(`[AxiomaticEventBus] #${sequenceId} tick=${tick}.${tickSequence} ${eventType}`, { id: event.id, payloadHash });
+    this.dispatch(event);
+    return event;
+  }
+
+  public subscribe<TPayload = unknown>(type: string, listener: AxiomaticListener<TPayload>, priority = 0): () => void {
+    return this.addListener(type, listener as AxiomaticListener, false, priority);
+  }
+
+  public once<TPayload = unknown>(type: string, listener: AxiomaticListener<TPayload>, priority = 0): () => void {
+    return this.addListener(type, listener as AxiomaticListener, true, priority);
+  }
+
+  public getHistory(type?: string): IAxiomaticEvent[] {
+    const events = type ? this.eventLedger.filter((event) => event.type === type) : this.eventLedger;
+    return [...events].sort((a, b) => a.sequenceId - b.sequenceId);
+  }
+
+  public getLedgerStats(): AxiomaticLedgerStats {
+    return {
+      size: this.eventLedger.length,
+      max: this.maxLedgerSize,
+      full: this.eventLedger.length >= this.maxLedgerSize,
+      currentTick: this.currentTick,
+      currentTickSequence: this.currentTickSequence,
+      currentResonance: this.globalResonanceState,
+      lastSequenceId: this.globalSequenceId - 1,
+      tickHz: WATCHDOG_TICK_HZ,
+      tickMs: WATCHDOG_TICK_MS,
+      deterministic: true,
+    };
+  }
+
+  public clearLedger(): void {
+    this.eventLedger.length = 0;
+    this.globalSequenceId = 0;
+    this.currentTick = 0;
+    this.currentTickSequence = 0;
+    this.globalResonanceState = 0;
+  }
+
+  private addListener(type: string, listener: AxiomaticListener, once: boolean, priority: number): () => void {
+    const safeType = sanitizeText(type, AXIOMATIC_WILDCARD_EVENT);
+    const entry: ListenerEntry = { id: ++this.listenerSequenceId, type: safeType, listener, once, priority: normalizePositiveInteger(priority, 0) };
+    const list = this.listeners.get(safeType) ?? [];
+    list.push(entry);
+    list.sort(compareListeners);
+    this.listeners.set(safeType, list);
+    return () => this.unsubscribeById(safeType, entry.id);
+  }
+
+  private unsubscribeById(type: string, listenerId: number): void {
+    const list = this.listeners.get(type);
+    if (!list) return;
+    const next = list.filter((entry) => entry.id !== listenerId);
+    if (next.length === 0) this.listeners.delete(type);
+    else this.listeners.set(type, next);
+  }
+
+  private dispatch(event: IAxiomaticEvent): void {
+    const executionList = [...(this.listeners.get(event.type) ?? []), ...(this.listeners.get(AXIOMATIC_WILDCARD_EVENT) ?? [])].sort(compareListeners);
+    for (const entry of executionList) {
+      try { entry.listener(event); } catch (err) { console.error(`[AxiomaticEventBus] Listener failed for ${event.type}`, err); }
+      if (entry.once) this.unsubscribeById(entry.type, entry.id);
+    }
+  }
+}
+
+function compareListeners(a: ListenerEntry, b: ListenerEntry): number {
+  if (b.priority !== a.priority) return b.priority - a.priority;
+  return a.id - b.id;
+}
+
+function readNumericField(value: unknown, key: string): number | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const raw = (value as Record<string, unknown>)[key];
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+}
+
+function readStringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const raw = (value as Record<string, unknown>)[key];
+  return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : undefined;
+}
+
+export const eventBus = AxiomaticEventBus.getInstance();

--- a/server/src/core/installDeterministicWatchdog.ts
+++ b/server/src/core/installDeterministicWatchdog.ts
@@ -1,0 +1,37 @@
+import { eventBus } from './axiomatic-event-bus';
+import { serverWatchdogEmitter } from './watchdog-emitter';
+import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS } from './watchdog-determinism';
+
+let installed = false;
+
+export function installDeterministicWatchdogRuntime(): void {
+  if (installed) return;
+  installed = true;
+
+  eventBus.beginTick(0);
+  eventBus.subscribe('*', (event) => {
+    if (event.type === 'server.watchdog.ready') return;
+    if (event.metadata?.severity === 'HIGH' || event.metadata?.severity === 'CRITICAL') {
+      console.warn(`[DeterministicWatchdog] ${event.type} tick=${event.tick}.${event.tickSequence} id=${event.id}`);
+    }
+  }, 1);
+
+  serverWatchdogEmitter.emit('server.watchdog.ready', {
+    status: 'ready',
+    tickHz: WATCHDOG_TICK_HZ,
+    tickMs: WATCHDOG_TICK_MS,
+    runtime: 'server-core',
+  }, 'LOW', 'server-core', 0);
+
+  console.log(`[DeterministicWatchdog] installed tick=${WATCHDOG_TICK_HZ}Hz step=${WATCHDOG_TICK_MS}ms ledger=${eventBus.getLedgerStats().size}`);
+}
+
+export function getDeterministicWatchdogStatus() {
+  const stats = eventBus.getLedgerStats();
+  return {
+    installed,
+    tickHz: WATCHDOG_TICK_HZ,
+    tickMs: WATCHDOG_TICK_MS,
+    ledger: stats,
+  };
+}

--- a/server/src/core/watchdog-determinism.ts
+++ b/server/src/core/watchdog-determinism.ts
@@ -1,0 +1,243 @@
+export const WATCHDOG_TICK_HZ = 10 as const;
+export const WATCHDOG_TICK_MS = 100 as const;
+export const WATCHDOG_DETERMINISM_VERSION = 2 as const;
+
+export type WatchdogSeverity =
+    | 'LOW'
+    | 'MEDIUM'
+    | 'HIGH'
+    | 'CRITICAL'
+    | 'DEBUG'
+    | 'INFO'
+    | 'WARN'
+    | 'ERROR'
+    | 'FATAL';
+
+export type CanonicalWatchdogSeverity = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+export interface WatchdogTickStamp {
+    /** Deterministic 10Hz simulation tick. Never wall-clock based. */
+    tick: number;
+    /** Monotonic sequence inside the watchdog relay/emitter. */
+    seq: number;
+    /** Deterministic simulation milliseconds: tick * 100 for 10Hz. */
+    timestamp: number;
+}
+
+export interface WatchdogEvent {
+    type: string;
+    severity: CanonicalWatchdogSeverity;
+    /** @deprecated Use origin. Kept for compatibility with older callers. */
+    source?: string;
+    origin?: string;
+    message?: string;
+    payload?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+    tick?: number;
+    seq?: number;
+    timestamp?: number;
+    channel?: string;
+}
+
+export interface DeterministicWatchdogEvent extends WatchdogEvent {
+    severity: CanonicalWatchdogSeverity;
+    origin: string;
+    message: string;
+    payload: Record<string, unknown>;
+    metadata: Record<string, unknown>;
+    tick: number;
+    seq: number;
+    timestamp: number;
+    channel: string;
+}
+
+export function toCanonicalWatchdogSeverity(severity: unknown): CanonicalWatchdogSeverity | null {
+    if (typeof severity !== 'string') return null;
+
+    const normalized = severity.trim().toUpperCase();
+
+    if (normalized === 'DEBUG' || normalized === 'INFO') return 'LOW';
+    if (normalized === 'WARN' || normalized === 'WARNING') return 'MEDIUM';
+    if (normalized === 'ERROR') return 'HIGH';
+    if (normalized === 'FATAL') return 'CRITICAL';
+
+    if (
+        normalized === 'LOW' ||
+        normalized === 'MEDIUM' ||
+        normalized === 'HIGH' ||
+        normalized === 'CRITICAL'
+    ) {
+        return normalized;
+    }
+
+    return null;
+}
+
+export function createWatchdogTickStamp(tick: number, seq: number): WatchdogTickStamp {
+    const safeTick = normalizePositiveInteger(tick, 0);
+    const safeSeq = normalizePositiveInteger(seq, 0);
+
+    return {
+        tick: safeTick,
+        seq: safeSeq,
+        timestamp: safeTick * WATCHDOG_TICK_MS,
+    };
+}
+
+export function normalizeWatchdogEvent(
+    input: WatchdogEvent,
+    stamp: WatchdogTickStamp,
+    fallbackOrigin = 'SYSTEM_CORE',
+): DeterministicWatchdogEvent {
+    const severity = toCanonicalWatchdogSeverity(input.severity) ?? 'LOW';
+    const origin = sanitizeText(input.origin || input.source || fallbackOrigin, fallbackOrigin);
+    const message = sanitizeText(input.message, input.type || 'watchdog.event');
+    const channel = sanitizeText(input.channel, 'watchdog');
+    const payload = normalizeRecord(input.payload);
+    const metadata = normalizeRecord(input.metadata);
+
+    return {
+        ...input,
+        type: sanitizeText(input.type, 'watchdog.event'),
+        severity,
+        source: origin,
+        origin,
+        message,
+        payload,
+        metadata: {
+            ...metadata,
+            determinismVersion: WATCHDOG_DETERMINISM_VERSION,
+            tickHz: WATCHDOG_TICK_HZ,
+            tickMs: WATCHDOG_TICK_MS,
+            payloadHash: deterministicPayloadHash(payload),
+        },
+        channel,
+        tick: stamp.tick,
+        seq: stamp.seq,
+        timestamp: stamp.timestamp,
+    };
+}
+
+export function validateWatchdogEventCandidate(input: unknown):
+    | { ok: true; event: WatchdogEvent }
+    | { ok: false; reason: string } {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        return { ok: false, reason: 'Watchdog event must be an object.' };
+    }
+
+    const candidate = input as Partial<WatchdogEvent>;
+
+    if (!candidate.type || typeof candidate.type !== 'string' || candidate.type.trim().length === 0) {
+        return { ok: false, reason: 'Watchdog event requires a non-empty string type.' };
+    }
+
+    if (!toCanonicalWatchdogSeverity(candidate.severity)) {
+        return { ok: false, reason: 'Watchdog event severity must be LOW, MEDIUM, HIGH, CRITICAL, DEBUG, INFO, WARN, ERROR or FATAL.' };
+    }
+
+    if (candidate.origin !== undefined && typeof candidate.origin !== 'string') {
+        return { ok: false, reason: 'Watchdog event origin must be a string when provided.' };
+    }
+
+    if (candidate.source !== undefined && typeof candidate.source !== 'string') {
+        return { ok: false, reason: 'Watchdog event source must be a string when provided.' };
+    }
+
+    if (candidate.message !== undefined && typeof candidate.message !== 'string') {
+        return { ok: false, reason: 'Watchdog event message must be a string when provided.' };
+    }
+
+    if (candidate.payload !== undefined && !isPlainRecord(candidate.payload)) {
+        return { ok: false, reason: 'Watchdog event payload must be a plain object when provided.' };
+    }
+
+    if (candidate.metadata !== undefined && !isPlainRecord(candidate.metadata)) {
+        return { ok: false, reason: 'Watchdog event metadata must be a plain object when provided.' };
+    }
+
+    if (candidate.tick !== undefined && normalizePositiveInteger(candidate.tick, -1) < 0) {
+        return { ok: false, reason: 'Watchdog event tick must be a non-negative integer when provided.' };
+    }
+
+    if (candidate.seq !== undefined && normalizePositiveInteger(candidate.seq, -1) < 0) {
+        return { ok: false, reason: 'Watchdog event seq must be a non-negative integer when provided.' };
+    }
+
+    if (candidate.timestamp !== undefined) {
+        const normalizedTick = normalizePositiveInteger(candidate.tick, 0);
+        const expectedTimestamp = normalizedTick * WATCHDOG_TICK_MS;
+        if (typeof candidate.timestamp !== 'number' || !Number.isFinite(candidate.timestamp) || candidate.timestamp < 0) {
+            return { ok: false, reason: 'Watchdog event timestamp must be a non-negative finite number when provided.' };
+        }
+        if (candidate.tick !== undefined && Math.floor(candidate.timestamp) !== expectedTimestamp) {
+            return { ok: false, reason: 'Watchdog event timestamp must equal tick * 100ms in strict deterministic mode.' };
+        }
+    }
+
+    return {
+        ok: true,
+        event: candidate as WatchdogEvent,
+    };
+}
+
+export function normalizePositiveInteger(value: unknown, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+    if (value < 0) return fallback;
+    return Math.floor(value);
+}
+
+export function sanitizeText(value: unknown, fallback: string): string {
+    if (typeof value !== 'string') return fallback;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : fallback;
+}
+
+export function normalizeRecord(value: unknown): Record<string, unknown> {
+    if (!isPlainRecord(value)) return {};
+    return value;
+}
+
+export function stableStringify(value: unknown): string {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'bigint') return `"${value.toString()}n"`;
+    if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '0';
+    if (typeof value === 'boolean') return value ? 'true' : 'false';
+    if (typeof value === 'string') return JSON.stringify(value);
+    if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+    if (typeof value === 'object') {
+        const record = value as Record<string, unknown>;
+        const keys = Object.keys(record).sort(compareStableText);
+        return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`;
+    }
+    return JSON.stringify(String(value));
+}
+
+export function fnv1a32(input: string): number {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < input.length; i += 1) {
+        hash ^= input.charCodeAt(i);
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash >>> 0;
+}
+
+export function fnv1a32Hex(input: string): string {
+    return fnv1a32(input).toString(16).padStart(8, '0');
+}
+
+export function deterministicPayloadHash(payload: unknown): string {
+    return fnv1a32Hex(stableStringify(payload));
+}
+
+export function createDeterministicEventFingerprint(event: Pick<DeterministicWatchdogEvent, 'tick' | 'seq' | 'type' | 'origin' | 'payload'>): string {
+    return fnv1a32Hex(`${event.tick}:${event.seq}:${event.type}:${event.origin}:${stableStringify(event.payload)}`);
+}
+
+export function compareStableText(a: string, b: string): number {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/server/src/core/watchdog-emitter.ts
+++ b/server/src/core/watchdog-emitter.ts
@@ -1,0 +1,67 @@
+import { AxiomaticEventBus } from './axiomatic-event-bus';
+import {
+  createWatchdogTickStamp,
+  normalizePositiveInteger,
+  normalizeWatchdogEvent,
+  type CanonicalWatchdogSeverity,
+  type DeterministicWatchdogEvent,
+  type WatchdogEvent,
+} from './watchdog-determinism';
+
+export type WatchdogSeverity = CanonicalWatchdogSeverity;
+export type { WatchdogEvent, DeterministicWatchdogEvent };
+
+export class WatchdogEmitter {
+  private readonly listeners: Array<(event: DeterministicWatchdogEvent) => void> = [];
+  private readonly bus = AxiomaticEventBus.getInstance();
+  private tick = 0;
+  private seq = 0;
+
+  public setWorldTick(tick: number): void {
+    this.tick = normalizePositiveInteger(tick, this.tick);
+    this.seq = 0;
+    this.bus.beginTick(this.tick);
+  }
+
+  public emit(type: string, payload: Record<string, unknown> = {}, severity: WatchdogSeverity = 'LOW', source = 'server-core', tick = this.tick): DeterministicWatchdogEvent {
+    const safeTick = normalizePositiveInteger(tick, this.tick);
+    if (safeTick !== this.tick) this.setWorldTick(safeTick);
+
+    const stamp = createWatchdogTickStamp(this.tick, ++this.seq);
+    const event = normalizeWatchdogEvent({ type, severity, source, origin: source, message: type, payload, metadata: {}, channel: 'watchdog.server-core' }, stamp, source);
+    this.broadcast(event);
+    return event;
+  }
+
+  public emitEvent(event: WatchdogEvent, tick = event.tick ?? this.tick): DeterministicWatchdogEvent {
+    const safeTick = normalizePositiveInteger(tick, this.tick);
+    if (safeTick !== this.tick) this.setWorldTick(safeTick);
+
+    const stamp = createWatchdogTickStamp(this.tick, ++this.seq);
+    const normalized = normalizeWatchdogEvent(event, stamp, event.origin || event.source || 'server-core');
+    this.broadcast(normalized);
+    return normalized;
+  }
+
+  public subscribe(listener: (event: DeterministicWatchdogEvent) => void): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index >= 0) this.listeners.splice(index, 1);
+    };
+  }
+
+  private broadcast(event: DeterministicWatchdogEvent): void {
+    for (const listener of this.listeners) {
+      try { listener(event); } catch (err) { console.error('[WatchdogEmitter] listener failed', err); }
+    }
+
+    this.bus.publish(
+      event.type,
+      { ...event.payload, severity: event.severity, source: event.origin, origin: event.origin, tick: event.tick, seq: event.seq, timestamp: event.timestamp, channel: event.channel },
+      { tick: event.tick, tickSequence: event.seq, source: event.origin, metadata: { severity: event.severity, channel: event.channel }, violationPolicy: 'reject', silent: true },
+    );
+  }
+}
+
+export const serverWatchdogEmitter = new WatchdogEmitter();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { loadRootEnvFiles } from "./config/loadRootEnv.js";
 loadRootEnvFiles();
 
 import { getSupabaseAuthInitInfo } from "./config/supabase.js";
+import { installDeterministicWatchdogRuntime } from "./core/installDeterministicWatchdog.js";
 import { ServerBootstrap } from "./core/ServerBootstrap.js";
 import { installRuntimeChatRelay } from "./modules/chat/installRuntimeChatRelay.js";
 import "./modules/loot/installLootBridge.js";
@@ -37,6 +38,7 @@ process.on("uncaughtException", (error) => {
 
 try {
   validateConfig();
+  installDeterministicWatchdogRuntime();
   installRuntimeChatRelay();
   const server = new ServerBootstrap();
   server.start();


### PR DESCRIPTION
## Was wurde gemacht

Variante 2 umgesetzt: Der deterministische Watchdog/Core-Bus liegt jetzt im echten `@wasd/server` Runtime-Pfad und wird beim Serverstart geladen.

### Neu in `server/src/core/**`

- `watchdog-determinism.ts`
  - 10Hz Konstanten
  - tick * 100ms Timestamp-Regel
  - stable stringify
  - FNV-1a Hashing
  - Payload-Hash
  - Event-Fingerprint
  - Watchdog-Event-Normalisierung/Validierung

- `axiomatic-event-bus.ts`
  - kompakter deterministischer EventBus für Server-Runtime
  - monotone Ticks
  - per-tick sequence
  - Payload-Hash
  - Resonance/Kappa-Metadaten
  - Ledger und Listener

- `watchdog-emitter.ts`
  - lokaler deterministischer Watchdog-Emitter
  - schreibt Events direkt in den AxiomaticEventBus

- `installDeterministicWatchdog.ts`
  - installiert Runtime beim Boot
  - schreibt `server.watchdog.ready`
  - exportiert Status/Stats

### Boot-Integration

- `server/src/index.ts` ruft jetzt `installDeterministicWatchdogRuntime()` vor dem eigentlichen Serverstart auf.

### Docker-Gate

`Dockerfile.vps` prüft jetzt im Builder und Runner:

- `server/dist/core/watchdog-determinism.js`
- `server/dist/core/axiomatic-event-bus.js`
- `server/dist/core/watchdog-emitter.js`
- `server/dist/core/installDeterministicWatchdog.js`
- `server/dist/index.js` enthält den Boot-Import

Damit ist sichergestellt, dass der Code im finalen Docker-Image unter `/app/server/dist/**` landet.

## Hinweis

Über den GitHub Connector konnte kein lokaler Build ausgeführt werden. Der Dockerfile-Gate wird aber beim VPS-Docker-Build prüfen, ob die Runtime-Dateien wirklich im Image liegen.