### PR TITLE
chore(quest): add quest state backup policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ pnpm-debug.log*
 .env.production.local
 !.env.example
 
+# Quest state and backups (never commit)
+data/
+*.backup
+*.bak
+
 # PnP configuration
 .pnp.*
 

--- a/docs/QUEST_PERSISTENCE_BACKUP.md
+++ b/docs/QUEST_PERSISTENCE_BACKUP.md
@@ -1,0 +1,132 @@
+# Quest Persistence Backup Policy
+
+## Overview
+
+Quest state is persisted either to JSON file or Postgres DB. This document covers the backup strategy for both persistence modes.
+
+## JSON Mode (Default)
+
+### Quest State File Location
+
+| Environment | Path |
+|-------------|------|
+| Container | `/app/data/quest-state.json` |
+| VPS Host | `/opt/areloria/data/quest-state.json` |
+| Custom ENV | `QUEST_STATE_FILE=/custom/path/quest-state.json` |
+
+### Backup Script
+
+```bash
+# Run backup manually
+APP_DIR=/opt/areloria scripts/backup-quest-state.sh
+
+# Or with custom paths
+QUEST_STATE_FILE=/opt/areloria/data/quest-state.json \
+QUEST_BACKUP_DIR=/opt/areloria/data/backups/quest \
+QUEST_BACKUP_KEEP=48 \
+scripts/backup-quest-state.sh
+```
+
+### Verify Backup
+
+```bash
+# Run dry-run validation
+scripts/restore-quest-state-dry-run.sh /opt/areloria/data/backups/quest/quest-state-YYYYMMDDTHHMMSSZ.json
+```
+
+### Cron Setup
+
+Add to crontab for automatic backups:
+
+```bash
+# Every 30 minutes
+*/30 * * * * cd /opt/areloria && APP_DIR=/opt/areloria scripts/backup-quest-state.sh >> /opt/areloria/logs/quest-backup.log 2>&1
+
+# Every hour
+0 * * * * cd /opt/areloria && APP_DIR=/opt/areloria scripts/backup-quest-state.sh >> /opt/areloria/logs/quest-backup.log 2>&1
+```
+
+## Postgres Mode
+
+When `QUEST_PERSISTENCE_DRIVER=postgres`, quest state is stored in the `player_quest_state` table.
+
+### Backup via pg_dump
+
+```bash
+# Backup entire quest state table
+pg_dump -t player_quest_state -d "$DATABASE_URL" > quest-state-backup-$(date +%Y%m%dT%H%M%SZ).sql
+
+# Restore (dry-run first)
+psql -d "$DATABASE_URL" -c "SELECT COUNT(*) FROM player_quest_state"  # verify table exists
+```
+
+### Combined Strategy
+
+For production, consider both:
+1. JSON file backups (fast, local)
+2. Database backups via pg_dump (durable, off-site)
+
+## Backup Rules
+
+1. **Never commit backups to git** - Add to `.gitignore`:
+   ```
+   data/
+   *.backup
+   *.bak
+   ```
+
+2. **Never restore destructively without confirmation** - Use dry-run validation first
+
+3. **Keep at least 24 backups** - Default rotation keeps newest 24
+
+4. **Verify sha256 before restore** - Every backup includes `.sha256` manifest
+
+5. **Backups contain gameplay state, not secrets** - No auth tokens or passwords
+
+## Restore Procedure
+
+### JSON Mode
+
+```bash
+# 1. Validate backup
+scripts/restore-quest-state-dry-run.sh /opt/areloria/data/backups/quest/quest-state-YYYYMMDDTHHMMSSZ.json
+
+# 2. If validation passes, restore manually
+#    (copy file to QUEST_STATE_FILE location with operator confirmation)
+cp /opt/areloria/data/backups/quest/quest-state-YYYYMMDDTHHMMSSZ.json \
+   /opt/areloria/data/quest-state.json
+
+# 3. Verify restored file
+scripts/restore-quest-state-dry-run.sh /opt/areloria/data/quest-state.json
+```
+
+### Postgres Mode
+
+```bash
+# 1. Verify backup exists
+psql -d "$DATABASE_URL" -c "SELECT COUNT(*) FROM player_quest_state"
+
+# 2. Restore from pg_dump (requires operator confirmation)
+psql -d "$DATABASE_URL" < quest-state-backup-YYYYMMDDTHHMMSSZ.sql
+```
+
+## Monitoring
+
+Check backup health via:
+
+```bash
+# Verify latest backup exists
+ls -la /opt/areloria/data/backups/quest/ | tail -5
+
+# Check backup log
+tail -20 /opt/areloria/logs/quest-backup.log
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Backup fails with permission error | Check `/opt/areloria/data` is writable by deploy user |
+| Manifest file missing | Run backup script again to regenerate |
+| sha256 mismatch | Backup may be corrupted; use previous backup |
+| No backups in rotation | Check cron is running: `systemctl status cron` |

--- a/scripts/backup-quest-state.sh
+++ b/scripts/backup-quest-state.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# =============================================================================
+# QUEST STATE BACKUP SCRIPT
+# 
+# Creates timestamped, sha256-verified backups of quest state.
+# Implements rotation to prevent unbounded disk growth.
+#
+# Usage:
+#   APP_DIR=/opt/areloria scripts/backup-quest-state.sh
+#   QUEST_STATE_FILE=/custom/path/scripts/backup-quest-state.sh
+#   QUEST_BACKUP_KEEP=48 scripts/backup-quest-state.sh
+#
+# Rules:
+# - Never commit backups to git
+# - Never restore destructively without explicit operator confirmation
+# - Keep at least 24 backups (configurable via QUEST_BACKUP_KEEP)
+# - Verify sha256 before restore
+# - Backups contain gameplay state, not secrets
+# =============================================================================
+
+set -euo pipefail
+
+# Configuration with defaults
+APP_DIR="${APP_DIR:-/opt/areloria}"
+QUEST_STATE_FILE="${QUEST_STATE_FILE:-${APP_DIR}/data/quest-state.json}"
+BACKUP_DIR="${QUEST_BACKUP_DIR:-${APP_DIR}/data/backups/quest}"
+KEEP="${QUEST_BACKUP_KEEP:-24}"
+
+# Color output helpers (no colors in production log files)
+log_info() { echo "[quest-backup] $(date -u +%Y-%m-%dT%H:%M:%SZ) $1"; }
+log_error() { echo "[quest-backup] ERROR: $1" >&2; }
+
+# Ensure backup directory exists
+mkdir -p "$BACKUP_DIR"
+
+# Check if quest state file exists
+if [ ! -f "$QUEST_STATE_FILE" ]; then
+  log_info "no quest state file found: $QUEST_STATE_FILE"
+  log_info "nothing to backup"
+  exit 0
+fi
+
+# Generate timestamp
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_FILE="${BACKUP_DIR}/quest-state-${STAMP}.json"
+MANIFEST_FILE="${BACKUP_FILE}.sha256"
+
+# Copy quest state to backup
+cp "$QUEST_STATE_FILE" "$BACKUP_FILE"
+
+# Create sha256 manifest
+sha256sum "$BACKUP_FILE" > "$MANIFEST_FILE"
+
+log_info "wrote backup: $BACKUP_FILE"
+log_info "wrote manifest: $MANIFEST_FILE"
+
+# Verify the backup was written correctly
+if [ ! -f "$BACKUP_FILE" ]; then
+  log_error "backup file was not created"
+  exit 1
+fi
+
+if [ ! -f "$MANIFEST_FILE" ]; then
+  log_error "manifest file was not created"
+  exit 1
+fi
+
+# Verify sha256 matches
+if ! sha256sum -c "$MANIFEST_FILE" > /dev/null 2>&1; then
+  log_error "sha256 verification failed for $BACKUP_FILE"
+  exit 1
+fi
+
+log_info "backup verified successfully"
+
+# Rotation: keep newest N json files and their sha256 manifests
+# Find old backups (excluding current backup)
+mapfile -t OLD_BACKUPS < <(find "$BACKUP_DIR" -maxdepth 1 -name 'quest-state-*.json' -type f ! -name "$(basename "$BACKUP_FILE")" | sort -r | tail -n +"$((KEEP + 1))")
+
+if [ ${#OLD_BACKUPS[@]} -eq 0 ]; then
+  log_info "no old backups to rotate"
+else
+  for old in "${OLD_BACKUPS[@]}"; do
+    rm -f "$old" "${old}.sha256" 2>/dev/null || true
+    log_info "removed old backup: $old"
+  done
+fi
+
+# Report backup statistics
+BACKUP_COUNT=$(find "$BACKUP_DIR" -maxdepth 1 -name 'quest-state-*.json' -type f | wc -l)
+log_info "total backups: $BACKUP_COUNT (keeping newest $KEEP)"
+
+exit 0

--- a/scripts/restore-quest-state-dry-run.sh
+++ b/scripts/restore-quest-state-dry-run.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# =============================================================================
+# QUEST STATE RESTORE DRY-RUN SCRIPT
+# 
+# Verifies a quest state backup without performing destructive restore.
+# Validates sha256 integrity and schema structure.
+#
+# Usage:
+#   scripts/restore-quest-state-dry-run.sh <backup-file>
+#   scripts/restore-quest-state-dry-run.sh /opt/areloria/data/backups/quest/quest-state-20240115T120000Z.json
+#
+# Rules:
+# - This script does NOT perform a destructive restore
+# - It validates the backup file before any restore operation
+# - sha256 verification is required
+# - Schema validation ensures backup compatibility
+# =============================================================================
+
+set -euo pipefail
+
+BACKUP_FILE="${1:-}"
+
+log_info() { echo "[quest-restore-dry-run] $(date -u +%Y-%m-%dT%H:%M:%SZ) $1"; }
+log_error() { echo "[quest-restore-dry-run] ERROR: $1" >&2; }
+
+# Validate arguments
+if [ -z "$BACKUP_FILE" ]; then
+  echo "Usage: $0 <backup-file>"
+  echo ""
+  echo "Validates a quest state backup without destructive restore."
+  echo "Verifies sha256 integrity and schema structure."
+  exit 2
+fi
+
+# Check if backup file exists
+if [ ! -f "$BACKUP_FILE" ]; then
+  log_error "backup file not found: $BACKUP_FILE"
+  exit 1
+fi
+
+# Check if manifest file exists
+MANIFEST_FILE="${BACKUP_FILE}.sha256"
+if [ ! -f "$MANIFEST_FILE" ]; then
+  log_error "manifest file not found: $MANIFEST_FILE"
+  log_error "cannot verify backup integrity without sha256 manifest"
+  exit 1
+fi
+
+# Verify sha256
+log_info "verifying sha256 integrity..."
+if ! sha256sum -c "$MANIFEST_FILE" > /dev/null 2>&1; then
+  log_error "sha256 verification failed for $BACKUP_FILE"
+  log_error "backup may be corrupted"
+  exit 1
+fi
+log_info "sha256 verification passed"
+
+# Validate JSON schema using Node.js
+log_info "validating quest backup schema..."
+node << 'NODEEOF'
+const fs = require('node:fs');
+const path = process.argv[1];
+const file = path;
+
+try {
+  const raw = fs.readFileSync(file, 'utf8');
+  const data = JSON.parse(raw);
+
+  // Validate schema structure
+  if (!data || typeof data.schemaVersion !== 'number') {
+    throw new Error('Invalid backup: missing or invalid schemaVersion');
+  }
+
+  if (data.schemaVersion !== 1) {
+    throw new Error(`Unsupported schema version: ${data.schemaVersion} (expected 1)`);
+  }
+
+  if (!Array.isArray(data.players)) {
+    throw new Error('Invalid backup: players must be an array');
+  }
+
+  // Validate each player entry
+  for (const player of data.players) {
+    if (typeof player.playerId !== 'string') {
+      throw new Error('Invalid player: missing playerId');
+    }
+
+    if (!Array.isArray(player.quests)) {
+      throw new Error(`Invalid quests for player ${player.playerId}: must be an array`);
+    }
+
+    // Validate each quest
+    for (const quest of player.quests) {
+      if (typeof quest.id !== 'string') {
+        throw new Error(`Invalid quest in ${player.playerId}: missing id`);
+      }
+    }
+  }
+
+  console.log(`[quest-restore-dry-run] Schema validation passed: ${data.players.length} players`);
+  process.exit(0);
+} catch (error) {
+  console.error(`[quest-restore-dry-run] ERROR: ${error.message}`);
+  process.exit(1);
+}
+NODEEOF
+"$BACKUP_FILE"
+
+NODE_EXIT=$?
+
+if [ $NODE_EXIT -ne 0 ]; then
+  log_error "schema validation failed"
+  exit 1
+fi
+
+log_info "dry-run validation complete: backup is valid"
+log_info "NOTE: This script does NOT perform a destructive restore"
+log_info "To restore, use restore-quest-state.sh with --confirm flag"
+
+exit 0


### PR DESCRIPTION
## Summary

Fügt Backup Policy für Quest State hinzu.

### Changes

- **scripts/backup-quest-state.sh**: Backup mit sha256 Manifest
- **scripts/restore-quest-state-dry-run.sh**: Dry-run Validierung
- **docs/QUEST_PERSISTENCE_BACKUP.md**: Dokumentation
- **.gitignore**: data/ und backups ausgeschlossen

### Usage

```bash
# Backup
APP_DIR=/opt/areloria scripts/backup-quest-state.sh

# Verify
scripts/restore-quest-state-dry-run.sh <backup>
```

### Cron

```bash
*/30 * * * * cd /opt/areloria && scripts/backup-quest-state.sh
```

---
*Generated by OpenHands Agent*