### PR TITLE
fix(hud): remove duplicate tick variable declaration

### DIFF
--- a/apps/client-2d/src/DeterministicWorldIsoApp.tsx
+++ b/apps/client-2d/src/DeterministicWorldIsoApp.tsx
@@ -780,7 +780,7 @@ chunkManager.init({
         // Extract vitals from heartbeat payload and update playerVitalState.
         // This is deterministic: tick + acknowledgedSeq drive the update.
         // NO Date.now(), NO Math.random(), NO client-side prediction.
-        const tick = event.payload?.tick ?? event.payload?.serverTick ?? null;
+        // Note: tick already declared above at line 759
         const acknowledgedSeq = event.payload?.acknowledgedInputSeq ?? event.payload?.ackSeq ?? -1;
         
         if (tick !== null) {


### PR DESCRIPTION
## Summary

Fix build error: `Identifier 'tick' has already been declared` in `DeterministicWorldIsoApp.tsx`.

**Problem:** `const tick` was declared twice in the same `WORLD_HEARTBEAT` handler:
- Line 759: `const tick = event.payload?.tick ?? event.payload?.serverTick ?? null;`
- Line 783 (now removed): same declaration again

**Fix:** Removed the duplicate declaration at line 783. The variable is already available from the first declaration.

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

```bash
# Local build test
cd apps/client-2d && pnpm build
```

This should resolve the CI failure from PR #1678.

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f1e66312-5455-48c4-92d8-fb6f4d2d2ce8)