### PR TITLE
test(root): run WorldTick guard in guard all

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "guard:monorepo": "node scripts/monorepo-guard.mjs",
     "guard:monorepo:frozen": "MONOREPO_GUARD_RUN_PNPM=1 node scripts/monorepo-guard.mjs",
     "guard:architecture": "node scripts/arelorian-architecture-lint.mjs",
-    "guard:all": "pnpm guard:monorepo && pnpm guard:architecture",
+    "guard:worldtick": "pnpm --filter @wasd/server guard:worldtick",
+    "guard:all": "pnpm guard:monorepo && pnpm guard:architecture && pnpm guard:worldtick",
     "clean": "pnpm -r exec rm -rf dist node_modules"
   },
   "engines": {


### PR DESCRIPTION
Adds the authoritative WorldTick policy guard to the root guard chain.

Changes:
- adds root script guard:worldtick
- updates guard:all to run monorepo, architecture and WorldTick guards

This makes the 10Hz/100ms/Kappa=1000/chunk=64 checks part of the standard repo guard flow.