### PR TITLE
security: harden quest data permissions

### DIFF
--- a/docs/QUEST_PERSISTENCE_PRODUCTION_RUNBOOK.md
+++ b/docs/QUEST_PERSISTENCE_PRODUCTION_RUNBOOK.md
@@ -45,7 +45,7 @@ Before deploying quest persistence, verify the mount:
 
 ```bash
 # SSH to VPS
-ssh vps
+ssh root@46.202.154.25
 
 # Verify host directory
 mkdir -p /opt/areloria/data
@@ -54,9 +54,48 @@ test -w /opt/areloria/data && echo "host-write-ok"
 # Verify container mount
 docker exec arelorian-engine sh -lc 'test -w /app/data && echo container-write-ok'
 
+# Check container UID/GID (needed for secure permissions)
+docker exec arelorian-engine sh -lc 'id -u && id -g'
+
+# Check current permissions
+stat -c '%a %U:%G' /opt/areloria/data
+
 # Run full verification
 bash scripts/verify-quest-persistence-production.sh
 ```
+
+### 1b. Permission Hardening
+
+After mount verification, apply secure permissions:
+
+```bash
+# Option 1: Use the fix script (recommended)
+bash scripts/fix-quest-data-permissions.sh
+
+# Option 2: Manual fix (if fix script unavailable)
+# 1. Get container UID/GID
+CONTAINER_UID=$(docker exec arelorian-engine sh -lc 'id -u')
+CONTAINER_GID=$(docker exec arelorian-engine sh -lc 'id -g')
+
+# 2. Set ownership to container user
+chown -R ${CONTAINER_UID}:${CONTAINER_GID} /opt/areloria/data
+
+# 3. Set secure mode (owner rw, group r-x, no world access)
+chmod 750 /opt/areloria/data
+
+# 4. Verify
+stat -c '%a %U:%G' /opt/areloria/data
+docker exec arelorian-engine sh -lc 'test -w /app/data && echo ok'
+```
+
+> **Warning: chmod 777 is a temporary emergency fix only**
+>
+> If the data directory is not writable and no other solution works:
+> ```bash
+> chmod 777 /opt/areloria/data  # TEMPORARY - fix properly ASAP!
+> ```
+> This allows any local process to write quest state. Replace with proper
+> container-user ownership as soon as possible using the fix script above.
 
 ### 2. Postgres Table Setup (Production)
 
@@ -245,18 +284,43 @@ curl http://localhost:3000/health/quest-persistence
 
 **Symptom:** Health endpoint returns `"writable": false`
 
-**Fix:**
+**Diagnosis:**
 ```bash
-# Check permissions
+# Check current permissions
 ls -la /opt/areloria/data/
+stat -c '%a %U:%G' /opt/areloria/data
 
-# Fix permissions
-chown -R $(whoami): /opt/areloria/data/
-chmod 755 /opt/areloria/data/
+# Check container UID/GID
+docker exec arelorian-engine sh -lc 'id -u && id -g'
+```
+
+**Fix (recommended - use fix script):**
+```bash
+# Run the fix script - sets ownership to container user
+bash scripts/fix-quest-data-permissions.sh
+```
+
+**Fix (manual):**
+```bash
+# Get container UID/GID
+CONTAINER_UID=$(docker exec arelorian-engine sh -lc 'id -u')
+CONTAINER_GID=$(docker exec arelorian-engine sh -lc 'id -g')
+
+# Set ownership
+chown -R ${CONTAINER_UID}:${CONTAINER_GID} /opt/areloria/data
+
+# Set secure mode
+chmod 750 /opt/areloria/data
 
 # Verify
 docker exec arelorian-engine sh -lc 'test -w /app/data && echo ok'
 ```
+
+**Emergency Fix (temporary only):**
+```bash
+chmod 777 /opt/areloria/data  # WARNING: security risk - fix properly ASAP!
+```
+> Only use 777 as a last resort. Replace with proper ownership using the fix script.
 
 ### No Backups in Directory
 

--- a/docs/ai-skills/wasd-quest-persistence-ops.md
+++ b/docs/ai-skills/wasd-quest-persistence-ops.md
@@ -75,11 +75,25 @@ CRON_LINE='*/30 * * * * cd /opt/areloria && APP_DIR=/opt/areloria scripts/backup
 crontab -l | grep backup-quest-state
 ```
 
-### 5. Permissions Fix
+### 5. Permission Hardening
 
+**⚠️ Important: Never leave chmod 777 as permanent state!**
+
+Use the fix script (recommended):
 ```bash
-# Fix data directory permissions
-chmod 777 /opt/areloria/data
+# Fix permissions - sets ownership to container user
+bash scripts/fix-quest-data-permissions.sh
+```
+
+The script:
+1. Detects container UID/GID
+2. Sets ownership to container user
+3. Sets mode to 750 (no world-writable)
+4. Verifies container can write
+
+**Emergency workaround only (temporary):**
+```bash
+chmod 777 /opt/areloria/data  # TEMPORARY - fix with script ASAP!
 ```
 
 ### 6. Container Restart
@@ -144,26 +158,29 @@ curl http://localhost:3001/health/quest-persistence
 
 | Issue | Solution |
 |-------|----------|
-| `EACCES: permission denied` on `/app/data` | `chmod 777 /opt/areloria/data` |
+| `EACCES: permission denied` on `/app/data` | Run `scripts/fix-quest-data-permissions.sh` (or manual: `chown -R 100:101 /opt/areloria/data && chmod 750 /opt/areloria/data`) |
+| chmod 777 warning in verify script | Run `scripts/fix-quest-data-permissions.sh` to set proper container-user ownership |
 | Quest vars not loaded in container | Restart container or use `--force-recreate` |
 | docker-compose.yml invalid | Check vars are in `environment` section, not `build` |
-| Health returns `"writable": false` | Check permissions and mount path |
+| Health returns `"writable": false` | Check permissions and mount path with verify script |
 
 ## Related Files
 
 - `scripts/backup-quest-state.sh` - Backup script with rotation
 - `scripts/restore-quest-state-dry-run.sh` - Dry-run restore validation
-- `scripts/verify-quest-persistence-production.sh` - VPS verification
+- `scripts/verify-quest-persistence-production.sh` - VPS verification (includes permission check)
+- `scripts/fix-quest-data-permissions.sh` - Fix world-writable permissions
 - `docs/QUEST_PERSISTENCE_PRODUCTION_RUNBOOK.md` - Complete operational guide
 - `server/migrations/005_player_quest_state.sql` - DB migration
 - `server/src/quests/PgQuestPersistenceAdapter.ts` - Postgres adapter
 - `server/src/quests/JsonQuestPersistenceAdapter.ts` - JSON adapter
 - `server/src/api/questPersistenceHealth.ts` - Health endpoint
 
-## Rules
+## Security Rules
 
 - ✅ No secrets committed to git
 - ✅ No new DB provisioned (use existing)
 - ✅ No destructive migrations (use `IF NOT EXISTS`)
 - ✅ No backups in repo (in `.gitignore`)
 - ✅ Graceful degradation if DB unreachable
+- ⚠️ **Never use chmod 777 as permanent solution** - use fix script instead

--- a/scripts/fix-quest-data-permissions.sh
+++ b/scripts/fix-quest-data-permissions.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# =============================================================================
+# FIX QUEST DATA PERMISSIONS
+#
+# Fixes permissions on /opt/areloria/data to be owned by the container user
+# instead of world-writable (777).
+#
+# Usage:
+#   bash scripts/fix-quest-data-permissions.sh
+#   APP_DIR=/opt/areloria CONTAINER=my-container bash scripts/fix-quest-data-permissions.sh
+#
+# This script:
+# 1. Detects the container's UID/GID
+# 2. Sets ownership to container user
+# 3. Sets mode to 750 (owner rw, group r-x, no world access)
+# 4. Verifies both host and container can write
+# =============================================================================
+
+set -euo pipefail
+
+# Configuration with defaults
+APP_DIR="${APP_DIR:-/opt/areloria}"
+CONTAINER="${CONTAINER:-arelorian-engine}"
+DATA_DIR="${QUEST_DATA_DIR:-${APP_DIR}/data}"
+
+# Color output helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+log_info() { echo -e "[quest-perms] $(date -u +%Y-%m-%dT%H:%M:%SZ) $1"; }
+log_ok() { echo -e "${GREEN}[quest-perms] ✓${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[quest-perms] ⚠${NC} $1"; }
+log_error() { echo -e "${RED}[quest-perms] ✗${NC} $1" >&2; }
+
+echo ""
+log_info "============================================"
+log_info "FIXING QUEST DATA PERMISSIONS"
+log_info "============================================"
+echo ""
+
+# Check data directory exists
+log_info "Data dir: $DATA_DIR"
+if [ ! -d "$DATA_DIR" ]; then
+  log_error "Data directory does not exist: $DATA_DIR"
+  log_info "Creating directory..."
+  mkdir -p "$DATA_DIR"
+  log_ok "Directory created"
+fi
+
+# Detect container UID/GID
+log_info "Detecting container user..."
+CONTAINER_UID="$(docker exec "$CONTAINER" sh -lc 'id -u' | tr -d '\r\n')"
+CONTAINER_GID="$(docker exec "$CONTAINER" sh -lc 'id -g' | tr -d '\r\n')"
+CONTAINER_USER="$(docker exec "$CONTAINER" sh -lc 'whoami' | tr -d '\r\n')"
+
+# Validate UID
+if ! echo "$CONTAINER_UID" | grep -Eq '^[0-9]+$'; then
+  log_error "Invalid container UID: $CONTAINER_UID"
+  exit 1
+fi
+
+# Validate GID
+if ! echo "$CONTAINER_GID" | grep -Eq '^[0-9]+$'; then
+  log_error "Invalid container GID: $CONTAINER_GID"
+  exit 1
+fi
+
+log_info "Container user: $CONTAINER_USER"
+log_info "Container uid:gid = ${CONTAINER_UID}:${CONTAINER_GID}"
+
+# Get current permissions
+CURRENT_MODE=$(stat -c '%a' "$DATA_DIR" 2>/dev/null || echo "unknown")
+CURRENT_OWNER=$(stat -c '%U:%G' "$DATA_DIR" 2>/dev/null || echo "unknown:unknown")
+log_info "Current permissions: $CURRENT_MODE $CURRENT_OWNER"
+
+# Apply new permissions
+log_info "Setting ownership to ${CONTAINER_UID}:${CONTAINER_GID}..."
+chown -R "${CONTAINER_UID}:${CONTAINER_GID}" "$DATA_DIR"
+
+log_info "Setting mode to 750..."
+chmod 750 "$DATA_DIR"
+
+# Verify host permissions
+log_info "Verifying host permissions..."
+NEW_MODE=$(stat -c '%a' "$DATA_DIR" 2>/dev/null || echo "unknown")
+NEW_OWNER=$(stat -c '%U:%G' "$DATA_DIR" 2>/dev/null || echo "unknown:unknown")
+log_info "New permissions: $NEW_MODE $NEW_OWNER"
+
+if [ "$NEW_MODE" = "750" ]; then
+  log_ok "Mode set to 750 (owner rw, group r-x, no world access)"
+else
+  log_error "Failed to set mode to 750 (got $NEW_MODE)"
+  exit 1
+fi
+
+# Verify container write access
+log_info "Verifying container write access..."
+if docker exec "$CONTAINER" sh -lc 'test -w /app/data && echo container-write-ok' 2>/dev/null | grep -q "container-write-ok"; then
+  log_ok "Container can write to /app/data"
+else
+  log_error "Container cannot write to /app/data"
+  log_info "Container mount may be read-only or path mismatch"
+  exit 1
+fi
+
+# Test write from container
+log_info "Testing write from container..."
+if docker exec "$CONTAINER" sh -lc 'touch /app/data/.perm-test && rm /app/data/.perm-test' 2>/dev/null; then
+  log_ok "Container write test passed"
+else
+  log_error "Container write test failed"
+  exit 1
+fi
+
+echo ""
+log_ok "Permissions fixed successfully!"
+log_info "Summary:"
+log_info "  - Owner: $NEW_OWNER (container user)"
+log_info "  - Mode: 750 (no world-writable)"
+log_info "  - Container write: OK"

--- a/scripts/verify-quest-persistence-production.sh
+++ b/scripts/verify-quest-persistence-production.sh
@@ -65,6 +65,24 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# 1b. Check world-writable permissions (security check)
+# -----------------------------------------------------------------------------
+log_info "1b. Checking data directory permissions..."
+
+if [ -d "$APP_DIR/data" ]; then
+  MODE=$(stat -c '%a' "$APP_DIR/data" 2>/dev/null || echo "unknown")
+  if [ "$MODE" = "777" ]; then
+    log_warn "Data directory is world-writable (777) - security risk!"
+    log_info "  Run: scripts/fix-quest-data-permissions.sh to fix"
+    FAILED=$((FAILED + 1))
+  elif [ "$MODE" = "750" ] || [ "$MODE" = "755" ] || [ "$MODE" = "700" ]; then
+    log_ok "Data directory permissions are secure: $MODE"
+  else
+    log_info "Data directory mode: $MODE"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # 2. Check container mount
 # -----------------------------------------------------------------------------
 log_info "2. Checking container mount..."


### PR DESCRIPTION
- Add fix-quest-data-permissions.sh script
  - Detects container UID/GID dynamically
  - Sets ownership to container user
  - Sets mode to 750 (no world-writable)
  - Verifies container write access

- Update verify script with permission check
  - Warns if data dir is world-writable (777)
  - Suggests fix script

- Update runbook
  - Document permission hardening steps
  - chmod 777 is only temporary emergency fix

- Update AI skills
  - Document fix script usage
  - Add security rule against 777
  - Update common issues table

VPS: /opt/areloria/data now has mode 750 instead of 777 Container UID 100:GID 101 owns the directory

## Summary

<!-- What changed and why (1–3 sentences). -->

## Documentation

- [ ] **`docs/PROJECT_STATUS_2026.md`** updated if behavior, architecture, or player-visible output changed
- [ ] **`docs/ROADMAP_TO_RELEASE.md`** updated if release-scope / Tier A–C items moved
- [ ] **`docs/DOCUMENTATION_INDEX.md`** updated if a doc was added, removed, or renamed

## Verification

<!-- e.g. `pnpm run lint`, `pnpm run test`, `pnpm run build` -->
