### PR TITLE
fix(ci): satisfy ARE scanner and portal WebCrypto types

### DIFF
--- a/packages/shared/src/areTime.ts
+++ b/packages/shared/src/areTime.ts
@@ -1,9 +1,9 @@
 /**
  * Canonical ARE simulation cadence shared by server, client and tooling.
  *
- * This module is intentionally pure: no Date.now(), no performance.now(), no
- * timers and no process/browser globals. It defines duration conversion only;
- * actual simulation authority remains tick-based.
+ * This module is intentionally pure. It defines duration conversion only;
+ * actual simulation authority remains tick-based and must be supplied by the
+ * authoritative world loop.
  */
 export const ARE_SIMULATION_TICK_HZ = 10;
 export const ARE_SIMULATION_TICK_MS = 1000 / ARE_SIMULATION_TICK_HZ;

--- a/portal/src/auth/StatelessGate.ts
+++ b/portal/src/auth/StatelessGate.ts
@@ -2,7 +2,7 @@
  * StatelessGate — deterministic HKDF gate for the 10Hz world server.
  *
  * Rules:
- * - No Date.now(), Math.random(), mutable singleton state, or wall-clock dependency.
+ * - No wall-clock dependency or mutable singleton state.
  * - Token material is derived only from secret + canonical scope + logical tick/index.
  * - The server remains authoritative for tick indexes and replay policy.
  * - Client-provided ticks are hints at most; verify against server-side tick windows.
@@ -39,7 +39,7 @@ export interface StatelessTokenScope {
   /** Realm/shard/world id. */
   realmId?: string;
 
-  /** Server/session/challenge id. Must be deterministic input, not random inside this class. */
+  /** Server/session/challenge id. Must be deterministic input, not generated inside this class. */
   challengeId?: string;
 
   /** Domain separation for different systems. */
@@ -293,7 +293,7 @@ export class StatelessGate {
   private async importKeyMaterial(secret: string): Promise<CryptoKey> {
     return this.getCrypto().subtle.importKey(
       "raw",
-      this.encoder.encode(secret),
+      this.toFixedBufferSource(this.encoder.encode(secret)),
       { name: "HKDF" },
       false,
       ["deriveBits"],
@@ -301,7 +301,7 @@ export class StatelessGate {
   }
 
   /** Stable 64-bit big-endian salt for the logical index/tick. */
-  private encodeIndexSalt(logicalIndex: number): Uint8Array {
+  private encodeIndexSalt(logicalIndex: number): ArrayBuffer {
     const buffer = new ArrayBuffer(8);
     const view = new DataView(buffer);
     const high = Math.floor(logicalIndex / 0x100000000);
@@ -310,11 +310,11 @@ export class StatelessGate {
     view.setUint32(0, high, false);
     view.setUint32(4, low, false);
 
-    return new Uint8Array(buffer);
+    return buffer;
   }
 
   /** Canonical length-prefixed HKDF info. No JSON order drift, no delimiter ambiguity. */
-  private encodeInfo(scope: StatelessTokenScope): Uint8Array {
+  private encodeInfo(scope: StatelessTokenScope): ArrayBuffer {
     const purpose = scope.purpose ?? "authentication";
     const fields: readonly [string, string][] = [
       ["namespace", this.namespace],
@@ -333,7 +333,13 @@ export class StatelessGate {
       })
       .join("");
 
-    return this.encoder.encode(canonical);
+    return this.toFixedBufferSource(this.encoder.encode(canonical));
+  }
+
+  private toFixedBufferSource(bytes: Uint8Array): ArrayBuffer {
+    const buffer = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(buffer).set(bytes);
+    return buffer;
   }
 
   private withTickPurpose(scope: StatelessTokenScope): StatelessTokenScope {

--- a/server/src/modules/playtester/PersistentPlaytesterNPC.ts
+++ b/server/src/modules/playtester/PersistentPlaytesterNPC.ts
@@ -5,7 +5,7 @@
  * Runs tests on all game systems, generates structured JSONL logs.
  *
  * Key design principles:
- * - Deterministic: Uses seed + tick for all decisions (no Math.random())
+ * - Deterministic: Uses seed plus tick for all decisions.
  * - Tags: Uses "playtester", "synthetic", "monitor", "persistent" tags
  * - Non-intrusive: Won't affect real player metrics (leaderboards, economy)
  */
@@ -100,7 +100,7 @@ export interface PersistentPlaytesterNPCConfig {
 }
 
 /**
- * FNV-1a hash function for deterministic randomness
+ * FNV-1a hash function for deterministic selection
  */
 function hashString(input: string): number {
   let h = 0x811c9dc5;
@@ -114,8 +114,8 @@ function hashString(input: string): number {
 }
 
 /**
- * Deterministic picker: picks an element from an array based on seed + tick.
- * No Math.random() - fully reproducible.
+ * Deterministic picker: picks an element from an array based on seed plus tick.
+ * Fully reproducible.
  */
 function pickDeterministic<T>(
   seed: string,

--- a/server/src/modules/playtester/PlaytesterJsonlLogger.ts
+++ b/server/src/modules/playtester/PlaytesterJsonlLogger.ts
@@ -23,14 +23,17 @@ export class PlaytesterJsonlLogger {
 
   /**
    * Write a log event to the JSONL file.
-   * @param event - The event object to log (will be merged with timestamp)
+   * The event tick is the canonical deterministic time source.
    */
   write(event: unknown): void {
     if (!this.options.enabled) return;
 
+    const record = event as Record<string, unknown>;
+    const tick = typeof record.tick === "number" && Number.isFinite(record.tick) ? Math.trunc(record.tick) : 0;
     const line = JSON.stringify({
-      loggedAt: new Date().toISOString(),
-      ...(event as Record<string, unknown>),
+      loggedTick: tick,
+      simulationMs: tick * 100,
+      ...record,
     });
 
     appendFileSync(this.options.logPath, `${line}\n`, "utf8");


### PR DESCRIPTION
## Fixes

Behebt die zwei gemeldeten CI-Blocker:

### ARE Guard Source Scanner

- `packages/shared/src/areTime.ts`
  - verbotene wall-clock Token aus Kommentaren entfernt
- `server/src/modules/playtester/PersistentPlaytesterNPC.ts`
  - verbotene random Token aus Kommentaren entfernt
  - Logik bleibt deterministic via FNV-1a + tick
- `server/src/modules/playtester/PlaytesterJsonlLogger.ts`
  - wall-clock Logging entfernt
  - nutzt jetzt `loggedTick` und `simulationMs = tick * 100`

### Portal TypeScript / WebCrypto

- `portal/src/auth/StatelessGate.ts`
  - HKDF `salt`, `info` und raw key material werden jetzt als feste `ArrayBuffer` übergeben
  - vermeidet `Uint8Array<ArrayBufferLike>` vs `BufferSource` Fehler unter neueren TS/DOM Types

## Hinweis

Kein lokaler CI-Lauf über den GitHub Connector möglich; die Änderungen sind direkt auf die gemeldeten Fehlstellen zugeschnitten.