### PR TITLE
feat(crafting): add deterministic recipe system consuming gathered resources

### DIFF
--- a/apps/client-2d/src/ModuleRegistry.ts
+++ b/apps/client-2d/src/ModuleRegistry.ts
@@ -82,6 +82,26 @@ export const ARELORIA_MODULE_REGISTRY: readonly AreloriaModuleRegistryEntry[] = 
     notes: "Separater Pfad - nicht Hauptclient. 3D kommt später.",
   },
   {
+    id: "crafting-system",
+    title: "Crafting System",
+    runtimeSurface: "server",
+    status: "partial",
+    deterministic: true,
+    serverAuthoritative: true,
+    visibleInClient: true,
+    hasE2ETest: true,
+    entrypoints: [
+      "/api/crafting/recipes",
+      "/api/crafting/craft",
+      "/api/gameplay/snapshot",
+      "server/src/crafting/CraftingService.ts",
+      "server/src/crafting/StarterRecipes.ts",
+      "apps/client-2d/src/ui/windows/CraftingWindow.tsx",
+    ],
+    notes:
+      "Deterministic starter recipe system consuming persistent inventory resources and granting crafting XP. MVP recipes only; crafting stations, tools, queueing, failure chances, economy and equipment outputs pending.",
+  },
+  {
     id: "deterministic-world-iso-app",
     title: "DeterministicWorldIsoApp",
     runtimeSurface: "client-2d",

--- a/apps/client-2d/src/game/crafting.ts
+++ b/apps/client-2d/src/game/crafting.ts
@@ -1,0 +1,35 @@
+/**
+ * Crafting API client
+ *
+ * Client-side API for crafting operations.
+ * Server-authoritative: client cannot create or consume items.
+ */
+
+export interface CraftingApiResponse {
+  ok: boolean;
+  result: {
+    ok: boolean;
+    playerId: string;
+    recipeId: string;
+    reason?: string;
+    consumed?: Array<{ itemId: string; quantity: number }>;
+    outputs?: Array<{ itemId: string; quantity: number }>;
+    craftingXpReward?: number;
+  };
+}
+
+/**
+ * Craft a recipe.
+ * Server-authoritative: consumes ingredients, adds outputs, grants XP.
+ */
+export async function craftRecipe(recipeId: string): Promise<CraftingApiResponse> {
+  const response = await fetch("/api/crafting/craft", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ recipeId }),
+  });
+
+  return response.json();
+}

--- a/apps/client-2d/src/game/liveGameplaySnapshot.ts
+++ b/apps/client-2d/src/game/liveGameplaySnapshot.ts
@@ -96,6 +96,44 @@ export interface PlayerInventorySnapshot {
   capacity: number;
 }
 
+/**
+ * Crafting Recipe Ingredient Snapshot shape
+ */
+export interface CraftingRecipeIngredientSnapshot {
+  itemId: string;
+  quantity: number;
+}
+
+/**
+ * Crafting Recipe Output Snapshot shape
+ */
+export interface CraftingRecipeOutputSnapshot {
+  itemId: string;
+  quantity: number;
+}
+
+/**
+ * Crafting Recipe Snapshot shape
+ */
+export interface CraftingRecipeSnapshot {
+  id: string;
+  title: string;
+  requiredLevel: number;
+  craftingXpReward: number;
+  ingredients: CraftingRecipeIngredientSnapshot[];
+  outputs: CraftingRecipeOutputSnapshot[];
+  craftTicks: number;
+  craftable: boolean;
+  blockedReason?: "level_too_low" | "missing_ingredients";
+}
+
+/**
+ * Crafting Snapshot shape
+ */
+export interface CraftingSnapshot {
+  recipes: CraftingRecipeSnapshot[];
+}
+
 export interface LiveGameplaySnapshot {
   status: LiveDataStatus;
   serverTick: number | null;
@@ -103,6 +141,7 @@ export interface LiveGameplaySnapshot {
   skills: SkillSnapshot[];
   resources: ResourceNodeSnapshot[];
   inventory: PlayerInventorySnapshot;
+  crafting: CraftingSnapshot;
   guild: GuildSnapshot;
   factions: FactionStandingSnapshot[];
   map: MapSnapshot;
@@ -120,6 +159,9 @@ export const EMPTY_LIVE_GAMEPLAY_SNAPSHOT: LiveGameplaySnapshot = {
     schemaVersion: 1,
     slots: [],
     capacity: 32,
+  },
+  crafting: {
+    recipes: [],
   },
   guild: {
     id: null,
@@ -152,6 +194,7 @@ export function normalizeLiveGameplaySnapshot(
     skills: normalizeSkills(input.skills),
     resources: normalizeResources(input.resources),
     inventory: normalizeInventory(input.inventory),
+    crafting: normalizeCrafting(input.crafting),
     guild: {
       id: input.guild?.id ?? null,
       name: input.guild?.name ?? null,
@@ -291,5 +334,45 @@ export function normalizeInventory(input: unknown): PlayerInventorySnapshot {
     schemaVersion: 1,
     capacity: Math.max(0, Math.floor(Number(raw.capacity ?? 32))),
     slots,
+  };
+}
+
+/**
+ * Normalize crafting snapshots from server.
+ * Pure function - no mutation of input.
+ */
+export function normalizeCrafting(input: unknown): CraftingSnapshot {
+  const raw = input && typeof input === "object" ? (input as any) : {};
+  const recipes = Array.isArray(raw.recipes) ? raw.recipes : [];
+
+  return {
+    recipes: recipes
+      .filter((recipe: any) =>
+        recipe &&
+        typeof recipe === "object" &&
+        typeof recipe.id === "string",
+      )
+      .map((recipe: any) => ({
+        id: String(recipe.id),
+        title: String(recipe.title ?? recipe.id),
+        requiredLevel: Math.max(1, Math.floor(Number(recipe.requiredLevel ?? 1))),
+        craftingXpReward: Math.max(0, Math.floor(Number(recipe.craftingXpReward ?? 0))),
+        craftTicks: Math.max(0, Math.floor(Number(recipe.craftTicks ?? 0))),
+        craftable: Boolean(recipe.craftable),
+        blockedReason: recipe.blockedReason,
+        ingredients: Array.isArray(recipe.ingredients)
+          ? recipe.ingredients.map((item: any) => ({
+              itemId: String(item.itemId),
+              quantity: Math.max(1, Math.floor(Number(item.quantity ?? 1))),
+            }))
+          : [],
+        outputs: Array.isArray(recipe.outputs)
+          ? recipe.outputs.map((item: any) => ({
+              itemId: String(item.itemId),
+              quantity: Math.max(1, Math.floor(Number(item.quantity ?? 1))),
+            }))
+          : [],
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
   };
 }

--- a/apps/client-2d/src/ui/UIManager.tsx
+++ b/apps/client-2d/src/ui/UIManager.tsx
@@ -8,6 +8,7 @@ import {
 import { CharacterWindow } from "./windows/CharacterWindow.js";
 import { SkillWindow } from "./windows/SkillWindow.js";
 import { GuildWindow } from "./windows/GuildWindow.js";
+import { CraftingWindow } from "./windows/CraftingWindow.js";
 import type { StorageSnapshot } from "./StorageOverlay.js";
 import "./windows/windows.css";
 
@@ -35,6 +36,7 @@ export type ActiveOverlay =
   | { readonly type: "INVENTORY" }
   | { readonly type: "CHARACTER" }
   | { readonly type: "SKILLS" }
+  | { readonly type: "CRAFTING" }
   | { readonly type: "GUILD" }
   | {
       readonly type: "STORAGE";
@@ -114,6 +116,10 @@ class InteractionUIManager {
     this.setState({ type: "SKILLS" });
   }
 
+  public openCrafting(): void {
+    this.setState({ type: "CRAFTING" });
+  }
+
   public openGuild(): void {
     this.setState({ type: "GUILD" });
   }
@@ -166,6 +172,15 @@ class InteractionUIManager {
     }
 
     this.openSkills();
+  }
+
+  public toggleCrafting(): void {
+    if (this.state.type === "CRAFTING") {
+      this.closeUI();
+      return;
+    }
+
+    this.openCrafting();
   }
 
   public toggleGuild(): void {
@@ -226,6 +241,16 @@ export function useOverlayRenderer(): {
           );
         };
 
+      case "CRAFTING":
+        return function CraftingOverlayComponent() {
+          return (
+            <CraftingWindow
+              isOpen={true}
+              onClose={() => interactionUI.closeUI()}
+            />
+          );
+        };
+
       case "GUILD":
         return function GuildOverlayComponent() {
           return (
@@ -278,6 +303,11 @@ function handleInteractionShortcut(event: KeyboardEvent): void {
     case "k":
       event.preventDefault();
       interactionUI.toggleSkills();
+      return;
+
+    case "b":
+      event.preventDefault();
+      interactionUI.toggleCrafting();
       return;
 
     case "g":

--- a/apps/client-2d/src/ui/windows/CraftingPanel.tsx
+++ b/apps/client-2d/src/ui/windows/CraftingPanel.tsx
@@ -1,0 +1,80 @@
+/**
+ * Crafting Panel
+ *
+ * Displays player crafting recipes from LiveGameplaySnapshot.
+ * Server-authoritative display only - client cannot craft directly.
+ *
+ * Rules:
+ * - No Math.random() for display
+ * - No Date.now() for state
+ * - Shows server-provided values only
+ */
+
+import React from "react";
+import type { CraftingSnapshot } from "../../game/liveGameplaySnapshot";
+
+interface Props {
+  crafting: CraftingSnapshot;
+  onCraft?: (recipeId: string) => void;
+}
+
+export function CraftingPanel({ crafting, onCraft }: Props) {
+  const recipes = crafting?.recipes ?? [];
+
+  if (!recipes.length) {
+    return (
+      <section data-testid="crafting-panel-empty" className="are-window">
+        <h2>Crafting</h2>
+        <p className="are-text-muted">No crafting recipes yet.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="crafting-panel-live" className="are-window">
+      <h2>Crafting</h2>
+
+      <div className="crafting-list">
+        {recipes.map((recipe) => (
+          <article key={recipe.id} className="crafting-row">
+            <div className="crafting-row__header">
+              <strong>{recipe.title}</strong>
+              <span>+{recipe.craftingXpReward} XP</span>
+            </div>
+
+            <div className="crafting-row__meta">
+              Requires Crafting Lv. {recipe.requiredLevel}
+            </div>
+
+            <div className="crafting-row__items">
+              <span>
+                Input:{" "}
+                {recipe.ingredients
+                  .map((item) => `${item.quantity}× ${item.itemId}`)
+                  .join(", ")}
+              </span>
+              <span>
+                Output:{" "}
+                {recipe.outputs
+                  .map((item) => `${item.quantity}× ${item.itemId}`)
+                  .join(", ")}
+              </span>
+            </div>
+
+            <button
+              type="button"
+              disabled={!recipe.craftable}
+              onClick={() => onCraft?.(recipe.id)}
+            >
+              {recipe.craftable
+                ? "Craft"
+                : recipe.blockedReason === "missing_ingredients"
+                  ? "Missing Items"
+                  : "Locked"}
+            </button>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/client-2d/src/ui/windows/CraftingWindow.tsx
+++ b/apps/client-2d/src/ui/windows/CraftingWindow.tsx
@@ -1,0 +1,109 @@
+/**
+ * Crafting Window
+ *
+ * Shows player crafting recipes from LiveGameplaySnapshot.
+ * Server-authoritative display only - client cannot craft directly.
+ * Uses LiveGameplaySnapshot for reactive updates.
+ */
+
+import { useEffect, useCallback } from "react";
+import { useLiveGameplaySnapshot } from "../../game/useLiveGameplaySnapshot";
+import { craftRecipe } from "../../game/crafting";
+import type { CraftingSnapshot } from "../../game/liveGameplaySnapshot";
+
+interface CraftingWindowProps {
+  readonly isOpen?: boolean;
+  readonly onClose?: () => void;
+}
+
+export function CraftingWindow({ isOpen = true, onClose }: CraftingWindowProps) {
+  const snapshot = useLiveGameplaySnapshot();
+  const crafting: CraftingSnapshot = snapshot.crafting ?? { recipes: [] };
+  const recipes = crafting.recipes ?? [];
+
+  const handleCraft = useCallback(async (recipeId: string) => {
+    const result = await craftRecipe(recipeId);
+    window.dispatchEvent(
+      new CustomEvent("wasd:toast", {
+        detail: {
+          type: result.ok && result.result.ok ? "success" : "error",
+          message: result.ok && result.result.ok
+            ? "Crafted item successfully!"
+            : `Craft failed: ${result.result?.reason ?? "unknown"}`,
+        },
+      })
+    );
+  }, []);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="wow-inventory-overlay" role="dialog" aria-label="Crafting">
+      <div className="wow-inventory-header">
+        <h2>CRAFTING</h2>
+
+        {onClose && (
+          <button className="wow-close-btn" onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div className="char-content">
+        {recipes.length === 0 ? (
+          <div className="crafting-empty">
+            <p>No crafting recipes available.</p>
+            <p className="are-text-muted">Gather resources to unlock recipes.</p>
+          </div>
+        ) : (
+          <div className="crafting-list">
+            {recipes.map((recipe) => (
+              <article key={recipe.id} className="crafting-row">
+                <div className="crafting-row__header">
+                  <strong>{recipe.title}</strong>
+                  <span className="crafting-row__xp">+{recipe.craftingXpReward} XP</span>
+                </div>
+
+                <div className="crafting-row__meta">
+                  Requires Crafting Lv. {recipe.requiredLevel}
+                </div>
+
+                <div className="crafting-row__items">
+                  <div className="crafting-row__ingredients">
+                    <span className="crafting-row__label">Input:</span>
+                    <span>
+                      {recipe.ingredients
+                        .map((item) => `${item.quantity}× ${item.itemId}`)
+                        .join(", ")}
+                    </span>
+                  </div>
+                  <div className="crafting-row__outputs">
+                    <span className="crafting-row__label">Output:</span>
+                    <span>
+                      {recipe.outputs
+                        .map((item) => `${item.quantity}× ${item.itemId}`)
+                        .join(", ")}
+                    </span>
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  className="crafting-row__button"
+                  disabled={!recipe.craftable}
+                  onClick={() => handleCraft(recipe.id)}
+                >
+                  {recipe.craftable
+                    ? "Craft"
+                    : recipe.blockedReason === "missing_ingredients"
+                      ? "Missing Items"
+                      : "Locked"}
+                </button>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/client-2d/src/ui/windows/windows.css
+++ b/apps/client-2d/src/ui/windows/windows.css
@@ -832,3 +832,134 @@
 .resource-row__status--depleted {
   color: var(--ouro-orange);
 }
+
+/* ─── Crafting Window Styles ───────────────────────────────────────────────── */
+
+.crafting-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 400px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(180, 160, 100, 0.5) rgba(0, 0, 0, 0.35);
+}
+
+.crafting-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.crafting-list::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.35);
+  border-left: 1px solid rgba(80, 90, 110, 0.25);
+}
+
+.crafting-list::-webkit-scrollbar-thumb {
+  background: rgba(180, 160, 100, 0.45);
+  border: 1px solid rgba(220, 200, 140, 0.25);
+}
+
+.crafting-row {
+  background: var(--ouro-bg-1);
+  border: 1px solid var(--ouro-border-muted);
+  padding: 12px;
+  transition: border-color var(--ouro-transition-fast);
+}
+
+.crafting-row:hover {
+  border-color: var(--ouro-border-gold);
+}
+
+.crafting-row__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.crafting-row__header strong {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ouro-text-strong);
+}
+
+.crafting-row__xp {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--ouro-gold);
+}
+
+.crafting-row__meta {
+  font-size: 0.72rem;
+  color: var(--ouro-text-dim);
+  margin-bottom: 8px;
+}
+
+.crafting-row__items {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.78rem;
+  color: var(--ouro-text-muted);
+  margin-bottom: 10px;
+}
+
+.crafting-row__label {
+  color: var(--ouro-text-dim);
+  margin-right: 4px;
+}
+
+.crafting-row__button {
+  width: 100%;
+  padding: 8px 12px;
+  background: rgba(30, 255, 0, 0.15);
+  border: 2px solid rgba(30, 255, 0, 0.5);
+  color: var(--ouro-green);
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background var(--ouro-transition-fast),
+    border-color var(--ouro-transition-fast),
+    box-shadow var(--ouro-transition-fast);
+}
+
+.crafting-row__button:hover:not(:disabled) {
+  background: rgba(30, 255, 0, 0.3);
+  box-shadow: 0 0 8px rgba(30, 255, 0, 0.4);
+}
+
+.crafting-row__button:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.crafting-row__button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  background: rgba(80, 90, 110, 0.15);
+  border-color: rgba(80, 90, 110, 0.3);
+  color: var(--ouro-text-dim);
+  box-shadow: none;
+}
+
+.crafting-row__button:disabled:hover {
+  background: rgba(80, 90, 110, 0.15);
+  box-shadow: none;
+}
+
+.crafting-empty {
+  padding: 20px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--ouro-text-muted);
+}
+
+.crafting-empty p {
+  margin: 0 0 8px 0;
+}
+
+.crafting-empty .are-text-muted {
+  color: var(--ouro-text-dim);
+  font-size: 0.78rem;
+}

--- a/docs/CRAFTING_LOOP.md
+++ b/docs/CRAFTING_LOOP.md
@@ -1,0 +1,147 @@
+# Crafting Loop
+
+## Status
+
+**PARTIAL MVP**.
+
+This system adds deterministic starter recipes that consume persistent inventory resources and grant Crafting XP.
+
+## Loop
+
+```
+Gather Resource
+→ Resource Item in Inventory
+→ Craft Recipe
+→ Consume Ingredients
+→ Add Output Item
+→ Grant Crafting XP
+→ LiveGameplaySnapshot update
+→ 2D Crafting Panel update
+```
+
+## Starter Recipes
+
+| Recipe ID | Input | Output | Crafting XP |
+|-----------|-------|--------|-------------|
+| craft_wood_plank | 2× wood_log | 1× wood_plank | 20 |
+| smelt_copper_ingot | 3× copper_ore | 1× copper_ingot | 30 |
+| cook_raw_fish | 1× raw_fish | 1× cooked_fish | 15 |
+
+## Determism Rules
+
+- No `Math.random()`.
+- No `Date.now()` for gameplay state.
+- Recipe IDs are stable.
+- Recipe order is sorted by ID.
+- Client never creates items.
+- Client never consumes items.
+- Server resolves player identity.
+- Server validates ingredients and skill level.
+- Same inventory state + same craft request produces same result.
+
+## Current Items
+
+### Inputs:
+
+- `wood_log`
+- `copper_ore`
+- `raw_fish`
+
+### Outputs:
+
+- `wood_plank`
+- `copper_ingot`
+- `cooked_fish`
+
+## Current Limits
+
+- MVP starter recipes only.
+- No crafting stations.
+- No tools required.
+- No queueing.
+- No failure chance.
+- No equipment outputs.
+- No trading/economy integration.
+- No crafting animation pipeline.
+
+## API Endpoints
+
+### GET /api/crafting/recipes
+
+Returns all crafting recipes with craftability status for the player.
+
+```json
+{
+  "ok": true,
+  "playerId": "player123",
+  "recipes": [
+    {
+      "id": "cook_raw_fish",
+      "title": "Cook Raw Fish",
+      "requiredLevel": 1,
+      "craftingXpReward": 15,
+      "craftTicks": 4,
+      "ingredients": [{ "itemId": "raw_fish", "quantity": 1 }],
+      "outputs": [{ "itemId": "cooked_fish", "quantity": 1 }],
+      "craftable": false,
+      "blockedReason": "missing_ingredients"
+    }
+  ]
+}
+```
+
+### POST /api/crafting/craft
+
+Attempts to craft a recipe. Consumes ingredients, adds outputs, grants crafting XP.
+
+```json
+// Request
+{
+  "recipeId": "craft_wood_plank"
+}
+
+// Response (success)
+{
+  "ok": true,
+  "result": {
+    "ok": true,
+    "playerId": "player123",
+    "recipeId": "craft_wood_plank",
+    "reason": "crafted",
+    "consumed": [{ "itemId": "wood_log", "quantity": 2 }],
+    "outputs": [{ "itemId": "wood_plank", "quantity": 1 }],
+    "craftingXpReward": 20
+  }
+}
+
+// Response (failure - missing ingredients)
+{
+  "ok": true,
+  "result": {
+    "ok": false,
+    "playerId": "player123",
+    "recipeId": "craft_wood_plank",
+    "reason": "missing_ingredients"
+  }
+}
+```
+
+## Verification
+
+```bash
+# Unit tests
+pnpm vitest run server/tests/crafting-recipes.test.ts
+
+# E2E tests
+pnpm run test:e2e -- e2e/crafting-loop.spec.ts
+pnpm run test:e2e -- e2e/client-2d-crafting-panel.spec.ts
+
+# Build client
+pnpm --filter @wasd/client-2d build
+```
+
+## Next Steps
+
+- `feat(crafting): add crafting stations and tool requirements`
+- `feat(equipment): craft and equip basic tools`
+- `feat(economy): price crafted goods through NPC demand`

--- a/docs/PROJECT_STATUS_2026.md
+++ b/docs/PROJECT_STATUS_2026.md
@@ -102,3 +102,70 @@ When runtime behavior changes, update this file together with:
 - `README.md`
 - `docs/ROADMAP_TO_RELEASE.md` (if release scope changed)
 - Relevant subsystem docs under `docs/`
+
+## Gameplay Vertical Slice Status (June 2026)
+
+### Complete Foundations
+
+- Quest persistence and production ops are merged.
+- Auth-bound player identity is active.
+- Quest, skill and inventory state support persistence paths.
+- Resource gathering connects world interaction to skills and inventory.
+- **Crafting loop complete**: Gather → Inventory → Craft → XP → Snapshot/UI
+
+### Current Live Gameplay Loop
+
+```
+Gather starter resource node
+→ Gain skill XP
+→ Receive persistent resource item
+→ Craft starter recipe
+→ Consume resource item
+→ Receive persistent crafted item
+→ Gain Crafting XP
+→ See updated state in LiveGameplaySnapshot and 2D panels
+```
+
+### Partial Systems
+
+| System | Status | Notes |
+|--------|--------|-------|
+| Quest Persistence | Foundation complete | Production ops and backup policy present |
+| Skill Progression | Partial | MVP skills and XP persistence exist |
+| Resource Gathering | Partial | Static starter nodes only |
+| Inventory | Partial | Resource/crafted items only |
+| Crafting | **Partial** | **Deterministic starter recipes only** |
+| Guild/Faction | Partial | Snapshot visible, data not fully wired |
+| Equipment | Partial | Panel exists, not fully connected |
+
+### Crafting System Details (MVP)
+
+Recipes:
+- `craft_wood_plank`: 2× wood_log → 1× wood_plank (+20 XP)
+- `smelt_copper_ingot`: 3× copper_ore → 1× copper_ingot (+30 XP)
+- `cook_raw_fish`: 1× raw_fish → 1× cooked_fish (+15 XP)
+
+Features:
+- Server-authoritative crafting flow
+- Persistent inventory consumption
+- Crafting XP grants to player skills
+- LiveGameplaySnapshot visibility
+- 2D Crafting Window (press B)
+
+### Not Yet Complete
+
+- Procedural resource placement
+- Crafting stations
+- Tool requirements
+- Equipment system (full)
+- Trading
+- NPC economy
+- Item pricing
+- Player-to-player exchange
+- Crafting animations
+
+### Next Real Block
+
+`feat(equipment): craft and equip basic gathering tools`
+
+Then Crafting becomes progression, not just inventory management.

--- a/e2e/client-2d-crafting-panel.spec.ts
+++ b/e2e/client-2d-crafting-panel.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * CLIENT 2D CRAFTING PANEL E2E TESTS
+ *
+ * End-to-end tests for the 2D client crafting panel.
+ * Tests that the crafting window opens and displays recipes.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.describe("2D Client Crafting Panel", () => {
+  test("shows crafting panel when pressing B key", async ({ page }) => {
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+    });
+
+    // Wait for the app to initialize
+    await page.waitForTimeout(2000);
+
+    // Press B to open crafting
+    await page.keyboard.press("b");
+
+    // Wait for the crafting window to appear
+    await page.waitForSelector('[role="dialog"][aria-label="Crafting"]', {
+      timeout: 5000,
+    });
+
+    // Verify the crafting window is visible
+    const craftingWindow = page.locator('[role="dialog"][aria-label="Crafting"]');
+    await expect(craftingWindow).toBeVisible();
+
+    // Verify the title is present
+    await expect(page.locator('text=CRAFTING')).toBeVisible();
+
+    // Verify all three recipes are displayed
+    await expect(page.locator('text=Craft Wood Plank')).toBeVisible();
+    await expect(page.locator('text=Smelt Copper Ingot')).toBeVisible();
+    await expect(page.locator('text=Cook Raw Fish')).toBeVisible();
+  });
+
+  test("crafting panel shows recipe details", async ({ page }) => {
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.waitForTimeout(2000);
+
+    // Open crafting
+    await page.keyboard.press("b");
+
+    await page.waitForSelector('[role="dialog"][aria-label="Crafting"]', {
+      timeout: 5000,
+    });
+
+    // Check for Wood Plank recipe details
+    await expect(page.locator('text=Requires Crafting Lv. 1').first()).toBeVisible();
+    await expect(page.locator('text=+20 XP').first()).toBeVisible();
+
+    // Check for input/output information
+    await expect(page.locator('text=2× wood_log')).toBeVisible();
+    await expect(page.locator('text=1× wood_plank').first()).toBeVisible();
+  });
+
+  test("crafting panel closes with Escape key", async ({ page }) => {
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.waitForTimeout(2000);
+
+    // Open crafting
+    await page.keyboard.press("b");
+
+    await page.waitForSelector('[role="dialog"][aria-label="Crafting"]', {
+      timeout: 5000,
+    });
+
+    // Close crafting with Escape
+    await page.keyboard.press("Escape");
+
+    // Verify the crafting window is no longer visible
+    await expect(
+      page.locator('[role="dialog"][aria-label="Crafting"]')
+    ).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test("toggle crafting with B key", async ({ page }) => {
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.waitForTimeout(2000);
+
+    // First press - opens crafting
+    await page.keyboard.press("b");
+    await page.waitForSelector('[role="dialog"][aria-label="Crafting"]', {
+      timeout: 5000,
+    });
+    await expect(page.locator('[role="dialog"][aria-label="Crafting"]')).toBeVisible();
+
+    // Second press - closes crafting
+    await page.keyboard.press("b");
+    await expect(
+      page.locator('[role="dialog"][aria-label="Crafting"]')
+    ).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/e2e/crafting-loop.spec.ts
+++ b/e2e/crafting-loop.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * CRAFTING LOOP E2E TESTS
+ *
+ * End-to-end tests for deterministic crafting system.
+ * Tests the full flow: gather tree → craft plank → verify inventory and XP.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Crafting Loop", () => {
+  test("gather wood then craft plank", async ({ request }) => {
+    const playerId = "crafting-e2e-player";
+
+    // Gather wood logs (need 2 for one plank)
+    const gather1 = await request.post(`/api/resource/gather`, {
+      data: {
+        nodeId: "starter_tree_001",
+        playerPosition: { x: 460, y: 500 },
+        currentTick: 1000,
+      },
+      params: { playerId },
+    });
+
+    expect(gather1.ok()).toBeTruthy();
+    const gather1Json = await gather1.json();
+    expect(gather1Json.result.ok).toBe(true);
+    expect(gather1Json.result.itemRewardId).toBe("wood_log");
+
+    // Gather second wood log
+    const gather2 = await request.post(`/api/resource/gather`, {
+      data: {
+        nodeId: "starter_tree_001",
+        playerPosition: { x: 460, y: 500 },
+        currentTick: 1031,
+      },
+      params: { playerId },
+    });
+
+    expect(gather2.ok()).toBeTruthy();
+    const gather2Json = await gather2.json();
+    expect(gather2Json.result.ok).toBe(true);
+
+    // Now craft wood plank
+    const craft = await request.post(`/api/crafting/craft`, {
+      data: {
+        recipeId: "craft_wood_plank",
+      },
+      params: { playerId },
+    });
+
+    expect(craft.ok()).toBeTruthy();
+    const craftJson = await craft.json();
+    expect(craftJson.ok).toBe(true);
+    expect(craftJson.result.ok).toBe(true);
+    expect(craftJson.result.reason).toBe("crafted");
+    expect(craftJson.result.outputs).toEqual([
+      {
+        itemId: "wood_plank",
+        quantity: 1,
+      },
+    ]);
+    expect(craftJson.result.craftingXpReward).toBe(20);
+
+    // Get gameplay snapshot and verify inventory
+    const snapshot = await request.get(`/api/gameplay/snapshot`, {
+      params: { playerId },
+    });
+
+    expect(snapshot.ok()).toBeTruthy();
+    const snapshotJson = await snapshot.json();
+
+    // Verify wood_plank is in inventory
+    const slots = snapshotJson.snapshot.inventory.slots;
+    const plankSlot = slots.find((slot: any) => slot.itemId === "wood_plank");
+    expect(plankSlot).toBeDefined();
+    expect(plankSlot.quantity).toBe(1);
+
+    // Verify crafting XP increased
+    const crafting = snapshotJson.snapshot.skills.find(
+      (skill: any) => skill.id === "crafting"
+    );
+    expect(crafting).toBeDefined();
+    expect(crafting.xp).toBeGreaterThanOrEqual(20);
+
+    // Verify wood_log was consumed (should have 0 remaining)
+    const woodLogSlot = slots.find((slot: any) => slot.itemId === "wood_log");
+    expect(woodLogSlot).toBeDefined();
+    expect(woodLogSlot.quantity).toBe(0);
+  });
+
+  test("rejects crafting without ingredients", async ({ request }) => {
+    const playerId = "crafting-no-items-player";
+
+    // Try to craft without gathering
+    const craft = await request.post(`/api/crafting/craft`, {
+      data: {
+        recipeId: "craft_wood_plank",
+      },
+      params: { playerId },
+    });
+
+    expect(craft.status()).toBe(409);
+
+    const json = await craft.json();
+    expect(json.ok).toBe(false);
+    expect(json.result.ok).toBe(false);
+    expect(json.result.reason).toBe("missing_ingredients");
+  });
+
+  test("crafting recipes are in gameplay snapshot", async ({ request }) => {
+    const playerId = "crafting-snapshot-player";
+
+    const snapshot = await request.get(`/api/gameplay/snapshot`, {
+      params: { playerId },
+    });
+
+    expect(snapshot.ok()).toBeTruthy();
+    const json = await snapshot.json();
+
+    // Verify crafting recipes are in snapshot
+    expect(json.snapshot.crafting).toBeDefined();
+    expect(json.snapshot.crafting.recipes).toBeDefined();
+    expect(Array.isArray(json.snapshot.crafting.recipes)).toBe(true);
+    expect(json.snapshot.crafting.recipes).toHaveLength(3);
+
+    // Verify all starter recipes are present
+    const recipeIds = json.snapshot.crafting.recipes.map((r: any) => r.id);
+    expect(recipeIds).toContain("craft_wood_plank");
+    expect(recipeIds).toContain("smelt_copper_ingot");
+    expect(recipeIds).toContain("cook_raw_fish");
+
+    // Verify recipe structure
+    const plankRecipe = json.snapshot.crafting.recipes.find(
+      (r: any) => r.id === "craft_wood_plank"
+    );
+    expect(plankRecipe).toEqual(
+      expect.objectContaining({
+        id: "craft_wood_plank",
+        title: "Craft Wood Plank",
+        requiredLevel: 1,
+        craftingXpReward: 20,
+        craftTicks: 5,
+        craftable: false, // No ingredients yet
+      })
+    );
+
+    // Verify ingredients and outputs
+    expect(plankRecipe.ingredients).toEqual([
+      { itemId: "wood_log", quantity: 2 },
+    ]);
+    expect(plankRecipe.outputs).toEqual([
+      { itemId: "wood_plank", quantity: 1 },
+    ]);
+  });
+
+  test("GET /api/crafting/recipes returns recipe list", async ({ request }) => {
+    const playerId = "crafting-recipes-api-player";
+
+    const response = await request.get(`/api/crafting/recipes`, {
+      params: { playerId },
+    });
+
+    expect(response.ok()).toBeTruthy();
+
+    const json = await response.json();
+    expect(json.ok).toBe(true);
+    expect(json.recipes).toBeDefined();
+    expect(json.recipes).toHaveLength(3);
+
+    // Recipes should be sorted
+    const recipeIds = json.recipes.map((r: any) => r.id);
+    expect(recipeIds).toEqual(["cook_raw_fish", "craft_wood_plank", "smelt_copper_ingot"]);
+  });
+
+  test("rejects invalid recipe ID", async ({ request }) => {
+    const playerId = "crafting-invalid-recipe-player";
+
+    const craft = await request.post(`/api/crafting/craft`, {
+      data: {
+        recipeId: "nonexistent_recipe",
+      },
+      params: { playerId },
+    });
+
+    expect(craft.status()).toBe(409);
+
+    const json = await craft.json();
+    expect(json.result.reason).toBe("recipe_not_found");
+  });
+
+  test("gather ore then smelt copper ingot", async ({ request }) => {
+    const playerId = "crafting-smelt-player";
+
+    // Gather 3 copper ore
+    for (let i = 0; i < 3; i++) {
+      const gather = await request.post(`/api/resource/gather`, {
+        data: {
+          nodeId: "starter_ore_001",
+          playerPosition: { x: 540, y: 520 },
+          currentTick: 1000 + i,
+        },
+        params: { playerId },
+      });
+
+      expect(gather.ok()).toBeTruthy();
+      const gatherJson = await gather.json();
+      expect(gatherJson.result.itemRewardId).toBe("copper_ore");
+    }
+
+    // Smelt copper ingot
+    const craft = await request.post(`/api/crafting/craft`, {
+      data: {
+        recipeId: "smelt_copper_ingot",
+      },
+      params: { playerId },
+    });
+
+    expect(craft.ok()).toBeTruthy();
+    const craftJson = await craft.json();
+    expect(craftJson.result.ok).toBe(true);
+    expect(craftJson.result.outputs).toEqual([
+      { itemId: "copper_ingot", quantity: 1 },
+    ]);
+    expect(craftJson.result.craftingXpReward).toBe(30);
+  });
+
+  test("gather fish then cook raw fish", async ({ request }) => {
+    const playerId = "crafting-cook-player";
+
+    // Gather raw fish
+    const gather = await request.post(`/api/resource/gather`, {
+      data: {
+        nodeId: "starter_fish_001",
+        playerPosition: { x: 500, y: 580 },
+        currentTick: 1000,
+      },
+      params: { playerId },
+    });
+
+    expect(gather.ok()).toBeTruthy();
+    const gatherJson = await gather.json();
+    expect(gatherJson.result.itemRewardId).toBe("raw_fish");
+
+    // Cook raw fish
+    const craft = await request.post(`/api/crafting/craft`, {
+      data: {
+        recipeId: "cook_raw_fish",
+      },
+      params: { playerId },
+    });
+
+    expect(craft.ok()).toBeTruthy();
+    const craftJson = await craft.json();
+    expect(craftJson.result.ok).toBe(true);
+    expect(craftJson.result.outputs).toEqual([
+      { itemId: "cooked_fish", quantity: 1 },
+    ]);
+    expect(craftJson.result.craftingXpReward).toBe(15);
+  });
+});

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -36,6 +36,7 @@ import { resolveWorldAssetsDir } from "./resolveWorldAssetsDir.js";
 import { resolveMirroredWorldAssetsDir } from "./resolveMirroredWorldAssetsDir.js";
 import { registerSelfHealingDashboard } from "../selfhealing/SelfHealingDashboard.js";
 import { createSelfHealWorkshopRouter } from "../routes/selfHealWorkshopRoute.js";
+import { default as craftingRouter } from "../routes/craftingRoute.js";
 import { PlaytesterConfig } from "../config/PlaytesterConfig.js";
 import { PlaytesterMonitorStream } from "../modules/playtester/PlaytesterMonitorStream.js";
 import { PlaytesterWebRTCSignaling } from "../modules/playtester/PlaytesterWebRTCSignaling.js";
@@ -196,6 +197,7 @@ export class ServerBootstrap {
     app.use("/api/skill", skillEventRouter);
     app.use("/api/resource", resourceGatherRouter);
     app.use("/api/inventory", inventoryRouter);
+    app.use("/api/crafting", craftingRouter);
     app.use("/api/self-healing", createSelfHealWorkshopRouter());
     app.use("/api/manifest", createManifestResyncRouter(tick));
     app.use("/api/finance", express.json({ limit: "1mb" }), financeRouter());

--- a/server/src/crafting/CraftingService.ts
+++ b/server/src/crafting/CraftingService.ts
@@ -1,0 +1,175 @@
+/**
+ * CRAFTING SERVICE
+ *
+ * Server-authoritative crafting service.
+ * Deterministic: No Math.random(), no Date.now(), stable recipe ordering.
+ */
+
+import { getInventoryService } from "../inventory/inventoryRuntime.js";
+import { getSkillProgressionService } from "../skills/skillRuntime.js";
+import type { SkillSnapshot } from "../skills/SkillTypes.js";
+import { STARTER_CRAFTING_RECIPES } from "./StarterRecipes.js";
+import type {
+  CraftingRecipe,
+  CraftingRecipeSnapshot,
+  CraftingResult,
+  RecipeId,
+} from "./CraftingTypes.js";
+
+function craftingLevelFromSkills(skills: SkillSnapshot[]): number {
+  return skills.find((skill) => skill.id === "crafting")?.level ?? 1;
+}
+
+export class CraftingService {
+  private readonly recipes = new Map<string, CraftingRecipe>();
+
+  constructor(recipes: readonly CraftingRecipe[] = STARTER_CRAFTING_RECIPES) {
+    for (const recipe of recipes) {
+      this.recipes.set(recipe.id, recipe);
+    }
+  }
+
+  listRecipes(): CraftingRecipe[] {
+    return [...this.recipes.values()].sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  async listRecipeSnapshots(playerId: string): Promise<CraftingRecipeSnapshot[]> {
+    const skillService = await getSkillProgressionService();
+    await skillService.hydratePlayer(playerId);
+    const skillState = await skillService.getPlayerSkillState(playerId);
+    const craftingLevel = craftingLevelFromSkills(skillState.skills);
+
+    const inventoryService = await getInventoryService();
+
+    return Promise.all(
+      this.listRecipes().map(async (recipe) => {
+        const hasIngredients = await inventoryService.hasItems({
+          playerId,
+          items: recipe.ingredients,
+        });
+
+        const levelOk = craftingLevel >= recipe.requiredLevel;
+
+        return {
+          ...recipe,
+          craftable: levelOk && hasIngredients,
+          blockedReason: !levelOk
+            ? "level_too_low"
+            : !hasIngredients
+              ? "missing_ingredients"
+              : undefined,
+        };
+      }),
+    );
+  }
+
+  async craft(input: {
+    playerId: string;
+    recipeId: string;
+  }): Promise<CraftingResult> {
+    if (!input.playerId || input.playerId === "anonymous") {
+      return {
+        ok: false,
+        playerId: input.playerId,
+        recipeId: input.recipeId,
+        reason: "invalid_player",
+      };
+    }
+
+    const recipe = this.recipes.get(input.recipeId);
+    if (!recipe) {
+      return {
+        ok: false,
+        playerId: input.playerId,
+        recipeId: input.recipeId,
+        reason: "recipe_not_found",
+      };
+    }
+
+    const skillService = await getSkillProgressionService();
+    await skillService.hydratePlayer(input.playerId);
+    const skillState = await skillService.getPlayerSkillState(input.playerId);
+    const craftingLevel = craftingLevelFromSkills(skillState.skills);
+
+    if (craftingLevel < recipe.requiredLevel) {
+      return {
+        ok: false,
+        playerId: input.playerId,
+        recipeId: recipe.id,
+        reason: "level_too_low",
+      };
+    }
+
+    const inventoryService = await getInventoryService();
+    const hasIngredients = await inventoryService.hasItems({
+      playerId: input.playerId,
+      items: recipe.ingredients,
+    });
+
+    if (!hasIngredients) {
+      return {
+        ok: false,
+        playerId: input.playerId,
+        recipeId: recipe.id,
+        reason: "missing_ingredients",
+      };
+    }
+
+    // Consume ingredients
+    for (const ingredient of recipe.ingredients) {
+      const removed = await inventoryService.removeItem({
+        playerId: input.playerId,
+        itemId: ingredient.itemId,
+        quantity: ingredient.quantity,
+      });
+
+      if (!removed.ok) {
+        return {
+          ok: false,
+          playerId: input.playerId,
+          recipeId: recipe.id,
+          reason: "missing_ingredients",
+        };
+      }
+    }
+
+    // Add outputs
+    for (const output of recipe.outputs) {
+      const added = await inventoryService.addItem({
+        playerId: input.playerId,
+        itemId: output.itemId,
+        quantity: output.quantity,
+      });
+
+      if (!added.ok) {
+        return {
+          ok: false,
+          playerId: input.playerId,
+          recipeId: recipe.id,
+          reason: "inventory_full",
+        };
+      }
+    }
+
+    // Grant crafting XP
+    await skillService.applyEvent({
+      type: "skill_xp_gain",
+      playerId: input.playerId,
+      skillId: "crafting",
+      amount: recipe.craftingXpReward,
+      source: "crafting",
+    });
+
+    return {
+      ok: true,
+      playerId: input.playerId,
+      recipeId: recipe.id,
+      reason: "crafted",
+      consumed: recipe.ingredients,
+      outputs: recipe.outputs,
+      craftingXpReward: recipe.craftingXpReward,
+    };
+  }
+}
+
+export const craftingService = new CraftingService();

--- a/server/src/crafting/CraftingTypes.ts
+++ b/server/src/crafting/CraftingTypes.ts
@@ -1,0 +1,61 @@
+/**
+ * CRAFTING TYPES
+ *
+ * Deterministic crafting recipe types for server-authoritative crafting.
+ * No Date.now(), no Math.random(), stable recipe IDs and ordering.
+ */
+
+import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+
+export type RecipeId =
+  | "craft_wood_plank"
+  | "smelt_copper_ingot"
+  | "cook_raw_fish";
+
+export interface RecipeIngredient {
+  itemId: InventoryItemId;
+  quantity: number;
+}
+
+export interface RecipeOutput {
+  itemId: InventoryItemId;
+  quantity: number;
+}
+
+export interface CraftingRecipe {
+  id: RecipeId;
+  title: string;
+  requiredLevel: number;
+  craftingXpReward: number;
+  ingredients: RecipeIngredient[];
+  outputs: RecipeOutput[];
+  craftTicks: number;
+}
+
+export interface CraftingResult {
+  ok: boolean;
+  playerId: string;
+  recipeId: RecipeId | string;
+  reason?:
+    | "crafted"
+    | "recipe_not_found"
+    | "level_too_low"
+    | "missing_ingredients"
+    | "inventory_full"
+    | "invalid_player";
+  consumed?: RecipeIngredient[];
+  outputs?: RecipeOutput[];
+  craftingXpReward?: number;
+}
+
+export interface CraftingRecipeSnapshot {
+  id: RecipeId;
+  title: string;
+  requiredLevel: number;
+  craftingXpReward: number;
+  ingredients: RecipeIngredient[];
+  outputs: RecipeOutput[];
+  craftTicks: number;
+  craftable: boolean;
+  blockedReason?: "level_too_low" | "missing_ingredients";
+}

--- a/server/src/crafting/StarterRecipes.ts
+++ b/server/src/crafting/StarterRecipes.ts
@@ -1,0 +1,72 @@
+/**
+ * STARTER CRAFTING RECIPES
+ *
+ * Deterministic starter recipes for the crafting system.
+ * No Date.now(), no Math.random(), stable recipe ordering.
+ */
+
+import type { CraftingRecipe } from "./CraftingTypes.js";
+
+export const STARTER_CRAFTING_RECIPES: readonly CraftingRecipe[] = [
+  {
+    id: "craft_wood_plank",
+    title: "Craft Wood Plank",
+    requiredLevel: 1,
+    craftingXpReward: 20,
+    craftTicks: 5,
+    ingredients: [
+      {
+        itemId: "wood_log",
+        quantity: 2,
+      },
+    ],
+    outputs: [
+      {
+        itemId: "wood_plank",
+        quantity: 1,
+      },
+    ],
+  },
+  {
+    id: "smelt_copper_ingot",
+    title: "Smelt Copper Ingot",
+    requiredLevel: 1,
+    craftingXpReward: 30,
+    craftTicks: 8,
+    ingredients: [
+      {
+        itemId: "copper_ore",
+        quantity: 3,
+      },
+    ],
+    outputs: [
+      {
+        itemId: "copper_ingot",
+        quantity: 1,
+      },
+    ],
+  },
+  {
+    id: "cook_raw_fish",
+    title: "Cook Raw Fish",
+    requiredLevel: 1,
+    craftingXpReward: 15,
+    craftTicks: 4,
+    ingredients: [
+      {
+        itemId: "raw_fish",
+        quantity: 1,
+      },
+    ],
+    outputs: [
+      {
+        itemId: "cooked_fish",
+        quantity: 1,
+      },
+    ],
+  },
+] as const;
+
+export function getRecipeIds(): string[] {
+  return STARTER_CRAFTING_RECIPES.map((recipe) => recipe.id).sort();
+}

--- a/server/src/inventory/InventoryService.ts
+++ b/server/src/inventory/InventoryService.ts
@@ -12,6 +12,7 @@ import {
 } from "./InventoryPersistence.js";
 import type {
   InventoryAddResult,
+  InventoryRemoveResult,
   InventoryItemId,
   PlayerInventoryState,
 } from "./InventoryTypes.js";
@@ -45,6 +46,32 @@ export class InventoryService {
     }
 
     return result;
+  }
+
+  async removeItem(input: {
+    playerId: string;
+    itemId: InventoryItemId | string;
+    quantity: number;
+  }): Promise<InventoryRemoveResult> {
+    await this.hydratePlayer(input.playerId);
+
+    const result = this.store.removeItem(input);
+
+    if (result.ok && result.state) {
+      await this.persistence.savePlayerInventory(
+        createPersistedPlayerInventoryState(input.playerId, result.state),
+      );
+    }
+
+    return result;
+  }
+
+  async hasItems(input: {
+    playerId: string;
+    items: Array<{ itemId: InventoryItemId; quantity: number }>;
+  }): Promise<boolean> {
+    await this.hydratePlayer(input.playerId);
+    return this.store.hasItems(input);
   }
 
   async hydratePlayer(playerId: string): Promise<void> {

--- a/server/src/inventory/InventoryStore.ts
+++ b/server/src/inventory/InventoryStore.ts
@@ -13,6 +13,7 @@ import {
   normalizePlayerInventoryState,
   normalizeQuantity,
   type InventoryAddResult,
+  type InventoryRemoveResult,
   type InventoryItemId,
   type PlayerInventoryState,
 } from "./InventoryTypes.js";
@@ -141,6 +142,87 @@ export class InventoryStore {
 
   replacePlayerInventory(playerId: string, state: PlayerInventoryState): void {
     this.inventories.set(playerId, normalizePlayerInventoryState(state, playerId));
+  }
+
+  removeItem(input: {
+    playerId: string;
+    itemId: InventoryItemId | string;
+    quantity: number;
+  }): InventoryRemoveResult {
+    if (!isInventoryItemId(input.itemId)) {
+      return {
+        ok: false,
+        playerId: input.playerId,
+        itemId: "wood_log",
+        quantity: 0,
+        reason: "invalid_item",
+      };
+    }
+
+    const quantity = normalizeQuantity(input.quantity);
+    if (quantity <= 0) {
+      return {
+        ok: false,
+        playerId: input.playerId,
+        itemId: input.itemId,
+        quantity: 0,
+        reason: "invalid_quantity",
+      };
+    }
+
+    const state = this.getPlayerInventory(input.playerId);
+    const existing = state.slots.find((slot) => slot.itemId === input.itemId);
+
+    if (!existing || existing.quantity < quantity) {
+      return {
+        ok: false,
+        playerId: input.playerId,
+        itemId: input.itemId,
+        quantity,
+        reason: "not_enough_items",
+        state,
+      };
+    }
+
+    const nextSlots =
+      existing.quantity === quantity
+        ? state.slots.filter((slot) => slot.itemId !== input.itemId)
+        : state.slots.map((slot) =>
+            slot.itemId === input.itemId
+              ? { ...slot, quantity: slot.quantity - quantity }
+              : slot,
+          );
+
+    const nextState = normalizePlayerInventoryState(
+      {
+        ...state,
+        slots: nextSlots,
+      },
+      input.playerId,
+    );
+
+    this.inventories.set(input.playerId, nextState);
+
+    return {
+      ok: true,
+      playerId: input.playerId,
+      itemId: input.itemId,
+      quantity,
+      reason: "removed",
+      state: nextState,
+    };
+  }
+
+  hasItems(input: {
+    playerId: string;
+    items: Array<{ itemId: InventoryItemId; quantity: number }>;
+  }): boolean {
+    const state = this.getPlayerInventory(input.playerId);
+
+    return input.items.every((required) => {
+      const slot = state.slots.find((candidate) => candidate.itemId === required.itemId);
+      return Boolean(slot && slot.quantity >= required.quantity);
+    });
   }
 
   clearForTests(): void {

--- a/server/src/inventory/InventoryTypes.ts
+++ b/server/src/inventory/InventoryTypes.ts
@@ -8,7 +8,10 @@
 export type InventoryItemId =
   | "wood_log"
   | "copper_ore"
-  | "raw_fish";
+  | "raw_fish"
+  | "wood_plank"
+  | "copper_ingot"
+  | "cooked_fish";
 
 export interface InventoryItemDefinition {
   id: InventoryItemId;
@@ -44,6 +47,15 @@ export interface InventoryAddResult {
   state?: PlayerInventoryState;
 }
 
+export interface InventoryRemoveResult {
+  ok: boolean;
+  playerId: string;
+  itemId: InventoryItemId;
+  quantity: number;
+  reason?: "removed" | "invalid_item" | "invalid_quantity" | "not_enough_items";
+  state?: PlayerInventoryState;
+}
+
 export const INVENTORY_CAPACITY = 32;
 
 export const ITEM_DEFINITIONS: Record<InventoryItemId, InventoryItemDefinition> = {
@@ -67,6 +79,27 @@ export const ITEM_DEFINITIONS: Record<InventoryItemId, InventoryItemDefinition> 
     stackable: true,
     maxStack: 999,
     category: "resource",
+  },
+  wood_plank: {
+    id: "wood_plank",
+    name: "Wood Plank",
+    stackable: true,
+    maxStack: 999,
+    category: "resource",
+  },
+  copper_ingot: {
+    id: "copper_ingot",
+    name: "Copper Ingot",
+    stackable: true,
+    maxStack: 999,
+    category: "resource",
+  },
+  cooked_fish: {
+    id: "cooked_fish",
+    name: "Cooked Fish",
+    stackable: true,
+    maxStack: 999,
+    category: "consumable",
   },
 };
 

--- a/server/src/inventory/inventoryRuntime.ts
+++ b/server/src/inventory/inventoryRuntime.ts
@@ -50,4 +50,4 @@ export function getInventoryStore(): InventoryStore {
 
 // Re-export for convenience
 export { InventoryStore } from "./InventoryStore.js";
-export type { InventoryItemId, PlayerInventoryState, InventoryAddResult } from "./InventoryTypes.js";
+export type { InventoryItemId, PlayerInventoryState, InventoryAddResult, InventoryRemoveResult } from "./InventoryTypes.js";

--- a/server/src/routes/craftingRoute.ts
+++ b/server/src/routes/craftingRoute.ts
@@ -1,0 +1,102 @@
+/**
+ * CRAFTING API ROUTE
+ *
+ * Server-authoritative crafting API.
+ * No Date.now(), no Math.random(), stable recipe ordering.
+ */
+
+import express, { Router } from "express";
+import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
+import { craftingService } from "../crafting/CraftingService.js";
+
+const router = Router();
+
+router.use(express.json());
+
+function parseRecipeId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!/^[a-zA-Z0-9_-]{1,96}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * GET /api/crafting/recipes
+ *
+ * List all crafting recipes with craftability status for the player.
+ */
+router.get("/recipes", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+
+  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    res.status(401).json({
+      ok: false,
+      error: "authenticated_player_required",
+    });
+    return;
+  }
+
+  try {
+    const recipes = await craftingService.listRecipeSnapshots(identity.playerId);
+
+    res.json({
+      ok: true,
+      playerId: identity.playerId,
+      recipes,
+    });
+  } catch (error) {
+    console.error("[crafting-recipes] Failed to list recipes:", error);
+    res.status(500).json({
+      ok: false,
+      error: "internal_error",
+    });
+  }
+});
+
+/**
+ * POST /api/crafting/craft
+ *
+ * Attempt to craft a recipe.
+ * Consumes ingredients, adds outputs, grants crafting XP.
+ */
+router.post("/craft", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+
+  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    res.status(401).json({
+      ok: false,
+      error: "authenticated_player_required",
+    });
+    return;
+  }
+
+  const recipeId = parseRecipeId(req.body?.recipeId);
+
+  if (!recipeId) {
+    res.status(400).json({
+      ok: false,
+      error: "invalid_recipe_id",
+    });
+    return;
+  }
+
+  try {
+    const result = await craftingService.craft({
+      playerId: identity.playerId,
+      recipeId,
+    });
+
+    res.status(result.ok ? 200 : 409).json({
+      ok: result.ok,
+      result,
+    });
+  } catch (error) {
+    console.error("[crafting-craft] Failed to craft:", error);
+    res.status(500).json({
+      ok: false,
+      error: "internal_error",
+    });
+  }
+});
+
+export default router;

--- a/server/src/routes/gameplaySnapshot.ts
+++ b/server/src/routes/gameplaySnapshot.ts
@@ -21,6 +21,7 @@ import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
 import { getSkillProgressionService } from "../skills/skillRuntime.js";
 import { gatheringService } from "../resources/GatheringService.js";
 import { getInventoryService } from "../inventory/inventoryRuntime.js";
+import { craftingService } from "../crafting/CraftingService.js";
 
 /**
  * Get current tick ID from WorldTick instance.
@@ -67,12 +68,18 @@ export function createGameplaySnapshotRouter(tick: WorldTick) {
     const inventoryService = await getInventoryService();
     const inventory = await inventoryService.getPlayerInventory(identity.playerId);
 
+    // Get crafting recipes
+    const craftingRecipes = await craftingService.listRecipeSnapshots(identity.playerId);
+
     const snapshot = createGameplaySnapshot({
       serverTick,
       quests: questState.quests,
       skills: skillState.skills,
       resources,
       inventory,
+      crafting: {
+        recipes: craftingRecipes,
+      },
       guild: null,
       factions: [],
       map: {},

--- a/server/src/routes/gameplaySnapshotUtils.ts
+++ b/server/src/routes/gameplaySnapshotUtils.ts
@@ -122,7 +122,45 @@ export interface PlayerInventorySnapshot {
 }
 
 /**
- * Live Gameplay Snapshot shape (includes skills, resources, and inventory)
+ * Crafting Recipe Ingredient Snapshot shape
+ */
+export interface CraftingRecipeIngredientSnapshot {
+  itemId: string;
+  quantity: number;
+}
+
+/**
+ * Crafting Recipe Output Snapshot shape
+ */
+export interface CraftingRecipeOutputSnapshot {
+  itemId: string;
+  quantity: number;
+}
+
+/**
+ * Crafting Recipe Snapshot shape
+ */
+export interface CraftingRecipeSnapshot {
+  id: string;
+  title: string;
+  requiredLevel: number;
+  craftingXpReward: number;
+  ingredients: CraftingRecipeIngredientSnapshot[];
+  outputs: CraftingRecipeOutputSnapshot[];
+  craftTicks: number;
+  craftable: boolean;
+  blockedReason?: "level_too_low" | "missing_ingredients";
+}
+
+/**
+ * Crafting Snapshot shape
+ */
+export interface CraftingSnapshot {
+  recipes: CraftingRecipeSnapshot[];
+}
+
+/**
+ * Live Gameplay Snapshot shape (includes skills, resources, inventory, and crafting)
  */
 export interface LiveGameplaySnapshot {
   status: "live";
@@ -131,13 +169,14 @@ export interface LiveGameplaySnapshot {
   skills: SkillSnapshot[];
   resources: ResourceNodeSnapshot[];
   inventory: PlayerInventorySnapshot;
+  crafting: CraftingSnapshot;
   guild: GuildSnapshot;
   factions: FactionStandingSnapshot[];
   map: MapSnapshot;
 }
 
 /**
- * Input for creating a gameplay snapshot (includes skills, resources, and inventory)
+ * Input for creating a gameplay snapshot (includes skills, resources, inventory, and crafting)
  */
 export interface GameplaySnapshotInput {
   serverTick: number;
@@ -145,6 +184,7 @@ export interface GameplaySnapshotInput {
   skills?: SkillSnapshot[];
   resources?: ResourceNodeSnapshot[];
   inventory?: PlayerInventorySnapshot | null;
+  crafting?: CraftingSnapshot | null;
   guild?: GuildSnapshot | null;
   factions?: FactionStandingSnapshot[];
   map?: Partial<MapSnapshot>;
@@ -164,6 +204,9 @@ export function createGameplaySnapshot(input: GameplaySnapshotInput): LiveGamepl
   // Sort inventory slots by itemId for deterministic output
   const sortedSlots = [...(input.inventory?.slots ?? [])].sort((a, b) => a.itemId.localeCompare(b.itemId));
 
+  // Sort crafting recipes by id for deterministic output
+  const sortedRecipes = [...(input.crafting?.recipes ?? [])].sort((a, b) => a.id.localeCompare(b.id));
+
   return {
     status: "live",
     serverTick: input.serverTick,
@@ -175,6 +218,9 @@ export function createGameplaySnapshot(input: GameplaySnapshotInput): LiveGamepl
       schemaVersion: 1,
       slots: sortedSlots,
       capacity: 32,
+    },
+    crafting: {
+      recipes: sortedRecipes,
     },
     guild: input.guild ?? {
       id: null,
@@ -206,6 +252,7 @@ export function createEmptyGameplaySnapshot(serverTick: number): LiveGameplaySna
     quests: [],
     skills: [],
     inventory: null,
+    crafting: null,
     guild: null,
     factions: [],
     map: {},

--- a/server/tests/crafting-recipes.test.ts
+++ b/server/tests/crafting-recipes.test.ts
@@ -1,0 +1,109 @@
+/**
+ * CRAFTING UNIT TESTS
+ *
+ * Tests for deterministic crafting recipes and service.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { CraftingService } from "../crafting/CraftingService";
+import { STARTER_CRAFTING_RECIPES } from "../crafting/StarterRecipes";
+
+describe("Starter crafting recipes", () => {
+  it("uses stable sorted recipe ids", () => {
+    const service = new CraftingService(STARTER_CRAFTING_RECIPES);
+    expect(service.listRecipes().map((recipe) => recipe.id)).toEqual([
+      "cook_raw_fish",
+      "craft_wood_plank",
+      "smelt_copper_ingot",
+    ]);
+  });
+
+  it("defines deterministic plank recipe", () => {
+    const plank = STARTER_CRAFTING_RECIPES.find(
+      (recipe) => recipe.id === "craft_wood_plank",
+    );
+
+    expect(plank).toEqual(
+      expect.objectContaining({
+        requiredLevel: 1,
+        craftingXpReward: 20,
+        craftTicks: 5,
+      }),
+    );
+
+    expect(plank?.ingredients).toEqual([
+      {
+        itemId: "wood_log",
+        quantity: 2,
+      },
+    ]);
+
+    expect(plank?.outputs).toEqual([
+      {
+        itemId: "wood_plank",
+        quantity: 1,
+      },
+    ]);
+  });
+
+  it("defines deterministic copper ingot recipe", () => {
+    const ingot = STARTER_CRAFTING_RECIPES.find(
+      (recipe) => recipe.id === "smelt_copper_ingot",
+    );
+
+    expect(ingot).toEqual(
+      expect.objectContaining({
+        requiredLevel: 1,
+        craftingXpReward: 30,
+        craftTicks: 8,
+      }),
+    );
+
+    expect(ingot?.ingredients).toEqual([
+      {
+        itemId: "copper_ore",
+        quantity: 3,
+      },
+    ]);
+
+    expect(ingot?.outputs).toEqual([
+      {
+        itemId: "copper_ingot",
+        quantity: 1,
+      },
+    ]);
+  });
+
+  it("defines deterministic cooked fish recipe", () => {
+    const fish = STARTER_CRAFTING_RECIPES.find(
+      (recipe) => recipe.id === "cook_raw_fish",
+    );
+
+    expect(fish).toEqual(
+      expect.objectContaining({
+        requiredLevel: 1,
+        craftingXpReward: 15,
+        craftTicks: 4,
+      }),
+    );
+
+    expect(fish?.ingredients).toEqual([
+      {
+        itemId: "raw_fish",
+        quantity: 1,
+      },
+    ]);
+
+    expect(fish?.outputs).toEqual([
+      {
+        itemId: "cooked_fish",
+        quantity: 1,
+      },
+    ]);
+  });
+
+  it("has all three starter recipes", () => {
+    const service = new CraftingService(STARTER_CRAFTING_RECIPES);
+    expect(service.listRecipes()).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a deterministic, server-authoritative crafting system that consumes persistent inventory resources and grants Crafting XP.

## Features

- **Crafted Item Definitions**: wood_plank, copper_ingot, cooked_fish
- **Inventory Consumption Support**: `removeItem()` and `hasItems()` methods added
- **Deterministic Starter Recipes**:
  - `craft_wood_plank`: 2× wood_log → 1× wood_plank (+20 XP)
  - `smelt_copper_ingot`: 3× copper_ore → 1× copper_ingot (+30 XP)
  - `cook_raw_fish`: 1× raw_fish → 1× cooked_fish (+15 XP)
- **CraftingService**: Server-authoritative craft flow with ingredient validation
- **API Endpoints**: `/api/crafting/recipes` and `/api/crafting/craft`
- **LiveGameplaySnapshot**: Crafting recipes visible in gameplay snapshot
- **2D Crafting Window**: Press **B** to open (follows existing Panzerschrank aesthetic)
- **Tests**: Unit tests and E2E tests for the gather → craft loop

## Safety & Determinism

- Client cannot create items directly
- Client cannot consume inventory directly
- Server validates player identity, ingredients, and crafting level
- **No `Math.random()`** - All recipe outcomes are deterministic
- **No `Date.now()`** for gameplay state
- Stable recipe IDs and sorted recipe ordering
- No secrets committed, no new DB provisioned

## Gameplay Loop

```
Gather starter resource node
→ Gain skill XP
→ Receive persistent resource item
→ Craft starter recipe
→ Consume resource item
→ Receive persistent crafted item
→ Gain Crafting XP
→ See updated state in LiveGameplaySnapshot and 2D panels
```

## Verification

```bash
# Unit tests
pnpm vitest run server/tests/crafting-recipes.test.ts

# E2E tests
pnpm run test:e2e -- e2e/crafting-loop.spec.ts
pnpm run test:e2e -- e2e/client-2d-crafting-panel.spec.ts

# Build client
pnpm --filter @wasd/client-2d build
```

## Status

**PARTIAL**: Starter crafting recipes consume persistent gathered resources and grant Crafting XP. Crafting stations, tools, queues, equipment outputs, trading, and economy are pending.

## Files Changed

- `server/src/inventory/InventoryTypes.ts` - New item definitions
- `server/src/inventory/InventoryStore.ts` - removeItem, hasItems methods
- `server/src/inventory/InventoryService.ts` - Persistence for remove/has
- `server/src/crafting/CraftingTypes.ts` - Recipe types
- `server/src/crafting/StarterRecipes.ts` - 3 starter recipes
- `server/src/crafting/CraftingService.ts` - Server-authoritative service
- `server/src/routes/craftingRoute.ts` - API endpoints
- `server/src/routes/gameplaySnapshot.ts` - Crafting in snapshot
- `server/src/routes/gameplaySnapshotUtils.ts` - Server crafting types
- `apps/client-2d/src/game/liveGameplaySnapshot.ts` - Client crafting types
- `apps/client-2d/src/game/crafting.ts` - Client API
- `apps/client-2d/src/ui/windows/CraftingWindow.tsx` - Crafting panel
- `apps/client-2d/src/ui/UIManager.tsx` - B shortcut
- `apps/client-2d/src/ui/windows/windows.css` - Styling
- `server/tests/crafting-recipes.test.ts` - Unit tests
- `e2e/crafting-loop.spec.ts` - Gather → craft E2E
- `e2e/client-2d-crafting-panel.spec.ts` - Client E2E
- `apps/client-2d/src/ModuleRegistry.ts` - Module entry
- `docs/CRAFTING_LOOP.md` - Documentation
- `docs/PROJECT_STATUS_2026.md` - Status update

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/47b73e52-4481-46d2-96c5-f41ef0a15a1e)