### PR TITLE
fix: Use ${INCLUDE_DIR} instead of hardcoded /etc/nginx/conf.d

### DIFF
--- a/scripts/vps-nginx-route-areloria.sh
+++ b/scripts/vps-nginx-route-areloria.sh
@@ -132,7 +132,7 @@ http {
     error_log /var/log/nginx/error.log;
     gzip on;
     client_max_body_size 999m;
-    include /etc/nginx/conf.d/*.conf;
+    include ${INCLUDE_DIR}/*.conf;
 }
 EOF
   fi
@@ -143,12 +143,12 @@ ensure_public_nginx_conf_includes_conf_d() {
   tmp=$(mktemp)
   
   if ! grep -q 'include.*conf.d/\*.conf' "$PUBLIC_NGINX_CONF" 2>/dev/null; then
-    echo "WARN: /etc/nginx/conf.d/*.conf is not included in nginx.conf. Patching..."
+    echo "WARN: ${INCLUDE_DIR}/*.conf is not included in nginx.conf. Patching..."
     cat "$PUBLIC_NGINX_CONF" > "$tmp"
     if grep -q '^http {' "$tmp"; then
-      sed -i '/^http {/a\    include /etc/nginx/conf.d/*.conf;' "$tmp"
+      sed -i "/^http {/a\\    include ${INCLUDE_DIR}/*.conf;" "$tmp"
     else
-      echo '    include /etc/nginx/conf.d/*.conf;' >> "$tmp"
+      echo "    include ${INCLUDE_DIR}/*.conf;" >> "$tmp"
     fi
     cat "$tmp" | write_root "$PUBLIC_NGINX_CONF"
   fi


### PR DESCRIPTION
## Summary

Fixes a bug in `scripts/vps-nginx-route-areloria.sh` where the nginx include path was hardcoded to `/etc/nginx/conf.d` instead of using the configurable `${INCLUDE_DIR}` variable.

## Problem

When `PUBLIC_NGINX_CONF` points to a non-default nginx tree (e.g., OpenResty/Kong at `/usr/local/openresty/nginx/conf/nginx.conf`), the script was still inserting `include /etc/nginx/conf.d/*.conf` into the config file. This meant the generated `00-wasd-areloria.conf` was never loaded because it was placed in `${INCLUDE_DIR}` but nginx was looking elsewhere.

## Fix

Replace all hardcoded `/etc/nginx/conf.d/*.conf` references with `${INCLUDE_DIR}/*.conf`:

- Line 135: Fallback nginx.conf template
- Line 146: Warning message  
- Line 149: `sed` command for patching
- Line 151: Direct echo fallback

## Testing

Manual code review confirms:
- `INCLUDE_DIR` is defined as `${PUBLIC_NGINX_ROOT}/conf.d` (line 11)
- This correctly resolves to the directory where `MANAGED_FILE` is written
- The include statement now matches where config files are actually placed

---

_This PR was created by an AI agent (OpenHands) on behalf of the repository owner._

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b3940f10-aec4-4343-bb58-a71927b8dd9f)