### PR TITLE
fix(client-2d): prevent production blank screen on 2d boot

### DIFF
--- a/apps/client-2d/index.html
+++ b/apps/client-2d/index.html
@@ -218,23 +218,122 @@
   </noscript>
 
   <div id="root">
-    <div id="boot-screen" aria-hidden="true">
-      <div class="boot-card">
-        <div class="boot-title">Areloria</div>
-        <div class="boot-subtitle">
-          Initialisiere REAL_PIXI_CLIENT · 10Hz Logic Engine · Ouroboros Loop
+    <!-- Boot fallback - visible if React fails to mount -->
+    <!-- React removes this element on successful mount -->
+    <div
+      id="boot-screen"
+      data-testid="areloria-boot-fallback"
+      aria-hidden="true"
+      style="
+        position:fixed;
+        inset:0;
+        display:grid;
+        place-items:center;
+        padding:24px;
+        background:#070711;
+        z-index:999;
+      "
+    >
+      <div
+        style="
+          max-width:420px;
+          width:100%;
+          border:1px solid rgba(0,229,255,.3);
+          border-radius:22px;
+          padding:22px;
+          background:rgba(7,7,17,.9);
+          box-shadow:0 0 42px rgba(0,229,255,.12);
+          text-align:center;
+          font-family:system-ui,sans-serif;
+          color:#f5f7ff;
+        "
+      >
+        <h1 style="margin:0 0 8px;font-size:22px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;">
+          Areloria
+        </h1>
+        <p style="margin:0 0 16px;color:rgba(245,247,255,.6);font-size:13px;line-height:1.5;">
+          Lade REAL_PIXI_CLIENT · 10Hz · Ouroboros
+        </p>
+        <div style="
+          height:8px;
+          border-radius:999px;
+          background:rgba(255,255,255,.08);
+          overflow:hidden;
+          margin-bottom:14px;
+        ">
+          <div style="
+            height:100%;
+            width:42%;
+            border-radius:inherit;
+            background:linear-gradient(90deg,#00e5ff,#39ff14,#ff7a00);
+            animation:boot-pulse 1.4s ease-in-out infinite;
+          "></div>
         </div>
-        <div class="boot-bar"></div>
-        <div class="boot-meta">
-          <span>PIXI</span>
-          <span>ARE</span>
-          <span>10HZ</span>
-        </div>
+        <p style="margin:0;color:rgba(245,247,255,.4);font-size:11px;letter-spacing:.08em;">
+          PIXI · ARE · 10HZ
+        </p>
+        <noscript>
+          <p style="margin-top:12px;color:#ff416c;">
+            ⚠️ JavaScript erforderlich für Areloria.
+          </p>
+        </noscript>
+        <p
+          id="boot-fallback-warning"
+          style="display:none;margin-top:12px;color:#ff7a00;font-size:12px;"
+        >
+          ⚠️ Boot fehlgeschlagen. Bitte neu laden.
+        </p>
       </div>
     </div>
   </div>
 
   <script type="module" src="/src/main.tsx"></script>
+
+  <!-- Boot timeout fallback - shows warning if React doesn't mount within 10s -->
+  <script>
+    (function() {
+      var BOOT_TIMEOUT_MS = 10000;
+      var checkInterval = null;
+
+      function showBootWarning() {
+        var warning = document.getElementById('boot-fallback-warning');
+        if (warning) {
+          warning.style.display = 'block';
+        }
+        console.warn('[Areloria] Boot timeout - React may have failed to mount');
+      }
+
+      function checkBootStatus() {
+        var bootAttr = document.body.dataset.areloriaBoot;
+        var bootOk = document.body.dataset.client2dBoot;
+
+        // If mounted successfully, stop checking
+        if (bootAttr === 'mounted' || bootOk === 'ok') {
+          clearInterval(checkInterval);
+          return;
+        }
+
+        // If boot failed, clear interval
+        if (bootAttr === 'failed' || bootOk === 'failed') {
+          clearInterval(checkInterval);
+          return;
+        }
+      }
+
+      // Start checking after initial load
+      setTimeout(function() {
+        checkBootStatus();
+        // If still not mounted after timeout, show warning
+        checkInterval = setInterval(function() {
+          var bootAttr = document.body.dataset.areloriaBoot;
+          if (bootAttr !== 'mounted' && bootAttr !== 'failed') {
+            showBootWarning();
+            clearInterval(checkInterval);
+          }
+        }, 2000);
+      }, BOOT_TIMEOUT_MS);
+    })();
+  </script>
 
   <!-- REAL_PIXI_CLIENT -->
 </body>

--- a/apps/client-2d/src/ArelorianStitchHud.tsx
+++ b/apps/client-2d/src/ArelorianStitchHud.tsx
@@ -226,7 +226,7 @@ export function ArelorianStitchHud({
   }
 
   return (
-    <div className={hudClasses} aria-label="Arelorian Science MMO HUD">
+    <div className={hudClasses} data-testid="arelorian-stitch-hud" aria-label="Arelorian Science MMO HUD">
       <div className="stitch-scanlines" aria-hidden="true" />
 
       <header className="stitch-topbar" role="banner">

--- a/apps/client-2d/src/CyberZenLoginGate.tsx
+++ b/apps/client-2d/src/CyberZenLoginGate.tsx
@@ -89,7 +89,7 @@ export function CyberZenLoginGate({ children }: Props): React.ReactElement {
   }
 
   return (
-    <main className="cz-login-root">
+    <main className="cz-login-root" data-testid="cyber-zen-login-gate">
       <section className="cz-login-card">
         <div className="cz-eyebrow">ARELORIA WASD · SOVEREIGN 10HZ GATE</div>
         <h1>Cyber-Zen Gateway</h1>

--- a/apps/client-2d/src/DeterministicWorldIsoApp.tsx
+++ b/apps/client-2d/src/DeterministicWorldIsoApp.tsx
@@ -1180,7 +1180,7 @@ chunkManager.init({
   }
 
   return (
-    <div className="az-shell">
+    <div className="az-shell" data-testid="deterministic-world-root">
       {/* Zero-Trust Divergence Alert - Military Panzerschrank Design */}
       {diverged && (
         <DivergenceAlert

--- a/apps/client-2d/src/game/liveGameplaySnapshot.ts
+++ b/apps/client-2d/src/game/liveGameplaySnapshot.ts
@@ -182,45 +182,52 @@ export const EMPTY_LIVE_GAMEPLAY_SNAPSHOT: LiveGameplaySnapshot = {
 };
 
 // Normalization helper - pure function, no mutation
+// Returns EMPTY_LIVE_GAMEPLAY_SNAPSHOT on any error to prevent crashes
 export function normalizeLiveGameplaySnapshot(
   input: Partial<LiveGameplaySnapshot> | null | undefined
 ): LiveGameplaySnapshot {
-  if (!input) return EMPTY_LIVE_GAMEPLAY_SNAPSHOT;
+  try {
+    if (!input) return EMPTY_LIVE_GAMEPLAY_SNAPSHOT;
 
-  return {
-    status: input.status ?? "waiting",
-    serverTick: typeof input.serverTick === "number" ? input.serverTick : null,
-    quests: Array.isArray(input.quests) ? input.quests : [],
-    skills: normalizeSkills(input.skills),
-    resources: normalizeResources(input.resources),
-    inventory: normalizeInventory(input.inventory),
-    crafting: normalizeCrafting(input.crafting),
-    guild: {
-      id: input.guild?.id ?? null,
-      name: input.guild?.name ?? null,
-      memberCount:
-        typeof input.guild?.memberCount === "number"
-          ? input.guild.memberCount
-          : 0,
-      rank: input.guild?.rank ?? null,
-      villageEligible: Boolean(input.guild?.villageEligible),
-      treasury:
-        typeof input.guild?.treasury === "number" ? input.guild.treasury : null,
-    },
-    factions: Array.isArray(input.factions) ? input.factions : [],
-    map: {
-      regionName: input.map?.regionName ?? "unknown",
-      chunkX:
-        typeof input.map?.chunkX === "number" ? input.map.chunkX : null,
-      chunkZ:
-        typeof input.map?.chunkZ === "number" ? input.map.chunkZ : null,
-      visibleChunks:
-        typeof input.map?.visibleChunks === "number"
-          ? input.map.visibleChunks
-          : null,
-      biome: input.map?.biome ?? null,
-    },
-  };
+    return {
+      status: (input.status && typeof input.status === "string") ? input.status : "waiting",
+      serverTick: typeof input.serverTick === "number" ? input.serverTick : null,
+      quests: Array.isArray(input.quests) ? input.quests : [],
+      skills: normalizeSkills(input.skills),
+      resources: normalizeResources(input.resources),
+      inventory: normalizeInventory(input.inventory),
+      crafting: normalizeCrafting(input.crafting),
+      guild: {
+        id: input.guild?.id ?? null,
+        name: input.guild?.name ?? null,
+        memberCount:
+          typeof input.guild?.memberCount === "number"
+            ? input.guild.memberCount
+            : 0,
+        rank: input.guild?.rank ?? null,
+        villageEligible: Boolean(input.guild?.villageEligible),
+        treasury:
+          typeof input.guild?.treasury === "number" ? input.guild.treasury : null,
+      },
+      factions: Array.isArray(input.factions) ? input.factions : [],
+      map: {
+        regionName: input.map?.regionName ?? "unknown",
+        chunkX:
+          typeof input.map?.chunkX === "number" ? input.map.chunkX : null,
+        chunkZ:
+          typeof input.map?.chunkZ === "number" ? input.map.chunkZ : null,
+        visibleChunks:
+          typeof input.map?.visibleChunks === "number"
+            ? input.map.visibleChunks
+            : null,
+        biome: input.map?.biome ?? null,
+      },
+    };
+  } catch (error) {
+    // Never crash the client - return empty snapshot on normalization error
+    console.error("[LiveGameplaySnapshot] normalize failed:", error);
+    return EMPTY_LIVE_GAMEPLAY_SNAPSHOT;
+  }
 }
 
 /**

--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -37,6 +37,7 @@ installViewportRuntime();
 
 /**
  * Fatal boot error display - prevents endless black screens
+ * Shows visible error overlay when React fails to mount
  */
 function showFatalBootError(error: unknown): void {
   const root = document.getElementById("root");
@@ -44,45 +45,71 @@ function showFatalBootError(error: unknown): void {
   const message =
     error instanceof Error
       ? `${error.name}: ${error.message}`
-      : String(error);
+      : String(error ?? "Unknown boot error");
+
+  const stack =
+    error instanceof Error && error.stack
+      ? error.stack
+      : "";
 
   console.error("[Areloria Boot Fatal]", error);
 
   if (!root) {
-    document.body.innerHTML = `<pre style="color:white;background:#070711;padding:24px;">${message}</pre>`;
+    document.body.innerHTML = `<pre style="color:white;background:#070711;padding:24px;">${message}\n\n${stack}</pre>`;
     return;
   }
 
+  // Escape HTML to prevent XSS in error display
+  const escapeHtml = (s: string) =>
+    s.replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+
   root.innerHTML = `
-    <div style="
-      min-height:100dvh;
-      display:grid;
-      place-items:center;
-      padding:24px;
-      background:#070711;
-      color:#f5f7ff;
-      font-family:system-ui,sans-serif;
-    ">
-      <div style="
-        max-width:520px;
-        border:1px solid rgba(255,65,108,.4);
+    <main
+      data-testid="boot-fatal-overlay"
+      style="
+        min-height:100dvh;
+        display:grid;
+        place-items:center;
+        padding:24px;
+        padding-top:calc(24px + env(safe-area-inset-top, 0px));
+        padding-bottom:calc(24px + env(safe-area-inset-bottom, 0px));
+        background:#070711;
+        color:#f5f7ff;
+        font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+      "
+    >
+      <section style="
+        max-width:560px;
+        width:100%;
+        border:1px solid rgba(255,65,108,.5);
         border-radius:20px;
-        padding:22px;
-        background:rgba(255,65,108,.08);
+        padding:24px;
+        background:rgba(255,65,108,.1);
+        box-shadow:0 0 48px rgba(255,65,108,.22);
       ">
-        <h1 style="font-size:20px;margin-bottom:10px;">Areloria Boot Error</h1>
-        <p style="opacity:.72;line-height:1.5;">
-          Der REAL_PIXI_CLIENT konnte nicht starten.
+        <h1 style="margin:0 0 8px;color:#ff416c;font-size:22px;">⚠️ Areloria Boot Fehler</h1>
+        <p style="margin:0 0 16px;color:rgba(245,247,255,.72);line-height:1.5;">
+          Der REAL_PIXI_CLIENT ist beim Starten abgestürzt.
         </p>
         <pre style="
-          margin-top:16px;
           overflow:auto;
-          white-space:pre-wrap;
+          max-height:40vh;
+          padding:16px;
+          border-radius:12px;
+          background:#000;
+          color:#ff9f7a;
           font-size:12px;
-          opacity:.86;
-        ">${message}</pre>
-      </div>
-    </div>
+          line-height:1.5;
+        ">${escapeHtml(message)}${stack ? "\n\n" + escapeHtml(stack) : ""}</pre>
+        <p style="margin:16px 0 0;color:rgba(245,247,255,.5);font-size:11px;">
+          Bitte Page neu laden oder Browser-Cache leeren.
+        </p>
+      </section>
+    </main>
   `;
 }
 
@@ -100,17 +127,28 @@ function registerServiceWorker(): void {
 }
 
 /**
- * Setup global error handlers
+ * Setup global error handlers to catch boot-time crashes
+ * Ensures any runtime error shows visible fatal overlay
  */
 function setupGlobalErrorHandlers(): void {
-  // Window error handler
+  // Window error handler - catch runtime errors
   window.addEventListener("error", (event) => {
-    console.error("[Areloria Window Error]", event.error ?? event.message);
+    const err = event.error ?? event.message;
+    console.error("[Areloria Window Error]", err);
+    // Show overlay if React hasn't mounted yet
+    if (!document.body.dataset.areloriaBoot || document.body.dataset.areloriaBoot === "cold") {
+      showFatalBootError(err);
+    }
   });
 
   // Unhandled promise rejection handler
   window.addEventListener("unhandledrejection", (event) => {
-    console.error("[Areloria Promise Rejection]", event.reason);
+    const reason = event.reason;
+    console.error("[Areloria Promise Rejection]", reason);
+    // Show overlay if React hasn't mounted yet
+    if (!document.body.dataset.areloriaBoot || document.body.dataset.areloriaBoot === "cold") {
+      showFatalBootError(reason);
+    }
   });
 }
 
@@ -270,6 +308,7 @@ function UIOverlayLayer() {
 }
 
 async function main(): Promise<void> {
+  // Mark boot start for E2E testing
   document.body.dataset.areloriaBoot = "mounting";
 
   const rootElement = document.getElementById("root");
@@ -278,28 +317,42 @@ async function main(): Promise<void> {
     throw new Error("Missing #root element");
   }
 
-  // Setup before rendering
+  // Setup error handlers BEFORE any code runs
   setupGlobalErrorHandlers();
   registerServiceWorker();
 
-  // Render app
-  ReactDOM.createRoot(rootElement).render(
-    <React.StrictMode>
-      <CyberZenLoginGate>
-        <DeterministicWorldIsoApp />
-        <LiveRealityBridge />
-        <WorldHeartMonitor />
-        <PixiModuleInspector />
-        <MobileMovePad />
-        <KenneyUiLiveSkinBadge />
-        <InteractionOverlayRoot />
-        <UIOverlayLayer />
-        <LiveGameplayNetworkBridge />
-      </CyberZenLoginGate>
-    </React.StrictMode>
-  );
+  // Remove the boot screen fallback once React mounts
+  const bootScreen = document.getElementById("boot-screen");
+  if (bootScreen) {
+    bootScreen.remove();
+  }
 
-  document.body.dataset.areloriaBoot = "mounted";
+  // Render app with full error capture
+  try {
+    ReactDOM.createRoot(rootElement).render(
+      <React.StrictMode>
+        <CyberZenLoginGate>
+          <DeterministicWorldIsoApp />
+          <LiveRealityBridge />
+          <WorldHeartMonitor />
+          <PixiModuleInspector />
+          <MobileMovePad />
+          <KenneyUiLiveSkinBadge />
+          <InteractionOverlayRoot />
+          <UIOverlayLayer />
+          <LiveGameplayNetworkBridge />
+        </CyberZenLoginGate>
+      </React.StrictMode>
+    );
+
+    // Success marker for E2E
+    document.body.dataset.areloriaBoot = "mounted";
+    document.body.dataset.client2dBoot = "ok";
+  } catch (error) {
+    document.body.dataset.areloriaBoot = "failed";
+    document.body.dataset.client2dBoot = "failed";
+    showFatalBootError(error);
+  }
 }
 
 main().catch(showFatalBootError);

--- a/apps/client-2d/src/ui/windows/windows.css
+++ b/apps/client-2d/src/ui/windows/windows.css
@@ -49,6 +49,39 @@
   border-radius: 0;
 }
 
+/* ─── are-window base class ──────────────────────────────────────────────── */
+/* Applied to all panel windows to ensure visibility above canvas */
+
+.are-window {
+  position: relative;
+  z-index: 50;
+}
+
+/* ─── z-index guarantees for UI layers ───────────────────────────────────── */
+
+[data-testid="cyber-zen-login-gate"],
+[data-testid="character-select"],
+[data-testid="arelorian-stitch-hud"],
+.az-shell {
+  position: relative;
+  z-index: 50;
+}
+
+canvas {
+  z-index: 1;
+}
+
+/* Mobile viewport safety */
+@media (max-width: 768px) {
+  .are-window,
+  [data-testid="cyber-zen-login-gate"],
+  [data-testid="arelorian-stitch-hud"] {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow: auto;
+  }
+}
+
 .char-content,
 .skill-content,
 .guild-content {

--- a/e2e/client-2d-boot-smoke.spec.ts
+++ b/e2e/client-2d-boot-smoke.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * E2E Blank Screen Smoke Test for 2D Client
+ *
+ * Tests that /2d/ shows visible UI (not just dark background).
+ * If the client crashes or fails to boot, the test fails.
+ *
+ * This is the primary regression test for the "production blank screen" bug.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.describe("2D Client Boot Smoke Test", () => {
+  test("shows visible login/character/world UI, not just background", async ({ page }) => {
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
+
+    // Capture console errors
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    // Capture page errors (unhandled exceptions)
+    page.on("pageerror", (err) => {
+      pageErrors.push(err.message);
+    });
+
+    // Navigate to 2D client
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+
+    // Wait for boot to complete (or timeout after 10s)
+    await page.waitForTimeout(5_000);
+
+    // Get body text content
+    const bodyText = (await page.locator("body").innerText()).trim();
+
+    // Report any errors for debugging (soft assertions)
+    expect.soft(
+      pageErrors,
+      `Page errors detected: ${pageErrors.join("\n")}`
+    ).toHaveLength(0);
+
+    expect.soft(
+      consoleErrors.filter(e => !e.includes("Warning") && !e.includes("DevTools")),
+      `Console errors detected: ${consoleErrors.join("\n")}`
+    ).toHaveLength(0);
+
+    // At minimum one of these must exist and be visible:
+    // 1. CyberZenLoginGate (login screen)
+    // 2. Character select
+    // 3. DeterministicWorldIsoApp (world renderer)
+    // 4. ArelorianStitchHud (HUD)
+    // 5. boot-fatal-overlay (error display)
+    const visibleBootTargets = [
+      page.getByTestId("cyber-zen-login-gate"),
+      page.getByTestId("character-select"),
+      page.getByTestId("deterministic-world-root"),
+      page.getByTestId("arelorian-stitch-hud"),
+      page.getByTestId("boot-fatal-overlay"),
+      // Fallback: look for the login gate class
+      page.locator(".cz-login-root"),
+      // Fallback: boot screen should be removed on success
+      page.locator("[data-testid='areloria-boot-fallback']"),
+    ];
+
+    let visibleCount = 0;
+    let visibleTarget = "";
+
+    for (const target of visibleBootTargets) {
+      const isVisible = await target.isVisible().catch(() => false);
+      if (isVisible) {
+        visibleCount++;
+        visibleTarget = await target.getAttribute("data-testid").catch(() => "class-based");
+        break;
+      }
+    }
+
+    // The body should have some text content (not just empty background)
+    expect(
+      bodyText.length,
+      `Body text should not be empty. Got: ${bodyText.slice(0, 200)}`
+    ).toBeGreaterThan(5);
+
+    // At least one UI element must be visible
+    expect(
+      visibleCount,
+      buildDebugMessage(
+        `Expected login/character/world/hud/error overlay to be visible. ` +
+        `Body text was: ${bodyText.slice(0, 200)}`,
+        { consoleErrors, pageErrors }
+      )
+    ).toBeGreaterThan(0);
+
+    // Check body data attributes for boot status
+    const bootAttr = await page.locator("body").getAttribute("data-areloria-boot");
+    const bootOk = await page.locator("body").getAttribute("data-client2d-boot");
+
+    // Either mounted successfully or showing fatal overlay
+    expect(
+      [bootAttr, bootOk],
+      "Boot should be 'mounted' or 'failed', not 'cold' or empty"
+    ).toContain("mounted");
+  });
+
+  test("boot screen fallback disappears on successful mount", async ({ page }) => {
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+
+    // Wait for React to potentially mount
+    await page.waitForTimeout(3_000);
+
+    // Check if boot screen is gone (successful mount) or still there (failed)
+    const bootScreen = page.locator("#boot-screen, [data-testid='areloria-boot-fallback']");
+    const bootVisible = await bootScreen.isVisible().catch(() => false);
+
+    // If boot screen is visible, check if it's showing warning (failed state)
+    if (bootVisible) {
+      const warning = page.locator("#boot-fallback-warning");
+      const warningVisible = await warning.isVisible().catch(() => false);
+
+      // If warning is visible, boot has failed - this is a test failure
+      expect(
+        warningVisible,
+        "Boot fallback warning should not be visible - React should have mounted"
+      ).toBe(false);
+    }
+
+    // Either way, some UI should be visible
+    const hasContent = (await page.locator("body").innerText()).trim().length > 5;
+    expect(hasContent, "Page should have visible content").toBe(true);
+  });
+
+  test("no critical errors in browser console", async ({ page }) => {
+    const criticalErrors: string[] = [];
+
+    page.on("pageerror", (err) => {
+      criticalErrors.push(err.message);
+    });
+
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+
+    await page.waitForTimeout(5_000);
+
+    // Filter out non-critical errors
+    const realErrors = criticalErrors.filter(
+      e => !e.includes("Warning") &&
+           !e.includes("DevTools") &&
+           !e.includes("favicon")
+    );
+
+    expect(
+      realErrors,
+      `Critical page errors should be empty. Found: ${realErrors.join("\n")}`
+    ).toHaveLength(0);
+  });
+});
+
+function buildDebugMessage(
+  message: string,
+  ctx: { consoleErrors: string[]; pageErrors: string[] }
+): string {
+  return `${message}
+
+--- Console Errors ---
+${ctx.consoleErrors.slice(0, 20).join("\n") || "none"}
+
+--- Page Errors ---
+${ctx.pageErrors.slice(0, 20).join("\n") || "none"}`;
+}

--- a/e2e/client-2d-mobile-boot-smoke.spec.ts
+++ b/e2e/client-2d-mobile-boot-smoke.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * E2E Mobile Blank Screen Smoke Test for 2D Client
+ *
+ * Tests that /2d/ shows visible UI on mobile viewport.
+ * This specifically targets the Android/Chrome blank screen issue.
+ */
+
+import { test, expect, devices } from "@playwright/test";
+
+// Use Pixel 5 as representative Android device
+const pixel5Config = devices["Pixel 5"];
+
+test.describe("2D Client Mobile Boot Smoke Test", () => {
+  test.use({
+    ...pixel5Config,
+  });
+
+  test("mobile /2d/ shows login or boot overlay", async ({ page }) => {
+    const pageErrors: string[] = [];
+
+    page.on("pageerror", (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+
+    // Wait for boot
+    await page.waitForTimeout(5_000);
+
+    // At least one of: login, character select, world, hud, or fatal overlay
+    // must be visible
+    await expect(
+      page.locator(
+        "[data-testid='cyber-zen-login-gate'], " +
+        "[data-testid='character-select'], " +
+        "[data-testid='deterministic-world-root'], " +
+        "[data-testid='arelorian-stitch-hud'], " +
+        "[data-testid='boot-fatal-overlay'], " +
+        ".cz-login-root"
+      ),
+      "Mobile should show login, character select, world, HUD, or fatal overlay"
+    ).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Body should have content
+    const bodyText = (await page.locator("body").innerText()).trim();
+    expect(bodyText.length, "Body should have visible text content").toBeGreaterThan(5);
+  });
+
+  test("mobile viewport shows UI elements, not just background", async ({ page }) => {
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+
+    await page.waitForTimeout(5_000);
+
+    // Get all visible text content
+    const bodyText = (await page.locator("body").innerText()).trim();
+
+    // Check for presence of meaningful content
+    const hasAreloriaContent = bodyText.includes("Areloria") ||
+                              bodyText.includes("ARELORIA") ||
+                              bodyText.includes("Collective") ||
+                              bodyText.includes("Cyber") ||
+                              bodyText.includes("PIXI") ||
+                              bodyText.includes("10Hz");
+
+    expect(
+      hasAreloriaContent,
+      `Mobile viewport should show Areloria content, not just dark background. Got: ${bodyText.slice(0, 100)}`
+    ).toBe(true);
+
+    // Boot status should be mounted (not cold or empty)
+    const bootAttr = await page.locator("body").getAttribute("data-areloria-boot");
+    expect(
+      bootAttr,
+      "Mobile boot should be 'mounted', not 'cold'"
+    ).toBe("mounted");
+  });
+
+  test("mobile no critical page errors", async ({ page }) => {
+    const criticalErrors: string[] = [];
+
+    page.on("pageerror", (err) => {
+      criticalErrors.push(err.message);
+    });
+
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+
+    await page.waitForTimeout(5_000);
+
+    // Filter non-critical
+    const realErrors = criticalErrors.filter(
+      e => !e.includes("Warning") && !e.includes("DevTools")
+    );
+
+    expect(
+      realErrors,
+      `Mobile critical errors should be empty. Found: ${realErrors.join("\n")}`
+    ).toHaveLength(0);
+  });
+});
+
+// Also test iPhone viewport
+test.describe("2D Client iPhone Boot Smoke Test", () => {
+  test.use({
+    ...devices["iPhone 13"],
+  });
+
+  test("iphone /2d/ shows login or world UI", async ({ page }) => {
+    await page.goto("/2d/", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+
+    await page.waitForTimeout(5_000);
+
+    // Check for any visible UI element
+    await expect(
+      page.locator(
+        "[data-testid='cyber-zen-login-gate'], " +
+        "[data-testid='character-select'], " +
+        "[data-testid='deterministic-world-root'], " +
+        ".cz-login-root"
+      ),
+      "iPhone should show login or world UI"
+    ).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/scripts/verify-client-2d-production.sh
+++ b/scripts/verify-client-2d-production.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# verify-client-2d-production.sh
+#
+# Verifies that the 2D client is properly deployed to production.
+# Checks HTML structure, script loading, and boot markers.
+#
+# Usage:
+#   BASE_URL=https://arelorian.de bash scripts/verify-client-2d-production.sh
+#   # Or with custom port:
+#   BASE_URL=http://localhost:3000 bash scripts/verify-client-2d-production.sh
+#
+# Exit codes:
+#   0 = all checks passed
+#   1 = one or more checks failed
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+# Default URL
+BASE_URL="${BASE_URL:-https://arelorian.de}"
+URL="${BASE_URL%/}/2d/"
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Areloria 2D Production Verification"
+echo "═══════════════════════════════════════════════════════════════"
+echo "  URL: $URL"
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+
+# Track failures
+FAILURES=0
+
+# ─── Check 1: HTML Response ───────────────────────────────────────────────────
+echo "[1/6] Checking HTML response..."
+
+HTML_RESPONSE=$(curl -fsS "$URL" 2>/dev/null) || {
+  echo "  ❌ FAIL: Cannot fetch $URL"
+  FAILURES=$((FAILURES + 1))
+}
+
+if [ -z "$HTML_RESPONSE" ]; then
+  echo "  ❌ FAIL: Empty response from $URL"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "  ✓ HTML fetched successfully ($(echo "$HTML_RESPONSE" | wc -c) bytes)"
+fi
+
+# ─── Check 2: REAL_PIXI_CLIENT Marker ─────────────────────────────────────────
+echo ""
+echo "[2/6] Checking REAL_PIXI_CLIENT marker..."
+
+if echo "$HTML_RESPONSE" | grep -q "REAL_PIXI_CLIENT"; then
+  echo "  ✓ REAL_PIXI_CLIENT marker found"
+else
+  echo "  ❌ FAIL: REAL_PIXI_CLIENT marker not found in HTML"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Check 3: Module Script ───────────────────────────────────────────────────
+echo ""
+echo "[3/6] Checking module script..."
+
+SCRIPT_TAG=$(echo "$HTML_RESPONSE" | grep -E 'type="module"' | head -1)
+
+if [ -n "$SCRIPT_TAG" ]; then
+  echo "  ✓ Module script found: $SCRIPT_TAG"
+
+  # Extract src path
+  SCRIPT_PATH=$(echo "$SCRIPT_TAG" | grep -Eo 'src="[^"]+"' | sed 's/src="//;s/"//')
+
+  if [ -n "$SCRIPT_PATH" ]; then
+    # Build full URL
+    if [[ "$SCRIPT_PATH" == /* ]]; then
+      SCRIPT_URL="${BASE_URL%/}${SCRIPT_PATH}"
+    else
+      SCRIPT_URL="${URL%/}/${SCRIPT_PATH}"
+    fi
+
+    echo "  ✓ Script path: $SCRIPT_PATH"
+    echo "  ✓ Script URL: $SCRIPT_URL"
+
+    # Verify script is accessible
+    HTTP_CODE=$(curl -fsS -o /dev/null -w "%{http_code}" "$SCRIPT_URL" 2>/dev/null || echo "000")
+    if [ "$HTTP_CODE" = "200" ]; then
+      echo "  ✓ Script accessible (HTTP $HTTP_CODE)"
+    else
+      echo "  ⚠️  Script returned HTTP $HTTP_CODE (may be normal for SPA)"
+    fi
+  fi
+else
+  echo "  ❌ FAIL: No type=\"module\" script found"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Check 4: Boot Fallback ───────────────────────────────────────────────────
+echo ""
+echo "[4/6] Checking boot fallback element..."
+
+if echo "$HTML_RESPONSE" | grep -q 'data-testid="areloria-boot-fallback"'; then
+  echo "  ✓ Boot fallback element found"
+else
+  echo "  ❌ FAIL: Boot fallback element not found"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Check 5: Health Endpoint ────────────────────────────────────────────────
+echo ""
+echo "[5/6] Checking health endpoint..."
+
+HEALTH_RESPONSE=$(curl -fsS "${BASE_URL%/}/health" 2>/dev/null) || {
+  echo "  ⚠️  Cannot fetch health endpoint (may be normal)"
+}
+
+if [ -n "$HEALTH_RESPONSE" ]; then
+  if echo "$HEALTH_RESPONSE" | grep -q '"ok"'; then
+    echo "  ✓ Health endpoint responding"
+  else
+    echo "  ⚠️  Health endpoint returned unexpected response"
+  fi
+fi
+
+# ─── Check 6: Build Stamp ─────────────────────────────────────────────────────
+echo ""
+echo "[6/6] Checking build stamp..."
+
+BUILD_STAMP=$(curl -fsS "${BASE_URL%/}/2d/build-stamp.json" 2>/dev/null) || {
+  echo "  ⚠️  Build stamp not found (may be normal)"
+}
+
+if [ -n "$BUILD_STAMP" ]; then
+  if echo "$BUILD_STAMP" | grep -q "REAL_PIXI_CLIENT"; then
+    echo "  ✓ Build stamp contains REAL_PIXI_CLIENT marker"
+  else
+    echo "  ⚠️  Build stamp doesn't contain expected marker"
+  fi
+fi
+
+# ─── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+
+if [ $FAILURES -eq 0 ]; then
+  echo "  ✅ All checks passed!"
+  echo "  The 2D client is properly deployed to production."
+else
+  echo "  ❌ $FAILURES check(s) failed."
+  echo "  Review the output above for details."
+fi
+
+echo "═══════════════════════════════════════════════════════════════"
+
+exit $FAILURES


### PR DESCRIPTION
## Summary

Fixes the production blank screen bug on https://www.arelorian.de/2d/

**Problem:**
Android Chrome showed only the dark background on /2d/. No login, no character selection, and no visible error appeared.

**Changes:**

1. **Boot Error Overlay** (`main.tsx`)
   - Adds `showFatalBootError()` function with `data-testid="boot-fatal-overlay"`
   - Shows visible error message with stack trace when React fails to mount
   - Global error handlers catch unhandled exceptions during boot

2. **HTML Boot Fallback** (`index.html`)
   - Adds visible fallback with `data-testid="areloria-boot-fallback"`
   - Shows "Lade REAL_PIXI_CLIENT" message if React doesn't mount
   - Boot timeout script shows warning after 10s if boot fails

3. **E2E Blank Screen Tests**
   - `e2e/client-2d-boot-smoke.spec.ts` - Desktop smoke test
   - `e2e/client-2d-mobile-boot-smoke.spec.ts` - Pixel 5 and iPhone 13 mobile tests

4. **Snapshot Normalizer Hardening** (`liveGameplaySnapshot.ts`)
   - Wrapped `normalizeLiveGameplaySnapshot()` in try-catch
   - Returns `EMPTY_LIVE_GAMEPLAY_SNAPSHOT` on any error to prevent crashes

5. **CSS z-index Guarantees** (`windows.css`)
   - Ensures login/HUD layers render above canvas (`z-index: 50`)
   - Mobile viewport safety for `.are-window` and HUD elements

6. **UI Panel Null-Safety**
   - Verified `InventoryPanel`, `CraftingWindow`, `ResourceNodePanel`, `SkillProgressionPanel` use null-safe access

7. **Production Verify Script** (`scripts/verify-client-2d-production.sh`)
   - Checks HTML response, REAL_PIXI_CLIENT marker, module script, boot fallback, health endpoint

8. **data-testid Attributes**
   - Added to: `cyber-zen-login-gate`, `deterministic-world-root`, `arelorian-stitch-hud`, `boot-fatal-overlay`, `areloria-boot-fallback`

## Safety

- ✅ No gameplay feature changes
- ✅ No secrets committed
- ✅ No Dockerfile.prod changes
- ✅ Dockerfile.vps remains the VPS Dockerfile

## Verification

```bash
# Build
pnpm --filter @wasd/client-2d build

# Production verify
BASE_URL=https://arelorian.de bash scripts/verify-client-2d-production.sh

# E2E tests (requires Playwright setup)
pnpm run test:e2e -- e2e/client-2d-boot-smoke.spec.ts
pnpm run test:e2e -- e2e/client-2d-mobile-boot-smoke.spec.ts
```

## Acceptance Criteria

- [ ] `/2d/` visibly shows login, character select, world root, HUD or fatal boot overlay
- [ ] Blank dark background alone fails E2E
- [ ] Mobile Chrome viewport has visible UI
- [ ] Build passes: `pnpm --filter @wasd/client-2d build`
- [ ] Production verify passes: `scripts/verify-client-2d-production.sh`

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2be541e5-356c-43a5-9a0c-6568feb19e20)