### PR TITLE
fix(client-2d): bind player vital external store snapshots

### DIFF
--- a/apps/client-2d/src/live/playerVitalState.ts
+++ b/apps/client-2d/src/live/playerVitalState.ts
@@ -25,6 +25,7 @@
  * - All updates are derived from server events only
  */
 
+import { useSyncExternalStore } from "react";
 import type { InventoryItem } from "../ui/InventoryPanel";
 
 // -----------------------------------------------------------------------------
@@ -169,26 +170,26 @@ class PlayerVitalStateManager {
   private lastServerTick: number = 0;
   private listeners = new Set<() => void>();
 
-  getState(): PlayerVitalState {
+  getState = (): PlayerVitalState => {
     return this.state;
-  }
+  };
 
-  getVitals(): PlayerVitals {
+  getVitals = (): PlayerVitals => {
     return this.state.vitals;
-  }
+  };
 
-  getInventory(): InventorySlot[] {
+  getInventory = (): InventorySlot[] => {
     return this.state.inventory;
-  }
+  };
 
-  getEquipment(): EquipmentSlots {
+  getEquipment = (): EquipmentSlots => {
     return this.state.equipment;
-  }
+  };
 
-  subscribe(listener: () => void): () => void {
+  subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
-  }
+  };
 
   private notify(): void {
     this.listeners.forEach((l) => l());
@@ -344,8 +345,6 @@ export const playerVitalState = new PlayerVitalStateManager();
 // -----------------------------------------------------------------------------
 // React Hook (Deterministic - uses useSyncExternalStore)
 // -----------------------------------------------------------------------------
-
-import { useSyncExternalStore } from "react";
 
 export function usePlayerVitalState(): PlayerVitalState {
   return useSyncExternalStore(


### PR DESCRIPTION
## Summary

Fixes the render crash inside `DeterministicWorldIsoApp` caused by unbound external-store snapshot methods.

## Problem

The production CDP smoke now gets past login and the post-login wrapper:

```txt
[smoke] post-login children root: OK
body.dataset.postLoginChildError = post-login-child-0
Timed out waiting for deterministic world root
```

`post-login-child-0` is `DeterministicWorldIsoApp`. During render it calls `usePlayerVitalState()`, which used `useSyncExternalStore` with unbound class methods:

```ts
playerVitalState.getState
```

Those methods read `this.state`; when React calls them as plain functions, `this` is undefined and render crashes before `deterministic-world-root` can commit.

## Changes

- Converts `PlayerVitalStateManager` snapshot methods to arrow properties:
  - `getState`
  - `getVitals`
  - `getInventory`
  - `getEquipment`
  - `subscribe`
- Keeps the public hook API unchanged.
- Moves `useSyncExternalStore` import to the top-level import section.

## Safety

- No gameplay logic changes.
- No backend schema changes.
- No secrets.
- No Dockerfile.prod.
- Keeps server-authoritative vital state design.

## Acceptance

- `usePlayerVitalState()` no longer throws during render.
- `DeterministicWorldIsoApp` can commit `data-testid="deterministic-world-root"`.
- Production smoke can progress to HUD/dock/character-surface checks.