### PR TITLE
feat(client-2d): add deterministic MMORPG gameplay layer phase 4

### DIFF
--- a/apps/client-2d/src/game/equipment.ts
+++ b/apps/client-2d/src/game/equipment.ts
@@ -1,0 +1,71 @@
+import { getItemDefinition } from "./items";
+
+export type EquipmentSlotId = "weapon" | "armor" | "trinket";
+
+export interface EquipmentState {
+  slots: Record<EquipmentSlotId, string | null>;
+}
+
+export type EquipmentEvent =
+  | {
+      type: "equipment_set";
+      slots: Record<EquipmentSlotId, string | null>;
+    }
+  | {
+      type: "equipment_equip";
+      slot: EquipmentSlotId;
+      itemId: string;
+    }
+  | {
+      type: "equipment_unequip";
+      slot: EquipmentSlotId;
+    };
+
+export function createEquipment(): EquipmentState {
+  return {
+    slots: {
+      weapon: null,
+      armor: null,
+      trinket: null
+    }
+  };
+}
+
+export function applyEquipmentEvent(
+  equipment: EquipmentState,
+  event: EquipmentEvent
+): EquipmentState {
+  if (event.type === "equipment_set") {
+    return {
+      slots: { ...event.slots }
+    };
+  }
+
+  if (event.type === "equipment_equip") {
+    const def = getItemDefinition(event.itemId);
+
+    if (!def) return equipment;
+
+    // Validate item kind matches slot type
+    if (event.slot === "weapon" && def.kind !== "weapon") return equipment;
+    if (event.slot === "armor" && def.kind !== "armor") return equipment;
+
+    return {
+      slots: {
+        ...equipment.slots,
+        [event.slot]: event.itemId
+      }
+    };
+  }
+
+  if (event.type === "equipment_unequip") {
+    return {
+      slots: {
+        ...equipment.slots,
+        [event.slot]: null
+      }
+    };
+  }
+
+  return equipment;
+}

--- a/apps/client-2d/src/game/gameplayEvents.ts
+++ b/apps/client-2d/src/game/gameplayEvents.ts
@@ -1,0 +1,79 @@
+import type { EquipmentEvent } from "./equipment";
+import type { InventoryEvent } from "./inventory";
+import type { QuestEvent } from "./quests";
+import type { SkillId } from "./skills";
+
+export type GameplayEvent =
+  | InventoryEvent
+  | EquipmentEvent
+  | QuestEvent
+  | {
+      type: "loot_pickup_requested";
+      tickId: number;
+      entityId: string;
+    }
+  | {
+      type: "loot_pickup_confirmed";
+      itemId: string;
+      quantity: number;
+      entityId?: string;
+    }
+  | {
+      type: "skill_requested";
+      tickId: number;
+      skillId: SkillId;
+      targetId?: string;
+      x?: number;
+      y?: number;
+    }
+  | {
+      type: "skill_confirmed";
+      tickId: number;
+      skillId: SkillId;
+    }
+  | {
+      type: "npc_interaction_requested";
+      tickId: number;
+      npcId: string;
+    }
+  | {
+      type: "npc_dialogue";
+      npcId: string;
+      npcName: string;
+      text: string;
+    };
+
+export interface GameplayEventQueue {
+  push(event: GameplayEvent): void;
+  drain(): GameplayEvent[];
+  size(): number;
+  clear(): void;
+}
+
+export function createGameplayEventQueue(maxEvents = 128): GameplayEventQueue {
+  const events: GameplayEvent[] = [];
+
+  return {
+    push(event) {
+      events.push(event);
+
+      while (events.length > maxEvents) {
+        events.shift();
+      }
+    },
+
+    drain() {
+      const drained = events.slice();
+      events.length = 0;
+      return drained;
+    },
+
+    size() {
+      return events.length;
+    },
+
+    clear() {
+      events.length = 0;
+    }
+  };
+}

--- a/apps/client-2d/src/game/interactions.ts
+++ b/apps/client-2d/src/game/interactions.ts
@@ -1,0 +1,40 @@
+import type { EntityState } from "../world/entities";
+
+export interface InteractionTarget {
+  entityId: string;
+  kind: "npc" | "loot";
+  label: string;
+  distance: number;
+}
+
+export function findNearestInteractionTarget(
+  player: EntityState | null,
+  entities: EntityState[],
+  maxDistance: number
+): InteractionTarget | null {
+  if (!player) return null;
+
+  let best: InteractionTarget | null = null;
+
+  for (const entity of entities) {
+    if (entity.kind !== "npc" && entity.kind !== "loot") continue;
+
+    const distance = Math.hypot(entity.x - player.x, entity.y - player.y);
+
+    if (distance > maxDistance) continue;
+
+    if (!best || distance < best.distance) {
+      best = {
+        entityId: entity.id,
+        kind: entity.kind,
+        label:
+          entity.kind === "npc"
+            ? `Talk to ${entity.name ?? "NPC"}`
+            : `Pick up ${entity.name ?? "Loot"}`,
+        distance
+      };
+    }
+  }
+
+  return best;
+}

--- a/apps/client-2d/src/game/inventory.ts
+++ b/apps/client-2d/src/game/inventory.ts
@@ -1,0 +1,143 @@
+import { getItemDefinition, type ItemStack } from "./items";
+
+export interface InventorySlot {
+  index: number;
+  stack: ItemStack | null;
+}
+
+export interface InventoryState {
+  slots: InventorySlot[];
+}
+
+export type InventoryEvent =
+  | {
+      type: "inventory_set";
+      slots: InventorySlot[];
+    }
+  | {
+      type: "inventory_add";
+      itemId: string;
+      quantity: number;
+    }
+  | {
+      type: "inventory_remove";
+      itemId: string;
+      quantity: number;
+    };
+
+export function createInventory(slotCount = 24): InventoryState {
+  return {
+    slots: Array.from({ length: slotCount }, (_, index) => ({
+      index,
+      stack: null
+    }))
+  };
+}
+
+export function countInventoryItems(inventory: InventoryState): number {
+  return inventory.slots.reduce((sum, slot) => {
+    return sum + (slot.stack?.quantity ?? 0);
+  }, 0);
+}
+
+export function applyInventoryEvent(
+  inventory: InventoryState,
+  event: InventoryEvent
+): InventoryState {
+  if (event.type === "inventory_set") {
+    return {
+      slots: event.slots.map((slot, index) => ({
+        index,
+        stack: slot.stack ? { ...slot.stack } : null
+      }))
+    };
+  }
+
+  if (event.type === "inventory_add") {
+    return addItem(inventory, event.itemId, event.quantity);
+  }
+
+  if (event.type === "inventory_remove") {
+    return removeItem(inventory, event.itemId, event.quantity);
+  }
+
+  return inventory;
+}
+
+export function addItem(
+  inventory: InventoryState,
+  itemId: string,
+  quantity: number
+): InventoryState {
+  const def = getItemDefinition(itemId);
+  if (!def || quantity <= 0) return inventory;
+
+  let remaining = quantity;
+
+  const slots = inventory.slots.map((slot) => ({
+    index: slot.index,
+    stack: slot.stack ? { ...slot.stack } : null
+  }));
+
+  // First pass: stack with existing items of same type
+  for (const slot of slots) {
+    if (!slot.stack || slot.stack.itemId !== itemId) continue;
+
+    const free = def.maxStack - slot.stack.quantity;
+    const move = Math.min(free, remaining);
+
+    if (move > 0) {
+      slot.stack.quantity += move;
+      remaining -= move;
+    }
+
+    if (remaining <= 0) break;
+  }
+
+  // Second pass: fill empty slots
+  for (const slot of slots) {
+    if (remaining <= 0) break;
+    if (slot.stack) continue;
+
+    const move = Math.min(def.maxStack, remaining);
+    slot.stack = {
+      itemId,
+      quantity: move
+    };
+
+    remaining -= move;
+  }
+
+  return { slots };
+}
+
+export function removeItem(
+  inventory: InventoryState,
+  itemId: string,
+  quantity: number
+): InventoryState {
+  if (quantity <= 0) return inventory;
+
+  let remaining = quantity;
+
+  const slots = inventory.slots.map((slot) => ({
+    index: slot.index,
+    stack: slot.stack ? { ...slot.stack } : null
+  }));
+
+  for (const slot of slots) {
+    if (!slot.stack || slot.stack.itemId !== itemId) continue;
+
+    const move = Math.min(slot.stack.quantity, remaining);
+    slot.stack.quantity -= move;
+    remaining -= move;
+
+    if (slot.stack.quantity <= 0) {
+      slot.stack = null;
+    }
+
+    if (remaining <= 0) break;
+  }
+
+  return { slots };
+}

--- a/apps/client-2d/src/game/items.ts
+++ b/apps/client-2d/src/game/items.ts
@@ -1,0 +1,63 @@
+export type ItemRarity = "common" | "uncommon" | "rare" | "epic" | "legendary";
+
+export type ItemKind =
+  | "weapon"
+  | "armor"
+  | "consumable"
+  | "material"
+  | "quest"
+  | "currency";
+
+export interface ItemDefinition {
+  id: string;
+  name: string;
+  kind: ItemKind;
+  rarity: ItemRarity;
+  icon?: string;
+  maxStack: number;
+  description?: string;
+}
+
+export interface ItemStack {
+  itemId: string;
+  quantity: number;
+}
+
+export const ITEM_DEFINITIONS: Record<string, ItemDefinition> = {
+  wood_sword: {
+    id: "wood_sword",
+    name: "Wood Sword",
+    kind: "weapon",
+    rarity: "common",
+    maxStack: 1,
+    description: "A simple starter blade."
+  },
+  training_armor: {
+    id: "training_armor",
+    name: "Training Armor",
+    kind: "armor",
+    rarity: "common",
+    maxStack: 1,
+    description: "Light protection for new adventurers."
+  },
+  slime_core: {
+    id: "slime_core",
+    name: "Slime Core",
+    kind: "material",
+    rarity: "uncommon",
+    maxStack: 99,
+    description: "A pulsing residue from a weak creature."
+  },
+  health_potion_small: {
+    id: "health_potion_small",
+    name: "Small Health Potion",
+    kind: "consumable",
+    rarity: "common",
+    maxStack: 20,
+    description: "Restores a small amount of health."
+  }
+};
+
+export function getItemDefinition(itemId: string): ItemDefinition | null {
+  return ITEM_DEFINITIONS[itemId] ?? null;
+}

--- a/apps/client-2d/src/game/quests.ts
+++ b/apps/client-2d/src/game/quests.ts
@@ -1,0 +1,133 @@
+export type QuestStatus = "locked" | "available" | "active" | "completed";
+
+export interface QuestObjective {
+  id: string;
+  label: string;
+  current: number;
+  required: number;
+}
+
+export interface QuestState {
+  id: string;
+  title: string;
+  description: string;
+  status: QuestStatus;
+  objectives: QuestObjective[];
+  tracked: boolean;
+}
+
+export type QuestEvent =
+  | {
+      type: "quest_snapshot";
+      quests: QuestState[];
+    }
+  | {
+      type: "quest_accept";
+      questId: string;
+    }
+  | {
+      type: "quest_progress";
+      questId: string;
+      objectiveId: string;
+      current: number;
+    }
+  | {
+      type: "quest_complete";
+      questId: string;
+    }
+  | {
+      type: "quest_track";
+      questId: string;
+    };
+
+export function createInitialQuests(): QuestState[] {
+  return [
+    {
+      id: "first_steps",
+      title: "First Steps",
+      description: "Learn the basics of movement, combat and interaction.",
+      status: "available",
+      tracked: true,
+      objectives: [
+        {
+          id: "move",
+          label: "Move around",
+          current: 0,
+          required: 1
+        },
+        {
+          id: "use_skill",
+          label: "Use a skill",
+          current: 0,
+          required: 1
+        }
+      ]
+    }
+  ];
+}
+
+export function getTrackedQuest(quests: QuestState[]): QuestState | null {
+  return quests.find((quest) => quest.tracked) ?? null;
+}
+
+export function applyQuestEvent(
+  quests: QuestState[],
+  event: QuestEvent
+): QuestState[] {
+  if (event.type === "quest_snapshot") {
+    return event.quests.map((quest) => ({
+      ...quest,
+      objectives: quest.objectives.map((objective) => ({ ...objective }))
+    }));
+  }
+
+  if (event.type === "quest_track") {
+    return quests.map((quest) => ({
+      ...quest,
+      tracked: quest.id === event.questId
+    }));
+  }
+
+  if (event.type === "quest_accept") {
+    return quests.map((quest) =>
+      quest.id === event.questId && quest.status === "available"
+        ? { ...quest, status: "active", tracked: true }
+        : quest
+    );
+  }
+
+  if (event.type === "quest_progress") {
+    return quests.map((quest) => {
+      if (quest.id !== event.questId) return quest;
+
+      return {
+        ...quest,
+        objectives: quest.objectives.map((objective) =>
+          objective.id === event.objectiveId
+            ? {
+                ...objective,
+                current: Math.min(objective.required, event.current)
+              }
+            : objective
+        )
+      };
+    });
+  }
+
+  if (event.type === "quest_complete") {
+    return quests.map((quest) =>
+      quest.id === event.questId
+        ? {
+            ...quest,
+            status: "completed",
+            objectives: quest.objectives.map((objective) => ({
+              ...objective,
+              current: objective.required
+            }))
+          }
+        : quest
+    );
+  }
+
+  return quests;
+}

--- a/apps/client-2d/src/game/skills.ts
+++ b/apps/client-2d/src/game/skills.ts
@@ -1,0 +1,92 @@
+export type SkillId = "primary" | "impact_buster" | "interact" | "pickup";
+
+export interface SkillDefinition {
+  id: SkillId;
+  label: string;
+  cooldownTicks: number;
+}
+
+export interface SkillState {
+  id: SkillId;
+  cooldownRemainingTicks: number;
+}
+
+export const SKILL_DEFINITIONS: Record<SkillId, SkillDefinition> = {
+  primary: {
+    id: "primary",
+    label: "Hit",
+    cooldownTicks: 4
+  },
+  impact_buster: {
+    id: "impact_buster",
+    label: "Impact",
+    cooldownTicks: 80
+  },
+  interact: {
+    id: "interact",
+    label: "Talk",
+    cooldownTicks: 5
+  },
+  pickup: {
+    id: "pickup",
+    label: "Loot",
+    cooldownTicks: 5
+  }
+};
+
+export function createSkillStates(): Record<SkillId, SkillState> {
+  return {
+    primary: {
+      id: "primary",
+      cooldownRemainingTicks: 0
+    },
+    impact_buster: {
+      id: "impact_buster",
+      cooldownRemainingTicks: 0
+    },
+    interact: {
+      id: "interact",
+      cooldownRemainingTicks: 0
+    },
+    pickup: {
+      id: "pickup",
+      cooldownRemainingTicks: 0
+    }
+  };
+}
+
+export function tickSkillCooldowns(
+  skills: Record<SkillId, SkillState>
+): Record<SkillId, SkillState> {
+  return Object.fromEntries(
+    Object.entries(skills).map(([id, state]) => [
+      id,
+      {
+        ...state,
+        cooldownRemainingTicks: Math.max(0, state.cooldownRemainingTicks - 1)
+      }
+    ])
+  ) as Record<SkillId, SkillState>;
+}
+
+export function canUseSkill(
+  skills: Record<SkillId, SkillState>,
+  skillId: SkillId
+): boolean {
+  return skills[skillId].cooldownRemainingTicks <= 0;
+}
+
+export function triggerSkillCooldown(
+  skills: Record<SkillId, SkillState>,
+  skillId: SkillId
+): Record<SkillId, SkillState> {
+  const def = SKILL_DEFINITIONS[skillId];
+
+  return {
+    ...skills,
+    [skillId]: {
+      id: skillId,
+      cooldownRemainingTicks: def.cooldownTicks
+    }
+  };
+}

--- a/apps/client-2d/src/net/networkClient.ts
+++ b/apps/client-2d/src/net/networkClient.ts
@@ -7,6 +7,13 @@ import type {
   CombatResultPayload,
   GuestLoginPayload,
   InputFrame,
+  InventorySnapshotPayload,
+  EquipmentSnapshotPayload,
+  QuestSnapshotPayload,
+  LootPickupResultPayload,
+  NpcDialoguePayload,
+  ChunkObservePayload,
+  SkillResultPayload,
   ServerEnvelope,
   SkillCastPayload,
   ToastPayload,
@@ -18,6 +25,13 @@ import {
   createClientEnvelope,
   isChatMessagePayload,
   isCombatResultPayload,
+  isInventorySnapshotPayload,
+  isEquipmentSnapshotPayload,
+  isQuestSnapshotPayload,
+  isLootPickupResultPayload,
+  isNpcDialoguePayload,
+  isChunkObservePayload,
+  isSkillResultPayload,
   isRecord,
   isServerHeartbeatPayload,
   isToastPayload,
@@ -35,6 +49,14 @@ export interface NetworkEvents {
   onCombatResult?: (payload: CombatResultPayload) => void;
   onServerHeartbeat?: (payload: { serverTimeMs: number; serverTick?: number; clientSentAtMs?: number }) => void;
   onStatusChange?: (status: NetworkStatus) => void;
+  // Phase 4 Events
+  onInventorySnapshot?: (payload: InventorySnapshotPayload) => void;
+  onEquipmentSnapshot?: (payload: EquipmentSnapshotPayload) => void;
+  onQuestSnapshot?: (payload: QuestSnapshotPayload) => void;
+  onLootPickupResult?: (payload: LootPickupResultPayload) => void;
+  onNpcDialogue?: (payload: NpcDialoguePayload) => void;
+  onChunkObserve?: (payload: ChunkObservePayload) => void;
+  onSkillResult?: (payload: SkillResultPayload) => void;
 }
 
 export interface NetworkClient {
@@ -43,6 +65,14 @@ export interface NetworkClient {
   sendInputFrame(frame: InputFrame): void;
   sendSkillCast(payload: SkillCastPayload): void;
   sendChat(text: string): void;
+  // Phase 4 Send Methods
+  sendLootPickupRequest(payload: { tickId: number; sequenceId: number; entityId: string }): void;
+  sendNpcInteractRequest(payload: { tickId: number; sequenceId: number; npcId: string }): void;
+  sendChunkObserve(payload: ChunkObservePayload): void;
+  sendQuestTrack(questId: string): void;
+  sendQuestAccept(questId: string): void;
+  sendInventoryAction(payload: { action: string; itemId?: string; slot?: number }): void;
+  sendEquipmentAction(payload: { action: string; slot?: string; itemId?: string }): void;
   getStatus(): NetworkStatus;
 }
 
@@ -158,6 +188,42 @@ export function createNetworkClient(
             : undefined
       });
     }
+
+    // Phase 4 Message Handlers
+    if (envelope.type === "inventory_snapshot" && isInventorySnapshotPayload(envelope.payload)) {
+      events.onInventorySnapshot?.(envelope.payload);
+      return;
+    }
+
+    if (envelope.type === "equipment_snapshot" && isEquipmentSnapshotPayload(envelope.payload)) {
+      events.onEquipmentSnapshot?.(envelope.payload);
+      return;
+    }
+
+    if (envelope.type === "quest_snapshot" && isQuestSnapshotPayload(envelope.payload)) {
+      events.onQuestSnapshot?.(envelope.payload);
+      return;
+    }
+
+    if (envelope.type === "loot_pickup_result" && isLootPickupResultPayload(envelope.payload)) {
+      events.onLootPickupResult?.(envelope.payload);
+      return;
+    }
+
+    if (envelope.type === "npc_dialogue" && isNpcDialoguePayload(envelope.payload)) {
+      events.onNpcDialogue?.(envelope.payload);
+      return;
+    }
+
+    if (envelope.type === "chunk_snapshot" && isRecord(envelope.payload)) {
+      // chunk_snapshot is optional, just pass through
+      return;
+    }
+
+    if (envelope.type === "skill_result" && isSkillResultPayload(envelope.payload)) {
+      events.onSkillResult?.(envelope.payload);
+      return;
+    }
   }
 
   function scheduleReconnect(connectFn: () => void): void {
@@ -252,6 +318,35 @@ export function createNetworkClient(
       if (payload.text.length > 0) {
         send("chat_send", payload);
       }
+    },
+
+    // Phase 4 Send Methods
+    sendLootPickupRequest(payload) {
+      send("loot_pickup_request", payload);
+    },
+
+    sendNpcInteractRequest(payload) {
+      send("npc_interact_request", payload);
+    },
+
+    sendChunkObserve(payload) {
+      send("chunk_observe", payload);
+    },
+
+    sendQuestTrack(questId) {
+      send("quest_track", { questId });
+    },
+
+    sendQuestAccept(questId) {
+      send("quest_accept", { questId });
+    },
+
+    sendInventoryAction(payload) {
+      send("inventory_action", payload);
+    },
+
+    sendEquipmentAction(payload) {
+      send("equipment_action", payload);
     },
 
     getStatus() {

--- a/apps/client-2d/src/net/protocol.ts
+++ b/apps/client-2d/src/net/protocol.ts
@@ -1,6 +1,10 @@
 import type { EntityState } from "../world/entities";
+import type { InventorySlot } from "../game/inventory";
+import type { EquipmentSlotId } from "../game/equipment";
+import type { QuestState } from "../game/quests";
+import type { SkillId } from "../game/skills";
 
-export const ARELORIA_PROTOCOL_VERSION = 3 as const;
+export const ARELORIA_PROTOCOL_VERSION = 4 as const;
 
 export type ClientMessageType =
   | "client_hello"
@@ -8,7 +12,14 @@ export type ClientMessageType =
   | "input_frame"
   | "skill_cast"
   | "chat_send"
-  | "client_heartbeat";
+  | "client_heartbeat"
+  | "loot_pickup_request"
+  | "npc_interact_request"
+  | "inventory_action"
+  | "equipment_action"
+  | "quest_accept"
+  | "quest_track"
+  | "chunk_observe";
 
 export type ServerMessageType =
   | "welcome"
@@ -16,7 +27,15 @@ export type ServerMessageType =
   | "combat_result"
   | "toast"
   | "chat_message"
-  | "server_heartbeat";
+  | "server_heartbeat"
+  | "inventory_snapshot"
+  | "equipment_snapshot"
+  | "quest_snapshot"
+  | "loot_pickup_result"
+  | "npc_dialogue"
+  | "skill_result"
+  | "chunk_snapshot"
+  | "gameplay_event";
 
 export interface InputFrame {
   sequenceId: number;
@@ -105,6 +124,70 @@ export interface CombatResultPayload {
   kind: "damage" | "heal" | "miss" | "block";
 }
 
+// Phase 4 Payload Types
+
+export interface LootPickupRequestPayload {
+  tickId: number;
+  sequenceId: number;
+  entityId: string;
+}
+
+export interface NpcInteractRequestPayload {
+  tickId: number;
+  sequenceId: number;
+  npcId: string;
+}
+
+export interface InventorySnapshotPayload {
+  slots: InventorySlot[];
+}
+
+export interface EquipmentSnapshotPayload {
+  slots: Record<EquipmentSlotId, string | null>;
+}
+
+export interface QuestSnapshotPayload {
+  quests: QuestState[];
+}
+
+export interface LootPickupResultPayload {
+  ok: boolean;
+  entityId?: string;
+  itemId?: string;
+  quantity?: number;
+  reason?: string;
+}
+
+export interface NpcDialoguePayload {
+  npcId: string;
+  npcName: string;
+  text: string;
+}
+
+export interface SkillResultPayload {
+  skillId: SkillId;
+  success: boolean;
+  tickId?: number;
+  reason?: string;
+}
+
+export interface ChunkObservePayload {
+  centerChunkId: string;
+  chunks: string[];
+}
+
+export interface ChunkSnapshotPayload {
+  chunks: Array<{
+    id: string;
+    entities?: EntityState[];
+  }>;
+}
+
+export interface GameplayEventPayload {
+  eventType: string;
+  data: Record<string, unknown>;
+}
+
 export interface ClientEnvelope<TType extends ClientMessageType, TPayload> {
   type: TType;
   payload: TPayload;
@@ -179,6 +262,54 @@ export function isServerHeartbeatPayload(
   value: unknown
 ): value is ServerHeartbeatPayload {
   return isRecord(value) && typeof value.serverTimeMs === "number";
+}
+
+// Phase 4 Payload Validators
+
+export function isInventorySnapshotPayload(value: unknown): value is InventorySnapshotPayload {
+  return isRecord(value) && Array.isArray(value.slots);
+}
+
+export function isEquipmentSnapshotPayload(value: unknown): value is EquipmentSnapshotPayload {
+  return (
+    isRecord(value) &&
+    isRecord(value.slots) &&
+    typeof value.slots.weapon === "string" ||
+    value.slots.weapon === null
+  );
+}
+
+export function isQuestSnapshotPayload(value: unknown): value is QuestSnapshotPayload {
+  return isRecord(value) && Array.isArray(value.quests);
+}
+
+export function isLootPickupResultPayload(value: unknown): value is LootPickupResultPayload {
+  return isRecord(value) && typeof value.ok === "boolean";
+}
+
+export function isNpcDialoguePayload(value: unknown): value is NpcDialoguePayload {
+  return (
+    isRecord(value) &&
+    typeof value.npcId === "string" &&
+    typeof value.npcName === "string" &&
+    typeof value.text === "string"
+  );
+}
+
+export function isChunkObservePayload(value: unknown): value is ChunkObservePayload {
+  return (
+    isRecord(value) &&
+    typeof value.centerChunkId === "string" &&
+    Array.isArray(value.chunks)
+  );
+}
+
+export function isSkillResultPayload(value: unknown): value is SkillResultPayload {
+  return (
+    isRecord(value) &&
+    typeof value.skillId === "string" &&
+    typeof value.success === "boolean"
+  );
 }
 
 export function createClientEnvelope<TType extends ClientMessageType, TPayload>(

--- a/apps/client-2d/src/system/clientVersion.ts
+++ b/apps/client-2d/src/system/clientVersion.ts
@@ -1,7 +1,7 @@
 export const CLIENT_VERSION = {
   name: "Areloria 2D",
   client: "REAL_PIXI_CLIENT",
-  phase: "PHASE_3_MULTIPLAYER_SYNC",
+  phase: "PHASE_4_MMORPG_GAMEPLAY",
   engine: "PIXI_2D",
   buildMode: import.meta.env.MODE,
   gitSha: import.meta.env.VITE_GIT_SHA ?? "local",

--- a/apps/client-2d/src/ui/DebugHud.tsx
+++ b/apps/client-2d/src/ui/DebugHud.tsx
@@ -15,6 +15,11 @@ interface Props {
   rttMs: number;
   networkQuality: string;
   serverOffsetMs: number;
+  // Phase 4 Props
+  inventoryCount?: number;
+  trackedQuestTitle?: string;
+  observedChunkCount?: number;
+  gameplayEventQueueSize?: number;
 }
 
 export function DebugHud({
@@ -30,7 +35,11 @@ export function DebugHud({
   acknowledgedInputSeq,
   rttMs,
   networkQuality,
-  serverOffsetMs
+  serverOffsetMs,
+  inventoryCount = 0,
+  trackedQuestTitle,
+  observedChunkCount = 0,
+  gameplayEventQueueSize = 0
 }: Props) {
   if (!config.design.showDebugHud) return null;
 
@@ -52,7 +61,7 @@ export function DebugHud({
         backdropFilter: "blur(10px)"
       }}
     >
-      <strong style={{ color: "#00e5ff" }}>ARELORIA DEBUG</strong>
+      <strong style={{ color: "#00e5ff" }}>ARELORIA DEBUG [P4]</strong>
       <div>boot: {bootPhase}</div>
       <div>net: {networkStatus}</div>
       <div>tick: {tickId}</div>
@@ -65,8 +74,16 @@ export function DebugHud({
       <div>rtt: {rttMs}ms</div>
       <div>quality: {networkQuality}</div>
       <div>offset: {serverOffsetMs}ms</div>
-      <div>mode: {config.mode}</div>
-      <div>ws: {config.network.wsUrl}</div>
+      {/* Phase 4 Display */}
+      <div style={{ marginTop: 8, borderTop: "1px solid rgba(0,229,255,.15)", paddingTop: 6 }}>
+        <strong style={{ color: "#00e5ff" }}>GAMEPLAY</strong>
+      </div>
+      <div>inventory: {inventoryCount} items</div>
+      <div>quest: {trackedQuestTitle ?? "none"}</div>
+      <div>chunks: {observedChunkCount}</div>
+      <div>events: {gameplayEventQueueSize}</div>
+      <div style={{ marginTop: 6 }}>mode: {config.mode}</div>
+      <div style={{ opacity: 0.6 }}>ws: {config.network.wsUrl}</div>
     </div>
   );
 }

--- a/apps/client-2d/src/ui/EquipmentPanel.tsx
+++ b/apps/client-2d/src/ui/EquipmentPanel.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import type { EquipmentState } from "../game/equipment";
+import { getItemDefinition } from "../game/items";
+
+interface Props {
+  open: boolean;
+  equipment: EquipmentState;
+  onClose: () => void;
+}
+
+export function EquipmentPanel({ open, equipment, onClose }: Props) {
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: "50%",
+        top: "50%",
+        transform: "translate(-50%, -50%)",
+        zIndex: 41,
+        width: "min(420px, 94vw)",
+        padding: 16,
+        borderRadius: 20,
+        border: "1px solid rgba(255,122,0,.32)",
+        background: "rgba(7,7,17,.92)",
+        color: "#f5f7ff",
+        backdropFilter: "blur(14px)"
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 14
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: 18 }}>Equipment</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          style={{
+            background: "rgba(255,255,255,.1)",
+            border: "1px solid rgba(255,255,255,.2)",
+            borderRadius: 8,
+            color: "#f5f7ff",
+            cursor: "pointer",
+            padding: "6px 12px"
+          }}
+        >
+          ✕
+        </button>
+      </header>
+
+      <div style={{ display: "grid", gap: 10 }}>
+        {Object.entries(equipment.slots).map(([slot, itemId]) => {
+          const def = itemId ? getItemDefinition(itemId) : null;
+
+          return (
+            <div
+              key={slot}
+              style={{
+                padding: 12,
+                borderRadius: 14,
+                border: "1px solid rgba(255,255,255,.12)",
+                background: "rgba(255,255,255,.06)"
+              }}
+            >
+              <strong style={{ textTransform: "capitalize" }}>{slot}</strong>
+              <div style={{ opacity: def ? 1 : 0.45 }}>
+                {def ? def.name : "Empty"}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/client-2d/src/ui/GameBoot.tsx
+++ b/apps/client-2d/src/ui/GameBoot.tsx
@@ -19,6 +19,20 @@ import { ToastStack, type ClientToast } from "./ui/ToastStack";
 import { ChatMiniPanel } from "./ui/ChatMiniPanel";
 import { NetworkQualityHud } from "./ui/NetworkQualityHud";
 import type { ChatMessagePayload } from "../net/protocol";
+// Phase 4 Game Modules
+import { createInventory, type InventoryState, applyInventoryEvent } from "../game/inventory";
+import { createEquipment, type EquipmentState, applyEquipmentEvent } from "../game/equipment";
+import { createInitialQuests, type QuestState, applyQuestEvent } from "../game/quests";
+import { createSkillStates, type SkillId, tickSkillCooldowns, canUseSkill, triggerSkillCooldown } from "../game/skills";
+import { createGameplayEventQueue, type GameplayEventQueue } from "../game/gameplayEvents";
+import { findNearestInteractionTarget } from "../game/interactions";
+import { createChunkObserver } from "../world/chunkObserver";
+// Phase 4 UI Components
+import { MobileActionBar } from "./MobileActionBar";
+import { InventoryPanel } from "./InventoryPanel";
+import { EquipmentPanel } from "./EquipmentPanel";
+import { QuestJournal } from "./QuestJournal";
+import { InteractionPrompt } from "./InteractionPrompt";
 
 type BootPhaseState =
   | "BOOTING"
@@ -57,6 +71,24 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
   const serverClockRef = useRef<ServerClock | null>(null);
   const combatFxRef = useRef<CombatFxStore | null>(null);
 
+  // Phase 4 Gameplay State Refs
+  const inventoryRef = useRef<InventoryState | null>(null);
+  const equipmentRef = useRef<EquipmentState | null>(null);
+  const questsRef = useRef<QuestState[]>([]);
+  const skillsRef = useRef<ReturnType<typeof createSkillStates> | null>(null);
+  const gameplayEventQueueRef = useRef<GameplayEventQueue | null>(null);
+  const chunkObserverRef = useRef<ReturnType<typeof createChunkObserver> | null>(null);
+  const interactionTargetRef = useRef<{ entityId: string; kind: "npc" | "loot"; label: string; distance: number } | null>(null);
+  const observedChunkCountRef = useRef<number>(0);
+
+  // Phase 4 UI State
+  const [inventoryOpen, setInventoryOpen] = useState(false);
+  const [equipmentOpen, setEquipmentOpen] = useState(false);
+  const [questOpen, setQuestOpen] = useState(false);
+  // UI display values (updated periodically)
+  const [inventoryCount, setInventoryCount] = useState(0);
+  const [trackedQuestTitle, setTrackedQuestTitle] = useState<string | undefined>(undefined);
+
   const networkStatusRef = useRef<NetworkStatus>("idle");
   const mountedRef = useRef(false);
   const lastSnapshotTickRef = useRef<number>(0);
@@ -69,6 +101,7 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
   const serverOffsetMsRef = useRef<number>(0);
   const toastsRef = useRef<ClientToast[]>([]);
   const chatMessagesRef = useRef<ChatMessagePayload[]>([]);
+  const gameplayEventQueueSizeRef = useRef<number>(0);
 
   // Force re-render for UI overlays
   const [, forceUpdate] = useState(0);
@@ -288,9 +321,68 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
               networkQualityRef.current = latencyTracker.getQuality();
               triggerUpdate();
             }
+          },
+          // Phase 4 Event Handlers
+          onInventorySnapshot(payload) {
+            if (inventoryRef.current) {
+              inventoryRef.current = applyInventoryEvent(inventoryRef.current, {
+                type: "inventory_set",
+                slots: payload.slots
+              });
+              triggerUpdate();
+            }
+          },
+          onEquipmentSnapshot(payload) {
+            if (equipmentRef.current) {
+              equipmentRef.current = applyEquipmentEvent(equipmentRef.current, {
+                type: "equipment_set",
+                slots: payload.slots
+              });
+              triggerUpdate();
+            }
+          },
+          onQuestSnapshot(payload) {
+            questsRef.current = applyQuestEvent(questsRef.current, {
+              type: "quest_snapshot",
+              quests: payload.quests
+            });
+            triggerUpdate();
+          },
+          onLootPickupResult(payload) {
+            if (payload.ok && payload.itemId) {
+              gameplayEventQueueRef.current?.push({
+                type: "loot_pickup_confirmed",
+                itemId: payload.itemId,
+                quantity: payload.quantity ?? 1,
+                entityId: payload.entityId
+              });
+              addToast(`+${payload.quantity ?? 1}x ${payload.itemId}`, "success");
+            } else if (payload.reason) {
+              addToast(payload.reason, "warning");
+            }
+          },
+          onNpcDialogue(payload) {
+            gameplayEventQueueRef.current?.push({
+              type: "npc_dialogue",
+              npcId: payload.npcId,
+              npcName: payload.npcName,
+              text: payload.text
+            });
+            addToast(`${payload.npcName}: ${payload.text.slice(0, 60)}...`, "info");
           }
         });
         networkClientRef.current = network;
+
+        // Phase 4: Initialize Gameplay Systems
+        inventoryRef.current = createInventory(24);
+        equipmentRef.current = createEquipment();
+        questsRef.current = createInitialQuests();
+        skillsRef.current = createSkillStates();
+        gameplayEventQueueRef.current = createGameplayEventQueue();
+        chunkObserverRef.current = createChunkObserver({
+          chunkSize: config.world.chunkSize,
+          radius: config.world.observerRadiusChunks
+        });
 
         // Phase 6: SYNCING_TICK - Start logic clock
         setPhase("SYNCING_TICK");
@@ -337,9 +429,55 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
             // 6. Step combat FX
             combatFx.step();
 
+            // Phase 4: Tick skill cooldowns
+            if (skillsRef.current) {
+              skillsRef.current = tickSkillCooldowns(skillsRef.current);
+            }
+
             // 7. Get view state
             const viewState = clientWorld.getViewState();
             entityCountRef.current = viewState.entities.length;
+
+            // Phase 4: Find interaction target
+            const localPlayer = viewState.entities.find(e => e.id === viewState.localPlayerId);
+            if (localPlayer) {
+              interactionTargetRef.current = findNearestInteractionTarget(
+                localPlayer,
+                viewState.entities,
+                80
+              );
+
+              // Phase 4: Update chunk observer
+              const chunkObserve = chunkObserverRef.current?.update(localPlayer.x, localPlayer.y);
+              if (chunkObserve) {
+                network.sendChunkObserve(chunkObserve);
+                observedChunkCountRef.current = chunkObserve.chunks.length;
+              }
+            }
+
+            // Phase 4: Drain and process gameplay events
+            const events = gameplayEventQueueRef.current?.drain() ?? [];
+            gameplayEventQueueSizeRef.current = events.length;
+
+            for (const event of events) {
+              if (inventoryRef.current) {
+                inventoryRef.current = applyInventoryEvent(inventoryRef.current, event as never);
+              }
+              if (equipmentRef.current) {
+                equipmentRef.current = applyEquipmentEvent(equipmentRef.current, event as never);
+              }
+              questsRef.current = applyQuestEvent(questsRef.current, event as never);
+            }
+
+            // Phase 4: Update UI display values
+            if (inventoryRef.current) {
+              const count = inventoryRef.current.slots.reduce((sum, slot) => sum + (slot.stack?.quantity ?? 0), 0);
+              if (count !== inventoryCount) setInventoryCount(count);
+            }
+            const tracked = questsRef.current.find(q => q.tracked);
+            if (tracked?.title !== trackedQuestTitle) {
+              setTrackedQuestTitle(tracked?.title);
+            }
 
             // 8. Render
             if (pixiRef.current) {
@@ -404,6 +542,89 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
   const serverOffsetMs = serverOffsetMsRef.current;
   const toasts = toastsRef.current;
   const chatMessages = chatMessagesRef.current;
+  const skills = skillsRef.current;
+  const inventory = inventoryRef.current;
+  const equipment = equipmentRef.current;
+  const quests = questsRef.current;
+  const interactionTarget = interactionTargetRef.current;
+  const observedChunkCount = observedChunkCountRef.current;
+  const gameplayEventQueueSize = gameplayEventQueueSizeRef.current;
+
+  // Phase 4 Action Handlers
+  function handleSkill(skillId: SkillId) {
+    const tickId = clockRef.current?.getTickId() ?? 0;
+    const sequenceId = lastSequenceIdRef.current + 1;
+
+    if (!canUseSkill(skillsRef.current ?? {}, skillId)) {
+      return;
+    }
+
+    // Trigger cooldown locally
+    if (skillsRef.current) {
+      skillsRef.current = triggerSkillCooldown(skillsRef.current, skillId);
+    }
+
+    // Push gameplay event
+    gameplayEventQueueRef.current?.push({
+      type: "skill_requested",
+      tickId,
+      skillId
+    });
+
+    // Send to network
+    networkClientRef.current?.sendSkillCast({
+      sequenceId,
+      tickId,
+      skillId: skillId === "impact_buster" ? "impact_buster" : "primary",
+      x: 0,
+      y: 0,
+      clientTimeMs: Date.now()
+    });
+
+    triggerUpdate();
+  }
+
+  function handleInteract() {
+    if (!interactionTarget) return;
+
+    const tickId = clockRef.current?.getTickId() ?? 0;
+    const sequenceId = lastSequenceIdRef.current + 1;
+
+    if (interactionTarget.kind === "loot") {
+      networkClientRef.current?.sendLootPickupRequest({
+        tickId,
+        sequenceId,
+        entityId: interactionTarget.entityId
+      });
+      gameplayEventQueueRef.current?.push({
+        type: "loot_pickup_requested",
+        tickId,
+        entityId: interactionTarget.entityId
+      });
+    } else if (interactionTarget.kind === "npc") {
+      networkClientRef.current?.sendNpcInteractRequest({
+        tickId,
+        sequenceId,
+        npcId: interactionTarget.entityId
+      });
+      gameplayEventQueueRef.current?.push({
+        type: "npc_interaction_requested",
+        tickId,
+        npcId: interactionTarget.entityId
+      });
+    }
+
+    triggerUpdate();
+  }
+
+  function handleQuestTrack(questId: string) {
+    networkClientRef.current?.sendQuestTrack(questId);
+    questsRef.current = applyQuestEvent(questsRef.current, {
+      type: "quest_track",
+      questId
+    });
+    triggerUpdate();
+  }
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -456,6 +677,53 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
         rttMs={rttMs}
         networkQuality={networkQuality}
         serverOffsetMs={serverOffsetMs}
+        inventoryCount={inventoryCount}
+        trackedQuestTitle={trackedQuestTitle}
+        observedChunkCount={observedChunkCount}
+        gameplayEventQueueSize={gameplayEventQueueSize}
+      />
+
+      {/* Phase 4: Mobile Action Bar */}
+      {phase === "READY" && skills && (
+        <MobileActionBar
+          skills={skills}
+          onSkill={handleSkill}
+          onInventory={() => setInventoryOpen(true)}
+          onQuest={() => setQuestOpen(true)}
+          onEquipment={() => setEquipmentOpen(true)}
+        />
+      )}
+
+      {/* Phase 4: Inventory Panel */}
+      {inventory && (
+        <InventoryPanel
+          open={inventoryOpen}
+          inventory={inventory}
+          onClose={() => setInventoryOpen(false)}
+        />
+      )}
+
+      {/* Phase 4: Equipment Panel */}
+      {equipment && (
+        <EquipmentPanel
+          open={equipmentOpen}
+          equipment={equipment}
+          onClose={() => setEquipmentOpen(false)}
+        />
+      )}
+
+      {/* Phase 4: Quest Journal */}
+      <QuestJournal
+        open={questOpen}
+        quests={quests}
+        onClose={() => setQuestOpen(false)}
+        onTrack={handleQuestTrack}
+      />
+
+      {/* Phase 4: Interaction Prompt */}
+      <InteractionPrompt
+        target={interactionTarget}
+        onInteract={handleInteract}
       />
 
       {/* Network quality HUD - only in dev mode */}

--- a/apps/client-2d/src/ui/InteractionPrompt.tsx
+++ b/apps/client-2d/src/ui/InteractionPrompt.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import type { InteractionTarget } from "../game/interactions";
+
+interface Props {
+  target: InteractionTarget | null;
+  onInteract: () => void;
+}
+
+export function InteractionPrompt({ target, onInteract }: Props) {
+  if (!target) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onInteract}
+      style={{
+        position: "fixed",
+        left: "50%",
+        bottom: 150,
+        transform: "translateX(-50%)",
+        zIndex: 22,
+        padding: "10px 14px",
+        borderRadius: 999,
+        border: "1px solid rgba(0,229,255,.35)",
+        background: "rgba(0,0,0,.45)",
+        color: "#f5f7ff",
+        fontWeight: 800,
+        backdropFilter: "blur(10px)",
+        cursor: "pointer"
+      }}
+    >
+      {target.label}
+    </button>
+  );
+}

--- a/apps/client-2d/src/ui/MobileActionBar.tsx
+++ b/apps/client-2d/src/ui/MobileActionBar.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import type { SkillId, SkillState } from "../game/skills";
+import { SKILL_DEFINITIONS } from "../game/skills";
+
+interface Props {
+  skills: Record<SkillId, SkillState>;
+  onSkill: (skillId: SkillId) => void;
+  onInventory: () => void;
+  onQuest: () => void;
+  onEquipment: () => void;
+}
+
+export function MobileActionBar({
+  skills,
+  onSkill,
+  onInventory,
+  onQuest,
+  onEquipment
+}: Props) {
+  const skillIds: SkillId[] = ["primary", "impact_buster", "interact", "pickup"];
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        right: 16,
+        bottom: 24,
+        zIndex: 18,
+        display: "grid",
+        gap: 8,
+        pointerEvents: "auto"
+      }}
+    >
+      {skillIds.map((skillId) => {
+        const state = skills[skillId];
+        const def = SKILL_DEFINITIONS[skillId];
+        const disabled = state.cooldownRemainingTicks > 0;
+
+        return (
+          <button
+            key={skillId}
+            type="button"
+            disabled={disabled}
+            onPointerDown={(event) => {
+              event.preventDefault();
+              onSkill(skillId);
+            }}
+            style={{
+              width: 82,
+              height: 48,
+              borderRadius: 14,
+              border: "1px solid rgba(0,229,255,.28)",
+              background: disabled
+                ? "rgba(255,255,255,.08)"
+                : "rgba(0,229,255,.22)",
+              color: "#f5f7ff",
+              fontWeight: 800,
+              touchAction: "none"
+            }}
+          >
+            <div>{def.label}</div>
+            {disabled && (
+              <small>{state.cooldownRemainingTicks}</small>
+            )}
+          </button>
+        );
+      })}
+
+      <div style={{ display: "flex", gap: 6 }}>
+        <button
+          type="button"
+          onClick={onInventory}
+          style={{
+            width: 48,
+            height: 36,
+            borderRadius: 10,
+            border: "1px solid rgba(0,229,255,.28)",
+            background: "rgba(0,229,255,.18)",
+            color: "#f5f7ff",
+            fontWeight: 700,
+            fontSize: 11
+          }}
+        >
+          INV
+        </button>
+        <button
+          type="button"
+          onClick={onEquipment}
+          style={{
+            width: 48,
+            height: 36,
+            borderRadius: 10,
+            border: "1px solid rgba(255,122,0,.28)",
+            background: "rgba(255,122,0,.18)",
+            color: "#f5f7ff",
+            fontWeight: 700,
+            fontSize: 11
+          }}
+        >
+          EQ
+        </button>
+        <button
+          type="button"
+          onClick={onQuest}
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 10,
+            border: "1px solid rgba(57,255,20,.28)",
+            background: "rgba(57,255,20,.18)",
+            color: "#f5f7ff",
+            fontWeight: 700,
+            fontSize: 11
+          }}
+        >
+          Q
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/client-2d/src/ui/QuestJournal.tsx
+++ b/apps/client-2d/src/ui/QuestJournal.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import type { QuestState } from "../game/quests";
+
+interface Props {
+  open: boolean;
+  quests: QuestState[];
+  onClose: () => void;
+  onTrack: (questId: string) => void;
+}
+
+export function QuestJournal({ open, quests, onClose, onTrack }: Props) {
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: "50%",
+        top: "50%",
+        transform: "translate(-50%, -50%)",
+        zIndex: 42,
+        width: "min(560px, 94vw)",
+        maxHeight: "80dvh",
+        overflow: "auto",
+        padding: 16,
+        borderRadius: 20,
+        border: "1px solid rgba(57,255,20,.26)",
+        background: "rgba(7,7,17,.92)",
+        color: "#f5f7ff",
+        backdropFilter: "blur(14px)"
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 14
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: 18 }}>Quest Journal</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          style={{
+            background: "rgba(255,255,255,.1)",
+            border: "1px solid rgba(255,255,255,.2)",
+            borderRadius: 8,
+            color: "#f5f7ff",
+            cursor: "pointer",
+            padding: "6px 12px"
+          }}
+        >
+          ✕
+        </button>
+      </header>
+
+      <div style={{ display: "grid", gap: 12 }}>
+        {quests.map((quest) => (
+          <article
+            key={quest.id}
+            style={{
+              padding: 12,
+              borderRadius: 14,
+              border: quest.tracked
+                ? "1px solid rgba(57,255,20,.45)"
+                : "1px solid rgba(255,255,255,.12)",
+              background: quest.tracked
+                ? "rgba(57,255,20,.08)"
+                : "rgba(255,255,255,.06)"
+            }}
+          >
+            <h3 style={{ margin: "0 0 8px 0", fontSize: 16 }}>
+              {quest.title}
+              {quest.tracked && (
+                <span
+                  style={{
+                    marginLeft: 8,
+                    fontSize: 10,
+                    color: "#39ff14",
+                    fontWeight: 400
+                  }}
+                >
+                  [TRACKED]
+                </span>
+              )}
+            </h3>
+            <p style={{ opacity: 0.7, margin: "0 0 8px 0", fontSize: 13 }}>
+              {quest.description}
+            </p>
+            <small
+              style={{
+                display: "inline-block",
+                padding: "2px 8px",
+                borderRadius: 6,
+                background:
+                  quest.status === "completed"
+                    ? "rgba(57,255,20,.2)"
+                    : "rgba(255,255,255,.1)",
+                fontSize: 11
+              }}
+            >
+              Status: {quest.status}
+            </small>
+
+            {quest.objectives.length > 0 && (
+              <ul
+                style={{
+                  marginTop: 10,
+                  paddingLeft: 18,
+                  fontSize: 12
+                }}
+              >
+                {quest.objectives.map((objective) => (
+                  <li key={objective.id}>
+                    {objective.label}: {objective.current}/{objective.required}
+                    {objective.current >= objective.required && (
+                      <span style={{ color: "#39ff14", marginLeft: 4 }}>✓</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {!quest.tracked && (
+              <button
+                type="button"
+                onClick={() => onTrack(quest.id)}
+                style={{
+                  marginTop: 8,
+                  padding: "4px 12px",
+                  borderRadius: 8,
+                  border: "1px solid rgba(57,255,20,.3)",
+                  background: "rgba(57,255,20,.15)",
+                  color: "#f5f7ff",
+                  cursor: "pointer",
+                  fontSize: 12
+                }}
+              >
+                Track
+              </button>
+            )}
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/client-2d/src/world/chunkObserver.ts
+++ b/apps/client-2d/src/world/chunkObserver.ts
@@ -1,0 +1,48 @@
+import { getObservedChunks, worldToChunk, type ChunkInfo } from "./chunks";
+
+export interface ChunkObservePayload {
+  centerChunkId: string;
+  chunks: string[];
+}
+
+export interface ChunkObserver {
+  update(playerX: number, playerY: number): ChunkObservePayload | null;
+  getObservedChunks(): ChunkInfo[];
+}
+
+export function createChunkObserver(options: {
+  chunkSize: number;
+  radius: number;
+}): ChunkObserver {
+  let lastCenter = "";
+  let observed: ChunkInfo[] = [];
+
+  return {
+    update(playerX, playerY) {
+      const center = worldToChunk(playerX, playerY, options.chunkSize);
+      const centerChunkId = `${center.cx}:${center.cy}`;
+
+      // Only emit if center chunk changed
+      if (centerChunkId === lastCenter) {
+        return null;
+      }
+
+      lastCenter = centerChunkId;
+      observed = getObservedChunks(
+        playerX,
+        playerY,
+        options.chunkSize,
+        options.radius
+      );
+
+      return {
+        centerChunkId,
+        chunks: observed.map((chunk) => chunk.id)
+      };
+    },
+
+    getObservedChunks() {
+      return observed.slice();
+    }
+  };
+}

--- a/docs/ai-skills/wasd-client-2d-boot-stack.md
+++ b/docs/ai-skills/wasd-client-2d-boot-stack.md
@@ -261,3 +261,91 @@ pnpm --filter client-2d typecheck  # if exists
 npx tsc --noEmit --project apps/client-2d/tsconfig.json
 npx eslint apps/client-2d/src/net apps/client-2d/src/logic apps/client-2d/src/ui/MobileHud.tsx apps/client-2d/src/ui/DebugHud.tsx apps/client-2d/src/engine/pixiClient.ts apps/client-2d/src/ui/GameBoot.tsx
 ```
+
+---
+
+## Phase 4: MMORPG Gameplay Layer (Current Implementation)
+
+### Architecture
+
+```
+GameBoot.tsx
+    |
+    +-- game/items.ts         (Item definitions & rarities)
+    +-- game/inventory.ts    (Inventory state & operations)
+    +-- game/equipment.ts    (Equipment slots)
+    +-- game/quests.ts       (Quest state & progress)
+    +-- game/skills.ts       (Skill definitions & cooldowns)
+    +-- game/gameplayEvents.ts (Event queue)
+    +-- game/interactions.ts   (NPC/Loot interaction)
+    +-- world/chunkObserver.ts (Chunk streaming)
+
+UI Components: MobileActionBar, InventoryPanel, EquipmentPanel, QuestJournal, InteractionPrompt
+```
+
+### New Files (Phase 4)
+
+| File | Purpose |
+|------|---------|
+| `game/items.ts` | Item definitions, rarities, stack types |
+| `game/inventory.ts` | Inventory state, add/remove items |
+| `game/equipment.ts` | Equipment slots (weapon/armor/trinket) |
+| `game/quests.ts` | Quest state, objectives, tracking |
+| `game/skills.ts` | Skill definitions, tick-based cooldowns |
+| `game/gameplayEvents.ts` | Event queue for gameplay changes |
+| `game/interactions.ts` | Find nearest NPC/Loot target |
+| `world/chunkObserver.ts` | Deterministic chunk streaming |
+| `ui/MobileActionBar.tsx` | Skill buttons with cooldown display |
+| `ui/EquipmentPanel.tsx` | Equipment slot display |
+| `ui/QuestJournal.tsx` | Quest list with tracking |
+| `ui/InteractionPrompt.tsx` | Contextual interaction prompt |
+
+### Updated Files
+
+| File | Changes |
+|------|---------|
+| `net/protocol.ts` | Protocol v4: +8 client messages, +8 server messages |
+| `net/networkClient.ts` | +7 send methods, +6 event handlers |
+| `ui/GameBoot.tsx` | Phase 4 state, logic tick integration |
+| `ui/DebugHud.tsx` | +4 gameplay display fields |
+| `system/clientVersion.ts` | Phase marker updated to P4 |
+
+### Protocol v4 Message Types
+
+**Client → Server:**
+- `loot_pickup_request` - Request loot from entity
+- `npc_interact_request` - Request NPC interaction
+- `inventory_action` - Inventory operations
+- `equipment_action` - Equip/unequip items
+- `quest_accept` - Accept a quest
+- `quest_track` - Track a quest
+- `chunk_observe` - Observe chunk boundaries
+
+**Server → Client:**
+- `inventory_snapshot` - Full inventory state
+- `equipment_snapshot` - Full equipment state
+- `quest_snapshot` - Full quest state
+- `loot_pickup_result` - Pickup success/failure
+- `npc_dialogue` - NPC dialogue text
+- `skill_result` - Skill cast result
+- `chunk_snapshot` - Chunk data
+- `gameplay_event` - Generic gameplay event
+
+### Deterministic Guarantees (Phase 4)
+
+1. **Gameplay runs through 10Hz logic loop** - All skill cooldowns tick down deterministically
+2. **UI does not own game rules** - React components only display state
+3. **Renderer does not own game rules** - PIXI only renders WorldViewState
+4. **Cooldowns are tick-based** - `tickSkillCooldowns()` called per tick, not setTimeout
+5. **Event-driven state changes** - Inventory, equipment, quests via events
+6. **Client playable without server** - Local state works offline
+7. **Network failures non-fatal** - Handlers use defensive checks
+8. **Chunk observe deterministic** - Only emits on chunk boundary change
+
+### Test Commands (Phase 4)
+
+```bash
+pnpm --filter client-2d build
+npx tsc --noEmit --project apps/client-2d/tsconfig.json
+npx eslint apps/client-2d/src/game apps/client-2d/src/world/apps/client-2d/src/ui apps/client-2d/src/net apps/client-2d/src/logic apps/client-2d/src/engine
+```


### PR DESCRIPTION
## Summary

Adds Phase 4 MMORPG gameplay layer to REAL_PIXI_CLIENT with deterministic 10Hz game logic:

- **New Game Modules**: Items, Inventory, Equipment, Quests, Skills, GameplayEvents, Interactions
- **New World Module**: ChunkObserver for deterministic chunk streaming
- **New UI Components**: MobileActionBar, EquipmentPanel, QuestJournal, InteractionPrompt
- **Protocol v4**: 8 new client messages, 8 new server messages
- **Network Layer**: 7 new send methods, 6 event handlers
- **Debug HUD**: Extended with inventory count, tracked quest, chunk count, event queue size

The client now has a real MMORPG gameplay shell: inventory, equipment, quests, skills, interactions, loot pickup and chunk observation.

**Deterministic Guarantees:**
- Gameplay runs through 10Hz logic loop
- UI does not own game rules
- Renderer does not own game rules
- Cooldowns are tick-based (not setTimeout)
- Event-driven state changes
- Client playable without server (offline/degraded mode)
- Network failures remain non-fatal

## Documentation

- [x] **`docs/ai-skills/wasd-client-2d-boot-stack.md`** - Phase 4 section added with architecture, files, and test commands

## Verification

```bash
pnpm --filter client-2d build
npx tsc --noEmit --project apps/client-2d/tsconfig.json
npx eslint apps/client-2d/src/game apps/client-2d/src/world apps/client-2d/src/ui apps/client-2d/src/net apps/client-2d/src/logic apps/client-2d/src/engine
```

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b3c6339d-f8f7-4601-93bd-5c4888a136ef)