### PR TITLE
chore(quest): verify persistent quest state volume mount

### DIFF
--- a/scripts/deploy-vps-docker.sh
+++ b/scripts/deploy-vps-docker.sh
@@ -379,6 +379,28 @@ docker rm -f arelorian-engine monitor-bridge arelorian-ingress-router >/dev/null
 neutralize_legacy_node_runtime
 free_host_port_safely "$ARELORIAN_PORT"
 assert_host_port_free_stable "$ARELORIAN_PORT" 5
+
+# === Quest State Persistence Mount Check ===
+QUEST_DATA_DIR="${QUEST_DATA_DIR:-/opt/areloria/data}"
+echo "[deploy] Ensuring quest persistence data dir: ${QUEST_DATA_DIR}"
+mkdir -p "$QUEST_DATA_DIR"
+
+# Schreibtest auf Hostseite
+QUEST_WRITE_TEST="${QUEST_DATA_DIR}/.quest-write-test"
+if printf 'ok\n' > "$QUEST_WRITE_TEST" 2>/dev/null; then
+  if [ "$(cat "$QUEST_WRITE_TEST" 2>/dev/null)" = "ok" ]; then
+    rm -f "$QUEST_WRITE_TEST"
+    echo "[deploy] Quest persistence host data dir writable: ${QUEST_DATA_DIR}"
+  else
+    rm -f "$QUEST_WRITE_TEST"
+    echo "ERROR: Quest persistence write test failed for ${QUEST_DATA_DIR}"
+    exit 1
+  fi
+else
+  echo "ERROR: Cannot write to quest persistence data dir: ${QUEST_DATA_DIR}"
+  exit 1
+fi
+
 compose_cmd up -d --remove-orphans arelorian-engine monitor-bridge
 if [ "$ARELORIAN_ENABLE_DOCKER_INGRESS" = "true" ]; then
   compose_cmd up -d --remove-orphans ingress-router

--- a/server/src/api/healthRoutes.ts
+++ b/server/src/api/healthRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import type { WorldTick } from '../core/WorldTick.js';
 import { getDeterministicWatchdogStatus } from '../core/installDeterministicWatchdog.js';
+import { checkQuestPersistenceWritable } from './questPersistenceHealth.js';
 
 export type HealthRouteOptions = {
   getTick: () => WorldTick | undefined;
@@ -67,6 +68,15 @@ export function healthRoutes(options: HealthRouteOptions): Router {
     const snapshot = safe(() => tick?.getWorldHashSnapshot?.() ?? null, null);
     const ok = Boolean(snapshot);
     res.status(ok ? 200 : 503).json({ ok, status: ok ? 'hashed' : 'unavailable', snapshot });
+  });
+
+  router.get('/quest-persistence', async (_req: Request, res: Response) => {
+    noStore(res);
+    const result = await checkQuestPersistenceWritable();
+    res.status(result.ok ? 200 : 503).json({
+      ok: result.ok,
+      persistence: result,
+    });
   });
 
   return router;

--- a/server/src/api/questPersistenceHealth.ts
+++ b/server/src/api/questPersistenceHealth.ts
@@ -1,0 +1,55 @@
+/**
+ * QUEST PERSISTENCE HEALTH CHECK
+ *
+ * Runtime diagnostic for quest state volume mount.
+ * Verifies that the quest persistence path is writable.
+ *
+ * Rules:
+ * - No secrets logged
+ * - No chmod 777 unless necessary (minimize permissions)
+ * - Deterministic - no Math.random() or Date.now()
+ */
+
+import { access, mkdir, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { resolveQuestStateFilePath } from "../quests/JsonQuestPersistenceAdapter.js";
+
+export interface QuestPersistenceHealthResult {
+  ok: boolean;
+  filePath: string;
+  dir: string;
+  writable: boolean;
+  error?: string;
+}
+
+/**
+ * Check if the quest persistence path is writable.
+ * Tests directory creation and file write permissions.
+ */
+export async function checkQuestPersistenceWritable(): Promise<QuestPersistenceHealthResult> {
+  const filePath = resolveQuestStateFilePath();
+  const dir = path.dirname(filePath);
+  const testPath = path.join(dir, ".quest-write-test");
+
+  try {
+    await mkdir(dir, { recursive: true });
+    await writeFile(testPath, "ok\n", "utf8");
+    await access(testPath);
+    await rm(testPath, { force: true });
+
+    return {
+      ok: true,
+      filePath,
+      dir,
+      writable: true,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      filePath,
+      dir,
+      writable: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/server/src/tests/quest-persistence-health.test.ts
+++ b/server/src/tests/quest-persistence-health.test.ts
@@ -1,0 +1,25 @@
+/**
+ * QUEST PERSISTENCE HEALTH TEST
+ *
+ * Verifies that the quest persistence health check works correctly.
+ */
+
+import { describe, expect, it } from "vitest";
+import { checkQuestPersistenceWritable } from "../api/questPersistenceHealth";
+
+describe("quest persistence health", () => {
+  it("reports writable quest persistence path", async () => {
+    const result = await checkQuestPersistenceWritable();
+    expect(result.filePath).toContain("quest-state.json");
+    expect(typeof result.ok).toBe("boolean");
+    expect(typeof result.writable).toBe("boolean");
+  });
+
+  it("returns error message on failure", async () => {
+    const result = await checkQuestPersistenceWritable();
+    // Either ok or error must be set
+    if (!result.ok) {
+      expect(result.error).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
Summary:
- Ensures VPS quest data directory exists before deploy
- Verifies host-side write access before container start
- Adds runtime quest persistence health check at /health/quest-persistence
- Keeps Dockerfile.vps as the only VPS Dockerfile path

Verification:
- curl /health/quest-persistence
- docker exec <container> sh -lc 'test -w /app/data && echo ok'
- docker compose config

Status: PARTIAL until live VPS confirms mount

## Summary

<!-- What changed and why (1–3 sentences). -->

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

<!-- e.g. `pnpm run lint`, `pnpm run test`, `pnpm run build` -->
