### PR TITLE
docs: refresh roadmap to release status

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,75 +1,124 @@
 # Onboarding & Technical Documentation
 
-## Systemvoraussetzungen
-- **Node.js**: Version 18.0.0 oder höher
-- **Python**: Version 3.10 oder höher
-- **Package Manager**: npm (integriert in Node.js) oder pip (Python)
+This file is a quick contributor onboarding guide for the **current** Areloria / WASD runtime.
 
-## Architektur-Übersicht
-Das Projekt ist als **Multi-Package Repository** ohne zentralen Orchestrator (wie Lerna oder Nx) strukturiert. Jedes Verzeichnis fungiert als eigenständige Einheit.
+For full status, read in this order:
 
-- **Frontend (`/client`)**: Basiert auf **Vite** und **Three.js** für performantes 3D-Rendering.
-- **Backend (`/server`)**: Python-basierte Logikschicht.
+1. `README_START_HERE.md`
+2. `docs/PROJECT_STATUS_2026.md`
+3. `docs/ROADMAP_TO_RELEASE.md`
+4. `docs/DOCUMENTATION_INDEX.md`
 
-## Repository-Struktur
-text
+---
+
+## System requirements
+
+- **Node.js:** 22.x recommended for production parity. The root package currently allows `>=18`, but deploy/runtime docs target Node 22.
+- **pnpm:** use the version declared by `package.json` / Corepack. At the time of this refresh the repo declares `pnpm@11.5.0`.
+- **Docker:** required for production-style VPS deploy testing.
+- **Python:** only needed for specific helper scripts; it is not the main server runtime.
+
+---
+
+## Current architecture overview
+
+The project is a pnpm workspace / monorepo.
+
+- **3D client (`client/`):** Vite + TypeScript + Babylon.js.
+- **2D client (`apps/client-2d/`):** PixiJS v7 + React UI.
+- **Server (`server/`):** Node.js + TypeScript + Express + WebSocket (`ws`).
+- **Simulation:** authoritative `WorldTick` at roughly 100 ms / 10 Hz.
+- **Data:** `game-data/` JSON content, optionally published into `published-content/current`.
+- **Auth:** Supabase JWT path with explicit guest/dev toggles.
+- **Persistence:** `PERSISTENCE_DRIVER=auto|postgres|file`.
+- **Optional services:** Redis, Soketi/Pusher-compatible services, Supabase/Postgres stack.
+
+---
+
+## Repository structure
+
+```text
 .
-├── client/             # Frontend (Vite + Three.js)
-│   ├── src/            # App-Logik und 3D-Szenen
-│   ├── public/         # Statische Assets
-│   └── package.json    # Frontend-Abhängigkeiten
-├── server/             # Backend (Python)
-│   ├── main.py         # Einstiegspunkt
-│   └── requirements.txt # Python-Abhängigkeiten
-└── ONBOARDING.md       # Diese Dokumentation
+├── apps/
+│   └── client-2d/          # PixiJS v7 + React 2D client
+├── client/                 # Vite + Babylon.js 3D browser client
+├── server/                 # Node/Express/WebSocket authoritative game server
+├── packages/               # Shared/core packages
+├── game-data/              # Authoritative JSON content
+├── docs/                   # Current docs, architecture notes, roadmaps, archives
+├── deploy/                 # VPS/env/deploy helper scripts
+├── scripts/                # Guard, audit, sync, import, and validation scripts
+└── .github/workflows/      # CI, deploy, verification, and automation workflows
+```
 
+---
 
-## Setup-Anleitung
+## Setup
 
-### 1. Frontend Setup
-Navigieren Sie in das Client-Verzeichnis und installieren Sie die Node-Module:
-bash
-cd client
-npm install
+Enable Corepack and install dependencies from the repository root:
 
+```bash
+corepack enable
+pnpm install
+```
 
-### 2. Backend Setup
-Navigieren Sie in das Server-Verzeichnis. Es wird empfohlen, eine virtuelle Umgebung zu verwenden:
-bash
-cd server
-python -m venv venv
+Build the active workspaces:
 
-# Aktivierung unter Windows:
-venv\Scripts\activate
-# Aktivierung unter macOS/Linux:
-source venv/bin/activate
+```bash
+pnpm run build
+```
 
-pip install -r requirements.txt
+Run architecture/monorepo/tick guards:
 
+```bash
+pnpm run guard:all
+```
 
-## Quick-Start Guide (Development)
+Targeted builds:
 
-### Frontend starten
-Startet den Vite-Development-Server mit Hot Module Replacement (HMR).
-bash
-cd client
-npm run dev
+```bash
+pnpm run build:2d
+pnpm run build:3d
+pnpm run build:web
+pnpm --filter @wasd/server --if-present build
+pnpm --filter @wasd/shared --if-present build
+```
 
-Der Zugriff erfolgt standardmäßig über `http://localhost:5173`.
+---
 
-### Backend starten
-Startet den Python-Server im Entwicklungsmodus.
-bash
-cd server
-# Stellen Sie sicher, dass venv aktiviert ist
-python main.py
+## Development commands
 
+```bash
+pnpm run dev:2d
+pnpm run dev:3d
+pnpm run dev:web
+pnpm run dev:all
+```
 
-## Verwendete Technologien
-- **Three.js**: High-Level 3D-Library zur Darstellung der Szenen im Browser.
-- **Vite**: Modernes Build-Tool für schnelle Frontend-Entwicklung.
-- **Python**: Verarbeitung von Logik und Daten im Hintergrund.
+Use the package scripts as source of truth before adding new commands.
 
-## Wichtige Hinweise
-- Da kein globaler Orchestrator verwendet wird, müssen Abhängigkeiten in den jeweiligen Unterverzeichnissen separat verwaltet werden.
-- Achten Sie darauf, dass Ports für Client und Server nicht mit anderen lokalen Diensten kollidieren.
+---
+
+## Validation checklist before a PR
+
+Minimum safe checks:
+
+```bash
+pnpm run build
+pnpm run guard:all
+pnpm --filter @wasd/server --if-present test
+pnpm run assets:pixi:validate
+pnpm run assets:pixi:validate-batches
+```
+
+For release-related changes, also run the determinism gate and relevant E2E/deploy verification workflows.
+
+---
+
+## Important rules
+
+- Do not treat historical reconstruction packs as source of truth.
+- Do not reintroduce hidden simulation nondeterminism (`Math.random()`, `Date.now()`, `new Date()`) into gameplay-result paths.
+- Do not damage protected player-built or paid structures unless an explicit reviewed policy allows it.
+- Keep `docs/PROJECT_STATUS_2026.md` and `docs/ROADMAP_TO_RELEASE.md` updated when behavior or release scope changes.
+- Work in small PRs. Preserve the working foundation.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,122 +1,215 @@
-# 1. OBJECTIVE
+# Areloria / WASD — Current Implementation Plan
 
-Analyze the Areloria/Wasd MMORPG project from the agent package documents and create a prioritized implementation plan for the next development steps. The goal is to continue building on the existing vertical slice while maintaining architectural integrity.
+This plan is a living, practical companion to:
 
-# 2. CONTEXT SUMMARY
+- `README_START_HERE.md`
+- `docs/PROJECT_STATUS_2026.md`
+- `docs/ROADMAP_TO_RELEASE.md`
+- `docs/DOCUMENTATION_INDEX.md`
 
-**Project:** Areloria/Ouroboros - Server-authoritative browser MMORPG built with TypeScript, Three.js (client), Express/WebSocket (server)
+It replaces older agent-package assumptions such as Three.js-only client, Python backend, npm-only setup, or one-off vertical-slice planning.
 
-**Current State (from Agent Package):**
-- Strong internal vertical slice with working gameplay loop
-- Data-driven NPCs, Quests, Dialogues, Spawns via JSON
-- Server-authoritative movement and state
-- Chunk system (64x64), Observer simulation
-- Item Registry as Source of Truth
-- Persistence over restart
-- Reputation system, Quest chains with prerequisites
-- Content Validator and Manifest system
+---
 
-**Documentation Files Present:**
-- README_START_HERE.md ✓
-- PROJECT_LOCK_RULES.md ✓
-- final-lock/FINAL_TRUTH.md ✓
-- 100+ design docs in /docs
-- 55+ JSON game-data files
+## 1. Objective
 
-**Core Rules (MUST NOT BREAK):**
-- Server authority
-- 64x64 chunks
-- Observer simulation
-- Data-driven content (NPCs, Quests, Dialogues, Spawns)
-- Item Registry as Source of Truth
-- Generic runtime (no One-Off logic)
+Continue building Areloria / WASD toward a stable public release while preserving the systems that already work.
 
-# 3. APPROACH OVERVIEW
+The current project is a server-authoritative browser MMORPG foundation with:
 
-Following the "Gardener Mode" from the agent package:
-1. **Assess current state** - Run builds and tests to understand what's working
-2. **Choose ONE small safe step** - Based on recommended paths in agent package
-3. **Implement and validate** - Run build, tests, and validators
-4. **Report structured results**
+- Node.js + TypeScript + Express + WebSocket server,
+- authoritative `WorldTick` at roughly 100 ms / 10 Hz,
+- Babylon.js 3D client,
+- PixiJS v7 + React 2D client,
+- JSON-driven content in `game-data/`,
+- Supabase-first auth path,
+- Postgres/file persistence drivers,
+- deterministic manifest and ARE guard direction,
+- live modules for combat, loot, quests, NPC runtime, chunks, resources, storage, warfront, world boss, voting, crafting, admin content, and playtester monitoring.
 
-**Safe vs Unsafe Categories (from Agent Package):**
-- SAFE: Content validation, Manifests, Data-driven content, Small UI/UX, Tests, Build hardening
-- UNSAFE: WorldTick redesign, Chunk/Observer changes, Combat core overhaul, Auth system
+The goal is not to rewrite the engine. The goal is to harden, expose, test, document, and polish what already lives.
 
-# 4. IMPLEMENTATION STEPS
+---
 
-## Step 1: Assess Current State
-**Goal:** Understand what works and what needs attention
-**Method:**
-- Run `npm run build` to verify client and server compile
-- Run `npm run test` to see test results
-- Check if Content Validator runs
-**Reference:** package.json, vitest.config.ts
+## 2. Current context summary
 
-## Step 2: Choose Priority Area
-**Goal:** Select the most impactful small next step
-**Method:** Based on agent package recommendations:
-- "Echte Live-In-Game-Beweise für vorhandene Systeme" (Real in-game proof)
-- "kleine Quest-/Dialog-Politur" (Small quest/dialogue polish)
-- "Build-/Validator-/Manifest-Härtung" (Build/Validator/Manifest hardening)
+### Project
 
-**Recommended First Step:** Run build and tests to establish baseline, then add a small data-driven enhancement or fix
+Areloria / Ouroboros / WASD — deterministic browser MMORPG and living-world simulation architecture.
 
-## Step 3: Execute Chosen Step
-**Goal:** Make ONE small, safe change
-**Method:**
-- If build passes: Add a small content pack or fix a minor issue
-- If issues found: Fix only what's necessary
-**Reference:** game-data/*.json for content, server/src/modules/* for code
+### Current runtime stack
 
-## Step 4: Validate and Report
-**Goal:** Verify the change doesn't break existing systems
-**Method:**
-- Run build
-- Run tests
-- Run content validator if available
-- Report in agent format (A. Ziel, B. Dateien, C. Änderungen, D. Prüfungen, E. Ergebnis, F. Risiken, G. Nächster Schritt)
+| Layer | Current path |
+|---|---|
+| Server | `server/` — Node.js, TypeScript, Express, `ws`, authoritative `WorldTick` |
+| 3D client | `client/` — Vite, TypeScript, Babylon.js |
+| 2D client | `apps/client-2d/` — PixiJS v7 + React |
+| Data | `game-data/` JSON, optional `published-content/current` pack |
+| Persistence | `PERSISTENCE_DRIVER=auto|postgres|file` |
+| Auth | Supabase JWT path with explicit guest/dev toggles |
+| Ops | VPS Docker/PM2 docs exist; active release work should verify current deploy workflow before trusting it |
 
+### Already live foundations
 
-# 5. TESTING AND VALIDATION
+- Server-authoritative movement/combat/skills.
+- Inventory, equipment, loot pickup/drop/sync.
+- Anti-Ninja Loot Lock.
+- Player stats sync.
+- Quest and questline systems.
+- NPC memory/relationship/proactive chat runtime.
+- Ouroboros agent tick.
+- Chunk/world/resource/weather/time systems.
+- Storage entities.
+- Warfront, world boss, vote, crafting.
+- Admin content tools and GLB/model-needs pipeline.
+- Playtester monitor with WebRTC mode.
+- Gameplay Fusion Director: quest echo, adaptive quest scene profiles, construction contracts.
+- Monorepo/architecture/WorldTick guards.
 
-## Success Criteria for Each Step
+---
 
-**Build Success:**
-- `npm run build` completes without errors
-- Both client and server compile successfully
+## 3. Core rules — must not break
 
-**Test Success:**
-- `npm run test` runs without critical failures
-- Core gameplay loop tests pass (quest, inventory, combat)
+1. **Server authority:** gameplay truth belongs on the server.
+2. **10 Hz simulation discipline:** no unbounded work inside `WorldTick`.
+3. **Determinism:** simulation-affecting results must not depend on hidden wall-clock time or process-local randomness.
+4. **64x64 chunk logic:** keep world partitioning consistent.
+5. **Observer principle:** expensive simulation should be tied to observation/relevance.
+6. **Data-driven content:** NPCs, quests, dialogue, spawns, items, and world content should stay generic and JSON/content driven where possible.
+7. **Protected structures:** do not damage player-built/paid/protected structures unless an explicit reviewed policy allows it.
+8. **Small PRs:** one focused change, clear verification, no unrelated lockfile churn.
 
-**Content Validation Success:**
-- Content Validator passes for any modified data files
-- All referenced IDs are valid (questIds, itemIds, npcIds, dialogue nodes)
+---
 
-## Validation Commands Reference
+## 4. Current priority order
+
+### Priority 1 — release blockers
+
+1. Verify production deploy path and domain routing.
+2. Harden persistence migration, backup, restore, and rollback policy.
+3. Lock down Supabase/session behavior for production.
+4. Finish deterministic migration/gate for Level A/B simulation paths.
+5. Validate Android/mobile performance budgets.
+6. Complete player-facing UI for critical systems.
+7. Audit release content pack and assets.
+8. Keep smoke/E2E/deploy gates green.
+
+### Priority 2 — player-visible MMORPG maturation
+
+1. Quest tracker, map, settings, combat log.
+2. Storage/crafting/voting/warfront/world-boss UI polish.
+3. NPC reputation effects, refusal/help rules, bounded memory scenarios.
+4. Combat/XP/stamina/mana balance.
+5. Content pack quality pass.
+
+### Priority 3 — deeper simulation systems
+
+1. Settlement/civilization lifecycle.
+2. Economy and Matrix Energy loop.
+3. NPC politics and civic parity.
+4. Housing/protected-structure validators.
+5. Procedural dungeons and world-boss distance rules.
+6. 13-point World Brain and advanced ARE research extensions.
+
+---
+
+## 5. Safe work categories
+
+Safe, preferred next PRs:
+
+- Documentation alignment.
+- Tests and E2E smoke coverage.
+- Content validation and model-path audit improvements.
+- UI panels that consume existing server state.
+- Guardrail improvements with low runtime risk.
+- Small content additions under `game-data/`.
+- Deploy verification docs/scripts that do not rewrite runtime behavior.
+
+Risky, isolate carefully:
+
+- `WorldTick` orchestration changes.
+- Auth/session behavior changes.
+- Persistence schema/migration behavior.
+- Chunk/observer simulation rules.
+- Combat/loot RNG and deterministic seed changes.
+- Protected-structure or monetization policy changes.
+- Broad workflow/deploy rewrites.
+
+---
+
+## 6. Standard implementation loop
+
+1. **Assess**
+   - Read current docs.
+   - Inspect the exact code path.
+   - Identify whether the change affects simulation truth, UI, ops, or docs only.
+
+2. **Choose one small step**
+   - Prefer one file group / one feature area.
+   - Avoid broad refactors while release blockers are open.
+
+3. **Implement**
+   - Preserve deterministic inputs.
+   - Feature-flag heavy systems.
+   - Keep tick work bounded.
+   - Update docs if behavior changes.
+
+4. **Validate**
+   - Run relevant package build/tests/guards.
+   - For release path changes, include deploy verification notes.
+
+5. **Report**
+   - Goal.
+   - Files changed.
+   - What changed.
+   - Checks run.
+   - Risks.
+   - Next step.
+
+---
+
+## 7. Validation command reference
+
+Use package scripts as source of truth.
 
 ```bash
-# Full build
-npm run build
-
-# Run tests
-npm run test
-
-# Run linter
-npm run lint
+corepack enable
+pnpm install
+pnpm run build
+pnpm run guard:all
+pnpm --filter @wasd/server --if-present test
+pnpm --filter @wasd/server --if-present build
+pnpm --filter @wasd/shared --if-present build
+pnpm --filter @wasd/client --if-present build
+pnpm --filter @wasd/client-2d --if-present build
+pnpm run assets:pixi:validate
+pnpm run assets:pixi:validate-batches
+node scripts/check-are-determinism.mjs
 ```
 
-## Next Steps After This Plan
+For release/deploy work, also verify:
 
-Based on the agent package's recommendations, the first actionable task should be:
+- `/health`
+- `/client-config.json`
+- `/`
+- `/portal`
+- WebSocket upgrade path
+- container/process state
+- recent engine logs
+- backup/restore proof when persistence is touched
 
-1. **Run build and tests** to establish baseline
-2. **Fix any blocking issues** found
-3. **Add one small enhancement** such as:
-   - A new quest chain via game-data/quests/quests.json
-   - A new NPC via game-data/npc/npcs.json
-   - A small UI polish that doesn't break data truth
-   - Additional test coverage for existing systems
+---
 
-The agent package emphasizes: **"Arbeite präzise. Arbeite klein. Arbeite nachvollziehbar. Beschädige nichts, was schon lebt."**
+## 8. Immediate recommended next work
+
+1. Merge the refreshed roadmap/docs PR.
+2. Run the full guard/build suite on the branch.
+3. Fix any workflow/docs mismatch around Docker vs PM2 deployment language.
+4. Add a deterministic E2E smoke scenario covering login, movement, NPC interaction, quest update, combat, loot pickup, and reconnect.
+5. Add a release checklist artifact that records exact green checks before alpha tags.
+
+---
+
+## 9. Operating principle
+
+Work precisely. Work small. Preserve what already lives. Make every release claim traceable to code, tests, docs, or a verified deploy.

--- a/docs/ROADMAP_TO_RELEASE.md
+++ b/docs/ROADMAP_TO_RELEASE.md
@@ -1,70 +1,204 @@
-# Roadmap to release — aligned with current codebase
+# Roadmap to release — current implementation alignment
 
 This roadmap tracks the gap between what is already live in the repository and what still needs to be completed for a stable public release.
 
-## How to use
+Read order:
 
-1. Read `docs/PROJECT_STATUS_2026.md` first (current state).
-2. Pick roadmap items, implement, and update both docs in the same PR/commit.
-3. Keep `docs/MASTER_DESIGN_BIBLE.md` for vision changes only.
+1. `README_START_HERE.md` — entry point and current-document hierarchy.
+2. `docs/PROJECT_STATUS_2026.md` — authoritative implementation snapshot.
+3. `docs/ROADMAP_TO_RELEASE.md` — this release backlog.
+4. `docs/MASTER_DESIGN_BIBLE.md` — vision and pillars only.
+5. `docs/DOCUMENTATION_INDEX.md` — current vs historical documentation map.
+
+Any PR or commit that changes runtime behavior must update `docs/PROJECT_STATUS_2026.md` and this roadmap if release scope changes.
+
+---
+
+## Release posture
+
+**Current state:** working browser-MMORPG foundation, not a finished commercial MMO.
+
+The repo now contains a serious live foundation: authoritative 10 Hz Node/WebSocket simulation, Vite/Babylon 3D client, PixiJS/React 2D client, server-authoritative gameplay modules, Supabase/Postgres/file persistence paths, optional Redis, deterministic manifest checks, admin content tools, autonomous playtester monitoring, and multiple live world systems.
+
+The release focus is therefore no longer “prove the engine exists”. The focus is:
+
+1. harden deterministic gameplay correctness,
+2. finish production deploy and backup discipline,
+3. complete player-facing UI coverage,
+4. stabilize mobile performance,
+5. replace placeholder content with audited assets,
+6. validate the whole loop through CI, E2E, replay, and live VPS verification.
+
+---
+
+## Completed / live integrations
+
+These are considered implemented or wired enough to be tracked as live foundations. They can still need balancing, UI polish, load testing, or ops hardening.
+
+| Area | Status | Notes |
+|---|---:|---|
+| Authoritative runtime | DONE | `server/src/core/WorldTick.ts` runs the main ~100 ms / 10 Hz simulation loop. |
+| WebSocket networking | DONE | Server networking is wired through `server/src/networking/WebSocketServer.ts`. |
+| 3D client foundation | DONE | Vite + Babylon.js client remains the primary 3D path. |
+| 2D client foundation | DONE | PixiJS v7 + React client is active under `apps/client-2d/`. |
+| 2D interpolation | DONE | `InterpolatedSpriteManager` smooths 10 Hz server state toward render FPS with teleport snap and precision locking. |
+| Manifest system | DONE | Server-authoritative hash-chain state under `server/src/core/manifest/`, client divergence detection under `apps/client-2d/src/manifest/`, resync API at `/api/manifest/*`. |
+| Supabase auth path | DONE | Supabase JWT flow and client auth provider are documented as the active production path. |
+| Persistence drivers | DONE | `PERSISTENCE_DRIVER=auto/postgres/file`, JSON fallback, and health summary are wired. |
+| Redis optional path | DONE | Optional Redis cache/chat relay paths degrade gracefully when unset. |
+| Health endpoint | DONE | `/health` summarizes auth, persistence, playtester, self-healing, and content-root status. |
+| Player movement/combat | DONE | Movement, target selection, attacks, skills, cooldown/mana, death/respawn are wired. |
+| Inventory/equipment/loot | DONE | Inventory stacks, equip/unequip, loot drops, pickup, and sync are active. |
+| Anti-Ninja Loot Lock | DONE | Loot ownership lock is active via `LootDirector` with 60-second / 600 tick kill lock. |
+| Player stats sync | DONE | `PlayerStatsDirector` broadcasts server-authoritative XP/level snapshots. |
+| Quest system | DONE | Quest start, progression, sync, talk/collect/combat updates are active. |
+| Questline system | DONE | Questline engine, bridge, and unlock propagation are wired. |
+| NPC runtime | DONE | `NPCSystem`, memory cache/persistence, relationships, and proactive chat are wired. |
+| Ouroboros agents | DONE | `OuroborosEngine` is instantiated and ticked from `WorldTick`. |
+| Chunk/world foundations | DONE | Chunks, observers, objects, weather/time, and terrain adapters are wired. |
+| Resource entities | DONE | Deterministic resource nodes are aligned through `ChunkModificationDirector` and `ResourcePopulator`. |
+| Storage system | DONE | `StorageEntity`, inventory, `open_storage`, and `transfer_item` handlers are wired. |
+| Warfront | DONE | `WarfrontSystem` lifecycle, status pushes, and reward claims are wired. |
+| World boss | DONE | `WorldBossDungeonSystem` encounter flow and ranking summaries are wired. |
+| Vote system | DONE | Vote banner/session/status and reward claims are wired. |
+| Crafting | DONE | Crafting handlers are wired through server message flow. |
+| Admin content tools | DONE | `/api/admin/content/*` routes and `/admin-content.html` are active. |
+| Playtester monitor | DONE | WebRTC monitor, signaling, viewer page, and publisher page are shipped. |
+| Gameplay Fusion Director | DONE | Quest echo beacons, adaptive quest scene profiles, and construction contracts are active. |
+| Content publish path | DONE | `pnpm run content:publish`, model-path audit, admin model needs, and GLB registry/pools are present. |
+| Pixi asset import scripts | DONE | Cozy/2D asset workflows are represented through import/validate scripts in root `package.json`. |
+| Monorepo/architecture guards | DONE | `guard:monorepo`, `guard:architecture`, `guard:worldtick`, and `guard:all` scripts exist. |
+| ARE deterministic primitives | DONE | `AREClock`, `SystemAREClock`, `FixedAREClock`, `ARERng`, `SeededARERng`, and `createARESeed` are documented primitives. |
+| Determinism gate | DONE / HARDENING | Gate exists; Level A/B simulation paths still need strict migration verification before public release. |
 
 ---
 
 ## Tier A — release blockers
 
-| ID | Area | Gap | Current |
-|----|------|-----|---------|
-| A1 | Client performance | Reduce startup and runtime cost on mobile and low-end devices | Babylon chunk split + mobile budgets exist; further dynamic loading and GPU profiling needed |
-| A1b | **2D Client Interpolation** | Smooth movement from 10 Hz server to 60 FPS render | **DONE**: `InterpolatedSpriteManager` with teleport-snap, precision-lock, delta-time scaling |
-| A2 | Combat UX | Improve clarity, feedback, and edge-case handling | Core combat works; still needs richer combat log, clearer party/revive integration |
-| A3 | Quest UX | Better objective feedback and progression visibility | Quest engine works; UI guidance and advanced objective summaries still limited |
-| A4 | Persistence hardening | Production migration + backup policy consistency | `PERSISTENCE_DRIVER` works (`auto/postgres/file`); release needs strict migration and rollback SOP |
-| A5 | Auth hardening | Supabase-first operational baseline across all docs/tools | Supabase is live path; remaining legacy references must stay archived only |
+These block a public release tag.
+
+| ID | Area | Release gap | Required outcome |
+|---|---|---|---|
+| A1 | Production deploy verification | VPS Docker deploy, Nginx routing, `/`, `/portal`, `/health`, `/client-config.json`, and WebSocket upgrade must be proven after each deploy. | One green deploy workflow plus one green final verification workflow against `arelorian.de`. |
+| A2 | Persistence + backups | Postgres migration, backup, restore, and rollback story must be operational, not only configurable. | Documented migration SOP, automated backup check, restore drill, and JSON fallback policy. |
+| A3 | Auth/session hardening | Supabase is the live path, but public launch needs strict session rules and dev bypass lockdown. | Production env rejects unintended guest/dev auth; rate limits and session expiry are tested. |
+| A4 | Deterministic simulation hardening | All Level A/B combat, loot, oracle, warfront, boss, and gameplay-result paths must avoid hidden wall-clock/randomness. | Determinism gate passes for simulation-critical paths; exceptions are documented and reviewed. |
+| A5 | Mobile performance | Android/tablet/browser startup and runtime cost must stay stable with real assets. | Measured FPS/memory/startup budget, chunk loading budget, and fallback quality levels. |
+| A6 | Player-facing UI coverage | Many systems exist server-side, but not every critical action has clear player UI. | Quest tracker, map, settings, combat log, inventory/equipment, storage, crafting, voting, warfront, boss, and death/respawn flows usable without dev knowledge. |
+| A7 | Release content pack | Placeholder or broken assets must not be part of the first public impression. | Audited `published-content/current` pack with model-path audit green and asset licenses tracked. |
+| A8 | Smoke/E2E release gate | Public release must not depend on manual hope. | `pnpm run build`, `pnpm run guard:all`, model audit, unit tests, E2E smoke, and deploy verification are green. |
 
 ---
 
-## Tier B — major system maturation
+## Tier B — major open work
+
+These do not necessarily block a closed alpha, but they define whether the project feels like a real MMORPG instead of a tech demo.
 
 | System | Current | Remaining |
-|--------|---------|-----------|
-| Playtester monitor | WebRTC monitor + signaling + viewer/publisher pages shipped | Add ops dashboards and alerting around stream health |
-| Admin content system | Upload, validation, publish-pack, model-needs shipped | Improve admin ergonomics and audit transparency for content edits |
-| NPC autonomy | NPC memory/relationships/chat + fusion hooks active | Expand deterministic behavior scenarios and balancing for large NPC counts |
-| Gameplay Fusion Director | Quest echo, adaptive profile overrides, construction contracts live | Add dedicated admin/debug visibility panel and tunable balancing config |
-| World systems | Chunk/terrain/weather/resource foundations active | Expand biome/content depth and optimize streaming boundaries |
-| **2D Client UI** | Inventory, Character overlay (press C), native CSS styling shipped | Expand with Quest tracker, Map, Settings panels |
+|---|---|---|
+| Combat and skills | Server-authoritative combat, skills, cooldown/mana, loot and respawn are wired. | Balance stamina/mana/XP curves, improve combat feedback, revive/party edge cases, boss telegraphs, and combat log clarity. |
+| Quest and questlines | Quest/questline systems are active, with fusion echo hooks. | Add richer objective summaries, map pins, quest tracker, branching outcomes, and QA fixtures for multi-step chains. |
+| NPC autonomy | NPC system, memory, relationships, proactive chat, and personality beta exist. | Expand deterministic behavior scenarios, bounded shared memory, reputation effects, refusal/help rules, genealogy, faction memory, and large-NPC load budgets. |
+| Civilization | Bible defines guild -> village -> city -> kingdom -> nation and equal NPC/player civic rights. | Implement settlement lifecycle, law/tax/election flows, NPC/player political parity, territory/biome borders, and protected structure policies. |
+| Economy and Matrix Energy | Economy/Matrix are design pillars; construction contracts are active. | Implement deterministic local markets, scarcity pricing, taxes, trade routes, Matrix Energy sinks/sources, and public works budget flow. |
+| World systems | Chunks, resources, weather/time, terrain adapters, world objects, warfronts, and bosses are wired. | Expand biome depth, dungeon templates, ecological pressure, migration triggers, world boss distance constraints, and streaming boundary tests. |
+| Crafting/storage/trading | Crafting and storage handlers are wired. | Finish UI, permissions, recipe discovery, item provenance, player trading, anti-duplication checks, and audit logs. |
+| Admin/GM content | Admin content API, content page, model needs, publish pack, and audits are active. | Improve audit transparency, content rollback, live moderation tools, edit history, and safe publish preview. |
+| Playtester monitor | WebRTC viewer/publisher and signaling are shipped. | Add stream-health dashboard, alerting, run history, deterministic scenario packs, and release-report export. |
+| Self-healing/runtime safeguards | Health endpoint includes self-healing summary; liveheal docs and patterns exist. | Tie safeguards to release dashboards, quarantine broken GLB/assets, add city-layout validators, and keep repair telemetry outside simulation truth. |
+| Observability | `/health` exists; deploy verification can check endpoints and logs. | Add SLOs for tick duration, WebSocket load, manifest divergence, playtester stream health, persistence failures, and asset audit failures. |
 
 ---
 
 ## Tier C — polish and operational quality
 
-- Stronger observability and SLOs for `/health`, websocket load, and playtester stream health.
-- Automated release checklist and smoke pipeline refinement.
-- Documentation hygiene enforcement in CI for stale references.
-- Better player-facing onboarding and troubleshooting copy.
+- Player onboarding: clear first-login path, first quest guidance, controls, death/respawn explanation, and troubleshooting copy.
+- Visual polish: replace placeholder UI copy, unify 2D/3D style language, improve hit/loot/quest feedback.
+- Accessibility: readable mobile HUD, touch-safe controls, reduced motion option, scalable text, and contrast checks.
+- Security: production env secret audit, CORS/session/rate-limit policy, admin route protection, and safe error messages.
+- Documentation hygiene: current docs must stay separate from historical reconstruction packs.
+- Release notes: keep player-facing changelog separate from internal engineering notes.
+
+---
+
+## Planned / vision integrations after release foundation
+
+These belong after the release blockers are controlled, unless a small isolated PR can land safely.
+
+| Integration | Target direction |
+|---|---|
+| Genealogy and houses | NPC family lines, inheritance, house reputation, and deterministic lineage history. |
+| Full NPC politics | NPCs vote, tax, declare war, negotiate peace, appoint rulers, rebel, and join/found factions. |
+| Guild/village/city/kingdom/nation hierarchy | Rule-bound civilization growth from player/NPC organizations through biome-bounded territories. |
+| Deep economy simulation | Supply/demand, scarcity, taxes, trade routes, public works, war pressure, and NPC merchant personality. |
+| Matrix Energy | Player-facing world/building energy loop with deterministic accounting and protected paid-asset policy. |
+| Housing and protected structures | Build permissions, placement validation, road/wall/gate constraints, ownership, protection tiers, and PvP/world-event policy. |
+| Procedural dungeons | Deterministic dungeon generation, boss distance rules, reward tables, replay-safe seeds, and party flow. |
+| ARE research extensions | Kappa-field replay, AREGuard proof reports, state compression, resonance/plexity scheduling, and deterministic anomaly zones. |
+| 13-point World Brain | Global directive vector from resources, population, conflict, environment, politics, market, culture, threats, opportunities, echoes, oracle resonance, and center aggregator. |
+| Future event layers | Aetheric Leylines, Chronos Anomaly zones, Void Swarm incursions, reality fissures, and oracle-driven world events. |
 
 ---
 
 ## Testing and quality gates
 
-- `pnpm run lint`
-- `pnpm run test`
-- `pnpm run build`
-- `pnpm run audit:model-paths`
-- `pnpm run test:e2e:ci` in CI before release tags
+Minimum local/release checks:
+
+```bash
+pnpm install
+pnpm run build
+pnpm run guard:all
+pnpm run assets:pixi:validate
+pnpm run assets:pixi:validate-batches
+pnpm --filter @wasd/server --if-present test
+pnpm --filter @wasd/server --if-present build
+pnpm --filter @wasd/shared --if-present build
+pnpm --filter @wasd/client --if-present build
+pnpm --filter @wasd/client-2d --if-present build
+node scripts/check-are-determinism.mjs
+```
+
+Release CI should additionally include:
+
+- model-path audit,
+- E2E smoke test,
+- manifest divergence/resync test,
+- WebSocket guest/login flow test,
+- content publish dry-run,
+- VPS deploy verification,
+- restore-drill proof for persistence backups.
 
 ---
 
 ## Documentation debt to keep watching
 
-- Historical reconstruction markdown files should remain explicitly non-authoritative.
-- Any auth/persistence/infra documentation changes must be reflected in:
-  - `README.md`
-  - `AGENTS.md`
-  - `docs/PROJECT_STATUS_2026.md`
-  - `DEPLOYMENT.md`
-  - `deploy/ENV_SETUP.md`
+Historical reconstruction markdown files should remain explicitly non-authoritative.
+
+Any auth, persistence, infra, deploy, gameplay, or architecture change must be reflected in the relevant source-of-truth docs:
+
+- `README.md`
+- `README_START_HERE.md`
+- `docs/PROJECT_STATUS_2026.md`
+- `docs/ROADMAP_TO_RELEASE.md`
+- `docs/DOCUMENTATION_INDEX.md`
+- `docs/MASTER_DESIGN_BIBLE.md` only when the vision changes
+- `DEPLOYMENT.md`
+- `deploy/ENV_SETUP.md`
+- `.env.example` / production env templates when config changes
 
 ---
 
-Last refreshed: 2026-04-26
+## Immediate next release sequence
+
+1. Green local build + guards.
+2. Green deterministic gate for Level A/B simulation paths.
+3. Green content/model/asset audits.
+4. Green E2E smoke with guest/login, movement, interaction, combat, loot, quest sync, and WebSocket reconnect.
+5. Green VPS Docker deploy to `/opt/areloria`.
+6. Green host verification for `arelorian.de`, `/`, `/portal`, `/health`, `/client-config.json`, and WebSocket upgrade.
+7. Backup and restore drill recorded.
+8. Public alpha release notes prepared.
+
+---
+
+Last refreshed: 2026-06-05


### PR DESCRIPTION
## Summary

Updates `docs/ROADMAP_TO_RELEASE.md` to match the current implementation snapshot and release posture.

Key changes:
- separates completed/live integrations from release blockers,
- adds current blockers for deploy verification, persistence, auth, determinism, mobile performance, UI coverage, release content, and E2E gates,
- moves major MMORPG systems into open maturation work,
- adds planned/vision integrations without marking them as shipped,
- refreshes testing, documentation debt, and immediate release sequence.

## Documentation

- [x] `docs/ROADMAP_TO_RELEASE.md` updated because release-scope / Tier A-C items moved
- [ ] `docs/PROJECT_STATUS_2026.md` unchanged because this PR only aligns roadmap text with existing status docs
- [ ] `docs/DOCUMENTATION_INDEX.md` unchanged because no doc was added, removed, or renamed

## Verification

Not run; documentation-only change.