### PR TITLE
feat(watchdog): deterministic AST interface sync for 10Hz world tick

### DIFF
--- a/backend/src/core/ast-interface-sync.ts
+++ b/backend/src/core/ast-interface-sync.ts
@@ -1,89 +1,319 @@
-import { Project, SyntaxKind, InterfaceDeclaration } from 'ts-morph';
+import { Project, QuoteKind, SourceFile, InterfaceDeclaration } from 'ts-morph';
+import * as fs from 'fs';
 import * as path from 'path';
 
+export interface DbSchemaProperty {
+    name: string;
+    type: string;
+    nullable?: boolean;
+    comment?: string;
+}
+
+export interface DbSchema {
+    tableName: string;
+    interfaceName?: string;
+    properties: DbSchemaProperty[];
+}
+
+export interface AstInterfaceSyncOptions {
+    strict?: boolean;
+    safeJson?: boolean;
+    useBigInt?: boolean;
+    format?: boolean;
+    tickHz?: number;
+    maxSyncBudgetMs?: number;
+    failOnBudgetOverrun?: boolean;
+    preserveSchemaOrder?: boolean;
+}
+
+export interface AstInterfaceSyncResult {
+    interfaceName: string;
+    tableName: string;
+    interfacePath: string;
+    added: string[];
+    updated: string[];
+    removed: string[];
+    unchanged: string[];
+    durationMs: number;
+    tickHz: number;
+    tickBudgetMs: number;
+    maxSyncBudgetMs: number;
+    budgetOverrun: boolean;
+    deterministicHash: string;
+}
+
+type RequiredOptions = Required<AstInterfaceSyncOptions>;
+
+/**
+ * Deterministic DB-schema -> TypeScript interface synchronizer.
+ * Built for the WASD watchdog and the 10Hz world-server rule:
+ * schema sync must never silently consume a full simulation tick.
+ */
 export class AstInterfaceSync {
     private project: Project;
+    private options: RequiredOptions;
 
-    constructor() {
+    constructor(options: AstInterfaceSyncOptions = {}) {
+        this.options = this.normalizeOptions(options);
         this.project = new Project({
+            skipAddingFilesFromTsConfig: true,
+            manipulationSettings: {
+                quoteKind: QuoteKind.Single,
+                useTrailingCommas: true,
+            },
             compilerOptions: {
-                allowJs: true,
+                allowJs: false,
                 declaration: true,
-            }
+                strict: true,
+                esModuleInterop: true,
+            },
         });
     }
 
-    /**
-     * Synchronisiert ein TS-Interface mit einem Datenbankschema.
-     * Nutzt AST (ts-morph) für deterministische Modifikationen.
-     */
-    public syncInterfaceWithSchema(interfacePath: string, schema: { tableName: string, properties: any[] }): void {
-        const sourceFile = this.project.addSourceFileAtPath(interfacePath);
-        // Suche nach dem Interface, das dem Tabellennamen entspricht (Case-Insensitive Match möglich)
-        let interfaceDeclaration = sourceFile.getInterface(schema.tableName);
-        
-        if (!interfaceDeclaration) {
-            // Fallback: Suche nach einem Interface, das ähnlich heißt oder erstelle es
-            interfaceDeclaration = sourceFile.addInterface({
-                name: schema.tableName,
-                isExported: true
+    public syncInterfaceWithSchema(
+        interfacePath: string,
+        schema: DbSchema,
+        options: AstInterfaceSyncOptions = {},
+    ): AstInterfaceSyncResult {
+        const startedAt = Date.now();
+        const effective = this.normalizeOptions({ ...this.options, ...options });
+        this.validateSchema(schema);
+
+        const absolutePath = path.resolve(interfacePath);
+        const sourceFile = this.getOrCreateSourceFile(absolutePath);
+        const interfaceName = this.toSafeInterfaceName(schema.interfaceName || schema.tableName);
+
+        let declaration = this.findInterfaceCaseInsensitive(sourceFile, interfaceName);
+        if (!declaration) {
+            declaration = sourceFile.addInterface({
+                name: interfaceName,
+                isExported: true,
             });
+            declaration.replaceWithText(writer => {
+                writer.writeLine('/**');
+                writer.writeLine(` * Generated from database table "${schema.tableName}".`);
+                writer.writeLine(' * Deterministic schema contract for server/client boundaries.');
+                writer.writeLine(' */');
+                writer.writeLine(`export interface ${interfaceName} {`);
+                writer.writeLine('}');
+            });
+            declaration = sourceFile.getInterfaceOrThrow(interfaceName);
         }
 
-        const existingProperties = interfaceDeclaration.getProperties();
-        const schemaPropNames = schema.properties.map(p => p.name);
+        const result = this.applySchema(declaration, absolutePath, schema, interfaceName, effective, startedAt);
 
-        // 1. Bestehende Properties aktualisieren oder neue hinzufügen
-        schema.properties.forEach((prop: any) => {
-            const property = interfaceDeclaration!.getProperty(prop.name);
-            const tsType = this.mapDbTypeToTs(prop.type);
-
-            if (property) {
-                property.setType(tsType);
-                property.setHasQuestionToken(prop.nullable);
-            } else {
-                interfaceDeclaration!.addProperty({
-                    name: prop.name,
-                    type: tsType,
-                    hasQuestionToken: prop.nullable,
-                });
-            }
-        });
-
-        // 2. Properties entfernen, die nicht mehr im Schema sind (Strict Sync)
-        existingProperties.forEach(prop => {
-            if (!schemaPropNames.includes(prop.getName())) {
-                prop.remove();
-            }
-        });
+        if (effective.format) {
+            sourceFile.formatText({ indentSize: 4 });
+        }
 
         sourceFile.saveSync();
-        console.log(`[AST Sync] Interface ${schema.tableName} in ${interfacePath} synchronisiert.`);
+        this.assertBudget(result, effective);
+
+        console.log(`[AST Sync] ${interfaceName} <= ${schema.tableName} | ${result.durationMs}ms | hash=${result.deterministicHash}`);
+        return result;
     }
 
-    private mapDbTypeToTs(dbType: string): string {
-        const mapping: Record<string, string> = {
-            'varchar': 'string',
-            'text': 'string',
-            'char': 'string',
-            'int': 'number',
-            'integer': 'number',
-            'bigint': 'number',
-            'smallint': 'number',
-            'decimal': 'number',
-            'numeric': 'number',
-            'real': 'number',
-            'double precision': 'number',
-            'boolean': 'boolean',
-            'bool': 'boolean',
-            'timestamp': 'Date',
-            'timestamptz': 'Date',
-            'date': 'Date',
-            'json': 'any',
-            'jsonb': 'any',
-            'uuid': 'string'
+    public syncBatchWithinTickBudget(
+        interfacesPath: string,
+        schemas: Iterable<[string, DbSchema]>,
+        options: AstInterfaceSyncOptions = {},
+    ): AstInterfaceSyncResult[] {
+        const effective = this.normalizeOptions({ ...this.options, ...options });
+        const startedAt = Date.now();
+        const results: AstInterfaceSyncResult[] = [];
+
+        for (const [modelName, schema] of schemas) {
+            if (Date.now() - startedAt >= effective.maxSyncBudgetMs) {
+                console.warn(`[AST Sync] Tick budget reached before ${modelName}; deferred to next watchdog pass.`);
+                break;
+            }
+
+            const interfacePath = path.join(interfacesPath, `${modelName}.ts`);
+            if (fs.existsSync(interfacePath)) {
+                results.push(this.syncInterfaceWithSchema(interfacePath, schema, effective));
+            }
+        }
+
+        return results;
+    }
+
+    private applySchema(
+        declaration: InterfaceDeclaration,
+        interfacePath: string,
+        schema: DbSchema,
+        interfaceName: string,
+        options: RequiredOptions,
+        startedAt: number,
+    ): AstInterfaceSyncResult {
+        const added: string[] = [];
+        const updated: string[] = [];
+        const removed: string[] = [];
+        const unchanged: string[] = [];
+        const schemaNames = new Set(schema.properties.map(p => p.name));
+
+        for (const prop of schema.properties) {
+            const property = declaration.getProperty(prop.name);
+            const tsType = this.mapDbTypeToTs(prop.type, options);
+            const optional = Boolean(prop.nullable);
+
+            if (property) {
+                const before = `${property.getName()}${property.hasQuestionToken() ? '?' : ''}:${property.getTypeNode()?.getText() || 'unknown'}`;
+                property.setType(tsType);
+                property.setHasQuestionToken(optional);
+                const after = `${property.getName()}${property.hasQuestionToken() ? '?' : ''}:${property.getTypeNode()?.getText() || 'unknown'}`;
+                if (before === after) unchanged.push(prop.name);
+                else updated.push(prop.name);
+            } else {
+                declaration.addProperty({
+                    name: prop.name,
+                    type: tsType,
+                    hasQuestionToken: optional,
+                    docs: prop.comment ? [{ description: this.escapeComment(prop.comment) }] : undefined,
+                });
+                added.push(prop.name);
+            }
+        }
+
+        if (options.strict) {
+            for (const property of declaration.getProperties()) {
+                const name = property.getName();
+                if (!schemaNames.has(name)) {
+                    property.remove();
+                    removed.push(name);
+                }
+            }
+        }
+
+        if (options.preserveSchemaOrder) {
+            const structures = schema.properties
+                .map(p => declaration.getProperty(p.name))
+                .filter((p): p is NonNullable<typeof p> => Boolean(p))
+                .map(p => p.getStructure());
+            declaration.getProperties().forEach(p => p.remove());
+            declaration.addProperties(structures);
+        }
+
+        const durationMs = Date.now() - startedAt;
+        const tickBudgetMs = Math.floor(1000 / options.tickHz);
+        const deterministicHash = this.stableHash({
+            interfaceName,
+            tableName: schema.tableName,
+            properties: schema.properties.map(p => ({
+                name: p.name,
+                type: this.mapDbTypeToTs(p.type, options),
+                nullable: Boolean(p.nullable),
+            })),
+        });
+
+        return {
+            interfaceName,
+            tableName: schema.tableName,
+            interfacePath,
+            added,
+            updated,
+            removed,
+            unchanged,
+            durationMs,
+            tickHz: options.tickHz,
+            tickBudgetMs,
+            maxSyncBudgetMs: options.maxSyncBudgetMs,
+            budgetOverrun: durationMs > options.maxSyncBudgetMs,
+            deterministicHash,
         };
-        const normalizedType = dbType.toLowerCase().split('(')[0].trim();
-        return mapping[normalizedType] || 'any';
+    }
+
+    private getOrCreateSourceFile(absolutePath: string): SourceFile {
+        const dir = path.dirname(absolutePath);
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        if (fs.existsSync(absolutePath)) {
+            return this.project.getSourceFile(absolutePath) || this.project.addSourceFileAtPath(absolutePath);
+        }
+        return this.project.createSourceFile(absolutePath, '/* eslint-disable */\n', { overwrite: false });
+    }
+
+    private findInterfaceCaseInsensitive(sourceFile: SourceFile, interfaceName: string): InterfaceDeclaration | undefined {
+        const needle = interfaceName.toLowerCase();
+        return sourceFile.getInterfaces().find(i => i.getName().toLowerCase() === needle);
+    }
+
+    private validateSchema(schema: DbSchema): void {
+        if (!schema || typeof schema.tableName !== 'string' || !Array.isArray(schema.properties)) {
+            throw new Error('[AST Sync] Invalid schema object.');
+        }
+        const seen = new Set<string>();
+        for (const prop of schema.properties) {
+            if (!prop.name || !prop.type) throw new Error(`[AST Sync] Invalid property in ${schema.tableName}.`);
+            if (seen.has(prop.name)) throw new Error(`[AST Sync] Duplicate property ${prop.name} in ${schema.tableName}.`);
+            seen.add(prop.name);
+        }
+    }
+
+    private toSafeInterfaceName(input: string): string {
+        const cleaned = input.replace(/[^a-zA-Z0-9_$]/g, '_').replace(/_+/g, '_').replace(/^_+|_+$/g, '');
+        const pascal = cleaned.split('_').filter(Boolean).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join('');
+        const safeName = pascal || 'GeneratedInterface';
+        return /^[0-9]/.test(safeName) ? `I${safeName}` : safeName;
+    }
+
+    private mapDbTypeToTs(dbType: string, options: RequiredOptions): string {
+        const normalized = dbType.toLowerCase().replace(/\s+/g, ' ').split('(')[0].trim();
+        const isArray = normalized.endsWith('[]');
+        const base = isArray ? normalized.slice(0, -2) : normalized;
+        const jsonType = options.safeJson ? 'unknown' : 'any';
+        const bigIntType = options.useBigInt ? 'bigint' : 'number';
+        const mapping: Record<string, string> = {
+            varchar: 'string', text: 'string', char: 'string', character: 'string', 'character varying': 'string', uuid: 'string', inet: 'string', cidr: 'string', macaddr: 'string',
+            int: 'number', int2: 'number', int4: 'number', integer: 'number', smallint: 'number', serial: 'number', smallserial: 'number',
+            bigint: bigIntType, int8: bigIntType, bigserial: bigIntType,
+            decimal: 'number', numeric: 'number', real: 'number', float: 'number', float4: 'number', float8: 'number', double: 'number', 'double precision': 'number',
+            boolean: 'boolean', bool: 'boolean',
+            timestamp: 'Date', timestamptz: 'Date', 'timestamp without time zone': 'Date', 'timestamp with time zone': 'Date', date: 'Date', time: 'string', timetz: 'string',
+            json: jsonType, jsonb: jsonType, bytea: 'Uint8Array',
+        };
+        const mapped = mapping[base] || 'unknown';
+        return isArray ? `${mapped}[]` : mapped;
+    }
+
+    private normalizeOptions(options: AstInterfaceSyncOptions): RequiredOptions {
+        const tickHz = Math.max(1, Math.floor(options.tickHz ?? 10));
+        const tickBudgetMs = Math.floor(1000 / tickHz);
+        return {
+            strict: options.strict ?? false,
+            safeJson: options.safeJson ?? true,
+            useBigInt: options.useBigInt ?? true,
+            format: options.format ?? true,
+            tickHz,
+            maxSyncBudgetMs: Math.max(1, Math.floor(options.maxSyncBudgetMs ?? tickBudgetMs / 2)),
+            failOnBudgetOverrun: options.failOnBudgetOverrun ?? false,
+            preserveSchemaOrder: options.preserveSchemaOrder ?? true,
+        };
+    }
+
+    private assertBudget(result: AstInterfaceSyncResult, options: RequiredOptions): void {
+        if (!result.budgetOverrun) return;
+        const message = `[AST Sync] Budget overrun: ${result.durationMs}ms > ${result.maxSyncBudgetMs}ms at ${result.tickHz}Hz.`;
+        if (options.failOnBudgetOverrun) throw new Error(message);
+        console.warn(message);
+    }
+
+    private stableHash(value: unknown): string {
+        const input = this.stableStringify(value);
+        let hash = 2166136261;
+        for (let i = 0; i < input.length; i++) {
+            hash ^= input.charCodeAt(i);
+            hash = Math.imul(hash, 16777619) >>> 0;
+        }
+        return hash.toString(16).padStart(8, '0');
+    }
+
+    private stableStringify(value: unknown): string {
+        if (value === null || typeof value !== 'object') return JSON.stringify(value);
+        if (Array.isArray(value)) return `[${value.map(v => this.stableStringify(v)).join(',')}]`;
+        const record = value as Record<string, unknown>;
+        return `{${Object.keys(record).sort().map(k => `${JSON.stringify(k)}:${this.stableStringify(record[k])}`).join(',')}}`;
+    }
+
+    private escapeComment(comment: string): string {
+        return comment.replace(/\*\//g, '* /');
     }
 }

--- a/backend/src/core/integrity-checker.ts
+++ b/backend/src/core/integrity-checker.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { AstInterfaceSync } from './ast-interface-sync';
+import { AstInterfaceSync, AstInterfaceSyncResult } from './ast-interface-sync';
 import { SchemaDiff } from './schema-diff';
 import { ConstraintValidator } from './constraint-validator';
 import { MigrationGenerator } from './migration-generator';
@@ -55,6 +55,8 @@ export interface WatchdogConfig {
     resetTimeoutMs: number;
     healthCheckTimeoutMs: number;
     externalServiceTimeoutMs: number;
+    tickHz: number;
+    astSyncBudgetMs: number;
 }
 
 export interface ModelSchema {
@@ -90,12 +92,11 @@ export interface HealthCheckResult {
 }
 
 export class SovereignWatchdog {
-    private astSync = new AstInterfaceSync();
     private emitter = new WatchdogEmitter(process.env.WATCHDOG_EMITTER_URL || 'ws://localhost:8080');
     private learning = new WatchdogLearning();
     private modelRegistry: Map<string, ModelSchema> = new Map();
     private auditReport: AuditEntry[] = [];
-    
+
     private breakerState: BreakerState = BreakerState.CLOSED;
     private failureCount = 0;
     private lastFailureTime: number = 0;
@@ -107,8 +108,20 @@ export class SovereignWatchdog {
         breakerThreshold: parseInt(process.env.WATCHDOG_BREAKER_THRESHOLD || '3'),
         resetTimeoutMs: 30000,
         healthCheckTimeoutMs: 5000,
-        externalServiceTimeoutMs: 3000
+        externalServiceTimeoutMs: 3000,
+        tickHz: parseInt(process.env.WATCHDOG_TICK_HZ || process.env.WORLD_TICK_HZ || '10'),
+        astSyncBudgetMs: parseInt(process.env.WATCHDOG_AST_SYNC_BUDGET_MS || '50')
     };
+
+    private astSync = new AstInterfaceSync({
+        strict: this.config.strict,
+        tickHz: this.config.tickHz,
+        maxSyncBudgetMs: this.config.astSyncBudgetMs,
+        safeJson: true,
+        useBigInt: true,
+        failOnBudgetOverrun: process.env.WATCHDOG_AST_SYNC_FAIL_ON_OVERRUN === 'true',
+        preserveSchemaOrder: true
+    });
 
     public registerSchema(modelName: string, schema: ModelSchema): void {
         this.modelRegistry.set(modelName, schema);
@@ -144,9 +157,6 @@ export class SovereignWatchdog {
         }
     }
 
-    /**
-     * Diagnostic Helper to ensure consistent error reporting.
-     */
     private createDiagnostic(code: string, error?: any, latency?: number): DiagnosticPayload {
         return {
             code,
@@ -163,14 +173,12 @@ export class SovereignWatchdog {
             case 'DB_TIMEOUT': return 'Increase DB instance performance or check network latency.';
             case 'ECONNREFUSED': return 'Database server is down or port is blocked.';
             case 'SCHEMA_DRIFT': return 'Execute prisma migrate dev or run the generated reconciliation script.';
+            case 'AST_SYNC_BUDGET_OVERRUN': return 'Move interface sync to a maintenance pass or lower WATCHDOG_AST_SYNC_BUDGET_MS pressure.';
             case 'WS_UNREACHABLE': return 'Check if the Watchdog Monitoring Gateway is online.';
             default: return 'Check internal logs for deep-trace analysis.';
         }
     }
 
-    /**
-     * Enhanced Health Check.
-     */
     public async performHealthCheck(dbClient: any): Promise<HealthCheckResult> {
         if (!this.evaluateBreaker()) {
             return { status: HealthStatus.CIRCUIT_OPEN, breaker: this.breakerState, error: 'Circuit Breaker is OPEN' };
@@ -182,10 +190,10 @@ export class SovereignWatchdog {
                 dbClient.query('SELECT 1'),
                 new Promise((_, reject) => setTimeout(() => reject(new Error('DB_TIMEOUT')), this.config.healthCheckTimeoutMs))
             ]);
-            
+
             const latency = Date.now() - start;
             this.recordSuccess();
-            
+
             return {
                 status: latency > 1500 ? HealthStatus.DEGRADED : HealthStatus.HEALTHY,
                 latencyMs: latency,
@@ -201,43 +209,35 @@ export class SovereignWatchdog {
         }
     }
 
-    /**
-     * Explicit validation of external services (e.g., Emitter Gateway).
-     */
     private async checkExternalServices(): Promise<void> {
-        // Logic to ping the emitter gateway or other registered microservices
         try {
             const isEmitterAlive = await this.emitter.ping(this.config.externalServiceTimeoutMs);
             if (!isEmitterAlive) {
-                this.addToAudit('EMITTER', 'ERROR', IntegrityCategory.EXTERNAL_SERVICE_OFFLINE, 
-                    'Watchdog Emitter Gateway is unreachable', 
+                this.addToAudit('EMITTER', 'ERROR', IntegrityCategory.EXTERNAL_SERVICE_OFFLINE,
+                    'Watchdog Emitter Gateway is unreachable',
                     this.createDiagnostic('WS_UNREACHABLE'), false);
             }
         } catch (err) {
-            // Silently log or handle non-critical emitter failures to prevent blocking main integrity flow
             console.error('[Watchdog] External service check failed:', err);
         }
     }
 
-    /**
-     * Resilient Integrity Flow with Structured Diagnostics.
-     */
     public async checkDatabaseHealth(dbClient: any): Promise<AuditEntry[]> {
         this.auditReport = [];
-        
+
         await this.checkExternalServices();
 
         const health = await this.performHealthCheck(dbClient);
-        
+
         if (health.status === HealthStatus.UNHEALTHY || health.status === HealthStatus.CIRCUIT_OPEN) {
             const diag = this.createDiagnostic(health.error || 'HEALTH_CHECK_FAILED', null, health.latencyMs);
             this.handleConnectionError(new Error(health.error || 'Health check failed'), 'PRE_STAGE_HEALTH');
             this.addToAudit(
-                'GLOBAL', 
-                'INFRA_OFFLINE', 
-                IntegrityCategory.HEALTH_CHECK_FAILED, 
-                `Database health check failed: ${health.error}`, 
-                diag, 
+                'GLOBAL',
+                'INFRA_OFFLINE',
+                IntegrityCategory.HEALTH_CHECK_FAILED,
+                `Database health check failed: ${health.error}`,
+                diag,
                 true
             );
             return this.auditReport;
@@ -252,9 +252,9 @@ export class SovereignWatchdog {
                 if (diff.additions.length > 0 || diff.removals.length > 0 || diff.changes.length > 0) {
                     const migrationPath = MigrationGenerator.generate(diff, expectedSchema.tableName, this.config.migrationDir);
                     const diag = this.createDiagnostic('SCHEMA_DRIFT', null, Date.now() - start);
-                    
-                    this.addToAudit(modelName, 'DRIFT', IntegrityCategory.SCHEMA_DRIFT, 
-                        `Structural mismatch in ${expectedSchema.tableName}. Recon Engine action required.`, 
+
+                    this.addToAudit(modelName, 'DRIFT', IntegrityCategory.SCHEMA_DRIFT,
+                        `Structural mismatch in ${expectedSchema.tableName}. Recon Engine action required.`,
                         { diff, migrationPath, ...diag }, this.config.strict
                     );
 
@@ -265,14 +265,14 @@ export class SovereignWatchdog {
 
                 const actualConstraints = await ConstraintValidator.fetchConstraints(dbClient, expectedSchema.tableName);
                 const constraintStatus = await ConstraintValidator.validate(expectedSchema, actualConstraints);
-                
+
                 if (!constraintStatus.valid) {
                     this.addToAudit(modelName, 'VALIDATION_FAILED', IntegrityCategory.CONSTRAINT_VIOLATION,
-                        `Constraint violation detected for ${expectedSchema.tableName}`, 
+                        `Constraint violation detected for ${expectedSchema.tableName}`,
                         { missing: constraintStatus.missing, unexpected: constraintStatus.unexpected }, true
                     );
                 } else {
-                    this.addToAudit(modelName, 'SUCCESS', IntegrityCategory.VALIDATION_ERROR, 
+                    this.addToAudit(modelName, 'SUCCESS', IntegrityCategory.VALIDATION_ERROR,
                         `Integrity verified for ${expectedSchema.tableName}`, null, false
                     );
                 }
@@ -282,13 +282,13 @@ export class SovereignWatchdog {
                     this.recordFailure();
                     const diag = this.createDiagnostic(error.code || 'CONNECTION_LOST', error);
                     this.handleConnectionError(error, modelName);
-                    this.addToAudit(modelName, 'CONNECTION_LOST', IntegrityCategory.CONNECTION, 
+                    this.addToAudit(modelName, 'CONNECTION_LOST', IntegrityCategory.CONNECTION,
                         `Lost connection during verification of ${modelName}: ${error.message}`, diag, true
                     );
-                    break; 
+                    break;
                 } else {
                     const diag = this.createDiagnostic('INTERNAL_ERROR', error);
-                    this.addToAudit(modelName, 'ERROR', IntegrityCategory.VALIDATION_ERROR, 
+                    this.addToAudit(modelName, 'ERROR', IntegrityCategory.VALIDATION_ERROR,
                         `Internal Logic Error during check for ${modelName}: ${error.message}`, diag, true
                     );
                 }
@@ -301,13 +301,14 @@ export class SovereignWatchdog {
 
     private syncWithStateReconstructionEngine(): void {
         const criticalIssues = this.auditReport.filter(a => a.isCritical);
-        
+
         if (criticalIssues.length > 0) {
             console.error(`[StateReconstructionEngine] ALERT: Found ${criticalIssues.length} critical integrity violations.`);
-            
+
             try {
                 this.emitter.emit('RECONSTRUCTION_REQUIRED', {
                     timestamp: new Date().toISOString(),
+                    tickHz: this.config.tickHz,
                     issues: criticalIssues,
                     remediation: criticalIssues.map(i => {
                         if (i.category === IntegrityCategory.SCHEMA_DRIFT) return 'RUN_MIGRATIONS';
@@ -321,9 +322,11 @@ export class SovereignWatchdog {
         }
 
         try {
-            this.emitter.emit('INTEGRITY_SUMMARY', { 
+            this.emitter.emit('INTEGRITY_SUMMARY', {
+                tickHz: this.config.tickHz,
+                astSyncBudgetMs: this.config.astSyncBudgetMs,
                 insights: this.learning.getInsights(),
-                auditTrail: this.auditReport 
+                auditTrail: this.auditReport
             });
         } catch (e) {
             // Summary failure is not critical
@@ -331,11 +334,11 @@ export class SovereignWatchdog {
     }
 
     private addToAudit(
-        model: string, 
-        status: AuditEntry['status'], 
-        category: IntegrityCategory, 
-        message: string, 
-        details: any = null, 
+        model: string,
+        status: AuditEntry['status'],
+        category: IntegrityCategory,
+        message: string,
+        details: any = null,
         isCritical: boolean = false
     ): void {
         const entry: AuditEntry = {
@@ -372,8 +375,8 @@ export class SovereignWatchdog {
 
     private isConnectionError(error: any): boolean {
         const connectionCodes = ['ECONNREFUSED', 'PROTOCOL_CONNECTION_LOST', 'ETIMEDOUT', '57P01', '08000', '08003', '08006', '57P03', 'ECONNRESET'];
-        return (error.code && connectionCodes.includes(error.code)) || 
-               error.message?.toLowerCase().includes('connection') || 
+        return (error.code && connectionCodes.includes(error.code)) ||
+               error.message?.toLowerCase().includes('connection') ||
                error.message?.toLowerCase().includes('refused') ||
                error.message === 'DB_TIMEOUT';
     }
@@ -388,9 +391,9 @@ export class SovereignWatchdog {
         console.error('====================================================');
 
         try {
-            this.emitter.emit('SYSTEM_CRITICAL', { 
-                point: LogicPoint.PERSISTENCE, 
-                error: 'DB_CONNECTION_FAILURE', 
+            this.emitter.emit('SYSTEM_CRITICAL', {
+                point: LogicPoint.PERSISTENCE,
+                error: 'DB_CONNECTION_FAILURE',
                 diagnostics: {
                     ...diagnostics,
                     context,
@@ -402,13 +405,41 @@ export class SovereignWatchdog {
         }
     }
 
-    public synchronizeAxioms(interfacesPath: string): void {
-        for (const [modelName, schema] of this.modelRegistry.entries()) {
-            const interfacePath = path.join(interfacesPath, `${modelName}.ts`);
-            if (fs.existsSync(interfacePath)) {
-                this.astSync.syncInterfaceWithSchema(interfacePath, schema);
+    public synchronizeAxioms(interfacesPath: string): AstInterfaceSyncResult[] {
+        const startedAt = Date.now();
+        const results = this.astSync.syncBatchWithinTickBudget(interfacesPath, this.modelRegistry.entries(), {
+            strict: this.config.strict,
+            tickHz: this.config.tickHz,
+            maxSyncBudgetMs: this.config.astSyncBudgetMs,
+            failOnBudgetOverrun: process.env.WATCHDOG_AST_SYNC_FAIL_ON_OVERRUN === 'true'
+        });
+
+        for (const result of results) {
+            if (result.budgetOverrun) {
+                this.addToAudit(
+                    result.interfaceName,
+                    'DEGRADED',
+                    IntegrityCategory.SCHEMA_DRIFT,
+                    `AST interface sync exceeded deterministic tick budget: ${result.durationMs}ms > ${result.maxSyncBudgetMs}ms`,
+                    { ...this.createDiagnostic('AST_SYNC_BUDGET_OVERRUN', null, result.durationMs), result },
+                    false
+                );
             }
         }
+
+        try {
+            this.emitter.emit('AST_INTERFACE_SYNC_SUMMARY', {
+                tickHz: this.config.tickHz,
+                tickBudgetMs: Math.floor(1000 / this.config.tickHz),
+                budgetMs: this.config.astSyncBudgetMs,
+                durationMs: Date.now() - startedAt,
+                results
+            });
+        } catch (e) {
+            // Emitter failure must never block deterministic watchdog sync.
+        }
+
+        return results;
     }
 
     public getAuditReport(): AuditEntry[] {


### PR DESCRIPTION
## Summary

Upgrades the watchdog AST interface synchronizer for stricter deterministic behavior and 10Hz world-server safety.

### Changed
- Hardened `backend/src/core/ast-interface-sync.ts`
  - typed schema/result contracts
  - deterministic interface-name normalization
  - stable schema hash generation
  - safer DB type mapping (`bigint`, `unknown` for JSON)
  - optional strict sync
  - schema-order preservation
  - 10Hz tick budget awareness
  - batch sync with budget cutoff
- Wired `backend/src/core/integrity-checker.ts`
  - `WATCHDOG_TICK_HZ` / `WORLD_TICK_HZ` support
  - `WATCHDOG_AST_SYNC_BUDGET_MS` support
  - `WATCHDOG_AST_SYNC_FAIL_ON_OVERRUN` support
  - AST sync telemetry event
  - degraded audit entries when sync exceeds deterministic budget

## Deterministic rule
Default budget is 50ms at 10Hz, so interface sync should not silently consume a full 100ms world tick.

## Docker/build note
The current production Dockerfile builds `@wasd/core-logic`, `@wasd/shared`, `@wasd/server`, and `apps/client-2d`; `backend` is present in the repo but is not currently a dedicated Docker build target. I avoided adding dependency/lockfile changes that could break frozen Docker installs.