### PR TITLE
fix(engine): prepare deterministic policy for ESM runtime use

### DIFF
--- a/engine/package.json
+++ b/engine/package.json
@@ -2,9 +2,11 @@
   "name": "@wasd/engine",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
     "typescript": "^6.0.3"


### PR DESCRIPTION
Prepares @wasd/engine for safer runtime use by follow-up WorldTick integration.

Changes:
- marks the engine package as ESM with type: module
- makes the build script explicit with tsc -p tsconfig.json
- adds a typecheck script for the engine package

This keeps the change intentionally small before wiring server/src/core/WorldTick.ts to the shared deterministic 10Hz policy.