### PR TITLE
chore: update VPS docker workflow for Stitch asset inbox

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -100,16 +100,33 @@ jobs:
       - name: Import Cozy Spring assets when inbox exists
         run: |
           set -euo pipefail
-          INBOX=".asset-inbox/cozy-spring"
+          INBOX="apps/client-2d/public/assets/cozy-spring"
           MANIFEST="apps/client-2d/public/assets/cozy-spring/manifest.json"
-          if [ -d "$INBOX" ]; then
-            echo "Importing Cozy Spring assets from $INBOX"
-            python3 scripts/extract-cozy-spring-objects.py --inbox "$INBOX" --output apps/client-2d/public/assets/cozy-spring --tmp .tmp/cozy-spring-extract --verbose
+          if [ -d ".asset-inbox/cozy-spring" ]; then
+            echo "Importing Cozy Spring assets from .asset-inbox/cozy-spring"
+            python3 scripts/extract-cozy-spring-objects.py --inbox ".asset-inbox/cozy-spring" --output "$INBOX" --tmp .tmp/cozy-spring-extract --verbose
           else
             echo "No Cozy inbox found; using committed fallback assets."
           fi
           test -f "$MANIFEST"
-          node -e "const m=require('./apps/client-2d/public/assets/cozy-spring/manifest.json'); if(m.importPolicy!=='tilesets-as-tiles-props-as-extracted-objects'||!m.props||Object.keys(m.props).length===0){throw new Error('Invalid Cozy manifest')}; console.log('Cozy manifest OK', Object.keys(m.props).length)"
+          node -e "const m=require('./${MANIFEST}'); if(m.importPolicy!=='tilesets-as-tiles-props-as-extracted-objects'||!m.props||Object.keys(m.props).length===0){throw new Error('Invalid Cozy manifest')}; console.log('Cozy manifest OK', Object.keys(m.props).length)"
+
+      - name: Import Stitch game assets when inbox exists
+        run: |
+          set -euo pipefail
+          STITCH_INBOX=".asset-inbox/stitch"
+          STITCH_OUT="apps/client-2d/public/2d-assets/game-assets"
+          if [ -d "$STITCH_INBOX" ] && [ -n "$(ls -A "$STITCH_INBOX" 2>/dev/null)" ]; then
+            echo "Importing Stitch game assets from $STITCH_INBOX"
+            mkdir -p "$STITCH_OUT"
+            # Copy stitch inbox contents to game-assets folder
+            cp -r "$STITCH_INBOX"/* "$STITCH_OUT/" 2>/dev/null || true
+            # Update manifest with stitch assets
+            node scripts/stitch-game-assets-importer.mjs --local-inbox "$STITCH_INBOX" --output "$STITCH_OUT"
+          else
+            echo "No Stitch inbox found; skipping Stitch asset import."
+          fi
+          echo "Stitch assets ready at $STITCH_OUT"
 
       - name: Build client-2d on GitHub runner
         run: |

--- a/scripts/stitch-game-assets-importer.mjs
+++ b/scripts/stitch-game-assets-importer.mjs
@@ -45,6 +45,8 @@ const repo = process.env.GITHUB_REPOSITORY || 'Arelorian/Ouroboros';
 const token = process.env.GITHUB_TOKEN;
 const issueNumber = String(process.env.ISSUE_NUMBER || '1071');
 const dryRun = process.argv.includes('--dry-run');
+const localInbox = process.argv.find(a => a.startsWith('--local-inbox='))?.split('=')[1] || null;
+const localOutput = process.argv.find(a => a.startsWith('--output='))?.split('=')[1] || null;
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const root = resolve(scriptDir, '..');
@@ -271,15 +273,15 @@ function defaultDepthMetadata(category, sourceText) {
 async function main() {
   log(`Starting Stitch game assets import (dry-run: ${dryRun})`);
   
-  if (!token && !dryRun) {
-    log('GITHUB_TOKEN not set. Running in demo mode with sample data.', 'warn');
-  }
-  
   // Setup directories
   rmSync(workRoot, { recursive: true, force: true });
   mkdirSync(extractRoot, { recursive: true });
   mkdirSync(zipRoot, { recursive: true });
   mkdirSync(gameAssetsRoot, { recursive: true });
+  
+  // Determine output path
+  const outputPath = localOutput || gameAssetsRoot;
+  mkdirSync(outputPath, { recursive: true });
   
   // Load or create root manifest
   const rootManifest = existsSync(manifestPath) 
@@ -289,7 +291,7 @@ async function main() {
   const gameAssetsManifest = {
     version: 1,
     generatedAt: new Date().toISOString(),
-    sourceIssue: Number(issueNumber),
+    sourceIssue: localInbox ? 'local-inbox' : Number(issueNumber),
     stitchProjectUrl: STITCH_PROJECT_URL,
     basePath: '/2d-assets/game-assets',
     categories: Object.keys(CATEGORIES),
@@ -308,8 +310,82 @@ async function main() {
     },
   };
   
-  // Import from GitHub issue attachments if token available
-  if (token) {
+  // LOCAL INBOX MODE - Import directly from local folder
+  if (localInbox && existsSync(localInbox)) {
+    log(`Importing from local inbox: ${localInbox}`);
+    
+    const files = listFiles(localInbox);
+    const pngFiles = files.filter((file) => extname(file).toLowerCase() === '.png');
+    const jsonFiles = files.filter((file) => extname(file).toLowerCase() === '.json');
+    
+    log(`Found ${pngFiles.length} PNG files in local inbox`);
+    
+    for (const pngFile of pngFiles) {
+      const folder = basename(dirname(pngFile));
+      const rel = relative(localInbox, pngFile);
+      const descriptor = `${folder} ${rel}`;
+      
+      const category = categoryFor(descriptor);
+      const culture = cultureFor(descriptor);
+      const config = CATEGORIES[category] || {};
+      
+      const atlasIdBase = slug(`stitch_${category}_${culture}_${folder}`, 72);
+      let atlasId = atlasIdBase;
+      let suffix = 2;
+      while (gameAssetsManifest.assets[category]?.[atlasId] || existsSync(join(outputPath, atlasId))) {
+        atlasId = `${atlasIdBase}_${String(suffix).padStart(2, '0')}`;
+        suffix++;
+      }
+      
+      const atlasDir = join(outputPath, atlasId);
+      mkdirSync(atlasDir, { recursive: true });
+      
+      const imageName = `${atlasId}.png`;
+      const jsonName = `${atlasId}.json`;
+      
+      const imageRel = `game-assets/${atlasId}/${imageName}`;
+      const jsonRel = `game-assets/${atlasId}/${jsonName}`;
+      
+      copyFileSync(pngFile, join(atlasDir, imageName));
+      
+      // Find matching JSON
+      let jsonPayload;
+      let repair = 'meta-image-normalized';
+      
+      const matchingJson = jsonFiles.find(f => slug(basename(f)) === slug(basename(pngFile, '.png') + '.json'));
+      
+      if (matchingJson) {
+        jsonPayload = patchSpritesheetJson(readJson(matchingJson), imageName, atlasId);
+      } else {
+        const frameSize = config.frameSize || 256;
+        jsonPayload = synthesizeGridJson({ imageName, framePrefix: atlasId, frameSize, columns: 4, rows: 4 });
+        repair = 'synthesized-grid';
+      }
+      
+      writeFileSync(join(atlasDir, jsonName), JSON.stringify(jsonPayload, null, 2) + '\n');
+      
+      // Create entry
+      const entry = {
+        src: `/2d-assets/${imageRel}`,
+        atlas: `/2d-assets/${jsonRel}`,
+        source: 'local-inbox',
+        sourcePath: rel,
+        license: 'Project-owned Stitch-generated asset.',
+        kind: category,
+        group: culture,
+        tags: ['stitch', 'game-asset', category, culture, ...(config.tags || [])],
+        ...defaultDepthMetadata(category, descriptor),
+      };
+      
+      gameAssetsManifest.assets[category][atlasId] = entry;
+      rootManifest[category] ??= {};
+      rootManifest[category][atlasId] = entry;
+    }
+    
+    log(`Imported ${pngFiles.length} assets from local inbox`);
+  }
+  // GITHUB ISSUE MODE - Import from ZIP attachments (only if no local inbox)
+  else if (!localInbox && token) {
     try {
       log('Fetching asset URLs from GitHub issue...');
       const issue = await gh(`/repos/${repo}/issues/${issueNumber}`);
@@ -429,7 +505,7 @@ async function main() {
   }
   
   // Write manifests
-  const stitchGameManifestPath = join(gameAssetsRoot, 'manifest.json');
+  const stitchGameManifestPath = join(outputPath, 'manifest.json');
   writeFileSync(stitchGameManifestPath, JSON.stringify(gameAssetsManifest, null, 2) + '\n');
   writeFileSync(manifestPath, JSON.stringify(rootManifest, null, 2) + '\n');
   


### PR DESCRIPTION
## Summary

Updated VPS Docker deploy workflow to process Stitch game assets from `.asset-inbox/stitch/` during CI build.

### Changes

**Workflow Update** (`.github/workflows/vps-docker-deploy.yml`):
- Added "Import Stitch game assets" step after Cozy Spring import
- Runs before client-2d build so assets are included in Docker image

**Import Script Enhancement** (`scripts/stitch-game-assets-importer.mjs`):
- Added `--local-inbox` and `--output` CLI flags
- Supports two modes:
  - **Local inbox mode**: For CI/CD directly from `.asset-inbox/stitch/`
  - **GitHub issue mode**: For manual import from GitHub issue ZIPs

### VPS Docker Workflow

When `.asset-inbox/stitch/` exists:
1. Assets are imported to `apps/client-2d/public/2d-assets/game-assets/`
2. Manifest updated with stitch assets
3. Built into client-2d Docker image
4. Deployed to VPS

### Usage

For Cozy Asset Director:
1. Add Stitch PNGs + JSONs to `.asset-inbox/stitch/`
2. Push to main
3. GitHub Actions builds and deploys with assets included

---

This PR was created by an AI agent on behalf of the project owner.

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f91f0e6a-6693-4968-8a0b-caa83925cf92)