### PR TITLE
fix(server): restore live character create and gameplay snapshot API

### DIFF
--- a/apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx
+++ b/apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx
@@ -11,6 +11,7 @@
  */
 
 import React, { useState } from "react";
+import { fetchGameplaySnapshot, liveGameplayStore } from "../../game/liveGameplayStore";
 
 const START_PATHS = [
   "wanderer",
@@ -180,6 +181,11 @@ export function CharacterSelectPanel({ onCreated }: Props) {
               : { ok: false, error: `Server returned non-JSON response (${response.status})` };
 
             if (result.ok) {
+              setStatus("Character created. Syncing world snapshot...");
+              const snapshot = await fetchGameplaySnapshot();
+              if (snapshot) {
+                liveGameplayStore.setSnapshot(snapshot);
+              }
               setStatus("Character created.");
               onCreated?.();
 

--- a/server/src/character/characterRoute.ts
+++ b/server/src/character/characterRoute.ts
@@ -2,6 +2,7 @@
  * CHARACTER PROFILE ROUTE
  *
  * REST API for character profile management.
+ * Mounted at /api/character by ServerBootstrap.
  * Deterministic: No Date.now(), no Math.random().
  */
 
@@ -15,10 +16,24 @@ import {
 
 const router = Router();
 
-router.get("/api/character/profile", async (req, res) => {
+function isGuestHttpAllowed(): boolean {
+  const allowGuest = !["0", "false", "no"].includes(
+    process.env.ALLOW_GUEST_LOGIN?.trim().toLowerCase() || "",
+  );
+  const allowDev = !["0", "false", "no"].includes(
+    process.env.ALLOW_DEV_LOGIN?.trim().toLowerCase() || "",
+  );
+  return allowGuest || allowDev || process.env.ALLOW_DEV_PLAYER_ID === "true";
+}
+
+function rejectUnauthenticatedInLockedProduction(identity: { authenticated: boolean }): boolean {
+  return process.env.NODE_ENV === "production" && !identity.authenticated && !isGuestHttpAllowed();
+}
+
+router.get("/profile", async (req, res) => {
   const identity = resolveHttpPlayerIdentity(req);
 
-  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+  if (rejectUnauthenticatedInLockedProduction(identity)) {
     res.status(401).json({ ok: false, error: "authenticated_player_required" });
     return;
   }
@@ -28,14 +43,16 @@ router.get("/api/character/profile", async (req, res) => {
   res.json({
     ok: true,
     playerId: identity.playerId,
+    playerIdentitySource: identity.source,
+    authenticated: identity.authenticated,
     profile,
   });
 });
 
-router.post("/api/character/create", async (req, res) => {
+router.post("/create", async (req, res) => {
   const identity = resolveHttpPlayerIdentity(req);
 
-  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+  if (rejectUnauthenticatedInLockedProduction(identity)) {
     res.status(401).json({ ok: false, error: "authenticated_player_required" });
     return;
   }
@@ -62,6 +79,9 @@ router.post("/api/character/create", async (req, res) => {
 
   res.status(result.ok ? 200 : 409).json({
     ok: result.ok,
+    playerId: identity.playerId,
+    playerIdentitySource: identity.source,
+    authenticated: identity.authenticated,
     result,
   });
 });

--- a/server/src/routes/gameplaySnapshot.ts
+++ b/server/src/routes/gameplaySnapshot.ts
@@ -11,7 +11,7 @@
  * - All values come from real server state
  * - Empty/null states are honest and allowed
  * - status="empty" means server reachable but no gameplay data yet
- * - Server determines playerId from auth/session, not client
+ * - Server determines playerId from auth/session, not client unless guest/dev fallback is enabled
  */
 
 import express from "express";
@@ -38,6 +38,20 @@ function getCurrentTickId(tick: WorldTick | null): number {
   return (tick as any).tickCount ?? 0;
 }
 
+function isGuestHttpAllowed(): boolean {
+  const allowGuest = !["0", "false", "no"].includes(
+    process.env.ALLOW_GUEST_LOGIN?.trim().toLowerCase() || "",
+  );
+  const allowDev = !["0", "false", "no"].includes(
+    process.env.ALLOW_DEV_LOGIN?.trim().toLowerCase() || "",
+  );
+  return allowGuest || allowDev || process.env.ALLOW_DEV_PLAYER_ID === "true";
+}
+
+function rejectUnauthenticatedInLockedProduction(identity: { authenticated: boolean }): boolean {
+  return process.env.NODE_ENV === "production" && !identity.authenticated && !isGuestHttpAllowed();
+}
+
 /**
  * Create gameplay snapshot router.
  * Requires WorldTick instance for server tick.
@@ -48,7 +62,7 @@ export function createGameplaySnapshotRouter(tick: WorldTick) {
   router.get("/snapshot", async (req, res) => {
     const identity = resolveHttpPlayerIdentity(req as Parameters<typeof resolveHttpPlayerIdentity>[0]);
 
-    if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    if (rejectUnauthenticatedInLockedProduction(identity)) {
       res.status(401).json({
         ok: false,
         error: "authenticated_player_required",


### PR DESCRIPTION
## Summary

Fixes the live blocker visible in Android screenshots: character creation does nothing and all gameplay panels stay on `Waiting for server snapshot`.

## Root cause

`ServerBootstrap` mounts the character router at `/api/character`, but `characterRoute.ts` defined full absolute paths internally:

- mounted path: `/api/character`
- route path before this PR: `/api/character/create`
- effective live route: `/api/character/api/character/create`

The client correctly calls `/api/character/create`, so the request missed the intended JSON route.

The gameplay snapshot also rejected unauthenticated HTTP fallback in production, even while guest/playtest WebSocket login is allowed. That leaves the HUD stuck at `Waiting for server snapshot`.

## Changes

- Changes character router paths to mounted-relative paths:
  - `GET /api/character/profile`
  - `POST /api/character/create`
- Allows guest/dev HTTP fallback for character and gameplay snapshot routes when guest/dev login is not explicitly disabled.
- Adds identity metadata to character responses for debugging.
- After successful character creation, client immediately refetches `/api/gameplay/snapshot` and pushes it into `liveGameplayStore`.

## Expected result

On Android `/2d/`:

1. Create character succeeds with JSON.
2. Starter resources are granted.
3. Gameplay snapshot stops waiting.
4. Inventory, skills, crafting, character, and quest panels receive live snapshot data.
5. Quest preview changes from `Waiting for server snapshot...` to the relevant start-path objective.

## Safety

- No schema changes.
- No Docker changes.
- No secrets.
- Guest fallback remains controllable via existing env flags.
- Production can still lock unauthenticated HTTP by disabling guest/dev login env flags.