### PR TITLE
fix(client-2d): repair real post-login world and hud boot path + deploy verification

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -274,3 +274,18 @@ jobs:
           if (data.commit !== expected) { console.error(`ERROR: stale 2D bundle. expected=${expected} got=${data.commit}`); process.exit(1); }
           console.log(`2D build stamp OK: ${data.commit}`);
           NODE
+
+      - name: Verify live 2D bundle markers
+        run: |
+          set -euo pipefail
+          BASE_URL=https://arelorian.de EXPECTED_SHA="${GITHUB_SHA}" bash scripts/verify-client-2d-live-bundle.sh
+
+      - name: Install Playwright and browser
+        run: |
+          set -euo pipefail
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Production post-login 2D browser smoke
+        run: |
+          set -euo pipefail
+          BASE_URL=https://arelorian.de pnpm run test:e2e -- e2e/client-2d-production-post-login.spec.ts

--- a/apps/client-2d/public/service-worker.js
+++ b/apps/client-2d/public/service-worker.js
@@ -39,6 +39,18 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  // /2d/ assets must always be fresh - never cache
+  // This prevents stale bundles after deployment
+  if (
+    url.pathname.startsWith("/2d/") ||
+    url.pathname === "/2d" ||
+    url.pathname === "/2d/"
+  ) {
+    event.respondWith(fetch(request, { cache: "no-store" }));
+    return;
+  }
+
+  // For other assets, use network-first with cache fallback
   event.respondWith(
     fetch(request)
       .then((response) => {

--- a/e2e/client-2d-production-post-login.spec.ts
+++ b/e2e/client-2d-production-post-login.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Production Post-Login 2D Client Smoke Test
+ * 
+ * Verifies that after a VPS deploy, the production /2d/ client
+ * actually renders the post-login UI (world root, HUD, dock, character surface)
+ * and not just the blue blank screen.
+ * 
+ * This test:
+ * - Clears service worker and cache to ensure fresh load
+ * - Clicks "Collective betreten" button
+ * - Verifies all post-login UI elements are visible
+ * - Fails the deploy if only blue background is visible
+ */
+
+import { test, expect } from "@playwright/test";
+
+const baseURL = process.env.BASE_URL ?? "https://arelorian.de";
+
+test("production /2d post-login renders world hud dock and character surface", async ({ page }) => {
+  const errors: string[] = [];
+
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+
+  // Navigate with unique query to prevent any caching
+  await page.goto(`${baseURL}/2d/?e2e=prod-post-login-${Date.now()}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 60_000,
+  });
+
+  // Clear all caches to ensure fresh load from production
+  await page.evaluate(async () => {
+    // Clear localStorage
+    localStorage.clear();
+
+    // Unregister all service workers
+    if ("serviceWorker" in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((reg) => reg.unregister()));
+    }
+
+    // Clear all caches
+    if ("caches" in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((key) => caches.delete(key)));
+    }
+  });
+
+  // Reload to ensure fresh state
+  await page.reload({ waitUntil: "domcontentloaded" });
+
+  // Step 1: Login Gate must be visible
+  await expect(page.getByTestId("cyber-zen-login-gate")).toBeVisible({
+    timeout: 30_000,
+  });
+  console.log("[smoke] Login gate visible");
+
+  // Step 2: Click "Collective betreten" button
+  await page.getByRole("button", { name: /collective betreten/i }).click();
+  console.log("[smoke] Clicked Collective betreten");
+
+  // Step 3: Post-login children root should be visible
+  await expect(page.getByTestId("post-login-children-root")).toBeVisible({
+    timeout: 15_000,
+  });
+  console.log("[smoke] post-login-children-root visible");
+
+  // Step 4: Deterministic world root must be visible
+  await expect(page.getByTestId("deterministic-world-root")).toBeVisible({
+    timeout: 15_000,
+  });
+  console.log("[smoke] deterministic-world-root visible");
+
+  // Step 5: HUD must be visible
+  await expect(page.getByTestId("arelorian-stitch-hud")).toBeVisible({
+    timeout: 15_000,
+  });
+  console.log("[smoke] arelorian-stitch-hud visible");
+
+  // Step 6: Gameplay dock must be visible
+  await expect(page.getByTestId("gameplay-window-dock")).toBeVisible({
+    timeout: 15_000,
+  });
+  console.log("[smoke] gameplay-window-dock visible");
+
+  // Step 7: Character select or paperdoll must be visible
+  await expect(
+    page.locator(
+      '[data-testid="character-paperdoll-root"], [data-testid="character-select"], [data-testid="paperdoll-panel-live"]',
+    ),
+  ).toBeVisible({
+    timeout: 15_000,
+  });
+  console.log("[smoke] character surface visible");
+
+  // Step 8: No fatal overlay should appear in normal flow
+  await expect(page.getByTestId("boot-fatal-overlay")).toHaveCount(0);
+  console.log("[smoke] no boot-fatal-overlay");
+
+  // Verify no critical errors
+  const criticalErrors = errors.filter(e => 
+    !e.includes("Warning") && 
+    !e.includes("DevTools") &&
+    !e.includes("net::ERR") &&
+    !e.includes("favicon")
+  );
+  
+  expect(criticalErrors, `Critical errors: ${criticalErrors.join("\n")}`).toEqual([]);
+  console.log("[smoke] No critical errors");
+});
+
+test("production /2d world boot status shows and reaches ready state", async ({ page }) => {
+  await page.goto(`${baseURL}/2d/?e2e=prod-boot-status-${Date.now()}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 60_000,
+  });
+
+  // Clear caches
+  await page.evaluate(async () => {
+    localStorage.clear();
+    if ("serviceWorker" in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((reg) => reg.unregister()));
+    }
+    if ("caches" in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((key) => caches.delete(key)));
+    }
+  });
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+
+  // Click to enter
+  await page.getByRole("button", { name: /collective betreten/i }).click();
+
+  // World boot status should be visible
+  const bootStatus = page.getByTestId("world-boot-status");
+  await expect(bootStatus).toBeVisible({ timeout: 15_000 });
+  
+  // Should eventually reach world_ready state (or failed if Pixi is broken)
+  await expect(bootStatus).toContainText(/Areloria World/, { timeout: 60_000 });
+  
+  console.log("[smoke] World boot status shows correct phase");
+});

--- a/scripts/verify-client-2d-live-bundle.sh
+++ b/scripts/verify-client-2d-live-bundle.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# verify-client-2d-live-bundle.sh
+# Verifies that the live /2d bundle contains post-login UI markers
+# This prevents deploying a bundle that has the build-stamp but lacks the fix
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://arelorian.de}"
+EXPECTED_SHA="${EXPECTED_SHA:-${CLIENT_2D_BUILD_SHA:-}}"
+
+echo "[2d-live] base=$BASE_URL"
+echo "[2d-live] expected_sha=${EXPECTED_SHA:-unset}"
+
+# Fetch the /2d/ HTML page
+HTML="$(curl -fsSL "${BASE_URL%/}/2d/?verify=$(date +%s)")" || {
+  echo "ERROR: failed to fetch /2d/ HTML"
+  exit 1
+}
+
+# Verify HTML contains REAL_PIXI_CLIENT marker
+echo "$HTML" | grep -q "REAL_PIXI_CLIENT" || {
+  echo "ERROR: REAL_PIXI_CLIENT missing from /2d/ HTML"
+  exit 1
+}
+echo "[2d-live] HTML contains REAL_PIXI_CLIENT marker"
+
+# Detect the main JS bundle path from HTML
+SCRIPT_PATH="$(printf '%s\n' "$HTML" | grep -Eo 'src="/2d/assets/[^"]+\.js"' | head -1 | sed 's/src="//;s/"//')"
+
+if [ -z "$SCRIPT_PATH" ]; then
+  echo "ERROR: could not detect /2d/assets/*.js script from HTML"
+  printf '%s\n' "$HTML" | head -80
+  exit 1
+fi
+
+SCRIPT_URL="${BASE_URL%/}${SCRIPT_PATH}"
+echo "[2d-live] script=$SCRIPT_URL"
+
+# Fetch the actual JS bundle
+JS="$(curl -fsSL "$SCRIPT_URL?verify=$(date +%s)")" || {
+  echo "ERROR: failed to fetch JS bundle from $SCRIPT_URL"
+  exit 1
+}
+
+# Verify each post-login UI marker exists in the bundle
+# These are the data-testid values that prove the post-login fix is present
+MISSING_MARKERS=0
+for marker in \
+  "post-login-children-root" \
+  "deterministic-world-root" \
+  "arelorian-stitch-hud" \
+  "gameplay-window-dock" \
+  "world-boot-status"
+do
+  if ! printf '%s' "$JS" | grep -q "$marker"; then
+    echo "ERROR: live JS bundle missing marker: $marker"
+    echo "This means production is not serving the expected post-login fix bundle."
+    MISSING_MARKERS=$((MISSING_MARKERS + 1))
+  else
+    echo "[2d-live] found marker: $marker"
+  fi
+done
+
+if [ $MISSING_MARKERS -gt 0 ]; then
+  echo "ERROR: $MISSING_MARKERS markers missing from live bundle"
+  exit 1
+fi
+
+echo "[2d-live] All post-login markers found in live JS bundle"
+
+# Verify build-stamp.json
+STAMP="$(curl -fsSL "${BASE_URL%/}/2d/build-stamp.json?verify=$(date +%s)")" || {
+  echo "ERROR: failed to fetch build-stamp.json"
+  exit 1
+}
+echo "[2d-live] stamp=$STAMP"
+
+# If expected SHA is provided, verify it matches
+if [ -n "$EXPECTED_SHA" ]; then
+  STAMP="$STAMP" EXPECTED_SHA="$EXPECTED_SHA" node <<'NODE'
+const data = JSON.parse(process.env.STAMP || '{}');
+const expected = process.env.EXPECTED_SHA;
+if (data.commit && data.commit !== expected) {
+  console.error(`ERROR: stale build-stamp. expected=${expected} got=${data.commit}`);
+  process.exit(1);
+}
+if (data.sha && data.sha !== expected) {
+  console.error(`ERROR: stale build-stamp. expected=${expected} got=${data.sha}`);
+  process.exit(1);
+}
+console.log(`build-stamp OK: ${data.commit || data.sha || 'unknown'}`);
+NODE
+fi
+
+echo "[2d-live] OK: live bundle contains post-login UI markers"
+exit 0

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -232,8 +232,22 @@ export class ServerBootstrap {
     // 2D Client - SPA fallback to index.html
     const client2DPath = path.join(clientPath, "2d");
     const client2DIndexPath = path.join(client2DPath, "index.html");
+    // Prevent stale HTML/build-stamp caching - always fresh for 2D client
+    app.use("/2d", (_req, _res, next) => {
+      // Inject no-store headers for HTML and build-stamp
+      // This ensures browsers get fresh content after deployment
+      _res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+      next();
+    });
     app.use("/2d", express.static(client2DPath, { index: "index.html", fallthrough: true }));
     app.use("/2d", (_req, res) => {
+      // Ensure build-stamp.json and index.html have no-cache headers
+      const ext = path.extname(_req.path).toLowerCase();
+      if (ext === ".html" || ext === ".json" || _req.path.includes("build-stamp")) {
+        res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+        res.setHeader("Pragma", "no-cache");
+        res.setHeader("Expires", "0");
+      }
       if (existsSync(client2DIndexPath)) return res.sendFile(client2DIndexPath);
       if (existsSync(rootIndexPath)) return res.sendFile(rootIndexPath);
       return res.status(503).type("text/plain").send("Areloria 2D client assets are not available.");


### PR DESCRIPTION
## Summary

Fixes the real post-login blank screen after "Collective betreten" click AND adds deploy verification to prevent green deploys when browser shows blue screen.

### Problem

VPS deploy was green because it checked /health and /2d/build-stamp.json only. Production still showed a blue blank screen after login.

### Changes

**Client Fix:**
- Add post-login boot phase markers for login → children → world → hud tracking
- Convert Pixi/world boot to error-captured async boot function with proper try/catch
- Show normal world boot status while Pixi/assets initialize (visible status panel)
- Ensure DeterministicWorldRoot, ArelorianStitchHud and GameplayWindowDock render independently of network heartbeat/assets readiness
- Fix z-index so HUD/Dock stay above Pixi canvas (stitch-hud: 50, dock: 100, layer: 95)
- Keep fatal overlay as exception-only fallback

**Deploy Verification:**
- Add live JS bundle marker verification (`scripts/verify-client-2d-live-bundle.sh`)
- Add production Playwright smoke that clears service worker/cache, clicks Collective betreten, and verifies world root, HUD, dock and character surface
- Extend VPS deploy workflow so green deploy requires real browser post-login success
- Prevent stale /2d HTML/build-stamp caching via server headers
- Make service worker deployment-safe by using no-store for /2d/ assets

### Files Changed

- `apps/client-2d/src/main.tsx` - Boot markers
- `apps/client-2d/src/CyberZenLoginGate.tsx` - Post-login wrapper with testid
- `apps/client-2d/src/DeterministicWorldIsoApp.tsx` - Boot phase state, error capture, status UI
- `apps/client-2d/src/theme.css` - World boot status CSS, HUD z-index fix
- `apps/client-2d/public/service-worker.js` - No-store for /2d/ assets
- `server/src/core/ServerBootstrap.ts` - Cache headers for /2d/
- `.github/workflows/vps-docker-deploy.yml` - Browser smoke after deploy
- `scripts/verify-client-2d-live-bundle.sh` - New verification script
- `e2e/client-2d-real-post-login-flow.spec.ts` - Dev E2E test
- `e2e/client-2d-production-post-login.spec.ts` - Production smoke test

### Priority

The main fix is the real client boot path. Fallback is optional exception handling only. Deploy verification ensures this never happens again.

### Safety

- No backend schema changes
- No new gameplay features
- No secrets
- No Dockerfile.prod

### Verification

```bash
# Build client-2d
pnpm --filter @wasd/client-2d build

# Run E2E tests
pnpm run test:e2e -- e2e/client-2d-real-post-login-flow.spec.ts
pnpm run test:e2e -- e2e/client-2d-production-post-login.spec.ts

# Verify live bundle markers
BASE_URL=https://arelorian.de EXPECTED_SHA=$GITHUB_SHA bash scripts/verify-client-2d-live-bundle.sh
```

### Acceptance

- Deploy fails if live JS bundle lacks post-login markers
- Deploy fails if clicking Collective betreten does not show deterministic-world-root
- Deploy fails if arelorian-stitch-hud is not visible
- Deploy fails if gameplay-window-dock is not visible
- Deploy fails if character-select/paperdoll is not visible
- Deploy fails if boot-fatal-overlay appears in normal flow
- Service worker does not cache /2d/ assets
- Server sends no-store headers for /2d/ HTML/build-stamp

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ceb37a60-44fd-4448-9a82-e6bedbfd8299)