### PR TITLE
feat(server): grant classless start path starter resources

### DIFF
--- a/server/src/character/CharacterService.ts
+++ b/server/src/character/CharacterService.ts
@@ -10,6 +10,7 @@ import {
   createPersistedCharacterProfile,
   type CharacterPersistenceAdapter,
 } from "./CharacterPersistence.js";
+import { applyStartPathStarterKit } from "./StartPathStarterKits.js";
 import type {
   CharacterArchetype,
   CharacterCreateResult,
@@ -43,6 +44,11 @@ export class CharacterService {
       await this.persistence.saveCharacterProfile(
         createPersistedCharacterProfile(input.playerId, result.profile),
       );
+
+      await applyStartPathStarterKit({
+        playerId: input.playerId,
+        archetype: result.profile.archetype,
+      });
     }
 
     return result;

--- a/server/src/character/StartPathStarterKits.ts
+++ b/server/src/character/StartPathStarterKits.ts
@@ -1,0 +1,106 @@
+/**
+ * START PATH STARTER KITS
+ *
+ * Classless starter support for Areloria character creation.
+ * These are NOT classes. They only grant deterministic starter resources,
+ * tutorial intent, and a first resource/crafting direction.
+ *
+ * Rules:
+ * - No Math.random()
+ * - No Date.now()
+ * - Stable ordering
+ * - No skill locks
+ */
+
+import { getInventoryService } from "../inventory/inventoryRuntime.js";
+import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+import type { CharacterArchetype } from "./CharacterTypes.js";
+
+export interface StartPathStarterGrant {
+  readonly itemId: InventoryItemId;
+  readonly quantity: number;
+}
+
+export interface StartPathStarterKit {
+  readonly archetype: CharacterArchetype;
+  readonly tutorialFocus: string;
+  readonly firstResourceSpotId: string | null;
+  readonly firstGoal: string;
+  readonly grants: readonly StartPathStarterGrant[];
+}
+
+export const START_PATH_STARTER_KITS: Record<CharacterArchetype, StartPathStarterKit> = {
+  wanderer: {
+    archetype: "wanderer",
+    tutorialFocus: "movement_npc_dialogue_first_combat",
+    firstResourceSpotId: null,
+    firstGoal: "talk_to_first_npc",
+    grants: [
+      { itemId: "cooked_fish", quantity: 1 },
+      { itemId: "wood_log", quantity: 1 },
+    ],
+  },
+  forager: {
+    archetype: "forager",
+    tutorialFocus: "woodcutting_and_nature_gathering",
+    firstResourceSpotId: "starter_tree_001",
+    firstGoal: "gather_3_nature_materials",
+    grants: [
+      { itemId: "wood_log", quantity: 2 },
+    ],
+  },
+  miner: {
+    archetype: "miner",
+    tutorialFocus: "mining_and_smelting_intro",
+    firstResourceSpotId: "starter_ore_001",
+    firstGoal: "mine_3_copper_ore",
+    grants: [
+      { itemId: "copper_ore", quantity: 2 },
+    ],
+  },
+  angler: {
+    archetype: "angler",
+    tutorialFocus: "fishing_and_cooking_intro",
+    firstResourceSpotId: "starter_fish_001",
+    firstGoal: "catch_3_raw_fish",
+    grants: [
+      { itemId: "raw_fish", quantity: 2 },
+    ],
+  },
+  artisan: {
+    archetype: "artisan",
+    tutorialFocus: "crafting_recipe_intro",
+    firstResourceSpotId: null,
+    firstGoal: "craft_first_plank_or_ingot",
+    grants: [
+      { itemId: "wood_log", quantity: 2 },
+      { itemId: "copper_ore", quantity: 3 },
+    ],
+  },
+};
+
+export function getStartPathStarterKit(archetype: CharacterArchetype): StartPathStarterKit {
+  return START_PATH_STARTER_KITS[archetype] ?? START_PATH_STARTER_KITS.wanderer;
+}
+
+export async function applyStartPathStarterKit(input: {
+  readonly playerId: string;
+  readonly archetype: CharacterArchetype;
+}): Promise<void> {
+  const kit = getStartPathStarterKit(input.archetype);
+  const inventory = await getInventoryService();
+
+  for (const grant of kit.grants) {
+    const result = await inventory.addItem({
+      playerId: input.playerId,
+      itemId: grant.itemId,
+      quantity: grant.quantity,
+    });
+
+    if (!result.ok) {
+      console.warn(
+        `[start-path] failed to grant ${grant.itemId} x${grant.quantity} to ${input.playerId}: ${result.reason}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds real server-side starter resources for each classless character start path.

## Intent

Areloria stays classless and RuneScape-like: the selected start path is not a class and does not lock skills. It now provides deterministic starter resources and a first tutorial/resource direction.

## Start path grants

- `wanderer`: cooked fish + wood log
- `forager`: wood logs and first nature/woodcutting direction
- `miner`: copper ore and first mining direction
- `angler`: raw fish and first fishing direction
- `artisan`: wood logs + copper ore for early crafting recipes

## Changes

- Adds `server/src/character/StartPathStarterKits.ts`
- Hooks starter-kit granting into `CharacterService.createCharacter()` after profile persistence succeeds
- Keeps backend field name `archetype` for compatibility, but treats it as classless start path logic
- Does not add skill locks, class restrictions, or endgame role restrictions

## Notes

Tool auto-equip is intentionally not included in this PR. The first safe server-side step is starter resources plus tutorial intent. Equipment auto-equip can follow after the starter equipment flow is validated.

## Safety

- No random generation
- No wall-clock timing
- No schema changes
- No Docker changes
- No secrets
- Existing characters are unaffected
