### PR TITLE
feat(client-2d): add deterministic playable Phase 2 client layer

### DIFF
--- a/apps/client-2d/src/engine/pixiClient.ts
+++ b/apps/client-2d/src/engine/pixiClient.ts
@@ -1,13 +1,20 @@
 import { Application, Container, Graphics, Text } from "pixi.js";
+import type { EntityState, WorldViewState } from "../world/entities";
+import { worldToChunk } from "../world/chunks";
 
 export interface PixiClientOptions {
   mount: HTMLElement;
   maxFps: number;
   theme: string;
+  chunkSize: number;
+  interpolationMs: number;
 }
 
 export interface PixiClient {
-  logicTick(tick: { tickId: number; fixedDtSec: number }): void;
+  logicTick(
+    tick: { tickId: number; fixedDtSec: number; driftMs?: number },
+    viewState: WorldViewState
+  ): void;
   destroy(): void;
   getApp(): Application | null;
 }
@@ -32,17 +39,17 @@ export async function createPixiClient(
   const world = new Container();
   app.stage.addChild(world);
 
-  // Draw grid
-  const grid = new Graphics();
-  world.addChild(grid);
+  // Chunk grid layer
+  const chunkGrid = new Graphics();
+  world.addChild(chunkGrid);
 
-  // Center marker
-  const centerMarker = new Graphics();
-  centerMarker.circle(0, 0, 14);
-  centerMarker.fill(0x00e5ff);
-  centerMarker.x = app.screen.width / 2;
-  centerMarker.y = app.screen.height / 2;
-  world.addChild(centerMarker);
+  // Entity layer
+  const entityLayer = new Container();
+  world.addChild(entityLayer);
+
+  // UI layer (screen space)
+  const uiLayer = new Container();
+  app.stage.addChild(uiLayer);
 
   // Debug label
   const label = new Text({
@@ -55,51 +62,216 @@ export async function createPixiClient(
 
   label.x = 16;
   label.y = 16;
-  app.stage.addChild(label);
+  uiLayer.addChild(label);
 
-  function drawGrid(): void {
-    grid.clear();
+  // Track entity sprites by id
+  const entitySprites = new Map<string, Graphics>();
+  const prevPositions = new Map<string, { x: number; y: number; time: number }>();
 
-    const size = 64;
-    const width = app.screen.width;
-    const height = app.screen.height;
+  function drawChunkGrid(cameraX: number, cameraY: number): void {
+    chunkGrid.clear();
 
-    grid.setStrokeStyle({
-      width: 1,
+    const screenW = app.screen.width;
+    const screenH = app.screen.height;
+
+    // Draw chunk grid (larger grid)
+    chunkGrid.setStrokeStyle({
+      width: 2,
       color: 0x00e5ff,
-      alpha: 0.12
+      alpha: 0.15
     });
 
-    for (let x = 0; x <= width; x += size) {
-      grid.moveTo(x, 0);
-      grid.lineTo(x, height);
+    const startX = Math.floor((cameraX - screenW / 2) / options.chunkSize) * options.chunkSize;
+    const startY = Math.floor((cameraY - screenH / 2) / options.chunkSize) * options.chunkSize;
+    const endX = startX + screenW + options.chunkSize * 2;
+    const endY = startY + screenH + options.chunkSize * 2;
+
+    for (let x = startX; x <= endX; x += options.chunkSize) {
+      chunkGrid.moveTo(x, startY);
+      chunkGrid.lineTo(x, endY);
     }
 
-    for (let y = 0; y <= height; y += size) {
-      grid.moveTo(0, y);
-      grid.lineTo(width, y);
+    for (let y = startY; y <= endY; y += options.chunkSize) {
+      chunkGrid.moveTo(startX, y);
+      chunkGrid.lineTo(endX, y);
     }
 
-    grid.stroke();
+    chunkGrid.stroke();
   }
 
-  drawGrid();
+  function getInterpolatedPos(
+    entity: EntityState,
+    nowMs: number
+  ): { x: number; y: number } {
+    const prev = prevPositions.get(entity.id);
+    const lerpFactor = 0.5; // Simple interpolation toward current position
 
-  app.renderer.on("resize", drawGrid);
+    if (prev) {
+      const timeSinceUpdate = nowMs - prev.time;
+      const interpolationFactor = Math.min(timeSinceUpdate / options.interpolationMs, 1);
+      const lerp = interpolationFactor * lerpFactor;
 
-  let phase = 0;
+      return {
+        x: prev.x + (entity.x - prev.x) * lerp,
+        y: prev.y + (entity.y - prev.y) * lerp
+      };
+    }
 
-  app.ticker.add((ticker) => {
-    phase += ticker.deltaTime * 0.04;
-    centerMarker.scale.set(1 + Math.sin(phase) * 0.035);
+    return { x: entity.x, y: entity.y };
+  }
+
+  function getEntityColor(kind: EntityState["kind"]): number {
+    switch (kind) {
+      case "player":
+        return 0x00e5ff; // cyan
+      case "npc":
+        return 0x39ff14; // green
+      case "loot":
+        return 0xff7a00; // orange
+      case "marker":
+        return 0xff416c; // pink/red
+      default:
+        return 0xffffff;
+    }
+  }
+
+  function getEntityRadius(kind: EntityState["kind"]): number {
+    switch (kind) {
+      case "player":
+        return 16;
+      case "npc":
+        return 12;
+      case "loot":
+        return 8;
+      case "marker":
+        return 6;
+      default:
+        return 10;
+    }
+  }
+
+  function renderEntities(viewState: WorldViewState, nowMs: number): void {
+    const screenW = app.screen.width;
+    const screenH = app.screen.height;
+
+    // Get local player position for camera
+    const localPlayer = viewState.entities.find((e) => e.id === viewState.localPlayerId);
+    const cameraX = localPlayer?.x ?? 0;
+    const cameraY = localPlayer?.y ?? 0;
+
+    // Update chunk grid based on camera
+    drawChunkGrid(cameraX, cameraY);
+
+    // Calculate center offset
+    const offsetX = screenW / 2;
+    const offsetY = screenH / 2;
+
+    // Track which entities we've rendered
+    const renderedIds = new Set<string>();
+
+    for (const entity of viewState.entities) {
+      renderedIds.add(entity.id);
+
+      // Interpolate position
+      const interp = getInterpolatedPos(entity, nowMs);
+
+      // Store previous position for interpolation
+      prevPositions.set(entity.id, { x: entity.x, y: entity.y, time: nowMs });
+
+      // Calculate screen position relative to camera
+      const screenX = offsetX + (interp.x - cameraX);
+      const screenY = offsetY + (interp.y - cameraY);
+
+      // Get or create sprite
+      let sprite = entitySprites.get(entity.id);
+      if (!sprite) {
+        sprite = new Graphics();
+        entityLayer.addChild(sprite);
+        entitySprites.set(entity.id, sprite);
+      }
+
+      // Draw entity
+      sprite.clear();
+
+      const color = getEntityColor(entity.kind);
+      const radius = getEntityRadius(entity.kind);
+
+      sprite.circle(0, 0, radius);
+      sprite.fill({ color, alpha: 0.9 });
+
+      // Draw direction indicator for players
+      if (entity.kind === "player" && (entity.vx !== 0 || entity.vy !== 0)) {
+        const angle = Math.atan2(entity.vy, entity.vx);
+        sprite.moveTo(0, 0);
+        sprite.lineTo(Math.cos(angle) * radius * 1.4, Math.sin(angle) * radius * 1.4);
+        sprite.stroke({ color, width: 3, alpha: 1 });
+      }
+
+      sprite.x = screenX;
+      sprite.y = screenY;
+
+      // Draw name tag if present
+      if (entity.name && entity.kind === "player") {
+        const nameText = new Text({
+          text: entity.name,
+          style: {
+            fill: 0xf5f7ff,
+            fontSize: 10
+          }
+        });
+        nameText.anchor.set(0.5, 1);
+        nameText.x = 0;
+        nameText.y = -radius - 2;
+        sprite.addChild(nameText);
+      }
+
+      // Draw HP bar for NPCs with health
+      if (entity.hp !== undefined && entity.maxHp !== undefined && entity.kind === "npc") {
+        const barW = 24;
+        const barH = 3;
+        const hpRatio = entity.hp / entity.maxHp;
+
+        // Background
+        sprite.rect(-barW / 2, -radius - 10, barW, barH);
+        sprite.fill({ color: 0x333333, alpha: 0.8 });
+
+        // HP fill
+        sprite.rect(-barW / 2, -radius - 10, barW * hpRatio, barH);
+        sprite.fill({ color: hpRatio > 0.5 ? 0x39ff14 : hpRatio > 0.25 ? 0xff7a00 : 0xff416c });
+      }
+    }
+
+    // Remove sprites for entities that no longer exist
+    for (const [id, sprite] of entitySprites) {
+      if (!renderedIds.has(id)) {
+        entityLayer.removeChild(sprite);
+        entitySprites.delete(id);
+        prevPositions.delete(id);
+      }
+    }
+  }
+
+  function destroyEntitySprites(): void {
+    for (const sprite of entitySprites.values()) {
+      entityLayer.removeChild(sprite);
+    }
+    entitySprites.clear();
+    prevPositions.clear();
+  }
+
+  app.renderer.on("resize", () => {
+    // Grid will be redrawn on next logicTick
   });
 
   return {
-    logicTick(tick) {
-      label.text = `Areloria · tick ${tick.tickId} · 10Hz`;
+    logicTick(tick, viewState) {
+      const nowMs = performance.now();
+      label.text = `Areloria · tick ${tick.tickId} · 10Hz · ${viewState.entities.length} entities`;
+      renderEntities(viewState, nowMs);
     },
 
     destroy() {
+      destroyEntitySprites();
       app.destroy(true, { children: true, texture: true });
     },
 

--- a/apps/client-2d/src/logic/clientWorld.ts
+++ b/apps/client-2d/src/logic/clientWorld.ts
@@ -1,0 +1,157 @@
+import type { InputFrame, WorldSnapshot } from "../net/protocol";
+import type { EntityState, WorldViewState } from "../world/entities";
+import { cloneEntity } from "../world/entities";
+import { applyPlayerInput } from "./playerController";
+
+export interface ClientWorldOptions {
+  localPlayerId?: string;
+  spawnX: number;
+  spawnY: number;
+  playerSpeed: number;
+}
+
+export interface ClientWorld {
+  readonly localPlayerId: string;
+  spawnLocalPlayer(): void;
+  setLocalPlayerId(id: string): void;
+  applyInput(input: InputFrame, fixedDtSec: number): void;
+  applySnapshot(snapshot: WorldSnapshot): void;
+  getViewState(): WorldViewState;
+  getEntityCount(): number;
+}
+
+function createGuestPlayerId(): string {
+  return `guest_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function createClientWorld(options: ClientWorldOptions): ClientWorld {
+  let localPlayerId = options.localPlayerId ?? createGuestPlayerId();
+  let tickId = 0;
+
+  const entities = new Map<string, EntityState>();
+
+  function ensureLocalPlayer(): EntityState {
+    const existing = entities.get(localPlayerId);
+
+    if (existing) return existing;
+
+    const player: EntityState = {
+      id: localPlayerId,
+      kind: "player",
+      x: options.spawnX,
+      y: options.spawnY,
+      vx: 0,
+      vy: 0,
+      hp: 100,
+      maxHp: 100,
+      name: "Guest"
+    };
+
+    entities.set(localPlayerId, player);
+    return player;
+  }
+
+  return {
+    get localPlayerId() {
+      return localPlayerId;
+    },
+
+    spawnLocalPlayer() {
+      ensureLocalPlayer();
+
+      if (!entities.has("npc_training_dummy")) {
+        entities.set("npc_training_dummy", {
+          id: "npc_training_dummy",
+          kind: "npc",
+          x: options.spawnX + 140,
+          y: options.spawnY + 40,
+          vx: 0,
+          vy: 0,
+          hp: 60,
+          maxHp: 60,
+          name: "Training Dummy"
+        });
+      }
+
+      if (!entities.has("marker_spawn")) {
+        entities.set("marker_spawn", {
+          id: "marker_spawn",
+          kind: "marker",
+          x: options.spawnX,
+          y: options.spawnY,
+          vx: 0,
+          vy: 0,
+          name: "Spawn"
+        });
+      }
+    },
+
+    setLocalPlayerId(id) {
+      if (!id || id === localPlayerId) return;
+
+      const old = entities.get(localPlayerId);
+      localPlayerId = id;
+
+      if (old) {
+        entities.delete(old.id);
+        entities.set(id, {
+          ...old,
+          id,
+          name: old.name ?? "Player"
+        });
+      }
+    },
+
+    applyInput(input, fixedDtSec) {
+      tickId = input.tickId;
+
+      const player = ensureLocalPlayer();
+      const nextPlayer = applyPlayerInput(player, input, fixedDtSec, {
+        speedUnitsPerSecond: options.playerSpeed
+      });
+
+      entities.set(localPlayerId, nextPlayer);
+
+      if (input.skill1) {
+        const markerId = `skill_${input.tickId}`;
+
+        entities.set(markerId, {
+          id: markerId,
+          kind: "marker",
+          x: nextPlayer.x,
+          y: nextPlayer.y,
+          vx: 0,
+          vy: 0,
+          name: "Impact"
+        });
+      }
+
+      for (const [id, entity] of entities) {
+        if (id.startsWith("skill_")) {
+          const createdTick = Number(id.replace("skill_", ""));
+          if (Number.isFinite(createdTick) && tickId - createdTick > 8) {
+            entities.delete(id);
+          }
+        }
+      }
+    },
+
+    applySnapshot(snapshot) {
+      for (const entity of snapshot.entities) {
+        entities.set(entity.id, cloneEntity(entity));
+      }
+    },
+
+    getViewState() {
+      return {
+        tickId,
+        localPlayerId,
+        entities: Array.from(entities.values()).map(cloneEntity)
+      };
+    },
+
+    getEntityCount() {
+      return entities.size;
+    }
+  };
+}

--- a/apps/client-2d/src/logic/inputBuffer.ts
+++ b/apps/client-2d/src/logic/inputBuffer.ts
@@ -1,0 +1,73 @@
+import type { InputFrame } from "../net/protocol";
+
+export interface InputBuffer {
+  setMove(x: number, y: number): void;
+  setPrimary(active: boolean): void;
+  setSkill1(active: boolean): void;
+  setPointer(x: number, y: number): void;
+  consumeForTick(tickId: number): InputFrame;
+  getLastInput(): InputFrame;
+}
+
+function clampAxis(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(-1, Math.min(1, value));
+}
+
+export function createInputBuffer(): InputBuffer {
+  let moveX = 0;
+  let moveY = 0;
+  let primary = false;
+  let skill1 = false;
+  let pointerX: number | undefined;
+  let pointerY: number | undefined;
+
+  let lastInput: InputFrame = {
+    tickId: 0,
+    moveX: 0,
+    moveY: 0,
+    primary: false,
+    skill1: false
+  };
+
+  return {
+    setMove(x, y) {
+      moveX = clampAxis(x);
+      moveY = clampAxis(y);
+    },
+
+    setPrimary(active) {
+      primary = active;
+    },
+
+    setSkill1(active) {
+      skill1 = active;
+    },
+
+    setPointer(x, y) {
+      pointerX = Number.isFinite(x) ? x : undefined;
+      pointerY = Number.isFinite(y) ? y : undefined;
+    },
+
+    consumeForTick(tickId) {
+      lastInput = {
+        tickId,
+        moveX,
+        moveY,
+        primary,
+        skill1,
+        pointerX,
+        pointerY
+      };
+
+      primary = false;
+      skill1 = false;
+
+      return lastInput;
+    },
+
+    getLastInput() {
+      return lastInput;
+    }
+  };
+}

--- a/apps/client-2d/src/logic/playerController.ts
+++ b/apps/client-2d/src/logic/playerController.ts
@@ -1,0 +1,27 @@
+import type { InputFrame } from "../net/protocol";
+import type { EntityState } from "../world/entities";
+import { normalizeVector } from "../world/entities";
+
+export interface PlayerControllerOptions {
+  speedUnitsPerSecond: number;
+}
+
+export function applyPlayerInput(
+  player: EntityState,
+  input: InputFrame,
+  fixedDtSec: number,
+  options: PlayerControllerOptions
+): EntityState {
+  const dir = normalizeVector(input.moveX, input.moveY);
+
+  const vx = dir.x * options.speedUnitsPerSecond;
+  const vy = dir.y * options.speedUnitsPerSecond;
+
+  return {
+    ...player,
+    vx,
+    vy,
+    x: player.x + vx * fixedDtSec,
+    y: player.y + vy * fixedDtSec
+  };
+}

--- a/apps/client-2d/src/net/networkClient.ts
+++ b/apps/client-2d/src/net/networkClient.ts
@@ -1,0 +1,214 @@
+import type { AreloriaBootConfig } from "../boot/boot.config";
+import type {
+  ClientHelloPayload,
+  GuestLoginPayload,
+  InputFrame,
+  ServerEnvelope,
+  SkillCastPayload,
+  WorldSnapshot
+} from "./protocol";
+import {
+  createClientEnvelope,
+  isRecord,
+  isWorldSnapshot
+} from "./protocol";
+
+export interface NetworkEvents {
+  onWelcome?: (payload: { playerId: string; sceneId?: string; serverTick?: number }) => void;
+  onWorldSnapshot?: (snapshot: WorldSnapshot) => void;
+  onToast?: (payload: { message: string; severity?: string }) => void;
+  onStatusChange?: (status: NetworkStatus) => void;
+}
+
+export type NetworkStatus = "idle" | "connecting" | "connected" | "disconnected";
+
+export interface NetworkClient {
+  connect(): void;
+  close(): void;
+  sendInputFrame(frame: InputFrame): void;
+  sendSkillCast(payload: SkillCastPayload): void;
+  getStatus(): NetworkStatus;
+}
+
+export function createNetworkClient(
+  config: AreloriaBootConfig,
+  events: NetworkEvents
+): NetworkClient {
+  let ws: WebSocket | null = null;
+  let status: NetworkStatus = "idle";
+  let closedByUser = false;
+  let reconnectAttempt = 0;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+  function setStatus(next: NetworkStatus): void {
+    status = next;
+    document.body.dataset.areloriaNetwork = next;
+    events.onStatusChange?.(next);
+  }
+
+  function send(type: string, payload: unknown): void {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify(createClientEnvelope(type as never, payload)));
+  }
+
+  function stopHeartbeat(): void {
+    if (heartbeatTimer !== undefined) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
+  }
+
+  function startHeartbeat(): void {
+    stopHeartbeat();
+
+    heartbeatTimer = setInterval(() => {
+      send("client_heartbeat", {
+        client: config.clientId
+      });
+    }, config.network.heartbeatMs);
+  }
+
+  function handleMessage(raw: string): void {
+    let envelope: ServerEnvelope<unknown, unknown>;
+
+    try {
+      envelope = JSON.parse(raw);
+    } catch {
+      console.warn("[Areloria Network] Invalid JSON", raw);
+      return;
+    }
+
+    if (!isRecord(envelope) || typeof envelope.type !== "string") {
+      return;
+    }
+
+    if (envelope.type === "welcome" && isRecord(envelope.payload)) {
+      const playerId = envelope.payload.playerId;
+
+      if (typeof playerId === "string") {
+        events.onWelcome?.({
+          playerId,
+          sceneId:
+            typeof envelope.payload.sceneId === "string"
+              ? envelope.payload.sceneId
+              : undefined,
+          serverTick:
+            typeof envelope.payload.serverTick === "number"
+              ? envelope.payload.serverTick
+              : undefined
+        });
+      }
+
+      return;
+    }
+
+    if (envelope.type === "world_snapshot" && isWorldSnapshot(envelope.payload)) {
+      events.onWorldSnapshot?.({
+        ...envelope.payload,
+        receivedAtMs: performance.now()
+      });
+      return;
+    }
+
+    if (envelope.type === "toast" && isRecord(envelope.payload)) {
+      events.onToast?.({
+        message:
+          typeof envelope.payload.message === "string"
+            ? envelope.payload.message
+            : "Server message",
+        severity:
+          typeof envelope.payload.severity === "string"
+            ? envelope.payload.severity
+            : "info"
+      });
+    }
+  }
+
+  function scheduleReconnect(connectFn: () => void): void {
+    if (closedByUser) return;
+
+    const delay = Math.min(
+      config.network.reconnectMaxMs,
+      config.network.reconnectMinMs * Math.pow(1.6, reconnectAttempt)
+    );
+
+    reconnectAttempt += 1;
+
+    setTimeout(() => {
+      if (!closedByUser) connectFn();
+    }, delay);
+  }
+
+  function connect(): void {
+    if (ws && ws.readyState === WebSocket.OPEN) return;
+
+    setStatus("connecting");
+
+    try {
+      ws = new WebSocket(config.network.wsUrl);
+    } catch (error) {
+      console.warn("[Areloria Network] WebSocket creation failed", error);
+      setStatus("disconnected");
+      scheduleReconnect(connect);
+      return;
+    }
+
+    ws.addEventListener("open", () => {
+      reconnectAttempt = 0;
+      setStatus("connected");
+      startHeartbeat();
+
+      const hello: ClientHelloPayload = {
+        client: config.clientId,
+        engine: config.engine,
+        logicHz: config.logicHz,
+        version: "phase-2"
+      };
+
+      const login: GuestLoginPayload = {
+        displayName: "Guest"
+      };
+
+      send("client_hello", hello);
+      send("guest_login", login);
+    });
+
+    ws.addEventListener("message", (event) => {
+      handleMessage(String(event.data));
+    });
+
+    ws.addEventListener("close", () => {
+      stopHeartbeat();
+      setStatus("disconnected");
+      scheduleReconnect(connect);
+    });
+
+    ws.addEventListener("error", () => {
+      console.warn("[Areloria Network] WebSocket error");
+    });
+  }
+
+  return {
+    connect,
+
+    close() {
+      closedByUser = true;
+      stopHeartbeat();
+      ws?.close();
+      ws = null;
+      setStatus("idle");
+    },
+
+    sendInputFrame(frame) {
+      send("input_frame", frame);
+    },
+
+    sendSkillCast(payload) {
+      send("skill_cast", payload);
+    },
+
+    getStatus() {
+      return status;
+    }
+  };
+}

--- a/apps/client-2d/src/net/protocol.ts
+++ b/apps/client-2d/src/net/protocol.ts
@@ -1,0 +1,95 @@
+import type { EntityState } from "../world/entities";
+
+export type ClientMessageType =
+  | "client_hello"
+  | "guest_login"
+  | "input_frame"
+  | "skill_cast"
+  | "client_heartbeat";
+
+export type ServerMessageType =
+  | "welcome"
+  | "world_snapshot"
+  | "combat_result"
+  | "toast"
+  | "server_heartbeat";
+
+export interface InputFrame {
+  tickId: number;
+  moveX: number;
+  moveY: number;
+  primary: boolean;
+  skill1: boolean;
+  pointerX?: number;
+  pointerY?: number;
+}
+
+export interface WorldSnapshot {
+  serverTick: number;
+  receivedAtMs: number;
+  entities: EntityState[];
+}
+
+export interface ClientHelloPayload {
+  client: "REAL_PIXI_CLIENT";
+  engine: "PIXI_2D";
+  logicHz: number;
+  version: string;
+}
+
+export interface GuestLoginPayload {
+  displayName: string;
+}
+
+export interface SkillCastPayload {
+  tickId: number;
+  skillId: "impact_buster" | "primary";
+  x: number;
+  y: number;
+}
+
+export interface ClientEnvelope<TType extends ClientMessageType, TPayload> {
+  type: TType;
+  payload: TPayload;
+  t: number;
+}
+
+export interface ServerEnvelope<TType extends ServerMessageType, TPayload> {
+  type: TType;
+  payload: TPayload;
+  t?: number;
+}
+
+export interface WelcomePayload {
+  playerId: string;
+  sceneId?: string;
+  serverTick?: number;
+}
+
+export interface ToastPayload {
+  message: string;
+  severity?: "info" | "success" | "warning" | "error";
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function isWorldSnapshot(value: unknown): value is WorldSnapshot {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.serverTick === "number" &&
+    Array.isArray(value.entities)
+  );
+}
+
+export function createClientEnvelope<TType extends ClientMessageType, TPayload>(
+  type: TType,
+  payload: TPayload
+): ClientEnvelope<TType, TPayload> {
+  return {
+    type,
+    payload,
+    t: Date.now()
+  };
+}

--- a/apps/client-2d/src/net/snapshotBuffer.ts
+++ b/apps/client-2d/src/net/snapshotBuffer.ts
@@ -1,0 +1,44 @@
+import type { WorldSnapshot } from "./protocol";
+
+export interface SnapshotBuffer {
+  push(snapshot: WorldSnapshot): void;
+  getLatest(): WorldSnapshot | null;
+  getLastServerTick(): number;
+  size(): number;
+  clear(): void;
+}
+
+export function createSnapshotBuffer(maxSnapshots = 12): SnapshotBuffer {
+  const snapshots: WorldSnapshot[] = [];
+
+  return {
+    push(snapshot) {
+      snapshots.push({
+        ...snapshot,
+        receivedAtMs: snapshot.receivedAtMs || performance.now()
+      });
+
+      snapshots.sort((a, b) => a.serverTick - b.serverTick);
+
+      while (snapshots.length > maxSnapshots) {
+        snapshots.shift();
+      }
+    },
+
+    getLatest() {
+      return snapshots.at(-1) ?? null;
+    },
+
+    getLastServerTick() {
+      return snapshots.at(-1)?.serverTick ?? 0;
+    },
+
+    size() {
+      return snapshots.length;
+    },
+
+    clear() {
+      snapshots.length = 0;
+    }
+  };
+}

--- a/apps/client-2d/src/system/clientVersion.ts
+++ b/apps/client-2d/src/system/clientVersion.ts
@@ -1,0 +1,9 @@
+export const CLIENT_VERSION = {
+  name: "Areloria 2D",
+  client: "REAL_PIXI_CLIENT",
+  phase: "PHASE_2_PLAYABLE_CLIENT",
+  engine: "PIXI_2D",
+  buildMode: import.meta.env.MODE,
+  gitSha: import.meta.env.VITE_GIT_SHA ?? "local",
+  builtAt: import.meta.env.VITE_BUILT_AT ?? "dev"
+} as const;

--- a/apps/client-2d/src/ui/DebugHud.tsx
+++ b/apps/client-2d/src/ui/DebugHud.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import type { AreloriaBootConfig } from "../boot/boot.config";
+
+interface Props {
+  config: AreloriaBootConfig;
+  bootPhase: string;
+  networkStatus: string;
+  tickId: number;
+  entityCount: number;
+  localPlayerId: string;
+  lastSnapshotTick: number;
+}
+
+export function DebugHud({
+  config,
+  bootPhase,
+  networkStatus,
+  tickId,
+  entityCount,
+  localPlayerId,
+  lastSnapshotTick
+}: Props) {
+  if (!config.design.showDebugHud) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: 10,
+        top: 10,
+        zIndex: 9,
+        width: 260,
+        padding: 12,
+        borderRadius: 16,
+        border: "1px solid rgba(0,229,255,.25)",
+        background: "rgba(0,0,0,.38)",
+        color: "rgba(245,247,255,.82)",
+        font: "12px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace",
+        pointerEvents: "none",
+        backdropFilter: "blur(10px)"
+      }}
+    >
+      <strong style={{ color: "#00e5ff" }}>ARELORIA DEBUG</strong>
+      <div>boot: {bootPhase}</div>
+      <div>net: {networkStatus}</div>
+      <div>tick: {tickId}</div>
+      <div>entities: {entityCount}</div>
+      <div>player: {localPlayerId}</div>
+      <div>snapshot: {lastSnapshotTick}</div>
+      <div>mode: {config.mode}</div>
+      <div>ws: {config.network.wsUrl}</div>
+    </div>
+  );
+}

--- a/apps/client-2d/src/ui/GameBoot.tsx
+++ b/apps/client-2d/src/ui/GameBoot.tsx
@@ -1,6 +1,16 @@
 import React, { useEffect, useRef, useState } from "react";
 import { BOOT_PHASES, type BootPhase } from "../theme/designTokens";
 import { BootOverlay } from "./BootOverlay";
+import { ARELORIA_BOOT_CONFIG, type AreloriaBootConfig } from "../boot/boot.config";
+import { createLogicClock, type LogicTick } from "../logic/logicClock";
+import { createInputBuffer, type InputBuffer } from "../logic/inputBuffer";
+import { createClientWorld, type ClientWorld } from "../logic/clientWorld";
+import { createNetworkClient, type NetworkStatus } from "../net/networkClient";
+import { createSnapshotBuffer, type SnapshotBuffer } from "../net/snapshotBuffer";
+import { createPixiClient, type PixiClient } from "../engine/pixiClient";
+import { MobileHud } from "./MobileHud";
+import { DebugHud } from "./DebugHud";
+import { VersionOverlay } from "./VersionOverlay";
 
 type BootPhaseState =
   | "BOOTING"
@@ -26,8 +36,70 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
   const [message, setMessage] = useState("Initialisiere Areloria…");
   const [fatal, setFatal] = useState<string | null>(null);
 
+  // Runtime state refs (not React state to avoid re-render storms)
+  const configRef = useRef<AreloriaBootConfig>(ARELORIA_BOOT_CONFIG);
+  const pixiRef = useRef<PixiClient | null>(null);
+  const clockRef = useRef<ReturnType<typeof createLogicClock> | null>(null);
+  const inputBufferRef = useRef<InputBuffer | null>(null);
+  const clientWorldRef = useRef<ClientWorld | null>(null);
+  const snapshotBufferRef = useRef<SnapshotBuffer | null>(null);
+  const networkStatusRef = useRef<NetworkStatus>("idle");
+  const mountedRef = useRef(false);
+  const lastSnapshotTickRef = useRef<number>(0);
+  const entityCountRef = useRef<number>(0);
+
+  // Force re-render for UI overlays
+  const [, forceUpdate] = useState(0);
+  const triggerUpdate = () => forceUpdate((n) => n + 1);
+
+  // Keyboard state for WASD
+  const keysRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (["w", "a", "s", "d", "arrowup", "arrowdown", "arrowleft", "arrowright"].includes(key)) {
+        e.preventDefault();
+        keysRef.current.add(key);
+        updateKeyboardInput();
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      keysRef.current.delete(key);
+      updateKeyboardInput();
+    };
+
+    function updateKeyboardInput() {
+      const input = inputBufferRef.current;
+      if (!input) return;
+
+      let x = 0;
+      let y = 0;
+
+      if (keysRef.current.has("a") || keysRef.current.has("arrowleft")) x -= 1;
+      if (keysRef.current.has("d") || keysRef.current.has("arrowright")) x += 1;
+      if (keysRef.current.has("w") || keysRef.current.has("arrowup")) y -= 1;
+      if (keysRef.current.has("s") || keysRef.current.has("arrowdown")) y += 1;
+
+      input.setMove(x, y);
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
   useEffect(() => {
     let disposed = false;
+    mountedRef.current = true;
 
     async function boot() {
       try {
@@ -35,18 +107,14 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
         setPhase("BOOTING");
         setMessage("Starte Areloria Client…");
 
-        // Small delay for visual feedback
         await new Promise((resolve) => setTimeout(resolve, 300));
-
         if (disposed) return;
 
         // Phase 2: CHECKING_DEVICE
         setPhase("CHECKING_DEVICE");
         setMessage("Prüfe Gerät, WebGL und Browser-Fähigkeiten…");
 
-        // Run client health check
         const healthResult = await runDeviceHealthCheck();
-
         if (disposed) return;
 
         if (!healthResult.ok) {
@@ -67,23 +135,107 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
           setPhase("OFFLINE");
           setMessage("Server nicht erreichbar. Starte im Offline-Modus.");
           onDegraded?.();
-          return;
         }
 
-        // Phase 4: LOADING_ASSETS
+        // Phase 4: LOADING_ASSETS (minimal - PIXI assets are simple)
         setPhase("LOADING_ASSETS");
         setMessage("Lade Spiel-Assets…");
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        if (disposed) return;
 
-        // Phase 5: CONNECTING_WORLD
+        // Phase 5: CONNECTING_WORLD - Initialize PIXI
         setPhase("CONNECTING_WORLD");
         setMessage("Verbinde mit der Spielwelt…");
 
-        // Phase 6: SYNCING_TICK
+        const mount = mountRef.current;
+        if (!mount) {
+          throw new Error("Mount element not found");
+        }
+
+        const config = configRef.current;
+        const pixi = await createPixiClient({
+          mount,
+          maxFps: config.renderMaxFps,
+          theme: config.design.theme,
+          chunkSize: config.world.chunkSize,
+          interpolationMs: config.world.interpolationMs
+        });
+        pixiRef.current = pixi;
+        if (disposed) return;
+
+        // Initialize core systems
+        const inputBuffer = createInputBuffer();
+        inputBufferRef.current = inputBuffer;
+
+        const clientWorld = createClientWorld({
+          spawnX: 0,
+          spawnY: 0,
+          playerSpeed: 80 // units per second
+        });
+        clientWorldRef.current = clientWorld;
+
+        const snapshotBuffer = createSnapshotBuffer();
+        snapshotBufferRef.current = snapshotBuffer;
+
+        // Connect network
+        const network = createNetworkClient(config, {
+          onStatusChange(status) {
+            networkStatusRef.current = status;
+            triggerUpdate();
+          },
+          onWelcome(payload) {
+            clientWorld.setLocalPlayerId(payload.playerId);
+          },
+          onWorldSnapshot(snapshot) {
+            snapshotBuffer.push(snapshot);
+            clientWorld.applySnapshot(snapshot);
+            lastSnapshotTickRef.current = snapshot.serverTick;
+            entityCountRef.current = clientWorld.getEntityCount();
+            triggerUpdate();
+          }
+        });
+
+        // Phase 6: SYNCING_TICK - Start logic clock
         setPhase("SYNCING_TICK");
         setMessage("Synchronisiere Spielzustand…");
 
-        // Ready
-        if (disposed) return;
+        // Spawn local player immediately for offline/degraded mode
+        clientWorld.spawnLocalPlayer();
+
+        // Start network connection (non-blocking, will reconnect automatically)
+        network.connect();
+
+        // Create logic clock at 10Hz
+        const clock = createLogicClock({
+          hz: config.logicHz,
+          onTick(logicTick: LogicTick) {
+            if (!mountedRef.current) return;
+
+            const input = inputBuffer.consumeForTick(logicTick.tickId);
+            clientWorld.applyInput(input, logicTick.fixedDtSec);
+            network.sendInputFrame(input);
+
+            const viewState = clientWorld.getViewState();
+            entityCountRef.current = viewState.entities.length;
+
+            if (pixiRef.current) {
+              pixiRef.current.logicTick(
+                { tickId: logicTick.tickId, fixedDtSec: logicTick.fixedDtSec },
+                viewState
+              );
+            }
+
+            triggerUpdate();
+          }
+        });
+
+        clockRef.current = clock;
+        clock.start();
+
+        if (disposed) {
+          clock.stop();
+          return;
+        }
 
         document.body.dataset.areloriaBoot = "ready";
         setPhase("READY");
@@ -102,8 +254,23 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
 
     return () => {
       disposed = true;
+      mountedRef.current = false;
+
+      if (clockRef.current) {
+        clockRef.current.stop();
+      }
+      if (pixiRef.current) {
+        pixiRef.current.destroy();
+      }
     };
   }, [onReady, onDegraded, onFatal]);
+
+  const config = configRef.current;
+  const tickId = clockRef.current?.getTickId() ?? 0;
+  const localPlayerId = clientWorldRef.current?.localPlayerId ?? "pending";
+  const networkStatus = networkStatusRef.current;
+  const entityCount = entityCountRef.current;
+  const lastSnapshotTick = lastSnapshotTickRef.current;
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -126,6 +293,23 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
           fatal={fatal}
         />
       )}
+
+      {/* Mobile touch controls - always visible */}
+      {inputBufferRef.current && <MobileHud input={inputBufferRef.current} />}
+
+      {/* Debug HUD - only in dev mode */}
+      <DebugHud
+        config={config}
+        bootPhase={phase}
+        networkStatus={networkStatus}
+        tickId={tickId}
+        entityCount={entityCount}
+        localPlayerId={localPlayerId}
+        lastSnapshotTick={lastSnapshotTick}
+      />
+
+      {/* Version overlay */}
+      <VersionOverlay config={config} />
     </div>
   );
 }
@@ -137,7 +321,6 @@ interface HealthCheckResult {
 
 async function runDeviceHealthCheck(): Promise<HealthCheckResult> {
   try {
-    // WebGL check
     const canvas = document.createElement("canvas");
     const gl =
       canvas.getContext("webgl2") ??
@@ -148,12 +331,10 @@ async function runDeviceHealthCheck(): Promise<HealthCheckResult> {
       return { ok: false, reason: "WebGL ist auf diesem Gerät nicht verfügbar." };
     }
 
-    // Online check
     if (!navigator.onLine) {
       return { ok: false, reason: "Gerät ist offline." };
     }
 
-    // Viewport check
     if (window.innerWidth < 320 || window.innerHeight < 240) {
       return { ok: false, reason: "Viewport zu klein für Areloria." };
     }
@@ -180,7 +361,6 @@ async function checkServerHealth(): Promise<boolean> {
     clearTimeout(timeoutId);
     return response.ok;
   } catch {
-    // Server health check failed - continue anyway (degraded mode)
     console.warn("[Areloria Boot] Server health check failed, continuing anyway");
     return true;
   }

--- a/apps/client-2d/src/ui/MobileHud.tsx
+++ b/apps/client-2d/src/ui/MobileHud.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import type { InputBuffer } from "../logic/inputBuffer";
+
+interface Props {
+  input: InputBuffer;
+}
+
+export function MobileHud({ input }: Props) {
+  const stickRef = React.useRef<HTMLDivElement | null>(null);
+  const pointerIdRef = React.useRef<number | null>(null);
+
+  function updateStick(event: React.PointerEvent<HTMLDivElement>): void {
+    const element = stickRef.current;
+    if (!element) return;
+
+    const rect = element.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+
+    const dx = event.clientX - cx;
+    const dy = event.clientY - cy;
+    const radius = rect.width / 2;
+
+    input.setMove(dx / radius, dy / radius);
+    input.setPointer(event.clientX, event.clientY);
+  }
+
+  function releaseStick(): void {
+    pointerIdRef.current = null;
+    input.setMove(0, 0);
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 7,
+        pointerEvents: "none",
+        touchAction: "none"
+      }}
+    >
+      <div
+        ref={stickRef}
+        onPointerDown={(event) => {
+          pointerIdRef.current = event.pointerId;
+          event.currentTarget.setPointerCapture(event.pointerId);
+          updateStick(event);
+        }}
+        onPointerMove={(event) => {
+          if (pointerIdRef.current === event.pointerId) {
+            updateStick(event);
+          }
+        }}
+        onPointerUp={releaseStick}
+        onPointerCancel={releaseStick}
+        style={{
+          position: "absolute",
+          left: 22,
+          bottom: 28,
+          width: 118,
+          height: 118,
+          borderRadius: 999,
+          border: "1px solid rgba(0,229,255,.35)",
+          background: "rgba(0,0,0,.25)",
+          boxShadow: "0 0 24px rgba(0,229,255,.12)",
+          pointerEvents: "auto",
+          touchAction: "none"
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            left: "50%",
+            top: "50%",
+            width: 42,
+            height: 42,
+            transform: "translate(-50%, -50%)",
+            borderRadius: 999,
+            background: "rgba(0,229,255,.42)"
+          }}
+        />
+      </div>
+
+      <button
+        type="button"
+        onPointerDown={(event) => {
+          event.preventDefault();
+          input.setSkill1(true);
+        }}
+        style={{
+          position: "absolute",
+          right: 24,
+          bottom: 34,
+          width: 86,
+          height: 86,
+          borderRadius: 999,
+          border: "1px solid rgba(255,122,0,.55)",
+          background: "rgba(255,122,0,.22)",
+          color: "#fff",
+          fontWeight: 800,
+          pointerEvents: "auto",
+          touchAction: "none"
+        }}
+      >
+        SKILL
+      </button>
+    </div>
+  );
+}

--- a/apps/client-2d/src/ui/VersionOverlay.tsx
+++ b/apps/client-2d/src/ui/VersionOverlay.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import type { AreloriaBootConfig } from "../boot/boot.config";
+import { CLIENT_VERSION } from "../system/clientVersion";
+
+interface Props {
+  config: AreloriaBootConfig;
+}
+
+export function VersionOverlay({ config }: Props) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        right: 10,
+        bottom: 10,
+        zIndex: 8,
+        padding: "8px 10px",
+        borderRadius: 12,
+        background: "rgba(0,0,0,.35)",
+        color: "rgba(245,247,255,.62)",
+        font: "11px/1.35 system-ui, sans-serif",
+        pointerEvents: "none",
+        backdropFilter: "blur(8px)"
+      }}
+    >
+      <div>{CLIENT_VERSION.client}</div>
+      <div>
+        {CLIENT_VERSION.phase} · {config.logicHz}Hz
+      </div>
+      <div>{CLIENT_VERSION.buildMode}</div>
+    </div>
+  );
+}

--- a/apps/client-2d/src/world/chunks.ts
+++ b/apps/client-2d/src/world/chunks.ts
@@ -1,0 +1,45 @@
+export interface ChunkCoord {
+  cx: number;
+  cy: number;
+}
+
+export interface ChunkInfo extends ChunkCoord {
+  id: string;
+  worldX: number;
+  worldY: number;
+}
+
+export function chunkId(cx: number, cy: number): string {
+  return `${cx}:${cy}`;
+}
+
+export function worldToChunk(x: number, y: number, chunkSize: number): ChunkCoord {
+  return {
+    cx: Math.floor(x / chunkSize),
+    cy: Math.floor(y / chunkSize)
+  };
+}
+
+export function getObservedChunks(
+  x: number,
+  y: number,
+  chunkSize: number,
+  radius: number
+): ChunkInfo[] {
+  const center = worldToChunk(x, y, chunkSize);
+  const chunks: ChunkInfo[] = [];
+
+  for (let cy = center.cy - radius; cy <= center.cy + radius; cy += 1) {
+    for (let cx = center.cx - radius; cx <= center.cx + radius; cx += 1) {
+      chunks.push({
+        cx,
+        cy,
+        id: chunkId(cx, cy),
+        worldX: cx * chunkSize,
+        worldY: cy * chunkSize
+      });
+    }
+  }
+
+  return chunks;
+}

--- a/apps/client-2d/src/world/entities.ts
+++ b/apps/client-2d/src/world/entities.ts
@@ -1,0 +1,36 @@
+export type EntityKind = "player" | "npc" | "loot" | "marker";
+
+export interface EntityState {
+  id: string;
+  kind: EntityKind;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  hp?: number;
+  maxHp?: number;
+  name?: string;
+}
+
+export interface WorldViewState {
+  tickId: number;
+  localPlayerId: string;
+  entities: EntityState[];
+}
+
+export function cloneEntity(entity: EntityState): EntityState {
+  return { ...entity };
+}
+
+export function normalizeVector(x: number, y: number): { x: number; y: number } {
+  const len = Math.hypot(x, y);
+
+  if (len <= 0.0001) {
+    return { x: 0, y: 0 };
+  }
+
+  return {
+    x: x / len,
+    y: y / len
+  };
+}

--- a/docs/ai-skills/wasd-client-2d-boot-stack.md
+++ b/docs/ai-skills/wasd-client-2d-boot-stack.md
@@ -169,3 +169,95 @@ test -f /app/client/dist/2d/service-worker.js
 - `apps/client-2d/src/engine/pixiClient.ts` - PIXI Renderer
 - `apps/client-2d/public/manifest.webmanifest` - PWA Manifest
 - `apps/client-2d/public/service-worker.js` - Offline Cache
+---
+
+## Phase 2: Playable Client (Current Implementation)
+
+### Architecture
+
+```
+GameBoot.tsx
+    |
+    +-- InputBuffer (WASD + Touch)
+    +-- ClientWorld (Entity State)
+    +-- SnapshotBuffer (Server Updates)
+    +-- NetworkClient (WebSocket)
+    +-- PixiClient (Renderer)
+    +-- LogicClock (10Hz)
+
+UI Overlays: MobileHud + DebugHud + VersionOverlay
+```
+
+### New Files (Phase 2)
+
+| File | Purpose |
+|------|---------|
+| `net/protocol.ts` | Network message types |
+| `net/networkClient.ts` | WebSocket with auto-reconnect |
+| `net/snapshotBuffer.ts` | Server snapshot queue |
+| `logic/inputBuffer.ts` | Deterministic input collector |
+| `logic/playerController.ts` | Movement calculation |
+| `logic/clientWorld.ts` | Entity state management |
+| `world/entities.ts` | Entity types |
+| `world/chunks.ts` | Chunk coordinate utilities |
+| `ui/MobileHud.tsx` | Touch joystick + SKILL button |
+| `ui/DebugHud.tsx` | Debug info overlay |
+| `ui/VersionOverlay.tsx` | Version display |
+| `system/clientVersion.ts` | Client version constants |
+
+### Deterministic Rules
+
+1. Logic remains fixed at 10Hz via `createLogicClock`
+2. Input consumed per tick: `inputBuffer.consumeForTick(tickId)`
+3. Renderer only renders `WorldViewState`
+4. Network snapshots buffered before world application
+5. Client renders without server (offline/degraded mode)
+6. WebSocket failure is non-fatal (auto-reconnect)
+7. All time uses tickId/fixedDtSec
+8. Mobile controls use pointer events
+9. Debug HUD configurable via `config.design.showDebugHud`
+
+### Key Types
+
+```typescript
+interface EntityState {
+  id: string;
+  kind: "player" | "npc" | "loot" | "marker";
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  hp?: number;
+  maxHp?: number;
+  name?: string;
+}
+
+interface WorldViewState {
+  tickId: number;
+  localPlayerId: string;
+  entities: EntityState[];
+}
+
+interface InputFrame {
+  tickId: number;
+  moveX: number;
+  moveY: number;
+  primary: boolean;
+  skill1: boolean;
+}
+
+interface WorldSnapshot {
+  serverTick: number;
+  receivedAtMs: number;
+  entities: EntityState[];
+}
+```
+
+### Test Commands
+
+```bash
+pnpm --filter client-2d build
+pnpm --filter client-2d typecheck  # if exists
+npx tsc --noEmit --project apps/client-2d/tsconfig.json
+npx eslint apps/client-2d/src/net apps/client-2d/src/logic apps/client-2d/src/ui/MobileHud.tsx apps/client-2d/src/ui/DebugHud.tsx apps/client-2d/src/engine/pixiClient.ts apps/client-2d/src/ui/GameBoot.tsx
+```


### PR DESCRIPTION
## REAL_PIXI_CLIENT Phase 2

Adds playable deterministic client layer for Areloria 2D.

### Added
- Network protocol layer (`src/net/protocol.ts`)
- WebSocket network client with auto-reconnect (`src/net/networkClient.ts`)
- Snapshot buffer for server updates (`src/net/snapshotBuffer.ts`)
- Deterministic input buffer for WASD + touch controls (`src/logic/inputBuffer.ts`)
- Client world state management (`src/logic/clientWorld.ts`)
- Player controller with movement calculation (`src/logic/playerController.ts`)
- Entity/chunk models (`src/world/entities.ts`, `src/world/chunks.ts`)
- Mobile touch HUD with joystick + SKILL button (`src/ui/MobileHud.tsx`)
- Debug HUD overlay (`src/ui/DebugHud.tsx`)
- Version overlay (`src/ui/VersionOverlay.tsx`)

### Modified
- `pixiClient.ts` - Entity rendering with interpolation
- `GameBoot.tsx` - Full Phase 2 wiring with 10Hz logic clock
- `wasd-client-2d-boot-stack.md` - Documentation updated

### Deterministic Rules
- Logic runs at fixed 10Hz via `createLogicClock`
- Input consumed per tick: `inputBuffer.consumeForTick(tickId)`
- Renderer only renders `WorldViewState`
- Network snapshots buffered before world application
- Client keeps rendering without server (offline/degraded mode)
- WebSocket failure is non-fatal (auto-reconnect with backoff)

### Result
The client now boots into a playable local world with keyboard/touch movement, skill button, chunk grid, player spawn, debug status and network reconnect support.

### Test Commands
```bash
pnpm --filter client-2d build
npx tsc --noEmit --project apps/client-2d/tsconfig.json
```

---

*This PR was created by an AI agent (OpenHands) on behalf of the contributor.*

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e0020824-d4f4-4d3c-82f3-9dd2b747cf4b)