### PR TITLE
feat(quest): bind quest playerId to server identity

### DIFF
--- a/server/src/auth/PlayerIdentityResolver.ts
+++ b/server/src/auth/PlayerIdentityResolver.ts
@@ -1,0 +1,106 @@
+/**
+ * PLAYER IDENTITY RESOLVER
+ *
+ * Server-authoritative player identity resolution for quest persistence.
+ * Ensures client cannot freely choose production quest playerId.
+ *
+ * Rules:
+ * - Auth identity wins over query/body playerId
+ * - No Math.random() for identity selection
+ * - No secrets logged
+ * - Production mode rejects unauthenticated playerId fallback
+ *
+ * Priority:
+ * 1. Auth middleware (user.id/sub/playerId)
+ * 2. Session middleware (session.playerId/userId)
+ * 3. Dev/test fallback (query.playerId) - only if NODE_ENV != production
+ * 4. Anonymous (no authenticated identity)
+ */
+
+export interface PlayerIdentity {
+  playerId: string;
+  source: "auth" | "session" | "dev-fallback" | "anonymous";
+  authenticated: boolean;
+}
+
+export interface PlayerIdentityRequestLike {
+  headers?: Record<string, string | string[] | undefined>;
+  query?: Record<string, unknown>;
+  body?: unknown;
+  user?: { id?: string; sub?: string; playerId?: string };
+  session?: { playerId?: string; userId?: string };
+}
+
+const DEV_FALLBACK_ENABLED =
+  process.env.NODE_ENV !== "production" ||
+  process.env.ALLOW_DEV_PLAYER_ID === "true";
+
+function normalizePlayerId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // Stable, boring, safe ID format - alphanumeric with safe punctuation
+  if (!/^[a-zA-Z0-9._:-]{1,96}$/.test(trimmed)) return null;
+
+  return trimmed;
+}
+
+export function resolveHttpPlayerIdentity(
+  req: PlayerIdentityRequestLike,
+): PlayerIdentity {
+  // 1. Prefer real auth middleware if it exists
+  const authUser = req as Record<string, unknown>;
+  const authId = normalizePlayerId(
+    (authUser.user as Record<string, unknown>)?.id ??
+    (authUser.user as Record<string, unknown>)?.sub ??
+    (authUser.user as Record<string, unknown>)?.playerId,
+  );
+
+  if (authId) {
+    return {
+      playerId: authId,
+      source: "auth",
+      authenticated: true,
+    };
+  }
+
+  // 2. Optional session middleware
+  const session = req as Record<string, unknown>;
+  const sessionId = normalizePlayerId(
+    (session.session as Record<string, unknown>)?.playerId ??
+    (session.session as Record<string, unknown>)?.userId,
+  );
+
+  if (sessionId) {
+    return {
+      playerId: sessionId,
+      source: "session",
+      authenticated: true,
+    };
+  }
+
+  // 3. Dev/test fallback only
+  if (DEV_FALLBACK_ENABLED) {
+    const queryId = normalizePlayerId(req.query?.playerId);
+    if (queryId) {
+      return {
+        playerId: queryId,
+        source: "dev-fallback",
+        authenticated: false,
+      };
+    }
+  }
+
+  return {
+    playerId: "anonymous",
+    source: "anonymous",
+    authenticated: false,
+  };
+}
+
+export function assertPlayerIdentityAllowed(identity: PlayerIdentity): void {
+  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    throw new Error("authenticated_player_required");
+  }
+}

--- a/server/src/routes/gameplaySnapshot.ts
+++ b/server/src/routes/gameplaySnapshot.ts
@@ -10,12 +10,14 @@
  * - All values come from real server state
  * - Empty/null states are honest and allowed
  * - status="empty" means server reachable but no gameplay data yet
+ * - Server determines playerId from auth/session, not client
  */
 
 import express from "express";
 import type { WorldTick } from "../core/WorldTick.js";
 import { createGameplaySnapshot } from "./gameplaySnapshotUtils.js";
 import { questProgressionStore } from "../quests/QuestProgressionStore.js";
+import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
 
 /**
  * Get current tick ID from WorldTick instance.
@@ -34,16 +36,22 @@ export function createGameplaySnapshotRouter(tick: WorldTick) {
   const router = express.Router();
 
   router.get("/snapshot", async (req, res) => {
+    const identity = resolveHttpPlayerIdentity(req as Parameters<typeof resolveHttpPlayerIdentity>[0]);
+
+    if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+      res.status(401).json({
+        ok: false,
+        error: "authenticated_player_required",
+      });
+      return;
+    }
+
     const serverTick = getCurrentTickId(tick);
-    const playerId =
-      typeof req.query.playerId === "string" && req.query.playerId.trim()
-        ? req.query.playerId.trim()
-        : "guest";
 
     // Hydrate persisted quest state before returning
-    await questProgressionStore.hydratePlayer(playerId);
+    await questProgressionStore.hydratePlayer(identity.playerId);
 
-    const questState = questProgressionStore.getPlayerQuestState(playerId);
+    const questState = questProgressionStore.getPlayerQuestState(identity.playerId);
 
     const snapshot = createGameplaySnapshot({
       serverTick,
@@ -55,7 +63,9 @@ export function createGameplaySnapshotRouter(tick: WorldTick) {
 
     res.json({
       ok: true,
-      playerId,
+      playerId: identity.playerId,
+      playerIdentitySource: identity.source,
+      authenticated: identity.authenticated,
       snapshot,
     });
   });

--- a/server/src/routes/questEventRoute.ts
+++ b/server/src/routes/questEventRoute.ts
@@ -5,8 +5,8 @@
  * Accepts only allowlisted event types - no arbitrary mutations.
  *
  * MVP Status:
- * - No auth required for test/dev
- * - Later: integrate with session/auth
+ * - Dev/test mode: query playerId allowed as fallback
+ * - Production mode: requires authenticated playerId
  * - Later: connect to real NPC/combat hooks
  *
  * Rules:
@@ -14,6 +14,7 @@
  * - Server determines progression
  * - Only accept allowlisted event types
  * - NPC id must match objective target for progression
+ * - Server-resolved playerId wins over client-provided
  */
 
 import { Router } from "express";
@@ -21,6 +22,7 @@ import {
   questProgressionStore,
   type QuestEvent,
 } from "../quests/QuestProgressionStore.js";
+import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
 
 export const questEventRouter = Router();
 
@@ -35,7 +37,20 @@ questEventRouter.post("/event", async (req, res) => {
     return;
   }
 
-  const event = parseQuestEvent(req.body);
+  const identity = resolveHttpPlayerIdentity(req as Parameters<typeof resolveHttpPlayerIdentity>[0]);
+
+  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    res.status(401).json({
+      ok: false,
+      error: "authenticated_player_required",
+    });
+    return;
+  }
+
+  const event = parseQuestEvent({
+    ...(req.body as Record<string, unknown>),
+    playerId: identity.playerId,
+  });
 
   if (!event) {
     res.status(400).json({
@@ -53,6 +68,8 @@ questEventRouter.post("/event", async (req, res) => {
   res.json({
     ok: true,
     playerId: event.playerId,
+    playerIdentitySource: identity.source,
+    authenticated: identity.authenticated,
     questState,
   });
 });
@@ -61,10 +78,11 @@ function parseQuestEvent(body: unknown): QuestEvent | null {
   const b = body as Record<string, unknown> | null;
   if (!b || typeof b !== "object") return null;
 
+  // playerId is now server-resolved from auth/session, not from body
   const playerId =
     typeof b.playerId === "string" && b.playerId.trim()
       ? b.playerId.trim()
-      : "guest";
+      : "anonymous";
 
   if (b.type === "quest_accept" && typeof b.questId === "string") {
     return {

--- a/server/src/tests/player-identity-resolver.test.ts
+++ b/server/src/tests/player-identity-resolver.test.ts
@@ -1,0 +1,121 @@
+/**
+ * PLAYER IDENTITY RESOLVER TEST
+ *
+ * Verifies server-authoritative player identity resolution.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver";
+
+describe("resolveHttpPlayerIdentity", () => {
+  describe("prefers authenticated user id", () => {
+    it("extracts playerId from user.id", () => {
+      const identity = resolveHttpPlayerIdentity({
+        user: { id: "user-123" },
+        query: { playerId: "evil-override" },
+      } as any);
+
+      expect(identity.playerId).toBe("user-123");
+      expect(identity.authenticated).toBe(true);
+      expect(identity.source).toBe("auth");
+    });
+
+    it("extracts playerId from user.sub", () => {
+      const identity = resolveHttpPlayerIdentity({
+        user: { sub: "user-sub-456" },
+      } as any);
+
+      expect(identity.playerId).toBe("user-sub-456");
+      expect(identity.authenticated).toBe(true);
+      expect(identity.source).toBe("auth");
+    });
+
+    it("ignores query playerId when auth is present", () => {
+      const identity = resolveHttpPlayerIdentity({
+        user: { id: "auth-player" },
+        query: { playerId: "query-player" },
+      } as any);
+
+      expect(identity.playerId).toBe("auth-player");
+      expect(identity.source).toBe("auth");
+    });
+  });
+
+  describe("session fallback", () => {
+    it("extracts playerId from session.playerId", () => {
+      const identity = resolveHttpPlayerIdentity({
+        session: { playerId: "session-player" },
+      } as any);
+
+      expect(identity.playerId).toBe("session-player");
+      expect(identity.authenticated).toBe(true);
+      expect(identity.source).toBe("session");
+    });
+
+    it("ignores query when session is present", () => {
+      const identity = resolveHttpPlayerIdentity({
+        session: { playerId: "session-player" },
+        query: { playerId: "query-player" },
+      } as any);
+
+      expect(identity.playerId).toBe("session-player");
+      expect(identity.source).toBe("session");
+    });
+  });
+
+  describe("dev/test fallback", () => {
+    it("allows query playerId in non-production", () => {
+      const identity = resolveHttpPlayerIdentity({
+        query: { playerId: "test-player" },
+      } as any);
+
+      expect(identity.playerId).toBe("test-player");
+      expect(identity.source).toBe("dev-fallback");
+      expect(identity.authenticated).toBe(false);
+    });
+
+    it("normalizes playerId to valid format", () => {
+      const identity = resolveHttpPlayerIdentity({
+        query: { playerId: "valid_player.123" },
+      } as any);
+
+      expect(identity.playerId).toBe("valid_player.123");
+    });
+  });
+
+  describe("rejects malformed ids", () => {
+    it("rejects path traversal attempts", () => {
+      const identity = resolveHttpPlayerIdentity({
+        query: { playerId: "../../bad" },
+      } as any);
+
+      expect(identity.playerId).not.toBe("../../bad");
+    });
+
+    it("rejects ids with invalid characters", () => {
+      const identity = resolveHttpPlayerIdentity({
+        query: { playerId: "bad<script>alert" },
+      } as any);
+
+      expect(identity.playerId).not.toBe("bad<script>alert");
+    });
+
+    it("rejects empty playerId", () => {
+      const identity = resolveHttpPlayerIdentity({
+        query: { playerId: "   " },
+      } as any);
+
+      expect(identity.playerId).not.toBe("   ");
+    });
+  });
+
+  describe("anonymous fallback", () => {
+    it("returns anonymous when no identity found", () => {
+      const identity = resolveHttpPlayerIdentity({} as any);
+
+      expect(identity.playerId).toBe("anonymous");
+      expect(identity.source).toBe("anonymous");
+      expect(identity.authenticated).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Summary:
- Adds PlayerIdentityResolver for HTTP/auth/session player identity
- Snapshot and quest event routes use server-resolved playerId
- Production mode rejects unauthenticated playerId fallback
- Dev/test fallback remains available outside production
- Prevents client-provided playerId from overriding authenticated user id

Safety:
- Client cannot freely choose production quest playerId
- Auth identity wins over query/body
- No secrets added
- No new auth provider invented

Verification:
- Unit tests for PlayerIdentityResolver
- Manual test with query playerId in dev vs prod mode

## Summary

<!-- What changed and why (1–3 sentences). -->

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

<!-- e.g. `pnpm run lint`, `pnpm run test`, `pnpm run build` -->
