### PR TITLE
feat(engine): harden deterministic 10Hz tick policy

### DIFF
--- a/engine/src/determinism/tickPolicy.ts
+++ b/engine/src/determinism/tickPolicy.ts
@@ -1,0 +1,43 @@
+export const WORLD_TICK_HZ = 10 as const;
+export const WORLD_TICK_MS = 100 as const;
+export const WORLD_TICK_KAPPA = 1000 as const;
+export const WORLD_TICK_CHUNK_SIZE = 64 as const;
+
+export interface DeterministicTickPolicy {
+  readonly hz: typeof WORLD_TICK_HZ;
+  readonly tickMs: typeof WORLD_TICK_MS;
+  readonly kappa: typeof WORLD_TICK_KAPPA;
+  readonly chunkSize: typeof WORLD_TICK_CHUNK_SIZE;
+  readonly maxCatchUpTicks: number;
+  readonly maxTickDriftMs: number;
+}
+
+export const DEFAULT_DETERMINISTIC_TICK_POLICY: DeterministicTickPolicy = Object.freeze({
+  hz: WORLD_TICK_HZ,
+  tickMs: WORLD_TICK_MS,
+  kappa: WORLD_TICK_KAPPA,
+  chunkSize: WORLD_TICK_CHUNK_SIZE,
+  maxCatchUpTicks: 5,
+  maxTickDriftMs: 250,
+});
+
+export function assertDeterministicTickPolicy(policy: DeterministicTickPolicy): void {
+  if (policy.hz !== WORLD_TICK_HZ) throw new Error(`WorldTick policy violation: expected ${WORLD_TICK_HZ}Hz, got ${policy.hz}Hz`);
+  if (policy.tickMs !== WORLD_TICK_MS) throw new Error(`WorldTick policy violation: expected ${WORLD_TICK_MS}ms tick, got ${policy.tickMs}ms`);
+  if (policy.kappa !== WORLD_TICK_KAPPA) throw new Error(`ARE policy violation: expected Kappa=${WORLD_TICK_KAPPA}, got ${policy.kappa}`);
+  if (policy.chunkSize !== WORLD_TICK_CHUNK_SIZE) throw new Error(`Spatial policy violation: expected ${WORLD_TICK_CHUNK_SIZE} tile chunks, got ${policy.chunkSize}`);
+  if (!Number.isInteger(policy.maxCatchUpTicks) || policy.maxCatchUpTicks < 0) throw new Error("WorldTick policy violation: maxCatchUpTicks must be a non-negative integer");
+  if (!Number.isInteger(policy.maxTickDriftMs) || policy.maxTickDriftMs < 0) throw new Error("WorldTick policy violation: maxTickDriftMs must be a non-negative integer");
+}
+
+export function deterministicTickToTimeMs(tick: number, policy: DeterministicTickPolicy = DEFAULT_DETERMINISTIC_TICK_POLICY): number {
+  if (!Number.isSafeInteger(tick) || tick < 0) throw new Error(`Invalid deterministic tick: ${tick}`);
+  assertDeterministicTickPolicy(policy);
+  return tick * policy.tickMs;
+}
+
+export function deterministicTimeMsToTick(timeMs: number, policy: DeterministicTickPolicy = DEFAULT_DETERMINISTIC_TICK_POLICY): number {
+  if (!Number.isSafeInteger(timeMs) || timeMs < 0) throw new Error(`Invalid deterministic timeMs: ${timeMs}`);
+  assertDeterministicTickPolicy(policy);
+  return Math.floor(timeMs / policy.tickMs);
+}

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./determinism/tickPolicy.js";

--- a/engine/tsconfig.json
+++ b/engine/tsconfig.json
@@ -1,20 +1,31 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "composite": true,
-    "rootDir": ".",
+    "incremental": true,
+    "tsBuildInfoFile": "../dist/engine.tsbuildinfo",
+    "rootDir": "src",
     "outDir": "../dist/engine",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "../dist", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Adds a strict engine-level deterministic tick policy and hardens the engine TypeScript config.

Changes:
- update engine/tsconfig.json for stricter deterministic builds
- add engine/src/determinism/tickPolicy.ts with 10Hz, 100ms, Kappa 1000 and chunk size 64 constants
- add engine/src/index.ts export

Repo check:
- server/src/core/WorldTick.ts already uses the 100ms authoritative loop
- existing docs already describe the 10Hz and 100ms WorldTick rule

Follow-up:
- import this policy into server/src/core/WorldTick.ts after CI confirms the package dependency path.