### PR TITLE
test(server): guard authoritative WorldTick policy

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "start": "node dist/index.js",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "guard:worldtick": "tsx src/core/WorldTickPolicy.guard.ts"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.28.0",

--- a/server/src/core/WorldTickPolicy.guard.ts
+++ b/server/src/core/WorldTickPolicy.guard.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  AUTHORITATIVE_WORLD_CHUNK_SIZE,
+  AUTHORITATIVE_WORLD_HEARTBEAT_TICKS,
+  AUTHORITATIVE_WORLD_TICK_KAPPA,
+  AUTHORITATIVE_WORLD_TICK_MS,
+  assertAuthoritativeWorldTickPolicy,
+  isHeartbeatTick,
+  worldTickToMs,
+} from "./WorldTickPolicy.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const worldTickSource = readFileSync(join(here, "WorldTick.ts"), "utf8");
+
+assertAuthoritativeWorldTickPolicy();
+
+if (!worldTickSource.includes(`setInterval(() => this.tick(), ${AUTHORITATIVE_WORLD_TICK_MS})`)) {
+  throw new Error(`WorldTick must run at ${AUTHORITATIVE_WORLD_TICK_MS}ms per authoritative tick`);
+}
+
+if (!worldTickSource.includes(`k: ${AUTHORITATIVE_WORLD_TICK_KAPPA}`)) {
+  throw new Error(`WorldTick ARE payload must keep Kappa=${AUTHORITATIVE_WORLD_TICK_KAPPA}`);
+}
+
+if (!worldTickSource.includes(`chunk:${AUTHORITATIVE_WORLD_CHUNK_SIZE}`)) {
+  throw new Error(`WorldTick deterministic seed must include chunk:${AUTHORITATIVE_WORLD_CHUNK_SIZE}`);
+}
+
+if (!worldTickSource.includes(`% ${AUTHORITATIVE_WORLD_HEARTBEAT_TICKS} === 0`)) {
+  throw new Error(`WorldTick heartbeat cadence must stay every ${AUTHORITATIVE_WORLD_HEARTBEAT_TICKS} ticks`);
+}
+
+if (worldTickToMs(0) !== 0 || worldTickToMs(10) !== 1000) {
+  throw new Error("WorldTick policy time conversion drift detected");
+}
+
+if (!isHeartbeatTick(10) || isHeartbeatTick(11)) {
+  throw new Error("WorldTick heartbeat helper drift detected");
+}
+
+console.log("[WorldTickPolicy.guard] authoritative 10Hz WorldTick policy OK");


### PR DESCRIPTION
Adds an executable server guard for the authoritative 10Hz WorldTick policy.

Changes:
- adds server/src/core/WorldTickPolicy.guard.ts
- adds npm script guard:worldtick

The guard checks:
- WorldTick still runs at 100ms per tick
- ARE Kappa remains 1000
- deterministic seed still carries chunk:64
- heartbeat cadence remains every 10 ticks
- policy helper conversion and heartbeat helpers do not drift

This keeps the large WorldTick.ts file untouched while preventing accidental drift from the new policy constants.