### PR TITLE
feat(server): bridge WorldTick into deterministic watchdog ledger

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -80,7 +80,10 @@ RUN test -f server/dist/core/watchdog-determinism.js && \
     test -f server/dist/core/axiomatic-event-bus.js && \
     test -f server/dist/core/watchdog-emitter.js && \
     test -f server/dist/core/installDeterministicWatchdog.js && \
+    test -f server/dist/core/installWorldTickWatchdogBridge.js && \
     grep -q 'installDeterministicWatchdogRuntime' server/dist/index.js && \
+    grep -q 'installWorldTickWatchdogBridge' server/dist/core/installDeterministicWatchdog.js && \
+    grep -q 'world.tick.heartbeat' server/dist/core/installWorldTickWatchdogBridge.js && \
     grep -q 'WATCHDOG_TICK_HZ' server/dist/core/watchdog-determinism.js
 
 RUN node scripts/sync-world-assets.mjs || true
@@ -152,7 +155,9 @@ RUN test -f /app/server/dist/core/watchdog-determinism.js && \
     test -f /app/server/dist/core/axiomatic-event-bus.js && \
     test -f /app/server/dist/core/watchdog-emitter.js && \
     test -f /app/server/dist/core/installDeterministicWatchdog.js && \
-    grep -q 'installDeterministicWatchdogRuntime' /app/server/dist/index.js
+    test -f /app/server/dist/core/installWorldTickWatchdogBridge.js && \
+    grep -q 'installDeterministicWatchdogRuntime' /app/server/dist/index.js && \
+    grep -q 'world.tick.heartbeat' /app/server/dist/core/installWorldTickWatchdogBridge.js
 
 RUN test -f /app/client/dist/2d/index.html && \
     test -f /app/server/client/dist/2d/index.html && \

--- a/server/src/api/healthRoutes.ts
+++ b/server/src/api/healthRoutes.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import type { WorldTick } from '../core/WorldTick.js';
+import { getDeterministicWatchdogStatus } from '../core/installDeterministicWatchdog.js';
 
 export type HealthRouteOptions = {
   getTick: () => WorldTick | undefined;
@@ -31,12 +32,14 @@ export function healthRoutes(options: HealthRouteOptions): Router {
     noStore(res);
     const initializing = options.isInitializing();
     const tick = options.getTick();
+    const watchdog = safe(() => (tick as any)?.getWatchdogLedgerStatus?.() ?? getDeterministicWatchdogStatus(), getDeterministicWatchdogStatus());
     res.status(initializing ? 503 : 200).json({
       ok: !initializing,
       status: initializing ? 'initializing' : 'ready',
       tickReady: Boolean(tick),
       uptimeSeconds: Math.round(process.uptime()),
       port: options.getPort(),
+      watchdog,
     });
   });
 
@@ -45,8 +48,17 @@ export function healthRoutes(options: HealthRouteOptions): Router {
     const tick = options.getTick();
     const guard = safe(() => tick?.getAREGuardStatus?.() ?? null, null);
     const replay = safe(() => tick?.getReplayRecorderStats?.() ?? null, null);
+    const watchdog = safe(() => (tick as any)?.getWatchdogLedgerStatus?.() ?? getDeterministicWatchdogStatus(), getDeterministicWatchdogStatus());
     const ok = Boolean(tick) && !options.isInitializing();
-    res.status(ok ? 200 : 503).json({ ok, status: ok ? 'deterministic' : 'unready', guard, replay });
+    res.status(ok ? 200 : 503).json({ ok, status: ok ? 'deterministic' : 'unready', guard, replay, watchdog });
+  });
+
+  router.get('/watchdog', (_req: Request, res: Response) => {
+    noStore(res);
+    const tick = options.getTick();
+    const watchdog = safe(() => (tick as any)?.getWatchdogLedgerStatus?.() ?? getDeterministicWatchdogStatus(), getDeterministicWatchdogStatus());
+    const ok = Boolean(watchdog?.installed);
+    res.status(ok ? 200 : 503).json({ ok, status: ok ? 'watchdog' : 'unavailable', watchdog });
   });
 
   router.get('/worldhash', (_req: Request, res: Response) => {

--- a/server/src/core/installDeterministicWatchdog.ts
+++ b/server/src/core/installDeterministicWatchdog.ts
@@ -1,6 +1,7 @@
 import { eventBus } from './axiomatic-event-bus';
 import { serverWatchdogEmitter } from './watchdog-emitter';
 import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS } from './watchdog-determinism';
+import { installWorldTickWatchdogBridge } from './installWorldTickWatchdogBridge.js';
 
 let installed = false;
 
@@ -16,14 +17,17 @@ export function installDeterministicWatchdogRuntime(): void {
     }
   }, 1);
 
+  installWorldTickWatchdogBridge();
+
   serverWatchdogEmitter.emit('server.watchdog.ready', {
     status: 'ready',
     tickHz: WATCHDOG_TICK_HZ,
     tickMs: WATCHDOG_TICK_MS,
     runtime: 'server-core',
+    worldTickBridge: true,
   }, 'LOW', 'server-core', 0);
 
-  console.log(`[DeterministicWatchdog] installed tick=${WATCHDOG_TICK_HZ}Hz step=${WATCHDOG_TICK_MS}ms ledger=${eventBus.getLedgerStats().size}`);
+  console.log(`[DeterministicWatchdog] installed tick=${WATCHDOG_TICK_HZ}Hz step=${WATCHDOG_TICK_MS}ms ledger=${eventBus.getLedgerStats().size} worldTickBridge=true`);
 }
 
 export function getDeterministicWatchdogStatus() {

--- a/server/src/core/installWorldTickWatchdogBridge.ts
+++ b/server/src/core/installWorldTickWatchdogBridge.ts
@@ -1,7 +1,7 @@
 import { WorldTick } from './WorldTick.js';
 import { eventBus } from './axiomatic-event-bus';
 import { serverWatchdogEmitter } from './watchdog-emitter';
-import { getDeterministicWatchdogStatus } from './installDeterministicWatchdog';
+import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS } from './watchdog-determinism';
 
 let installed = false;
 
@@ -84,8 +84,12 @@ export function installWorldTickWatchdogBridge(): void {
   };
 
   proto.getWatchdogLedgerStatus = function getWatchdogLedgerStatus() {
+    const ledger = eventBus.getLedgerStats();
     return {
-      ...getDeterministicWatchdogStatus(),
+      installed: true,
+      tickHz: WATCHDOG_TICK_HZ,
+      tickMs: WATCHDOG_TICK_MS,
+      ledger,
       worldTick: Number(this.tickCount ?? 0),
       worldHash: this.lastWorldHashSnapshot?.worldHash ?? null,
       guard: this.lastAREGuardStatus ?? null,

--- a/server/src/core/installWorldTickWatchdogBridge.ts
+++ b/server/src/core/installWorldTickWatchdogBridge.ts
@@ -1,0 +1,111 @@
+import { WorldTick } from './WorldTick.js';
+import { eventBus } from './axiomatic-event-bus';
+import { serverWatchdogEmitter } from './watchdog-emitter';
+import { getDeterministicWatchdogStatus } from './installDeterministicWatchdog';
+
+let installed = false;
+
+export function installWorldTickWatchdogBridge(): void {
+  if (installed) return;
+  installed = true;
+
+  const proto = WorldTick.prototype as any;
+  if (proto.__watchdogTickBridgeInstalled) return;
+  proto.__watchdogTickBridgeInstalled = true;
+
+  const originalTick = proto.tick;
+  if (typeof originalTick !== 'function') {
+    throw new Error('[WorldTickWatchdogBridge] WorldTick.tick is not a function.');
+  }
+
+  proto.tick = function watchdogWrappedTick(...args: unknown[]) {
+    const beforeTick = Number(this.tickCount ?? 0);
+    const nextTick = beforeTick + 1;
+
+    eventBus.beginTick(nextTick);
+    serverWatchdogEmitter.setWorldTick(nextTick);
+    eventBus.publish('world.tick.begin', {
+      tick: nextTick,
+      previousTick: beforeTick,
+      phase: 'begin',
+    }, {
+      tick: nextTick,
+      source: 'worldtick',
+      metadata: { subsystem: 'WorldTick', phase: 'begin' },
+      silent: true,
+    });
+
+    try {
+      const result = originalTick.apply(this, args);
+      const committedTick = Number(this.tickCount ?? nextTick);
+
+      eventBus.beginTick(committedTick);
+      eventBus.publish('world.tick.end', {
+        tick: committedTick,
+        phase: 'end',
+        players: safeCount(() => this.playerSystem?.getAllPlayers?.()),
+        npcs: safeCount(() => this.npcSystem?.getAllNPCs?.()),
+        loot: safeSize(this.lootEntities),
+        guardOk: Boolean(this.lastAREGuardStatus?.ok ?? true),
+        worldHash: this.lastWorldHashSnapshot?.worldHash ?? null,
+      }, {
+        tick: committedTick,
+        source: 'worldtick',
+        metadata: { subsystem: 'WorldTick', phase: 'end' },
+        silent: true,
+      });
+
+      if (committedTick % 10 === 0) {
+        serverWatchdogEmitter.emit('world.tick.heartbeat', {
+          tick: committedTick,
+          players: safeCount(() => this.playerSystem?.getAllPlayers?.()),
+          npcs: safeCount(() => this.npcSystem?.getAllNPCs?.()),
+          loot: safeSize(this.lootEntities),
+          ledger: eventBus.getLedgerStats(),
+        }, 'LOW', 'worldtick', committedTick);
+      }
+
+      if (this.lastAREGuardStatus && this.lastAREGuardStatus.ok === false && committedTick % 10 === 0) {
+        serverWatchdogEmitter.emit('world.tick.guard_violation', {
+          tick: committedTick,
+          violations: this.lastAREGuardStatus.violations ?? [],
+          worldHash: this.lastWorldHashSnapshot?.worldHash ?? null,
+        }, 'HIGH', 'worldtick', committedTick);
+      }
+
+      return result;
+    } catch (error) {
+      serverWatchdogEmitter.emit('world.tick.exception', {
+        tick: nextTick,
+        message: error instanceof Error ? error.message : String(error),
+      }, 'CRITICAL', 'worldtick', nextTick);
+      throw error;
+    }
+  };
+
+  proto.getWatchdogLedgerStatus = function getWatchdogLedgerStatus() {
+    return {
+      ...getDeterministicWatchdogStatus(),
+      worldTick: Number(this.tickCount ?? 0),
+      worldHash: this.lastWorldHashSnapshot?.worldHash ?? null,
+      guard: this.lastAREGuardStatus ?? null,
+    };
+  };
+
+  console.log('[WorldTickWatchdogBridge] installed');
+}
+
+function safeCount(read: () => unknown): number {
+  try {
+    const value = read();
+    return Array.isArray(value) ? value.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function safeSize(value: unknown): number {
+  return value && typeof value === 'object' && 'size' in value && typeof (value as { size?: unknown }).size === 'number'
+    ? Number((value as { size: number }).size)
+    : 0;
+}


### PR DESCRIPTION
## Was wurde gemacht

Nächster Schritt der Watchdog-Integration:

- `WorldTick` wird über `installWorldTickWatchdogBridge()` in den deterministischen Watchdog-Ledger gespiegelt.
- Jeder echte `WorldTick.tick()` erzeugt:
  - `world.tick.begin`
  - `world.tick.end`
- Alle 10 Ticks erzeugt der Server:
  - `world.tick.heartbeat`
- Bei ARE-Guard-Verletzungen erzeugt der Server:
  - `world.tick.guard_violation`
- Bei Tick-Exceptions erzeugt der Server:
  - `world.tick.exception`
- `WorldTick` bekommt runtime-seitig `getWatchdogLedgerStatus()`.
- `/health/ready` und `/health/determinism` enthalten jetzt Watchdog-Status.
- Neuer Endpoint:
  - `/health/watchdog`
- `Dockerfile.vps` erzwingt jetzt zusätzlich:
  - `server/dist/core/installWorldTickWatchdogBridge.js`
  - `world.tick.heartbeat` im finalen Runtime-Image

## Warum kein direkter Rewrite von `WorldTick.ts`?

`WorldTick.ts` ist sehr groß und kritisch. Statt fragilem Voll-Rewrite wird die Tick-Methode kontrolliert über den Server-Core-Installer gewrappt. Dadurch bleibt die bestehende WorldTick-Logik unverändert, aber jeder echte Tick landet deterministisch im Watchdog/EventBus.

## Hinweis

Über den GitHub Connector konnte kein lokaler Docker-Build ausgeführt werden. Die Dockerfile-Gates prüfen beim VPS-Build, ob die Bridge wirklich in `server/dist/**` und im finalen Image vorhanden ist.