### PR TITLE
feat(server): add live watchdog sensors to WorldTick runtime

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -81,9 +81,12 @@ RUN test -f server/dist/core/watchdog-determinism.js && \
     test -f server/dist/core/watchdog-emitter.js && \
     test -f server/dist/core/installDeterministicWatchdog.js && \
     test -f server/dist/core/installWorldTickWatchdogBridge.js && \
+    test -f server/dist/core/watchdog-live-sensors.js && \
     grep -q 'installDeterministicWatchdogRuntime' server/dist/index.js && \
     grep -q 'installWorldTickWatchdogBridge' server/dist/core/installDeterministicWatchdog.js && \
     grep -q 'world.tick.heartbeat' server/dist/core/installWorldTickWatchdogBridge.js && \
+    grep -q 'liveWatchdogSensors' server/dist/core/installWorldTickWatchdogBridge.js && \
+    grep -q 'world.sensor.frame' server/dist/core/watchdog-live-sensors.js && \
     grep -q 'WATCHDOG_TICK_HZ' server/dist/core/watchdog-determinism.js
 
 RUN node scripts/sync-world-assets.mjs || true
@@ -156,8 +159,10 @@ RUN test -f /app/server/dist/core/watchdog-determinism.js && \
     test -f /app/server/dist/core/watchdog-emitter.js && \
     test -f /app/server/dist/core/installDeterministicWatchdog.js && \
     test -f /app/server/dist/core/installWorldTickWatchdogBridge.js && \
+    test -f /app/server/dist/core/watchdog-live-sensors.js && \
     grep -q 'installDeterministicWatchdogRuntime' /app/server/dist/index.js && \
-    grep -q 'world.tick.heartbeat' /app/server/dist/core/installWorldTickWatchdogBridge.js
+    grep -q 'world.tick.heartbeat' /app/server/dist/core/installWorldTickWatchdogBridge.js && \
+    grep -q 'world.sensor.frame' /app/server/dist/core/watchdog-live-sensors.js
 
 RUN test -f /app/client/dist/2d/index.html && \
     test -f /app/server/client/dist/2d/index.html && \

--- a/server/src/core/installWorldTickWatchdogBridge.ts
+++ b/server/src/core/installWorldTickWatchdogBridge.ts
@@ -2,6 +2,7 @@ import { WorldTick } from './WorldTick.js';
 import { eventBus } from './axiomatic-event-bus';
 import { serverWatchdogEmitter } from './watchdog-emitter';
 import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS } from './watchdog-determinism';
+import { liveWatchdogSensors } from './watchdog-live-sensors.js';
 
 let installed = false;
 
@@ -38,9 +39,7 @@ export function installWorldTickWatchdogBridge(): void {
     try {
       const result = originalTick.apply(this, args);
       const committedTick = Number(this.tickCount ?? nextTick);
-
-      eventBus.beginTick(committedTick);
-      eventBus.publish('world.tick.end', {
+      const frame = {
         tick: committedTick,
         phase: 'end',
         players: safeCount(() => this.playerSystem?.getAllPlayers?.()),
@@ -48,6 +47,16 @@ export function installWorldTickWatchdogBridge(): void {
         loot: safeSize(this.lootEntities),
         guardOk: Boolean(this.lastAREGuardStatus?.ok ?? true),
         worldHash: this.lastWorldHashSnapshot?.worldHash ?? null,
+      };
+      const sensorResult = liveWatchdogSensors.evaluate(frame);
+
+      eventBus.beginTick(committedTick);
+      eventBus.publish('world.tick.end', {
+        ...frame,
+        sensors: {
+          alerts: sensorResult.alerts,
+          state: sensorResult.state,
+        },
       }, {
         tick: committedTick,
         source: 'worldtick',
@@ -58,9 +67,12 @@ export function installWorldTickWatchdogBridge(): void {
       if (committedTick % 10 === 0) {
         serverWatchdogEmitter.emit('world.tick.heartbeat', {
           tick: committedTick,
-          players: safeCount(() => this.playerSystem?.getAllPlayers?.()),
-          npcs: safeCount(() => this.npcSystem?.getAllNPCs?.()),
-          loot: safeSize(this.lootEntities),
+          players: frame.players,
+          npcs: frame.npcs,
+          loot: frame.loot,
+          guardOk: frame.guardOk,
+          worldHash: frame.worldHash,
+          sensors: sensorResult,
           ledger: eventBus.getLedgerStats(),
         }, 'LOW', 'worldtick', committedTick);
       }
@@ -93,6 +105,7 @@ export function installWorldTickWatchdogBridge(): void {
       worldTick: Number(this.tickCount ?? 0),
       worldHash: this.lastWorldHashSnapshot?.worldHash ?? null,
       guard: this.lastAREGuardStatus ?? null,
+      sensors: liveWatchdogSensors.getState(),
     };
   };
 

--- a/server/src/core/watchdog-live-sensors.ts
+++ b/server/src/core/watchdog-live-sensors.ts
@@ -1,0 +1,139 @@
+import { eventBus } from './axiomatic-event-bus';
+import { serverWatchdogEmitter } from './watchdog-emitter';
+import { WATCHDOG_TICK_MS, normalizePositiveInteger } from './watchdog-determinism';
+
+export interface LiveWatchdogFrame {
+  tick: number;
+  players: number;
+  npcs: number;
+  loot: number;
+  guardOk: boolean;
+  worldHash: string | null;
+}
+
+export interface LiveWatchdogSensorState {
+  lastTick: number;
+  lastPlayers: number;
+  lastNpcs: number;
+  lastLoot: number;
+  lastWorldHash: string | null;
+  stableHashStreak: number;
+}
+
+export interface LiveWatchdogSensorResult {
+  tick: number;
+  alerts: string[];
+  state: LiveWatchdogSensorState;
+}
+
+const DEFAULT_STATE: LiveWatchdogSensorState = {
+  lastTick: 0,
+  lastPlayers: 0,
+  lastNpcs: 0,
+  lastLoot: 0,
+  lastWorldHash: null,
+  stableHashStreak: 0,
+};
+
+export class LiveWatchdogSensors {
+  private state: LiveWatchdogSensorState = { ...DEFAULT_STATE };
+
+  public evaluate(frame: LiveWatchdogFrame): LiveWatchdogSensorResult {
+    const tick = normalizePositiveInteger(frame.tick, this.state.lastTick);
+    const alerts: string[] = [];
+
+    if (tick < this.state.lastTick) {
+      alerts.push('tick_regression');
+      serverWatchdogEmitter.emit('world.sensor.tick_regression', {
+        tick,
+        previousTick: this.state.lastTick,
+      }, 'CRITICAL', 'live-watchdog-sensors', tick);
+    }
+
+    const npcDelta = frame.npcs - this.state.lastNpcs;
+    const playerDelta = frame.players - this.state.lastPlayers;
+    const lootDelta = frame.loot - this.state.lastLoot;
+
+    if (Math.abs(npcDelta) > 250) {
+      alerts.push('npc_density_jump');
+      serverWatchdogEmitter.emit('world.sensor.npc_density_jump', {
+        tick,
+        npcs: frame.npcs,
+        previousNpcs: this.state.lastNpcs,
+        delta: npcDelta,
+      }, 'HIGH', 'live-watchdog-sensors', tick);
+    }
+
+    if (Math.abs(playerDelta) > 100) {
+      alerts.push('player_population_jump');
+      serverWatchdogEmitter.emit('world.sensor.player_population_jump', {
+        tick,
+        players: frame.players,
+        previousPlayers: this.state.lastPlayers,
+        delta: playerDelta,
+      }, 'MEDIUM', 'live-watchdog-sensors', tick);
+    }
+
+    if (lootDelta > 500) {
+      alerts.push('loot_growth_spike');
+      serverWatchdogEmitter.emit('world.sensor.loot_growth_spike', {
+        tick,
+        loot: frame.loot,
+        previousLoot: this.state.lastLoot,
+        delta: lootDelta,
+      }, 'MEDIUM', 'live-watchdog-sensors', tick);
+    }
+
+    if (!frame.guardOk) {
+      alerts.push('guard_violation_seen');
+      serverWatchdogEmitter.emit('world.sensor.guard_violation_seen', {
+        tick,
+        worldHash: frame.worldHash,
+      }, 'HIGH', 'live-watchdog-sensors', tick);
+    }
+
+    const sameHash = frame.worldHash !== null && frame.worldHash === this.state.lastWorldHash;
+    const stableHashStreak = sameHash ? this.state.stableHashStreak + 1 : 0;
+
+    if (frame.players > 0 && frame.npcs > 0 && stableHashStreak >= 600) {
+      alerts.push('world_hash_stall');
+      serverWatchdogEmitter.emit('world.sensor.world_hash_stall', {
+        tick,
+        worldHash: frame.worldHash,
+        stableHashStreak,
+        simulationMs: stableHashStreak * WATCHDOG_TICK_MS,
+      }, 'MEDIUM', 'live-watchdog-sensors', tick);
+    }
+
+    eventBus.publish('world.sensor.frame', {
+      ...frame,
+      alerts,
+      npcDelta,
+      playerDelta,
+      lootDelta,
+      stableHashStreak,
+    }, {
+      tick,
+      source: 'live-watchdog-sensors',
+      metadata: { subsystem: 'LiveWatchdogSensors' },
+      silent: true,
+    });
+
+    this.state = {
+      lastTick: tick,
+      lastPlayers: frame.players,
+      lastNpcs: frame.npcs,
+      lastLoot: frame.loot,
+      lastWorldHash: frame.worldHash,
+      stableHashStreak,
+    };
+
+    return { tick, alerts, state: { ...this.state } };
+  }
+
+  public getState(): LiveWatchdogSensorState {
+    return { ...this.state };
+  }
+}
+
+export const liveWatchdogSensors = new LiveWatchdogSensors();


### PR DESCRIPTION
## Summary

Adds live deterministic watchdog sensors to the real server runtime path under `server/src/core`.

## Changes

- Adds `server/src/core/watchdog-live-sensors.ts`
- Updates `server/src/core/installWorldTickWatchdogBridge.ts`
- Updates `Dockerfile.vps` runtime assertions

## Runtime behavior

After each `WorldTick.tick()` call, the bridge now evaluates a deterministic sensor frame containing:

- tick
- player count
- npc count
- loot count
- ARE guard status
- world hash

The sensor frame is published as `world.sensor.frame`. The existing heartbeat also includes sensor state.

## Docker check

The VPS Docker build now checks that `watchdog-live-sensors.js` exists in `server/dist/core` and in the final runner image.