### PR TITLE
fix(GameBoot): use getViewState() instead of missing getLocalPlayer()

### DIFF
--- a/apps/client-2d/src/ui/GameBoot.tsx
+++ b/apps/client-2d/src/ui/GameBoot.tsx
@@ -402,8 +402,9 @@ export function GameBoot({ onReady, onDegraded, onFatal }: GameBootProps): React
             entityCountRef.current = clientWorld.getEntityCount();
             pendingInputCountRef.current = pendingInputQueue.getPendingCount();
 
-            // Extract player position from local player
-            const localPlayer = clientWorld.getLocalPlayer();
+            // Extract player position from local player via getViewState()
+            const viewState = clientWorld.getViewState();
+            const localPlayer = viewState.entities.find(e => e.id === viewState.localPlayerId);
             if (localPlayer) {
               playerPosRef.current = { x: localPlayer.x, z: localPlayer.y };
               // Calculate chunk coords from player position


### PR DESCRIPTION
## Summary

Fixes `TypeError: clientWorld.getLocalPlayer is not a function` that was thrown on every `world_snapshot` event.

## Problem

In `apps/client-2d/src/ui/GameBoot.tsx`, the snapshot handler called `clientWorld.getLocalPlayer()` which is not part of the `ClientWorld` interface. The interface only exposes:
- `getViewState()`
- `getEntityCount()`  
- `getTickId()`

This caused the debug refs and `triggerUpdate()` to never complete, and every snapshot produced an unhandled handler error.

## Solution

Use `getViewState()` to retrieve `viewState.localPlayerId` and find the local player entity in the entities array:

```typescript
const viewState = clientWorld.getViewState();
const localPlayer = viewState.entities.find(e => e.id === viewState.localPlayerId);
```

## Changes

- `apps/client-2d/src/ui/GameBoot.tsx`: Replace missing `getLocalPlayer()` call with proper `getViewState()` usage

This PR was created by an AI agent (OpenHands) on behalf of the development team.

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/be199230-5df1-4e6f-9745-a45103fc0d8b)