### PR TITLE
chore: add stitch asset inbox folder for Cozy Asset Director

### DIFF
--- a/.asset-inbox/stitch/README.md
+++ b/.asset-inbox/stitch/README.md
@@ -1,0 +1,58 @@
+# Stitch Game Assets Inbox
+
+This folder is for Stitch-generated game assets (models, effects, biomes, symbols, weather).
+
+## Workflow
+
+1. Generate assets in Stitch: https://stitch.withgoogle.com/projects/5320982353793182486
+2. Export as PNG sprite sheets with JSON atlas metadata
+3. ZIP the assets and upload to GitHub issue #1071
+4. Run import script: `node scripts/stitch-game-assets-importer.mjs`
+
+## Expected Asset Structure
+
+```
+stitch/
+├── models/           # Character sprites, NPC animations (256x256 frames)
+│   ├── samurai/
+│   ├── mongolian/
+│   └── medieval/
+├── effects/          # Skill particles, combat FX (128x128 frames)
+│   ├── fire/
+│   ├── ice/
+│   └── lightning/
+├── biomes/           # Environment terrain tiles (64x64 tiles)
+│   ├── forest/
+│   ├── desert/
+│   └── snow/
+├── symbols/          # UI icons, item graphics (64x64 icons)
+│   ├── icons/
+│   └── items/
+└── weather/          # Weather overlays, particles (128x128 overlays)
+    ├── rain/
+    └── snow/
+```
+
+## Categories
+
+| Category | Frame Size | Description |
+|----------|------------|-------------|
+| models | 256x256 | Character sprites, NPC animations |
+| effects | 128x128 | Skill particles, combat FX |
+| biomes | 64x64 | Environment terrain tiles |
+| symbols | 64x64 | UI icons, item graphics |
+| weather | 128x128 | Weather overlays, particles |
+
+## Import Script
+
+```bash
+node scripts/stitch-game-assets-importer.mjs --dry-run  # Verify without importing
+node scripts/stitch-game-assets-importer.mjs              # Full import
+```
+
+Generated assets will be placed in:
+- `apps/client-2d/public/2d-assets/game-assets/`
+
+---
+
+Last updated: 2026-06-04


### PR DESCRIPTION
## Summary

Added Stitch asset inbox folder `.asset-inbox/stitch/` for Cozy Asset Director workflow.

### Changes

- `.asset-inbox/stitch/README.md` - Workflow documentation for Stitch game assets

### Purpose

The inbox folder is ready for Stitch-generated assets:
- **models**: Character sprites, NPC animations (256x256 frames)
- **effects**: Skill particles, combat FX (128x128 frames)
- **biomes**: Environment terrain tiles (64x64 tiles)
- **symbols**: UI icons, item graphics (64x64 icons)
- **weather**: Weather overlays, particles (128x128 overlays)

### Workflow

1. Generate assets in Stitch
2. Export as ZIP with PNG + JSON atlas
3. Upload to GitHub issue #1071
4. Run `node scripts/stitch-game-assets-importer.mjs`

---

This PR was created by an AI agent on behalf of the project owner.

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f91f0e6a-6693-4968-8a0b-caa83925cf92)