### PR TITLE
build(vps): verify all core logic before Docker build

### DIFF
--- a/scripts/verify-vps-build-logic.mjs
+++ b/scripts/verify-vps-build-logic.mjs
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from "node:fs";
+
+const requiredFiles = [
+  "engine/src/determinism/tickPolicy.ts",
+  "server/src/core/WorldTickPolicy.ts",
+  "server/src/core/WorldTickPolicy.guard.ts",
+  "backend/src/core/ast-interface-sync.ts",
+  "backend/src/core/integrity-checker.ts",
+  "packages/core-logic/package.json",
+  "packages/shared/package.json",
+];
+
+const requiredSnippets = [
+  ["engine/src/determinism/tickPolicy.ts", "WORLD_TICK_HZ = 10 as const"],
+  ["engine/src/determinism/tickPolicy.ts", "WORLD_TICK_MS = 100 as const"],
+  ["engine/src/determinism/tickPolicy.ts", "WORLD_TICK_KAPPA = 1000 as const"],
+  ["engine/src/determinism/tickPolicy.ts", "WORLD_TICK_CHUNK_SIZE = 64 as const"],
+  ["server/src/core/WorldTickPolicy.ts", "AUTHORITATIVE_WORLD_TICK_MS = 100 as const"],
+  ["server/src/core/WorldTickPolicy.ts", "AUTHORITATIVE_WORLD_TICK_KAPPA = 1000 as const"],
+  ["server/src/core/WorldTickPolicy.ts", "AUTHORITATIVE_WORLD_CHUNK_SIZE = 64 as const"],
+  ["backend/src/core/ast-interface-sync.ts", "syncBatchWithinTickBudget"],
+  ["backend/src/core/integrity-checker.ts", "WATCHDOG_AST_SYNC_BUDGET_MS"],
+];
+
+let failed = false;
+
+for (const file of requiredFiles) {
+  if (!existsSync(file)) {
+    failed = true;
+    console.error(`[vps-build-logic] missing required logic file: ${file}`);
+  }
+}
+
+for (const [file, snippet] of requiredSnippets) {
+  if (!existsSync(file)) continue;
+  const content = readFileSync(file, "utf8");
+  if (!content.includes(snippet)) {
+    failed = true;
+    console.error(`[vps-build-logic] ${file} missing required logic marker: ${snippet}`);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log("[vps-build-logic] source logic verification OK");


### PR DESCRIPTION
Adds scripts/verify-vps-build-logic.mjs as a strict source-logic verifier for the VPS Docker build path.

It checks that the Docker build context contains the core logic that must not silently fall out of the image:
- engine deterministic tick policy
- server authoritative WorldTick policy and guard
- backend AST sync and integrity checker logic
- core-logic package
- shared package

Important follow-up for Dockerfile.vps:
- add engine to the Docker-generated pnpm-workspace.yaml in both workspace rewrite blocks
- add @wasd/engine to both pnpm install filter chains
- run node scripts/verify-vps-build-logic.mjs before package builds
- build @wasd/engine before @wasd/server
- assert dist/engine/index.js and dist/engine/determinism/tickPolicy.js exist
- copy /app/engine and /app/dist/engine into the runner stage

I attempted to patch Dockerfile.vps directly in this session, but the connector safety layer blocked the full Dockerfile write. This PR adds the verifier first so the next Dockerfile.vps patch has a clear build gate.