### PR TITLE
ci(deploy): replace Playwright install with dependency-free CDP smoke

### DIFF
--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -47,7 +47,6 @@ jobs:
       CLIENT_2D_ARCHIVE: wasd-client-2d-dist-${{ github.sha }}.tgz
       CLIENT_2D_MARKER: REAL_PIXI_CLIENT
       CLIENT_2D_BUILD_SHA: ${{ github.sha }}
-      PLAYWRIGHT_VERSION: 1.56.1
 
     steps:
       - name: Checkout repository
@@ -72,7 +71,7 @@ jobs:
           grep -q 'liveWatchdogSensors' server/src/core/installWorldTickWatchdogBridge.ts
           grep -q 'world.sensor.frame' server/src/core/watchdog-live-sensors.ts
           grep -q 'installDeterministicWatchdogRuntime' server/src/index.ts
-          echo "Strict source gate OK: current checkout contains live watchdog deploy logic."
+          echo "Strict source gate OK."
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -204,7 +203,6 @@ jobs:
           REPO_URL="https://github.com/${{ github.repository }}.git"
           mkdir -p "$APP_DIR"
           cd "$APP_DIR"
-
           if [ ! -d .git ]; then
             git clone --branch "$BRANCH" "$REPO_URL" .
           else
@@ -213,7 +211,6 @@ jobs:
             git reset --hard "origin/$BRANCH"
             git clean -fd -e .env -e .env.local -e .env.docker -e data/ -e logs/ -e "$CLIENT_2D_ARCHIVE" -e apps/client-2d/dist/ -e .asset-inbox/ || true
           fi
-
           echo "Remote HEAD=$(git rev-parse HEAD)"
           echo "Expected HEAD=$GITHUB_SHA_EXPECTED"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA_EXPECTED"
@@ -227,7 +224,6 @@ jobs:
           grep -q 'world.sensor.frame' server/src/core/watchdog-live-sensors.ts
           grep -q 'installDeterministicWatchdogRuntime' server/src/index.ts
           echo "Remote strict source gate OK."
-
           if [ -n "${CLIENT_2D_ARCHIVE:-}" ] && [ -f "$APP_DIR/$CLIENT_2D_ARCHIVE" ]; then
             rm -rf apps/client-2d/dist
             mkdir -p apps/client-2d
@@ -239,7 +235,6 @@ jobs:
           else
             echo "WARN: no prebuilt client-2d archive found; Dockerfile must build it."
           fi
-
           chmod +x scripts/deploy-vps-docker.sh scripts/vps-docker-inline-deploy.sh 2>/dev/null || true
           ARELORIAN_PORT="${ARELORIAN_PORT:-3001}" \
           ARELORIAN_DOCKER_NETWORK="${ARELORIAN_DOCKER_NETWORK:-areloria_arelorian-network}" \
@@ -278,14 +273,7 @@ jobs:
           set -euo pipefail
           BASE_URL=https://arelorian.de EXPECTED_SHA="${GITHUB_SHA}" bash scripts/verify-client-2d-live-bundle.sh
 
-      - name: Install Playwright production-smoke dependencies
-        run: |
-          set -euo pipefail
-          pnpm add -Dw "@playwright/test@${PLAYWRIGHT_VERSION}" --no-frozen-lockfile --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
-          pnpm exec playwright --version
-          pnpm exec playwright install --with-deps chromium
-
       - name: Production post-login 2D browser smoke
         run: |
           set -euo pipefail
-          BASE_URL=https://arelorian.de E2E_SKIP_WEBSERVER=1 E2E_BASE_URL=https://arelorian.de pnpm exec playwright test e2e/client-2d-production-post-login.spec.ts --project=chromium --config=playwright.config.ts
+          BASE_URL=https://arelorian.de node scripts/production-post-login-smoke.mjs

--- a/scripts/production-post-login-smoke.mjs
+++ b/scripts/production-post-login-smoke.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 
 const baseUrl = process.env.BASE_URL || 'https://arelorian.de';
 const targetUrl = `${baseUrl.replace(/\/$/, '')}/2d/?cdp-smoke=${Date.now()}`;
@@ -18,13 +19,7 @@ function findChrome() {
     '/usr/bin/chromium',
     '/usr/bin/chromium-browser',
   ].filter(Boolean);
-  return candidates.find((path) => {
-    try {
-      return path && require('node:fs').existsSync(path);
-    } catch {
-      return false;
-    }
-  });
+  return candidates.find((path) => path && existsSync(path));
 }
 
 async function waitForJson(url, deadline) {

--- a/scripts/production-post-login-smoke.mjs
+++ b/scripts/production-post-login-smoke.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const baseUrl = process.env.BASE_URL || 'https://arelorian.de';
+const targetUrl = `${baseUrl.replace(/\/$/, '')}/2d/?cdp-smoke=${Date.now()}`;
+const timeoutMs = Number(process.env.SMOKE_TIMEOUT_MS || 90_000);
+const debugPort = Number(process.env.CHROME_DEBUG_PORT || 9222);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function findChrome() {
+  const candidates = [
+    process.env.CHROME_BIN,
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  ].filter(Boolean);
+  return candidates.find((path) => {
+    try {
+      return path && require('node:fs').existsSync(path);
+    } catch {
+      return false;
+    }
+  });
+}
+
+async function waitForJson(url, deadline) {
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return await response.json();
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(250);
+  }
+  throw lastError ?? new Error(`Timed out waiting for ${url}`);
+}
+
+class CdpClient {
+  constructor(wsUrl) {
+    this.wsUrl = wsUrl;
+    this.seq = 0;
+    this.pending = new Map();
+    this.events = [];
+  }
+
+  async connect() {
+    this.ws = new WebSocket(this.wsUrl);
+    this.ws.addEventListener('message', (event) => {
+      const message = JSON.parse(event.data);
+      if (message.id && this.pending.has(message.id)) {
+        const { resolve, reject } = this.pending.get(message.id);
+        this.pending.delete(message.id);
+        if (message.error) reject(new Error(`${message.error.message || 'CDP error'} ${JSON.stringify(message.error)}`));
+        else resolve(message.result ?? {});
+        return;
+      }
+      if (message.method) this.events.push(message);
+    });
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Timed out connecting to Chrome DevTools WebSocket')), 15_000);
+      this.ws.addEventListener('open', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      this.ws.addEventListener('error', (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+    });
+  }
+
+  send(method, params = {}) {
+    const id = ++this.seq;
+    const payload = JSON.stringify({ id, method, params });
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(payload);
+      setTimeout(() => {
+        if (this.pending.has(id)) {
+          this.pending.delete(id);
+          reject(new Error(`Timed out waiting for CDP method ${method}`));
+        }
+      }, 20_000);
+    });
+  }
+
+  async eval(expression, awaitPromise = true) {
+    const result = await this.send('Runtime.evaluate', {
+      expression,
+      awaitPromise,
+      returnByValue: true,
+      userGesture: true,
+    });
+    if (result.exceptionDetails) {
+      throw new Error(`Evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+    }
+    return result.result?.value;
+  }
+
+  close() {
+    try { this.ws?.close(); } catch {}
+  }
+}
+
+async function waitFor(client, label, expression, deadline) {
+  let lastValue;
+  while (Date.now() < deadline) {
+    lastValue = await client.eval(expression).catch((error) => `ERROR: ${error.message}`);
+    if (lastValue === true) {
+      console.log(`[smoke] ${label}: OK`);
+      return;
+    }
+    await sleep(500);
+  }
+  const bodyDataset = await client.eval('JSON.stringify(document.body?.dataset ?? {})').catch(() => '{}');
+  const location = await client.eval('location.href').catch(() => 'unknown');
+  throw new Error(`[smoke] Timed out waiting for ${label}. last=${String(lastValue)} location=${location} body.dataset=${bodyDataset}`);
+}
+
+async function main() {
+  const chrome = findChrome();
+  if (!chrome) {
+    throw new Error('No Chrome/Chromium binary found on runner. Expected google-chrome, google-chrome-stable, chromium, or chromium-browser.');
+  }
+
+  const userDataDir = `/tmp/areloria-cdp-smoke-${process.pid}`;
+  const chromeArgs = [
+    '--headless=new',
+    '--no-sandbox',
+    '--disable-dev-shm-usage',
+    '--disable-gpu',
+    '--disable-extensions',
+    '--disable-background-networking',
+    '--disable-default-apps',
+    '--disable-sync',
+    '--no-first-run',
+    '--disable-features=Translate,BackForwardCache',
+    `--user-data-dir=${userDataDir}`,
+    `--remote-debugging-port=${debugPort}`,
+    'about:blank',
+  ];
+
+  console.log(`[smoke] launching ${chrome}`);
+  const child = spawn(chrome, chromeArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+  child.stdout.on('data', (chunk) => process.stdout.write(`[chrome] ${chunk}`));
+  child.stderr.on('data', (chunk) => process.stderr.write(`[chrome] ${chunk}`));
+
+  const deadline = Date.now() + timeoutMs;
+  let client;
+  try {
+    const version = await waitForJson(`http://127.0.0.1:${debugPort}/json/version`, deadline);
+    client = new CdpClient(version.webSocketDebuggerUrl);
+    await client.connect();
+    await client.send('Page.enable');
+    await client.send('Runtime.enable');
+    await client.send('Log.enable');
+    await client.send('Network.enable');
+
+    console.log(`[smoke] navigating to ${targetUrl}`);
+    await client.send('Page.navigate', { url: targetUrl });
+
+    await waitFor(client, 'document ready', 'document.readyState === "interactive" || document.readyState === "complete"', deadline);
+
+    await client.eval(`(async () => {
+      localStorage.clear();
+      sessionStorage.clear();
+      if ('serviceWorker' in navigator) {
+        const regs = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(regs.map((reg) => reg.unregister()));
+      }
+      if ('caches' in window) {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((key) => caches.delete(key)));
+      }
+      return true;
+    })()`);
+
+    await client.send('Page.navigate', { url: `${targetUrl}&fresh=1` });
+    await waitFor(client, 'login gate visible', 'Boolean(document.querySelector(`[data-testid="cyber-zen-login-gate"]`))', deadline);
+
+    const clicked = await client.eval(`(() => {
+      const buttons = [...document.querySelectorAll('button')];
+      const button = buttons.find((b) => /collective betreten/i.test(b.textContent || ''));
+      if (!button) return false;
+      button.click();
+      return true;
+    })()`);
+    if (!clicked) throw new Error('Could not find/click Collective betreten button');
+    console.log('[smoke] clicked Collective betreten');
+
+    await waitFor(client, 'post-login children root', 'Boolean(document.querySelector(`[data-testid="post-login-children-root"]`))', deadline);
+    await waitFor(client, 'deterministic world root', 'Boolean(document.querySelector(`[data-testid="deterministic-world-root"]`))', deadline);
+    await waitFor(client, 'Arelorian stitch HUD', 'Boolean(document.querySelector(`[data-testid="arelorian-stitch-hud"]`))', deadline);
+    await waitFor(client, 'gameplay window dock', 'Boolean(document.querySelector(`[data-testid="gameplay-window-dock"]`))', deadline);
+    await waitFor(client, 'character surface', 'Boolean(document.querySelector(`[data-testid="character-paperdoll-root"], [data-testid="character-select"], [data-testid="paperdoll-panel-live"]`))', deadline);
+
+    const fatalCount = await client.eval('document.querySelectorAll(`[data-testid="boot-fatal-overlay"]`).length');
+    if (fatalCount !== 0) throw new Error(`boot-fatal-overlay appeared (${fatalCount})`);
+
+    console.log('[smoke] production post-login 2D flow OK');
+  } finally {
+    client?.close();
+    child.kill('SIGTERM');
+    setTimeout(() => child.kill('SIGKILL'), 3000).unref?.();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Replaces the fragile Playwright install step in the VPS deploy workflow with a dependency-free Chrome DevTools Protocol production smoke test.

## Problem

The new VPS deploy path already reached:

- Docker deploy: success
- Public health check: success
- Live 2D bundle marker check: success

Then it failed at `Install Playwright production-smoke dependencies` before the real post-login browser smoke could run. Installing `@playwright/test` during deploy is brittle because it mutates root dev dependencies/lockfile state and can trigger dependency policy checks.

## Changes

- Adds `scripts/production-post-login-smoke.mjs`.
- Uses the Chrome/Chromium binary already available on the GitHub runner.
- Talks directly to Chrome via DevTools Protocol using Node 22 built-in `WebSocket` and `fetch`.
- Clears localStorage, sessionStorage, service workers and caches.
- Opens production `/2d/`.
- Clicks `Collective betreten`.
- Verifies:
  - `post-login-children-root`
  - `deterministic-world-root`
  - `arelorian-stitch-hud`
  - `gameplay-window-dock`
  - character surface: `character-paperdoll-root`, `character-select`, or `paperdoll-panel-live`
  - no `boot-fatal-overlay`
- Updates `.github/workflows/vps-docker-deploy.yml` to remove Playwright install and run the CDP smoke directly.

## Safety

- No gameplay changes.
- No backend schema changes.
- No secrets.
- No Dockerfile.prod.
- Keeps Docker deploy, public health check, live bundle marker verification and real browser post-login verification.

## Acceptance

- VPS deploy no longer fails while installing Playwright.
- Production post-login browser smoke still runs after deploy.
- Deploy fails if production only shows the blue blank screen after login.