### PR TITLE
ci(deploy): connect CDP smoke to page target

### DIFF
--- a/scripts/production-post-login-smoke.mjs
+++ b/scripts/production-post-login-smoke.mjs
@@ -37,6 +37,18 @@ async function waitForJson(url, deadline) {
   throw lastError ?? new Error(`Timed out waiting for ${url}`);
 }
 
+async function waitForPageTarget(deadline) {
+  let lastTargets = [];
+  while (Date.now() < deadline) {
+    const targets = await waitForJson(`http://127.0.0.1:${debugPort}/json/list`, deadline);
+    lastTargets = targets;
+    const page = targets.find((target) => target.type === 'page' && target.webSocketDebuggerUrl);
+    if (page) return page;
+    await sleep(250);
+  }
+  throw new Error(`Timed out waiting for Chrome page target. targets=${JSON.stringify(lastTargets)}`);
+}
+
 class CdpClient {
   constructor(wsUrl) {
     this.wsUrl = wsUrl;
@@ -150,8 +162,10 @@ async function main() {
   const deadline = Date.now() + timeoutMs;
   let client;
   try {
-    const version = await waitForJson(`http://127.0.0.1:${debugPort}/json/version`, deadline);
-    client = new CdpClient(version.webSocketDebuggerUrl);
+    await waitForJson(`http://127.0.0.1:${debugPort}/json/version`, deadline);
+    const pageTarget = await waitForPageTarget(deadline);
+    console.log(`[smoke] connecting to page target ${pageTarget.id || pageTarget.url}`);
+    client = new CdpClient(pageTarget.webSocketDebuggerUrl);
     await client.connect();
     await client.send('Page.enable');
     await client.send('Runtime.enable');


### PR DESCRIPTION
## Summary

Addresses the Codex review on PR #1719: the dependency-free CDP production smoke now connects to a Chrome page target before issuing `Page.*` and `Runtime.*` commands.

## Problem

PR #1719 used the browser-level DevTools socket from `/json/version`. That socket exposes browser/target domains, not page domains, so `Page.enable` and `Page.navigate` can fail with CDP method errors.

## Changes

- Adds `waitForPageTarget()` using `http://127.0.0.1:${CHROME_DEBUG_PORT}/json/list`.
- Selects the first `type === "page"` target with `webSocketDebuggerUrl`.
- Connects `CdpClient` to that page target socket.
- Keeps `/json/version` only as readiness probe for Chrome DevTools startup.
- Leaves the deploy workflow unchanged from #1719.

## Safety

- No gameplay changes.
- No backend schema changes.
- No secrets.
- No Dockerfile.prod.
- Keeps the production post-login browser smoke mandatory.

## Acceptance

- CDP smoke can use `Page.enable`, `Page.navigate`, `Runtime.evaluate`, and DOM checks correctly.
- VPS deploy still fails if production shows only the blue post-login background.