### PR TITLE
fix(client-2d): add DnD provider and clarify classless start paths

### DIFF
--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -51,20 +51,46 @@ jobs:
       - name: Verify runtime files
         run: |
           set -euo pipefail
-          test -f client/dist/index.html
-          test -f client/dist/3d/index.html
-          test -f client/dist/portal/index.html
-          test -f client/dist/apps/index.html
-          test -f client/dist/are-console.html
-          test -f client/dist/sovereign-truth.html
-          test -f client/dist/runtime-build-info.json
-          test -f apps/client-2d/dist/index.html
-          grep -q 'CHOOSE' client/dist/index.html
-          grep -q 'Sovereign Tools' client/dist/index.html
-          grep -q 'SCIENCE PORTAL' client/dist/portal/index.html
-          grep -q 'SOVEREIGN TOOLS' client/dist/apps/index.html
-          grep -q 'ARE Runtime Console' client/dist/are-console.html
-          grep -q '"/2d/"' client/dist/runtime-build-info.json
-          grep -q '"/3d/"' client/dist/runtime-build-info.json
-          grep -q '"/apps/"' client/dist/runtime-build-info.json
+
+          require_file() {
+            local path="$1"
+            if [ ! -f "$path" ]; then
+              echo "::error::Missing runtime file: $path"
+              echo "client/dist tree:"
+              find client/dist -maxdepth 3 -type f | sort || true
+              echo "apps/client-2d/dist tree:"
+              find apps/client-2d/dist -maxdepth 2 -type f | sort || true
+              exit 1
+            fi
+          }
+
+          require_grep() {
+            local needle="$1"
+            local path="$2"
+            if ! grep -q "$needle" "$path"; then
+              echo "::error::Missing marker '$needle' in $path"
+              echo "--- $path head ---"
+              sed -n '1,80p' "$path" || true
+              echo "--- $path grep context ---"
+              grep -nE 'CHOOSE|Sovereign|SCIENCE|SOVEREIGN|ARE Runtime|/2d/|/3d/|/apps/' "$path" || true
+              exit 1
+            fi
+          }
+
+          require_file client/dist/index.html
+          require_file client/dist/3d/index.html
+          require_file client/dist/portal/index.html
+          require_file client/dist/apps/index.html
+          require_file client/dist/are-console.html
+          require_file client/dist/sovereign-truth.html
+          require_file client/dist/runtime-build-info.json
+          require_file apps/client-2d/dist/index.html
+          require_grep 'CHOOSE' client/dist/index.html
+          require_grep 'Sovereign Tools' client/dist/index.html
+          require_grep 'SCIENCE PORTAL' client/dist/portal/index.html
+          require_grep 'SOVEREIGN TOOLS' client/dist/apps/index.html
+          require_grep 'ARE Runtime Console' client/dist/are-console.html
+          require_grep '"/2d/"' client/dist/runtime-build-info.json
+          require_grep '"/3d/"' client/dist/runtime-build-info.json
+          require_grep '"/apps/"' client/dist/runtime-build-info.json
           echo 'Public route hub smoke OK'

--- a/apps/client-2d/src/main.tsx
+++ b/apps/client-2d/src/main.tsx
@@ -8,6 +8,7 @@ import { PixiModuleInspector } from "./PixiModuleInspector";
 import { WorldHeartMonitor } from "./WorldHeartMonitor";
 import { KenneyUiLiveSkinBadge } from "./KenneyUiLiveSkinBadge";
 import { InteractionOverlayRoot } from "./ui/InteractionOverlayRoot";
+import { DnDProvider } from "./ui/dnd/DnDContext";
 import { LootFeed } from "./ui/LootFeed";
 import { ToastStack, type ClientToast } from "./ui/ToastStack";
 import { NpcDialoguePanel } from "./ui/NpcDialoguePanel";
@@ -333,17 +334,19 @@ async function main(): Promise<void> {
   try {
     ReactDOM.createRoot(rootElement).render(
       <React.StrictMode>
-        <CyberZenLoginGate>
-          <DeterministicWorldIsoApp />
-          <LiveRealityBridge />
-          <WorldHeartMonitor />
-          <PixiModuleInspector />
-          <MobileMovePad />
-          <KenneyUiLiveSkinBadge />
-          <InteractionOverlayRoot />
-          <UIOverlayLayer />
-          <LiveGameplayNetworkBridge />
-        </CyberZenLoginGate>
+        <DnDProvider>
+          <CyberZenLoginGate>
+            <DeterministicWorldIsoApp />
+            <LiveRealityBridge />
+            <WorldHeartMonitor />
+            <PixiModuleInspector />
+            <MobileMovePad />
+            <KenneyUiLiveSkinBadge />
+            <InteractionOverlayRoot />
+            <UIOverlayLayer />
+            <LiveGameplayNetworkBridge />
+          </CyberZenLoginGate>
+        </DnDProvider>
       </React.StrictMode>
     );
 

--- a/apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx
+++ b/apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx
@@ -7,11 +7,12 @@
  * Determinism rule:
  * - Character creation uses validated input only.
  * - Server determines success/failure.
+ * - The start path is not a class; it only selects starter kit/tutorial focus.
  */
 
 import React, { useState } from "react";
 
-const ARCHETYPES = [
+const START_PATHS = [
   "wanderer",
   "forager",
   "miner",
@@ -19,19 +20,32 @@ const ARCHETYPES = [
   "artisan",
 ] as const;
 
+type StartPath = (typeof START_PATHS)[number];
+
+const START_PATH_LABELS: Record<StartPath, string> = {
+  wanderer: "Wanderer — neutraler Start",
+  forager: "Forager — Sammeln-Tutorial",
+  miner: "Miner — Erz & Spitzhacke",
+  angler: "Angler — Wasser & Angel",
+  artisan: "Artisan — Werkbank & Crafting",
+};
+
 interface Props {
   onCreated?: () => void;
 }
 
 export function CharacterSelectPanel({ onCreated }: Props) {
   const [displayName, setDisplayName] = useState("");
-  const [archetype, setArchetype] = useState<(typeof ARCHETYPES)[number]>("wanderer");
+  const [startPath, setStartPath] = useState<StartPath>("wanderer");
   const [status, setStatus] = useState<string>("");
 
   return (
     <section data-testid="character-select" className="are-window character-select-panel">
-      <h2>Character Selection</h2>
-      <p>Create your first Areloria character.</p>
+      <h2>Character Creation</h2>
+      <p>
+        Erstelle deinen ersten Areloria-Charakter. Areloria ist klassenlos: Skills wachsen durch Nutzung,
+        nicht durch eine feste Klasse.
+      </p>
 
       <label className="character-form-label">
         Name
@@ -47,19 +61,24 @@ export function CharacterSelectPanel({ onCreated }: Props) {
       </label>
 
       <label className="character-form-label">
-        Archetype
+        Startpfad
         <select
-          value={archetype}
-          onChange={(event) => setArchetype(event.target.value as (typeof ARCHETYPES)[number])}
+          value={startPath}
+          onChange={(event) => setStartPath(event.target.value as StartPath)}
           className="character-form-select"
         >
-          {ARCHETYPES.map((id) => (
+          {START_PATHS.map((id) => (
             <option key={id} value={id}>
-              {id}
+              {START_PATH_LABELS[id]}
             </option>
           ))}
         </select>
       </label>
+
+      <p className="character-form-hint">
+        Keine Klasse, keine Sperren: Der Startpfad bestimmt nur Startausrüstung und Tutorial-Fokus.
+        Danach kannst du alle Skills frei trainieren.
+      </p>
 
       <button
         type="button"
@@ -80,12 +99,15 @@ export function CharacterSelectPanel({ onCreated }: Props) {
               },
               body: JSON.stringify({
                 displayName: displayName.trim(),
-                archetype,
+                archetype: startPath,
                 currentTick: 0,
               }),
             });
 
-            const result = await response.json();
+            const contentType = response.headers.get("content-type") ?? "";
+            const result = contentType.includes("application/json")
+              ? await response.json()
+              : { ok: false, error: `Server returned non-JSON response (${response.status})` };
 
             if (result.ok) {
               setStatus("Character created.");

--- a/apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx
+++ b/apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx
@@ -22,12 +22,56 @@ const START_PATHS = [
 
 type StartPath = (typeof START_PATHS)[number];
 
-const START_PATH_LABELS: Record<StartPath, string> = {
-  wanderer: "Wanderer — neutraler Start",
-  forager: "Forager — Sammeln-Tutorial",
-  miner: "Miner — Erz & Spitzhacke",
-  angler: "Angler — Wasser & Angel",
-  artisan: "Artisan — Werkbank & Crafting",
+interface StartPathInfo {
+  readonly label: string;
+  readonly shortLabel: string;
+  readonly starterKit: readonly string[];
+  readonly tutorialFocus: string;
+  readonly firstResourceSpot: string;
+  readonly firstGoal: string;
+}
+
+const START_PATH_INFO: Record<StartPath, StartPathInfo> = {
+  wanderer: {
+    label: "Wanderer — neutraler Start",
+    shortLabel: "Wanderer",
+    starterKit: ["Reiseration", "Trainingsspeer", "Wegmarke"],
+    tutorialFocus: "Bewegen, NPC ansprechen, erste Quest, erster Kampf.",
+    firstResourceSpot: "Dorfplatz, Übungsfeld und erster NPC am Wegstein.",
+    firstGoal: "Sprich mit dem ersten NPC und sichere den Außenposten.",
+  },
+  forager: {
+    label: "Forager — Sammeln-Tutorial",
+    shortLabel: "Forager",
+    starterKit: ["Sammelbeutel", "Kräutermesser", "Feldnotiz"],
+    tutorialFocus: "Kräuter, Beeren, Pilze und einfache Naturmaterialien finden.",
+    firstResourceSpot: "Kräuterwiese am Waldrand mit Foraging-Knoten.",
+    firstGoal: "Sammle 3 Kräuter und bringe sie zur Vorratskiste.",
+  },
+  miner: {
+    label: "Miner — Erz & Spitzhacke",
+    shortLabel: "Miner",
+    starterKit: ["Einfache Spitzhacke", "Erzbeutel", "Kupfermarke"],
+    tutorialFocus: "Stein, Kupfer, Erzadern und robuste Materialien abbauen.",
+    firstResourceSpot: "Felsnase nördlich des Starts mit Stein- und Kupferadern.",
+    firstGoal: "Baue 3 Kupfererz ab und prüfe den ersten Schmelzauftrag.",
+  },
+  angler: {
+    label: "Angler — Wasser & Angel",
+    shortLabel: "Angler",
+    starterKit: ["Einfache Angel", "Köderbeutel", "Kleines Netz"],
+    tutorialFocus: "Fishing-Spots erkennen, Fisch fangen und später Kochen lernen.",
+    firstResourceSpot: "Ufersteg am nahen Wasser mit markiertem Fishing-Spot.",
+    firstGoal: "Fange 3 Fische und bereite den ersten Kochauftrag vor.",
+  },
+  artisan: {
+    label: "Artisan — Werkbank & Crafting",
+    shortLabel: "Artisan",
+    starterKit: ["Werkzeugrolle", "Holzplanke", "Rezeptkarte"],
+    tutorialFocus: "Werkbank, erste Rezepte, einfache Verarbeitung und Reparatur.",
+    firstResourceSpot: "Werkbank-Zelt beim Startlager mit Crafting-Auftrag.",
+    firstGoal: "Fertige eine Holzplanke oder repariere ein einfaches Werkzeug.",
+  },
 };
 
 interface Props {
@@ -38,6 +82,7 @@ export function CharacterSelectPanel({ onCreated }: Props) {
   const [displayName, setDisplayName] = useState("");
   const [startPath, setStartPath] = useState<StartPath>("wanderer");
   const [status, setStatus] = useState<string>("");
+  const selectedPath = START_PATH_INFO[startPath];
 
   return (
     <section data-testid="character-select" className="are-window character-select-panel">
@@ -69,15 +114,40 @@ export function CharacterSelectPanel({ onCreated }: Props) {
         >
           {START_PATHS.map((id) => (
             <option key={id} value={id}>
-              {START_PATH_LABELS[id]}
+              {START_PATH_INFO[id].label}
             </option>
           ))}
         </select>
       </label>
 
+      <article className="character-start-path-card" data-testid="character-start-path-card">
+        <header>
+          <strong>{selectedPath.shortLabel}</strong>
+          <span>Startpfad · keine Klasse</span>
+        </header>
+        <dl>
+          <div>
+            <dt>Starter-Kit</dt>
+            <dd>{selectedPath.starterKit.join(" · ")}</dd>
+          </div>
+          <div>
+            <dt>Tutorial-Fokus</dt>
+            <dd>{selectedPath.tutorialFocus}</dd>
+          </div>
+          <div>
+            <dt>Erster Ressourcen-Spot</dt>
+            <dd>{selectedPath.firstResourceSpot}</dd>
+          </div>
+          <div>
+            <dt>Erstes Ziel</dt>
+            <dd>{selectedPath.firstGoal}</dd>
+          </div>
+        </dl>
+      </article>
+
       <p className="character-form-hint">
-        Keine Klasse, keine Sperren: Der Startpfad bestimmt nur Startausrüstung und Tutorial-Fokus.
-        Danach kannst du alle Skills frei trainieren.
+        Keine Klasse, keine Sperren: Der Startpfad bestimmt nur Startausrüstung, Tutorial-Fokus und den ersten
+        Ressourcen-Spot. Danach kannst du alle Skills frei trainieren.
       </p>
 
       <button


### PR DESCRIPTION
## Summary

Fixes the visible post-login runtime error and clarifies character creation language for Areloria's classless skill-based design.

## Problem

Production now reaches the new HUD, but the first post-login child reports:

```txt
Post-login module failed: post-login-child-0
Error: useDnD must be used within DnDProvider
```

That means a visible inventory/equipment/paperdoll panel uses `useDnD()` without a provider above the 2D app tree.

Also, the character creation dropdown used `Archetype`, which reads like a class system. Areloria is intended to be RuneScape-like and classless: skills progress by usage.

## Changes

- Wraps the 2D live app tree with `DnDProvider` in `apps/client-2d/src/main.tsx`.
- Renames the character creation UI from `Archetype` to `Startpfad`.
- Adds copy explaining that the start path is not a class and only controls starter kit/tutorial focus.
- Keeps the API payload field as `archetype` for backend compatibility.
- Hardens character creation response handling so non-JSON server responses do not crash the UI with `Unexpected token '<'`.

## Safety

- No backend schema changes.
- No gameplay locks/classes introduced.
- No Docker changes.
- No secrets.
- Keeps classless skill-based design intact.

## Acceptance

- `useDnD must be used within DnDProvider` no longer appears.
- Post-login child 0 can render its DnD-dependent panels.
- Character creation no longer presents start options as classes.
- Non-JSON API errors show a readable status instead of a JSON parse exception.