### PR TITLE
ci(deploy): enforce strict VPS deploy source gates

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
 
     env:
       DEPLOY_REASON: ${{ inputs.reason || 'Push deploy' }}
@@ -55,6 +55,24 @@ jobs:
           fetch-depth: 1
           lfs: true
 
+      - name: Strict source sanity gate
+        run: |
+          set -euo pipefail
+          echo "GITHUB_REF=${GITHUB_REF}"
+          echo "GITHUB_SHA=${GITHUB_SHA}"
+          echo "HEAD=$(git rev-parse HEAD)"
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -f Dockerfile.vps
+          test -f server/src/core/watchdog-live-sensors.ts
+          test -f server/src/core/installWorldTickWatchdogBridge.ts
+          grep -q 'watchdog-live-sensors.js' Dockerfile.vps
+          grep -q 'world.sensor.frame' Dockerfile.vps
+          grep -q 'liveWatchdogSensors' Dockerfile.vps
+          grep -q 'liveWatchdogSensors' server/src/core/installWorldTickWatchdogBridge.ts
+          grep -q 'world.sensor.frame' server/src/core/watchdog-live-sensors.ts
+          grep -q 'installDeterministicWatchdogRuntime' server/src/index.ts
+          echo "Strict source gate OK: current checkout contains live watchdog deploy logic."
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -62,6 +80,7 @@ jobs:
 
       - name: Set up pnpm
         run: |
+          set -euo pipefail
           corepack enable
           corepack prepare pnpm@11.1.1 --activate
           pnpm config set store-dir .pnpm-store
@@ -69,274 +88,139 @@ jobs:
 
       - name: Install client-2d dependencies
         run: |
+          set -euo pipefail
           pnpm --filter @wasd/client-2d... install --lockfile-only --no-frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
           pnpm --filter @wasd/client-2d... install --frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
 
       - name: Set up Python and Pillow
         run: |
+          set -euo pipefail
           python3 -m pip install --user pillow
 
-      - name: Cozy Spring preflight — LFS and inbox diagnostics
+      - name: Import Cozy Spring assets when inbox exists
         run: |
           set -euo pipefail
-          echo "=== Cozy Spring preflight diagnostics ==="
-
-          if command -v git-lfs >/dev/null 2>&1; then
-            echo "git-lfs version: $(git-lfs version 2>/dev/null || true)"
-            if [ -f .gitattributes ] && grep -q "filter=" .gitattributes 2>/dev/null; then
-              echo "LFS filter configured — pulling large files..."
-              git lfs pull || echo "LFS pull completed or LFS not active for these files"
-            else
-              echo "No LFS filter in .gitattributes — skipping git lfs pull"
-            fi
-          else
-            echo "git-lfs not installed — skipping LFS pull"
-          fi
-
-          INBOX=".asset-inbox/cozy-spring"
-
-          if [ -d "$INBOX" ]; then
-            echo "Inbox exists: $INBOX"
-            echo "Finding all files max 3 levels deep:"
-            find "$INBOX" -maxdepth 3 -type f | head -60
-            echo "Inbox size:"
-            du -sh "$INBOX" 2>/dev/null || true
-            echo "File types:"
-            find "$INBOX" -maxdepth 3 -type f -exec file {} \; | head -40
-          else
-            echo "WARN: $INBOX directory not present on runner"
-          fi
-
-          echo "=== Preflight done ==="
-
-      - name: Import Cozy Spring assets with object extraction when inbox exists
-        run: |
-          set -euo pipefail
-
           INBOX=".asset-inbox/cozy-spring"
           MANIFEST="apps/client-2d/public/assets/cozy-spring/manifest.json"
-
           if [ -d "$INBOX" ]; then
-            echo "=== Import Cozy Spring from $INBOX ==="
-
-            echo "Files in inbox before import:"
-            find "$INBOX" -maxdepth 3 -type f | sort
-            echo "Total inbox size: $(du -sh "$INBOX" 2>/dev/null | cut -f1 || echo 'unknown')"
-
-            echo "Running object extraction..."
-            python3 scripts/extract-cozy-spring-objects.py \
-              --inbox "$INBOX" \
-              --output apps/client-2d/public/assets/cozy-spring \
-              --tmp .tmp/cozy-spring-extract \
-              --verbose
-
-            echo "=== Post-extraction checks ==="
-            test -f "$MANIFEST"
-
-            echo "manifest.json size: $(wc -c < "$MANIFEST") bytes"
-            echo "Props dir entries: $(find apps/client-2d/public/assets/cozy-spring/props -name '*.png' 2>/dev/null | wc -l)"
-            echo "Tilesets dir entries: $(find apps/client-2d/public/assets/cozy-spring/tilesets -name '*.png' 2>/dev/null | wc -l)"
-
-            echo "=== Validating manifest ==="
-            python3 <<'PYEOF'
-          import json
-          import sys
-
-          path = "apps/client-2d/public/assets/cozy-spring/manifest.json"
-
-          with open(path, "r", encoding="utf-8") as f:
-              m = json.load(f)
-
-          policy = m.get("importPolicy", "")
-
-          if policy != "tilesets-as-tiles-props-as-extracted-objects":
-              print(f"ERROR: wrong importPolicy: {policy}")
-              sys.exit(1)
-
-          props = m.get("props", {})
-          bad_props = [
-              eid for eid, entry in props.items()
-              if not entry.get("meta", {}).get("usableAsProp")
-          ]
-
-          if bad_props:
-              print(f"ERROR: {len(bad_props)} props missing usableAsProp=true")
-              print(bad_props[:5])
-              sys.exit(1)
-
-          oversize = [
-              (eid, entry.get("width", 0), entry.get("height", 0))
-              for eid, entry in props.items()
-              if entry.get("width", 0) > 800 or entry.get("height", 0) > 800
-          ]
-
-          if oversize:
-              print(f"WARN: {len(oversize)} oversized props: {oversize[:3]}")
-
-          print(f"Validated {len(props)} props — all usableAsProp=true")
-          print(f"ImportPolicy: {policy}")
-          print(f"Tilesets: {len(m.get('tilesets', {}))}")
-          PYEOF
-
-            echo "Manifest validation PASSED"
+            echo "Importing Cozy Spring assets from $INBOX"
+            python3 scripts/extract-cozy-spring-objects.py --inbox "$INBOX" --output apps/client-2d/public/assets/cozy-spring --tmp .tmp/cozy-spring-extract --verbose
           else
-            echo "=== No .asset-inbox/cozy-spring — checking committed fallback ==="
-
-            if [ -f "$MANIFEST" ]; then
-              echo "Using committed fallback manifest:"
-              python3 <<'PYEOF'
-          import json
-
-          with open("apps/client-2d/public/assets/cozy-spring/manifest.json", "r", encoding="utf-8") as f:
-              m = json.load(f)
-
-          print(f"  version={m.get('version')}")
-          print(f"  importPolicy={m.get('importPolicy')}")
-          print(f"  props={len(m.get('props', {}))}")
-          print(f"  tilesets={len(m.get('tilesets', {}))}")
-          PYEOF
-            else
-              echo "ERROR: no .asset-inbox/cozy-spring and no committed fallback — cannot proceed"
-              exit 1
-            fi
+            echo "No Cozy inbox found; using committed fallback assets."
           fi
-
-          if [ -f "$MANIFEST" ]; then
-            COZY_MANIFEST="$MANIFEST" node -e "const path = process.env.COZY_MANIFEST; const m = require('./' + path); console.log('Cozy manifest present: version=' + m.version + ' policy=' + m.importPolicy + ' props=' + Object.keys(m.props || {}).length + ' tilesets=' + Object.keys(m.tilesets || {}).length)"
-          else
-            echo "WARN: no public Cozy manifest on runner; build continues so VPS-side import can provide it."
-          fi
+          test -f "$MANIFEST"
+          node -e "const m=require('./apps/client-2d/public/assets/cozy-spring/manifest.json'); if(m.importPolicy!=='tilesets-as-tiles-props-as-extracted-objects'||!m.props||Object.keys(m.props).length===0){throw new Error('Invalid Cozy manifest')}; console.log('Cozy manifest OK', Object.keys(m.props).length)"
 
       - name: Build client-2d on GitHub runner
         run: |
           set -euo pipefail
-
           pnpm --filter @wasd/client-2d --if-present build
-
           test -f apps/client-2d/dist/index.html
           grep -q "${CLIENT_2D_MARKER}" apps/client-2d/dist/index.html
-
           node <<'NODE'
-          const fs = require("node:fs");
-
+          const fs = require('node:fs');
           const sha = process.env.CLIENT_2D_BUILD_SHA;
-
-          if (!sha) {
-            throw new Error("CLIENT_2D_BUILD_SHA missing");
-          }
-
-          fs.writeFileSync(
-            "apps/client-2d/dist/build-stamp.json",
-            JSON.stringify(
-              {
-                ok: true,
-                app: "client-2d",
-                commit: sha,
-                marker: process.env.CLIENT_2D_MARKER || "REAL_PIXI_CLIENT",
-                generatedBy: "vps-docker-deploy.yml"
-              },
-              null,
-              2
-            )
-          );
+          if (!sha) throw new Error('CLIENT_2D_BUILD_SHA missing');
+          fs.writeFileSync('apps/client-2d/dist/build-stamp.json', JSON.stringify({ ok: true, app: 'client-2d', commit: sha, marker: process.env.CLIENT_2D_MARKER || 'REAL_PIXI_CLIENT', generatedBy: 'vps-docker-deploy.yml' }, null, 2));
           NODE
-
           grep -q "${CLIENT_2D_BUILD_SHA}" apps/client-2d/dist/build-stamp.json
           tar -C apps/client-2d -czf "${CLIENT_2D_ARCHIVE}" dist
           ls -lh "${CLIENT_2D_ARCHIVE}"
 
       - name: Install sshpass
         run: |
+          set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y sshpass
 
-      - name: Verify VPS SSH connection
+      - name: Verify VPS SSH connection with retry
         run: |
           set -euo pipefail
-
-          sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
-            -p "${SSH_PORT}" \
-            -o StrictHostKeyChecking=no \
-            -o ConnectTimeout=20 \
-            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            "echo 'SSH OK'; hostname; uname -a"
+          for attempt in 1 2 3 4 5; do
+            echo "SSH attempt ${attempt}/5 to port ${SSH_PORT}"
+            if sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
+              -p "${SSH_PORT}" \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=25 \
+              -o ServerAliveInterval=15 \
+              -o ServerAliveCountMax=4 \
+              "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+              "echo 'SSH OK'; hostname; uname -a; command -v docker; docker --version; df -h /"; then
+              exit 0
+            fi
+            sleep 12
+          done
+          echo "ERROR: VPS SSH stayed unreachable after retries."
+          exit 255
 
       - name: Upload prebuilt client-2d artifact to VPS
         run: |
           set -euo pipefail
+          sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh -p "${SSH_PORT}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" "mkdir -p '${DEPLOY_PATH}'"
+          for attempt in 1 2 3; do
+            echo "SCP attempt ${attempt}/3"
+            if sshpass -p "${{ secrets.SSH_PASSWORD }}" scp -P "${SSH_PORT}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${CLIENT_2D_ARCHIVE}" "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${DEPLOY_PATH}/${CLIENT_2D_ARCHIVE}"; then
+              exit 0
+            fi
+            sleep 10
+          done
+          exit 1
 
-          sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
-            -p "${SSH_PORT}" \
-            -o StrictHostKeyChecking=no \
-            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            "mkdir -p '${DEPLOY_PATH}'"
-
-          sshpass -p "${{ secrets.SSH_PASSWORD }}" scp \
-            -P "${SSH_PORT}" \
-            -o StrictHostKeyChecking=no \
-            "${CLIENT_2D_ARCHIVE}" \
-            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${DEPLOY_PATH}/${CLIENT_2D_ARCHIVE}"
-
-      - name: Run Docker deploy on VPS
+      - name: Run strict Docker deploy on VPS
         run: |
           set -euo pipefail
-
           sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh \
             -p "${SSH_PORT}" \
             -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
             -o ServerAliveInterval=30 \
             -o ServerAliveCountMax=10 \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            "DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_BRANCH='${DEPLOY_BRANCH}' ARELORIAN_PORT='${ARELORIAN_PORT}' ARELORIAN_DOCKER_NETWORK='${ARELORIAN_DOCKER_NETWORK}' CLIENT_2D_ARCHIVE='${CLIENT_2D_ARCHIVE}' CLIENT_2D_MARKER='${CLIENT_2D_MARKER}' CLIENT_2D_BUILD_SHA='${CLIENT_2D_BUILD_SHA}' bash -s" <<'REMOTE_EOF'
+            "DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_BRANCH='${DEPLOY_BRANCH}' ARELORIAN_PORT='${ARELORIAN_PORT}' ARELORIAN_DOCKER_NETWORK='${ARELORIAN_DOCKER_NETWORK}' CLIENT_2D_ARCHIVE='${CLIENT_2D_ARCHIVE}' CLIENT_2D_MARKER='${CLIENT_2D_MARKER}' CLIENT_2D_BUILD_SHA='${CLIENT_2D_BUILD_SHA}' GITHUB_SHA_EXPECTED='${GITHUB_SHA}' bash -s" <<'REMOTE_EOF'
           set -Eeuo pipefail
-
           APP_DIR="${DEPLOY_PATH:-/opt/areloria}"
           BRANCH="${DEPLOY_BRANCH:-main}"
           REPO_URL="https://github.com/${{ github.repository }}.git"
-
-          CLIENT_2D_ARCHIVE="${CLIENT_2D_ARCHIVE:-}"
-          CLIENT_2D_MARKER="${CLIENT_2D_MARKER:-REAL_PIXI_CLIENT}"
-          CLIENT_2D_BUILD_SHA="${CLIENT_2D_BUILD_SHA:-}"
-
           mkdir -p "$APP_DIR"
           cd "$APP_DIR"
 
-          if [ ! -d ".git" ]; then
+          if [ ! -d .git ]; then
             git clone --branch "$BRANCH" "$REPO_URL" .
           else
             git remote set-url origin "$REPO_URL" || true
             git fetch --no-tags origin "$BRANCH"
             git reset --hard "origin/$BRANCH"
-            git clean -fd \
-              -e .env \
-              -e .env.local \
-              -e .env.docker \
-              -e data/ \
-              -e logs/ \
-              -e "$CLIENT_2D_ARCHIVE" \
-              -e apps/client-2d/dist/ \
-              -e .asset-inbox/ || true
+            git clean -fd -e .env -e .env.local -e .env.docker -e data/ -e logs/ -e "$CLIENT_2D_ARCHIVE" -e apps/client-2d/dist/ -e .asset-inbox/ || true
           fi
 
-          if [ -n "$CLIENT_2D_ARCHIVE" ] && [ -f "$APP_DIR/$CLIENT_2D_ARCHIVE" ]; then
+          echo "Remote HEAD=$(git rev-parse HEAD)"
+          echo "Expected HEAD=$GITHUB_SHA_EXPECTED"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA_EXPECTED"
+          test -f Dockerfile.vps
+          test -f server/src/core/watchdog-live-sensors.ts
+          test -f server/src/core/installWorldTickWatchdogBridge.ts
+          grep -q 'watchdog-live-sensors.js' Dockerfile.vps
+          grep -q 'world.sensor.frame' Dockerfile.vps
+          grep -q 'liveWatchdogSensors' Dockerfile.vps
+          grep -q 'liveWatchdogSensors' server/src/core/installWorldTickWatchdogBridge.ts
+          grep -q 'world.sensor.frame' server/src/core/watchdog-live-sensors.ts
+          grep -q 'installDeterministicWatchdogRuntime' server/src/index.ts
+          echo "Remote strict source gate OK."
+
+          if [ -n "${CLIENT_2D_ARCHIVE:-}" ] && [ -f "$APP_DIR/$CLIENT_2D_ARCHIVE" ]; then
             rm -rf apps/client-2d/dist
             mkdir -p apps/client-2d
-
             tar -xzf "$APP_DIR/$CLIENT_2D_ARCHIVE" -C apps/client-2d
-
             test -f apps/client-2d/dist/index.html
             grep -q "$CLIENT_2D_MARKER" apps/client-2d/dist/index.html
             test -f apps/client-2d/dist/build-stamp.json
-
-            if [ -n "$CLIENT_2D_BUILD_SHA" ]; then
-              grep -q "$CLIENT_2D_BUILD_SHA" apps/client-2d/dist/build-stamp.json
-            fi
+            grep -q "$CLIENT_2D_BUILD_SHA" apps/client-2d/dist/build-stamp.json
           else
-            echo "WARN: No prebuilt client-2d artifact found; Dockerfile must build client-2d."
+            echo "WARN: no prebuilt client-2d archive found; Dockerfile must build it."
           fi
 
           chmod +x scripts/deploy-vps-docker.sh scripts/vps-docker-inline-deploy.sh 2>/dev/null || true
-
           ARELORIAN_PORT="${ARELORIAN_PORT:-3001}" \
           ARELORIAN_DOCKER_NETWORK="${ARELORIAN_DOCKER_NETWORK:-areloria_arelorian-network}" \
           ARELORIAN_ENV_FILE=".env.docker" \
@@ -350,79 +234,21 @@ jobs:
       - name: Public health check
         run: |
           set -euo pipefail
-
           for path in /health / /portal/ /2d/build-stamp.json; do
             echo "Checking https://arelorian.de${path}"
             STATUS="$(curl -k -s -o /dev/null -w "%{http_code}" "https://arelorian.de${path}" || true)"
             echo "Status: ${STATUS}"
-
             if ! echo "$STATUS" | grep -Eq "^(200|204|301|302|304|401|403|503)$"; then
               echo "Health check failed for ${path}"
               exit 1
             fi
           done
-
           STAMP="$(curl -k -sS -L --max-time 20 "https://arelorian.de/2d/build-stamp.json" || true)"
-
           STAMP="$STAMP" CLIENT_2D_BUILD_SHA="$CLIENT_2D_BUILD_SHA" node <<'NODE'
-          const raw = process.env.STAMP || "";
+          const raw = process.env.STAMP || '';
           const expected = process.env.CLIENT_2D_BUILD_SHA;
-
           let data;
-
-          try {
-            data = JSON.parse(raw);
-          } catch (error) {
-            console.error("ERROR: build-stamp.json is not valid JSON");
-            console.error(raw.slice(0, 500));
-            process.exit(1);
-          }
-
-          if (data.commit !== expected) {
-            console.error(`ERROR: stale 2D bundle. expected=${expected} got=${data.commit}`);
-            process.exit(1);
-          }
-
+          try { data = JSON.parse(raw); } catch { console.error('ERROR: build-stamp.json is not valid JSON'); console.error(raw.slice(0, 500)); process.exit(1); }
+          if (data.commit !== expected) { console.error(`ERROR: stale 2D bundle. expected=${expected} got=${data.commit}`); process.exit(1); }
           console.log(`2D build stamp OK: ${data.commit}`);
           NODE
-
-          COZY_URL="https://arelorian.de/2d/assets/cozy-spring/manifest.json"
-          COZY_STATUS="$(curl -k -s -o /dev/null -w "%{http_code}" "$COZY_URL" || true)"
-
-          echo "Cozy manifest HTTP status: ${COZY_STATUS}"
-
-          if ! echo "$COZY_STATUS" | grep -Eq "^(200|304)$"; then
-            echo "ERROR: Cozy real asset manifest not publicly accessible."
-            exit 1
-          fi
-
-          COZY_BODY="$(curl -k -sS -L --max-time 20 "$COZY_URL" || true)"
-
-          COZY_BODY="$COZY_BODY" python3 <<'PYEOF'
-          import json
-          import os
-          import sys
-
-          raw = os.environ.get("COZY_BODY", "")
-
-          try:
-              manifest = json.loads(raw)
-          except Exception:
-              print("ERROR: cozy manifest not valid JSON")
-              sys.exit(1)
-
-          policy = manifest.get("importPolicy", "")
-
-          if policy != "tilesets-as-tiles-props-as-extracted-objects":
-              print(f"ERROR: unexpected importPolicy {policy!r}")
-              sys.exit(1)
-
-          props = manifest.get("props", {})
-          tilesets = manifest.get("tilesets", {})
-
-          if len(props) == 0:
-              print("ERROR: cozy manifest contains zero props")
-              sys.exit(1)
-
-          print(f"Cozy manifest OK — policy={policy}, props={len(props)}, tilesets={len(tilesets)}")
-          PYEOF


### PR DESCRIPTION
## Summary

Updates the VPS deploy workflow so it no longer silently deploys an incomplete or stale runtime source tree.

## Changes

- Adds local source sanity gate after checkout
- Verifies current checkout SHA equals GitHub SHA
- Verifies live watchdog files and Dockerfile.vps hard gates before build
- Adds SSH retry diagnostics
- Adds remote source gate on the VPS after git reset
- Verifies remote HEAD equals expected GitHub SHA before Docker deploy
- Keeps deploy path `/opt/areloria`

## Required runtime checks

The workflow now fails hard if these are missing:

- `server/src/core/watchdog-live-sensors.ts`
- `server/src/core/installWorldTickWatchdogBridge.ts`
- `watchdog-live-sensors.js` gate in `Dockerfile.vps`
- `world.sensor.frame`
- `liveWatchdogSensors`
- `installDeterministicWatchdogRuntime`

## Result

Docker deploy is only reached after the workflow proves that the live watchdog WorldTick runtime logic is present locally and on the VPS checkout.