### PR TITLE
fix(server): preserve completed start path quest state

### DIFF
--- a/server/src/quests/QuestProgressionStore.ts
+++ b/server/src/quests/QuestProgressionStore.ts
@@ -180,6 +180,24 @@ export class QuestProgressionStore {
     return quest;
   }
 
+  /**
+   * Preserve derived quest completion from server-authoritative snapshots.
+   * This is used for start-path quests whose objectives are derived from inventory.
+   * Once completed, they must not regress when follow-up crafting consumes items.
+   */
+  upsertDerivedQuestSnapshot(playerId: string, quest: QuestSnapshot): QuestSnapshot {
+    const normalized = normalizeQuestSnapshot(quest);
+    const existing = this.getOrCreatePlayerQuestMap(playerId).get(normalized.id);
+
+    if (existing?.status === "completed") {
+      return existing;
+    }
+
+    this.setQuest(playerId, normalized);
+    void this.persistPlayerState(playerId);
+    return normalized;
+  }
+
   applyEvent(event: QuestEvent): PlayerQuestState {
     if (event.type === "quest_accept") {
       this.acceptQuest(event.playerId, event.questId);

--- a/server/src/routes/gameplaySnapshot.ts
+++ b/server/src/routes/gameplaySnapshot.ts
@@ -83,10 +83,24 @@ export function createGameplaySnapshotRouter(tick: WorldTick) {
     // Get character profile
     const character = await characterService.getCharacterProfile(identity.playerId);
     const characterSnapshot = toCharacterProfileSnapshot(character);
-    const startPathQuest = createStartPathQuestSnapshot({
+    const derivedStartPathQuest = createStartPathQuestSnapshot({
       character: characterSnapshot,
       inventory,
     });
+
+    const persistedStartPathQuest = derivedStartPathQuest
+      ? questState.quests.find((quest) => quest.id === derivedStartPathQuest.id)
+      : null;
+
+    const startPathQuest = persistedStartPathQuest?.status === "completed"
+      ? persistedStartPathQuest
+      : derivedStartPathQuest?.status === "completed"
+        ? questProgressionStore.upsertDerivedQuestSnapshot(identity.playerId, derivedStartPathQuest)
+        : derivedStartPathQuest;
+
+    const baseQuests = startPathQuest
+      ? questState.quests.filter((quest) => quest.id !== startPathQuest.id)
+      : questState.quests;
 
     // Create paperdoll snapshot from character and equipment
     const paperdoll = createPaperdollSnapshot({
@@ -99,8 +113,8 @@ export function createGameplaySnapshotRouter(tick: WorldTick) {
       character: characterSnapshot,
       paperdoll,
       quests: startPathQuest
-        ? [...questState.quests, startPathQuest]
-        : questState.quests,
+        ? [...baseQuests, startPathQuest]
+        : baseQuests,
       skills: skillState.skills,
       resources,
       inventory,


### PR DESCRIPTION
## Summary

Addresses Codex review feedback from #1725: completed start-path quests must not regress after follow-up crafting consumes the items used for the objective.

## Problem

#1725 derived start-path quest status from current inventory quantity. Example:

1. Angler reaches 3 Raw Fish → `start_path_angler` completed.
2. Player cooks one Raw Fish.
3. Current inventory becomes 2 Raw Fish.
4. The derived snapshot would incorrectly show the quest as active at 2/3 again.

The same applies to wood, copper ore, and plank goals when materials are spent in follow-up crafting.

## Changes

- Adds `QuestProgressionStore.upsertDerivedQuestSnapshot()`.
- Persists a derived quest once it reaches `completed`.
- Gameplay snapshot prefers an already persisted completed start-path quest over the current derived inventory count.
- Filters duplicate start-path quest IDs before composing the snapshot.

## Acceptance

- Once `start_path_angler` reaches completed at 3/3, it stays completed after cooking/spending fish.
- Same non-regression behavior for Forager, Miner, Artisan, and Wanderer start-path quests.
- Active quests still show live progress from current inventory before completion.

## Safety

- No schema changes.
- No random generation.
- No wall-clock timing.
- No client-side completion decisions.
- Persistence failures remain non-fatal through existing quest-store behavior.
