### PR TITLE
fix(client-2d): isolate post-login child render failures

### DIFF
--- a/apps/client-2d/src/CyberZenLoginGate.tsx
+++ b/apps/client-2d/src/CyberZenLoginGate.tsx
@@ -15,6 +15,54 @@ interface GateIdentity {
   identityHash: string;
 }
 
+interface PostLoginChildBoundaryProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+interface PostLoginChildBoundaryState {
+  error: string | null;
+}
+
+class PostLoginChildBoundary extends React.Component<PostLoginChildBoundaryProps, PostLoginChildBoundaryState> {
+  public state: PostLoginChildBoundaryState = { error: null };
+
+  public static getDerivedStateFromError(error: unknown): PostLoginChildBoundaryState {
+    return {
+      error: error instanceof Error ? `${error.name}: ${error.message}` : String(error ?? "Unknown child render error"),
+    };
+  }
+
+  public componentDidCatch(error: unknown, info: React.ErrorInfo): void {
+    const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error ?? "Unknown child render error");
+    document.body.dataset.postLoginChildError = this.props.label;
+    console.error(`[Areloria PostLogin Child Error] ${this.props.label}`, error, info.componentStack);
+    window.dispatchEvent(new CustomEvent("wasd:post-login-child-error", {
+      detail: {
+        label: this.props.label,
+        message,
+        componentStack: info.componentStack,
+      },
+    }));
+  }
+
+  public render(): React.ReactNode {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <section
+        className="post-login-child-error"
+        data-testid="post-login-child-error"
+        data-child-label={this.props.label}
+        role="alert"
+      >
+        <strong>Post-login module failed: {this.props.label}</strong>
+        <code>{this.state.error}</code>
+      </section>
+    );
+  }
+}
+
 const ROLES: Role[] = ["Scavenger", "Trader", "Guardian", "Oracle", "Builder", "Warden"];
 const LOADOUTS: Record<Role, string[]> = {
   Scavenger: ["rusted_blade", "scrap_satchel", "echo_ration"],
@@ -70,6 +118,14 @@ function deriveIdentity(handleRaw: string): GateIdentity {
   };
 }
 
+function wrapPostLoginChildren(children: React.ReactNode): React.ReactNode {
+  return React.Children.map(children, (child, index) => (
+    <PostLoginChildBoundary label={`post-login-child-${index}`}>
+      {child}
+    </PostLoginChildBoundary>
+  ));
+}
+
 export function CyberZenLoginGate({ children }: Props): React.ReactElement {
   const [name, setName] = useState(() => localStorage.getItem("wasd:2d:name") ?? "Thomas");
   const [entered, setEntered] = useState(() => localStorage.getItem("wasd:2d:entered") === "1");
@@ -79,7 +135,7 @@ export function CyberZenLoginGate({ children }: Props): React.ReactElement {
     document.body.dataset.postLoginShell = "entered-rendering-children";
     return (
       <div data-testid="post-login-children-root" className="post-login-children-root">
-        {children}
+        {wrapPostLoginChildren(children)}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Adds error boundaries around every direct post-login child rendered by `CyberZenLoginGate`.

## Problem

The production CDP smoke now proves the click reaches the post-login state:

```txt
body.dataset.postLoginShell = entered-rendering-children
```

But `post-login-children-root` was not committed to the DOM. That means the login click worked, but a post-login child likely threw during render before React committed the wrapper, producing the blue blank screen again.

## Changes

- Adds `PostLoginChildBoundary` in `CyberZenLoginGate.tsx`.
- Wraps every direct post-login child independently.
- If one child crashes, the root wrapper still commits.
- Failed child renders a visible `post-login-child-error` panel.
- Records `document.body.dataset.postLoginChildError` for smoke/debug diagnostics.
- Emits `wasd:post-login-child-error` event for future telemetry.

## Safety

- No gameplay logic changes.
- No backend schema changes.
- No secrets.
- No Dockerfile.prod.
- Does not weaken production smoke.

## Acceptance

- `post-login-children-root` commits after clicking Collective betreten.
- One crashing child no longer blanks the whole post-login shell.
- Production smoke can progress to the next real missing/failed UI target instead of timing out on the wrapper.