### PR TITLE
feat(watchdog): connect backend watchdog sensors to deterministic runtime

### DIFF
--- a/backend/src/core/watchdog-cascade.ts
+++ b/backend/src/core/watchdog-cascade.ts
@@ -1,20 +1,15 @@
-import { WatchdogEmitter } from './watchdog-emitter.js';
+import { emitBackendWatchdogEvent, getBackendWatchdogTick } from './watchdog-runtime';
 
 export class WatchdogCascadeMonitor {
-    private emitter: WatchdogEmitter;
+    monitorCascade(cascadeActive: boolean, tick = getBackendWatchdogTick()): void {
+        if (!cascadeActive) return;
 
-    constructor(emitterUrl: string = 'ws://localhost:9090') {
-        this.emitter = new WatchdogEmitter(emitterUrl);
-    }
-
-    monitorCascade(cascadeActive: boolean): void {
-        if (cascadeActive) {
-            this.emitter.emit(
-                'CASCADE_WARNING',
-                { message: 'Resonance Cascade detected. Threat levels inverted.' },
-                'HIGH',
-                'CASCADE_MONITOR'
-            );
-        }
+        emitBackendWatchdogEvent(
+            'CASCADE_WARNING',
+            { message: 'Resonance Cascade detected. Threat levels inverted.', cascadeActive },
+            'HIGH',
+            'CASCADE_MONITOR',
+            tick,
+        );
     }
 }

--- a/backend/src/core/watchdog-chrono-synaptic.ts
+++ b/backend/src/core/watchdog-chrono-synaptic.ts
@@ -1,24 +1,22 @@
-import { WatchdogEmitter } from './watchdog-emitter.js';
+import { emitBackendWatchdogEvent, getBackendWatchdogTick } from './watchdog-runtime';
 
 export class WatchdogChronoSynapticMonitor {
-    private emitter: WatchdogEmitter;
     private readonly tickThresholdMs: number = 50;
 
-    constructor(emitterUrl: string = 'ws://localhost:9090') {
-        this.emitter = new WatchdogEmitter(emitterUrl);
-    }
+    monitorTickTime(tickTimeMs: number, tick = getBackendWatchdogTick()): void {
+        if (tickTimeMs <= this.tickThresholdMs) return;
 
-    monitorTickTime(tickTimeMs: number): void {
-        if (tickTimeMs > this.tickThresholdMs) {
-            this.emitter.emit(
-                'SYNAPTIC_OVERLOAD',
-                {
-                    message: `Critical tick delay detected: ${tickTimeMs}ms. Initiating Chrono-Synaptic time dilation.`,
-                    overloadFactor: tickTimeMs / this.tickThresholdMs
-                },
-                'WARNING',
-                'CHRONO_SYNAPTIC_MONITOR'
-            );
-        }
+        emitBackendWatchdogEvent(
+            'SYNAPTIC_OVERLOAD',
+            {
+                message: 'Tick duration threshold crossed.',
+                tickTimeMs,
+                thresholdMs: this.tickThresholdMs,
+                overloadFactor: tickTimeMs / this.tickThresholdMs,
+            },
+            'MEDIUM',
+            'CHRONO_SYNAPTIC_MONITOR',
+            tick,
+        );
     }
 }

--- a/backend/src/core/watchdog-chrono.ts
+++ b/backend/src/core/watchdog-chrono.ts
@@ -1,20 +1,18 @@
-import { WatchdogEmitter } from './watchdog-emitter.js';
+import { emitBackendWatchdogEvent, getBackendWatchdogTick } from './watchdog-runtime';
 
 export class WatchdogChronoMonitor {
-    private emitter: WatchdogEmitter;
+    monitorDilation(dilationFactor: number, tick = getBackendWatchdogTick()): void {
+        if (dilationFactor >= 0.2) return;
 
-    constructor(emitterUrl: string = 'ws://localhost:9090') {
-        this.emitter = new WatchdogEmitter(emitterUrl);
-    }
-
-    monitorDilation(dilationFactor: number): void {
-        if (dilationFactor < 0.2) {
-            this.emitter.emit(
-                'TEMPORAL_ANOMALY',
-                { message: `Extreme time dilation detected (factor: ${dilationFactor}). Physics desync risk.` },
-                'HIGH',
-                'CHRONO_MONITOR'
-            );
-        }
+        emitBackendWatchdogEvent(
+            'TEMPORAL_ANOMALY',
+            {
+                message: 'Temporal drift threshold crossed.',
+                dilationFactor,
+            },
+            'HIGH',
+            'CHRONO_MONITOR',
+            tick,
+        );
     }
 }

--- a/backend/src/core/watchdog-fissure.ts
+++ b/backend/src/core/watchdog-fissure.ts
@@ -1,32 +1,31 @@
-import { WatchdogEmitter } from './watchdog-emitter.js';
-import { RealityFissureBrain, FissureData } from '../../server/src/modules/brain/RealityFissureBrain.js';
+import { RealityFissureBrain } from '../../server/src/modules/brain/RealityFissureBrain.js';
+import { emitBackendWatchdogEvent, getBackendWatchdogTick } from './watchdog-runtime';
 
 export class WatchdogFissureMonitor {
-    private emitter: WatchdogEmitter;
     private brain: RealityFissureBrain;
 
-    constructor(emitterUrl: string = 'ws://localhost:9090') {
-        this.emitter = new WatchdogEmitter(emitterUrl);
+    constructor() {
         this.brain = new RealityFissureBrain();
     }
 
-    public reportParadoxToBrain(chunkId: string, paradoxType: string) {
+    public reportParadoxToBrain(chunkId: string, paradoxType: string, tick = getBackendWatchdogTick()): void {
         this.brain.reportParadox(chunkId, paradoxType);
-        this.evaluateFissures();
+        this.evaluateFissures(tick);
     }
 
-    private evaluateFissures(): void {
+    private evaluateFissures(tick: number): void {
         const criticalFissures = this.brain.getCriticalFissures();
 
         for (const fissure of criticalFissures) {
-            this.emitter.emit(
+            emitBackendWatchdogEvent(
                 'REALITY_FISSURE_ISOLATION',
                 {
-                    message: `Critical Reality Fissure detected in chunk ${fissure.chunkId}. Isolating and freezing physics.`,
-                    fissure
+                    message: 'Critical reality fissure detected.',
+                    fissure,
                 },
                 'CRITICAL',
-                'FISSURE_WATCHDOG'
+                'FISSURE_WATCHDOG',
+                tick,
             );
         }
     }

--- a/backend/src/core/watchdog-integrity-bridge.ts
+++ b/backend/src/core/watchdog-integrity-bridge.ts
@@ -1,0 +1,39 @@
+import { integrityChecker, type AuditEntry } from './integrity-checker';
+import { emitBackendWatchdogEvent, publishBackendLedgerEvent, advanceBackendWatchdogTick, getBackendWatchdogStatus } from './watchdog-runtime';
+
+export interface IntegrityBridgeResult {
+  ok: boolean;
+  audit: AuditEntry[];
+  watchdog: ReturnType<typeof getBackendWatchdogStatus>;
+}
+
+export class WatchdogIntegrityBridge {
+  public async checkDatabase(dbClient: any): Promise<IntegrityBridgeResult> {
+    const tick = advanceBackendWatchdogTick();
+    const audit = await integrityChecker.checkDatabaseHealth(dbClient);
+    const failed = audit.filter((entry) => entry.isCritical || entry.status !== 'SUCCESS');
+
+    publishBackendLedgerEvent('watchdog.integrity.bridge.result', {
+      tick,
+      auditCount: audit.length,
+      failedCount: failed.length,
+      failed: failed.map((entry) => ({ model: entry.model, status: entry.status, category: entry.category })),
+    }, 'watchdog-integrity-bridge', tick);
+
+    if (failed.length > 0) {
+      emitBackendWatchdogEvent('WATCHDOG_INTEGRITY_ATTENTION', {
+        tick,
+        failedCount: failed.length,
+        failed: failed.map((entry) => ({ model: entry.model, status: entry.status, category: entry.category })),
+      }, 'HIGH', 'WATCHDOG_INTEGRITY_BRIDGE', tick);
+    }
+
+    return {
+      ok: failed.length === 0,
+      audit,
+      watchdog: getBackendWatchdogStatus(),
+    };
+  }
+}
+
+export const watchdogIntegrityBridge = new WatchdogIntegrityBridge();

--- a/backend/src/core/watchdog-learning.ts
+++ b/backend/src/core/watchdog-learning.ts
@@ -1,3 +1,5 @@
+import { createBackendAuditStamp, getBackendWatchdogTick, publishBackendLedgerEvent } from './watchdog-runtime';
+
 export interface ViolationPattern {
     pattern: string;
     frequency: number;
@@ -9,14 +11,17 @@ export class WatchdogLearning {
     private patterns: Map<string, ViolationPattern> = new Map();
 
     /**
-     * Speichert eine Verletzung und analysiert sie auf wiederkehrende Muster.
+     * Speichert eine Verletzung deterministisch und analysiert sie auf wiederkehrende Muster.
      */
     public record(violation: any): void {
-        this.violations.push({
+        const enriched = {
             ...violation,
-            timestamp: Date.now()
-        });
+            tick: getBackendWatchdogTick(),
+            auditStamp: createBackendAuditStamp(),
+        };
 
+        this.violations.push(enriched);
+        publishBackendLedgerEvent('watchdog.learning.recorded', enriched, 'watchdog-learning');
         this.analyze(violation);
     }
 
@@ -36,6 +41,7 @@ export class WatchdogLearning {
             const existing = this.patterns.get(patternKey) || { pattern: patternKey, frequency: 0, suggestion };
             existing.frequency++;
             this.patterns.set(patternKey, existing);
+            publishBackendLedgerEvent('watchdog.learning.pattern', { pattern: patternKey, frequency: existing.frequency, suggestion }, 'watchdog-learning');
         }
     }
 

--- a/backend/src/core/watchdog-orchestrator.ts
+++ b/backend/src/core/watchdog-orchestrator.ts
@@ -1,0 +1,68 @@
+import { WatchdogCascadeMonitor } from './watchdog-cascade';
+import { WatchdogChronoMonitor } from './watchdog-chrono';
+import { WatchdogChronoSynapticMonitor } from './watchdog-chrono-synaptic';
+import { WatchdogFissureMonitor } from './watchdog-fissure';
+import { WatchdogPrecognitionMonitor } from './watchdog-precognition';
+import { WatchdogSwarmMonitor } from './watchdog-swarm';
+import { watchdogIntegrityBridge } from './watchdog-integrity-bridge';
+import {
+  advanceBackendWatchdogTick,
+  emitBackendWatchdogEvent,
+  getBackendWatchdogStatus,
+  setBackendWatchdogTick,
+} from './watchdog-runtime';
+
+export interface WatchdogFrameInput {
+  tick?: number;
+  cascadeActive?: boolean;
+  dilationFactor?: number;
+  tickTimeMs?: number;
+  activeConnections?: number;
+  npcCount?: number;
+  entities?: { id: string; x: number; y: number; z: number }[];
+  fissures?: { chunkId: string; paradoxType: string }[];
+}
+
+export class WatchdogOrchestrator {
+  public readonly cascade = new WatchdogCascadeMonitor();
+  public readonly chrono = new WatchdogChronoMonitor();
+  public readonly chronoSynaptic = new WatchdogChronoSynapticMonitor();
+  public readonly fissure = new WatchdogFissureMonitor();
+  public readonly precognition = new WatchdogPrecognitionMonitor();
+  public readonly swarm = new WatchdogSwarmMonitor();
+  public readonly integrity = watchdogIntegrityBridge;
+
+  public runFrame(input: WatchdogFrameInput = {}) {
+    const tick = input.tick === undefined ? advanceBackendWatchdogTick() : setBackendWatchdogTick(input.tick);
+
+    if (input.cascadeActive !== undefined) this.cascade.monitorCascade(input.cascadeActive, tick);
+    if (input.dilationFactor !== undefined) this.chrono.monitorDilation(input.dilationFactor, tick);
+    if (input.tickTimeMs !== undefined) this.chronoSynaptic.monitorTickTime(input.tickTimeMs, tick);
+    if (input.activeConnections !== undefined || input.npcCount !== undefined) {
+      this.precognition.feedData(input.activeConnections ?? 0, input.npcCount ?? 0, tick);
+    }
+    if (input.entities) this.swarm.evaluateEntities(input.entities, tick);
+    if (input.fissures) {
+      for (const fissure of input.fissures) {
+        this.fissure.reportParadoxToBrain(fissure.chunkId, fissure.paradoxType, tick);
+      }
+    }
+
+    emitBackendWatchdogEvent('WATCHDOG_FRAME_EVALUATED', {
+      tick,
+      checks: {
+        cascade: input.cascadeActive !== undefined,
+        chrono: input.dilationFactor !== undefined,
+        chronoSynaptic: input.tickTimeMs !== undefined,
+        precognition: input.activeConnections !== undefined || input.npcCount !== undefined,
+        swarm: Boolean(input.entities),
+        fissure: Boolean(input.fissures),
+      },
+      status: getBackendWatchdogStatus(),
+    }, 'LOW', 'WATCHDOG_ORCHESTRATOR', tick);
+
+    return getBackendWatchdogStatus();
+  }
+}
+
+export const watchdogOrchestrator = new WatchdogOrchestrator();

--- a/backend/src/core/watchdog-precognition.ts
+++ b/backend/src/core/watchdog-precognition.ts
@@ -1,44 +1,44 @@
-import { WatchdogEmitter } from './watchdog-emitter.js';
 import { MatrixPrecognitionBrain, PrecognitionData } from '../../server/src/modules/brain/MatrixPrecognitionBrain.js';
+import { emitBackendWatchdogEvent, getBackendWatchdogTick } from './watchdog-runtime';
 
 export class WatchdogPrecognitionMonitor {
-    private emitter: WatchdogEmitter;
     private brain: MatrixPrecognitionBrain;
 
-    constructor(emitterUrl: string = 'ws://localhost:9090') {
-        this.emitter = new WatchdogEmitter(emitterUrl);
+    constructor() {
         this.brain = new MatrixPrecognitionBrain();
     }
 
-    public feedData(activeConnections: number, npcCount: number) {
+    public feedData(activeConnections: number, npcCount: number, tick = getBackendWatchdogTick()): void {
         this.brain.recordState(activeConnections, npcCount);
-        this.evaluate();
+        this.evaluate(tick);
     }
 
-    private evaluate(): void {
+    private evaluate(tick: number): void {
         const data: PrecognitionData = this.brain.analyzeMatrixFlux();
 
         if (data.projectedLoad > 0.8) {
-             this.emitter.emit(
+             emitBackendWatchdogEvent(
                 'MATRIX_OVERLOAD_PREDICTION',
                 {
-                    message: `High Matrix Load Projected. Scaling shards proactive alert.`,
-                    data
+                    message: 'High matrix load projected.',
+                    data,
                 },
                 'HIGH',
-                'PRECOGNITION_WATCHDOG'
+                'PRECOGNITION_WATCHDOG',
+                tick,
             );
         }
 
         if (data.densitySpikeRisk > 0.7) {
-            this.emitter.emit(
+            emitBackendWatchdogEvent(
                 'DENSITY_SPIKE_WARNING',
                 {
-                    message: `Rapid density increase detected. Swarm threshold approaching.`,
-                    data
+                    message: 'Density spike risk threshold crossed.',
+                    data,
                 },
                 'MEDIUM',
-                'PRECOGNITION_WATCHDOG'
+                'PRECOGNITION_WATCHDOG',
+                tick,
             );
         }
     }

--- a/backend/src/core/watchdog-runtime.ts
+++ b/backend/src/core/watchdog-runtime.ts
@@ -1,0 +1,86 @@
+import { AxiomaticEventBus } from './axiomatic-event-bus';
+import { WatchdogEmitter, type WatchdogSeverity } from './watchdog-emitter';
+import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS, normalizePositiveInteger } from './watchdog-determinism';
+
+let currentTick = 0;
+let localSequence = 0;
+
+const sinkUrl = process.env.WATCHDOG_EMITTER_URL || 'ws://localhost:8080';
+
+export const backendWatchdogBus = AxiomaticEventBus.getInstance();
+export const backendWatchdogEmitter = new WatchdogEmitter(sinkUrl, {
+  initialTick: currentTick,
+  role: 'backend-core',
+  localOnly: process.env.WATCHDOG_LOCAL_ONLY === '1',
+});
+
+export function setBackendWatchdogTick(tick: number): number {
+  currentTick = normalizePositiveInteger(tick, currentTick);
+  localSequence = 0;
+  backendWatchdogBus.beginTick(currentTick);
+  backendWatchdogEmitter.setWorldTick(currentTick);
+  return currentTick;
+}
+
+export function advanceBackendWatchdogTick(): number {
+  return setBackendWatchdogTick(currentTick + 1);
+}
+
+export function getBackendWatchdogTick(): number {
+  return currentTick;
+}
+
+export function getBackendWatchdogTimestamp(): number {
+  return currentTick * WATCHDOG_TICK_MS;
+}
+
+export function nextBackendWatchdogSequence(): number {
+  localSequence += 1;
+  return localSequence;
+}
+
+export function createBackendAuditStamp(): string {
+  return `tick:${currentTick};seq:${nextBackendWatchdogSequence()};ms:${getBackendWatchdogTimestamp()}`;
+}
+
+export function emitBackendWatchdogEvent(
+  type: string,
+  payload: Record<string, unknown> = {},
+  severity: WatchdogSeverity = 'LOW',
+  source = 'BACKEND_WATCHDOG',
+  tick = currentTick,
+) {
+  setBackendWatchdogTick(tick);
+  return backendWatchdogEmitter.emit(type, payload, severity, source, currentTick);
+}
+
+export function publishBackendLedgerEvent(
+  type: string,
+  payload: Record<string, unknown> = {},
+  source = 'backend-watchdog',
+  tick = currentTick,
+) {
+  setBackendWatchdogTick(tick);
+  return backendWatchdogBus.publish(type, payload, {
+    tick: currentTick,
+    source,
+    metadata: {
+      tickHz: WATCHDOG_TICK_HZ,
+      tickMs: WATCHDOG_TICK_MS,
+      backendRuntime: true,
+    },
+    violationPolicy: 'reject',
+    silent: true,
+  });
+}
+
+export function getBackendWatchdogStatus() {
+  return {
+    tick: currentTick,
+    seq: localSequence,
+    timestamp: getBackendWatchdogTimestamp(),
+    tickHz: WATCHDOG_TICK_HZ,
+    tickMs: WATCHDOG_TICK_MS,
+    ledger: backendWatchdogBus.getLedgerStats(),
+  };
+}

--- a/backend/src/core/watchdog-swarm.ts
+++ b/backend/src/core/watchdog-swarm.ts
@@ -1,38 +1,38 @@
-import { WatchdogEmitter } from './watchdog-emitter.js';
-import { ChronoSwarmBrain, SwarmData } from '../../server/src/modules/brain/ChronoSwarmBrain.js';
+import { ChronoSwarmBrain } from '../../server/src/modules/brain/ChronoSwarmBrain.js';
+import { emitBackendWatchdogEvent, getBackendWatchdogTick } from './watchdog-runtime';
 
 export class WatchdogSwarmMonitor {
-    private emitter: WatchdogEmitter;
     private brain: ChronoSwarmBrain;
 
-    constructor(emitterUrl: string = 'ws://localhost:9090') {
-        this.emitter = new WatchdogEmitter(emitterUrl);
+    constructor() {
         this.brain = new ChronoSwarmBrain();
     }
 
-    public evaluateEntities(entities: { id: string; x: number; y: number; z: number }[]) {
+    public evaluateEntities(entities: { id: string; x: number; y: number; z: number }[], tick = getBackendWatchdogTick()): void {
         const swarms = this.brain.analyzeSpatialDistribution(entities);
 
         for (const swarm of swarms) {
             if (swarm.physicsThreatLevel > 0.8) {
-                this.emitter.emit(
+                emitBackendWatchdogEvent(
                     'CHRONO_SWARM_CRITICAL',
                     {
-                        message: `Critical entity swarm detected at ${swarm.center.x}, ${swarm.center.y}, ${swarm.center.z}. Physics desync imminent.`,
-                        swarm
+                        message: 'Critical entity swarm detected.',
+                        swarm,
                     },
                     'CRITICAL',
-                    'SWARM_WATCHDOG'
+                    'SWARM_WATCHDOG',
+                    tick,
                 );
             } else if (swarm.physicsThreatLevel > 0.5) {
-                this.emitter.emit(
+                emitBackendWatchdogEvent(
                     'CHRONO_SWARM_WARNING',
                     {
-                        message: `High density swarm forming. Engaging crowd control heuristics.`,
-                        swarm
+                        message: 'High density swarm forming.',
+                        swarm,
                     },
                     'MEDIUM',
-                    'SWARM_WATCHDOG'
+                    'SWARM_WATCHDOG',
+                    tick,
                 );
             }
         }


### PR DESCRIPTION
## Was wurde gemacht

Die sinnvollen Watchdog-Dateien aus `backend/src/core/**` wurden auf einen gemeinsamen deterministischen Flow gelegt.

### Neuer Runtime-Hub

- `backend/src/core/watchdog-runtime.ts`
  - gemeinsamer `AxiomaticEventBus`
  - gemeinsamer `WatchdogEmitter`
  - deterministischer Tick-Kontext
  - `tick * 100ms` Timestamp-Regel
  - Runtime-Status für Ledger/Seq/Tick

### Neue Integrationsschicht

- `backend/src/core/watchdog-integrity-bridge.ts`
  - spiegelt Legacy-`integrityChecker` Ergebnisse in den deterministischen Watchdog-Ledger
  - erzeugt `WATCHDOG_INTEGRITY_ATTENTION` bei kritischen Audit-Einträgen

- `backend/src/core/watchdog-orchestrator.ts`
  - zentraler Sensor-Orchestrator für sinnvolle Watchdog-Module
  - verbindet Cascade, Chrono, Chrono-Synaptic, Fissure, Precognition, Swarm und Integrity
  - erzeugt pro Frame `WATCHDOG_FRAME_EVALUATED`

### Umverdrahtete Sensoren

Diese Dateien erzeugen jetzt Events über den Runtime-Hub statt jeweils eigene lose Emitter-Instanzen zu bauen:

- `watchdog-cascade.ts`
- `watchdog-chrono.ts`
- `watchdog-chrono-synaptic.ts`
- `watchdog-fissure.ts`
- `watchdog-precognition.ts`
- `watchdog-swarm.ts`
- `watchdog-learning.ts`

### Warum `integrity-checker.ts` nicht komplett ersetzt wurde

Die Datei ist groß und legacy-kritisch. Ein Vollersatz wurde vom Connector blockiert und wäre riskanter gewesen. Stattdessen wurde eine deterministic Bridge ergänzt, damit bestehende Logik weiterläuft und trotzdem in den neuen Watchdog-Ledger gespiegelt wird.

## Hinweis

Der aktive Docker-Server nutzt primär `server/src/core/**`; `backend/src/core/**` bleibt ein separater Watchdog-/Tooling-Cluster. Diese Änderung verbindet den Backend-Cluster intern sauber und deterministisch, deployt ihn aber nicht automatisch als Server-Runtime-Service.