### PR TITLE
fix(client-2d): clean mobile HUD and send guest player id

### DIFF
--- a/apps/client-2d/src/areHeartbeat.css
+++ b/apps/client-2d/src/areHeartbeat.css
@@ -148,36 +148,42 @@
   vertical-align: middle;
 }
 
+/* Hide noisy debug overlays in the public mobile play surface. */
+.stitch-debug,
+.stitch-are-heartbeat {
+  display: none !important;
+}
+
 /* ─── Quest Preview & Journal ─────────────────────────────────────────────── */
 .quest-preview-panel {
   position: absolute;
-  left: 14px;
-  top: 112px;
-  z-index: 88;
+  right: calc(env(safe-area-inset-right, 0px) + 14px);
+  top: calc(env(safe-area-inset-top, 0px) + 102px);
+  z-index: 74;
   display: grid;
-  gap: 8px;
-  width: min(330px, calc(100vw - 28px));
-  padding: 12px 14px;
-  border: 1px solid rgba(255, 215, 106, 0.34);
-  border-radius: 18px;
-  background: linear-gradient(135deg, rgba(4, 8, 14, 0.82), rgba(21, 18, 8, 0.58));
-  box-shadow: 0 0 26px rgba(255, 215, 106, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  gap: 6px;
+  width: min(240px, calc(100vw - 28px));
+  padding: 9px 10px;
+  border: 1px solid rgba(255, 215, 106, 0.28);
+  border-radius: 14px;
+  background: rgba(4, 8, 14, 0.48);
+  box-shadow: 0 0 18px rgba(255, 215, 106, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.06);
   color: var(--cz-text);
   pointer-events: auto;
-  backdrop-filter: blur(14px);
+  backdrop-filter: blur(10px);
 }
 
 .quest-preview-panel header {
   display: grid;
-  gap: 2px;
+  gap: 1px;
 }
 
 .quest-preview-panel small,
 .quest-journal-card small {
   color: var(--st-gold);
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 950;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
@@ -186,12 +192,16 @@
   color: #fff6d7;
 }
 
+.quest-preview-panel strong {
+  font-size: 12px;
+}
+
 .quest-preview-objective,
 .quest-journal-objective {
   display: grid;
-  gap: 6px;
+  gap: 5px;
   color: rgba(244, 247, 255, 0.82);
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .quest-preview-objective b,
@@ -203,7 +213,7 @@
 .quest-preview-objective i,
 .quest-journal-objective i {
   display: block;
-  height: 7px;
+  height: 6px;
   overflow: hidden;
   border: 1px solid rgba(0, 229, 255, 0.24);
   border-radius: 999px;
@@ -223,12 +233,12 @@
   justify-self: start;
   border: 1px solid rgba(0, 229, 255, 0.34);
   border-radius: 999px;
-  padding: 8px 11px;
+  padding: 6px 9px;
   color: #05060b;
   background: linear-gradient(135deg, var(--st-aether), var(--st-gold));
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 950;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
 }
 
@@ -278,19 +288,25 @@
 
 /* Mobile */
 @media (max-width: 760px) {
+  .stitch-mobile-toggles,
+  .stitch-fullscreen-toggle {
+    display: none !important;
+  }
+
   .quest-preview-panel {
-    top: auto;
-    left: 10px;
-    right: 10px;
-    bottom: 234px;
-    width: auto;
-    padding: 10px 11px;
-    border-radius: 16px;
+    top: calc(env(safe-area-inset-top, 0px) + 96px);
+    right: calc(env(safe-area-inset-right, 0px) + 10px);
+    left: auto;
+    bottom: auto;
+    width: min(210px, 48vw);
+    padding: 8px 9px;
+    border-radius: 13px;
+    opacity: 0.88;
   }
 
   .quest-preview-panel button {
-    min-height: 42px;
-    padding-inline: 14px;
+    min-height: 34px;
+    padding-inline: 10px;
   }
 }
 

--- a/apps/client-2d/src/game/liveGameplayStore.ts
+++ b/apps/client-2d/src/game/liveGameplayStore.ts
@@ -69,11 +69,12 @@ export class LiveGameplayStore {
 
 export const liveGameplayStore = new LiveGameplayStore();
 
-// HTTP fallback fetch for when WebSocket hasn't delivered data yet
-const DEFAULT_PLAYER_ID = "guest";
+// HTTP fallback fetch for when WebSocket hasn't delivered data yet.
+// This ID intentionally matches the guest/playtest HTTP fallback path.
+export const DEFAULT_GAMEPLAY_PLAYER_ID = "guest";
 
 export async function fetchGameplaySnapshot(
-  playerId: string = DEFAULT_PLAYER_ID
+  playerId: string = DEFAULT_GAMEPLAY_PLAYER_ID
 ): Promise<LiveGameplaySnapshot | null> {
   try {
     const encodedPlayerId = encodeURIComponent(playerId);
@@ -81,6 +82,9 @@ export async function fetchGameplaySnapshot(
       `/api/gameplay/snapshot?playerId=${encodedPlayerId}`,
       {
         cache: "no-store",
+        headers: {
+          "x-player-id": playerId,
+        },
       }
     );
     if (!response.ok) return null;

--- a/apps/client-2d/src/mobilePlayability.css
+++ b/apps/client-2d/src/mobilePlayability.css
@@ -23,6 +23,8 @@ body,
 
 .az-touch-pad {
   touch-action: none;
+  z-index: 120 !important;
+  pointer-events: auto !important;
 }
 
 .az-touch-pad button,

--- a/apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx
+++ b/apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx
@@ -11,7 +11,11 @@
  */
 
 import React, { useState } from "react";
-import { fetchGameplaySnapshot, liveGameplayStore } from "../../game/liveGameplayStore";
+import {
+  DEFAULT_GAMEPLAY_PLAYER_ID,
+  fetchGameplaySnapshot,
+  liveGameplayStore,
+} from "../../game/liveGameplayStore";
 
 const START_PATHS = [
   "wanderer",
@@ -163,12 +167,15 @@ export function CharacterSelectPanel({ onCreated }: Props) {
           setStatus("Creating character...");
 
           try {
-            const response = await fetch("/api/character/create", {
+            const playerId = DEFAULT_GAMEPLAY_PLAYER_ID;
+            const response = await fetch(`/api/character/create?playerId=${encodeURIComponent(playerId)}`, {
               method: "POST",
               headers: {
                 "content-type": "application/json",
+                "x-player-id": playerId,
               },
               body: JSON.stringify({
+                playerId,
                 displayName: displayName.trim(),
                 archetype: startPath,
                 currentTick: 0,
@@ -182,7 +189,7 @@ export function CharacterSelectPanel({ onCreated }: Props) {
 
             if (result.ok) {
               setStatus("Character created. Syncing world snapshot...");
-              const snapshot = await fetchGameplaySnapshot();
+              const snapshot = await fetchGameplaySnapshot(playerId);
               if (snapshot) {
                 liveGameplayStore.setSnapshot(snapshot);
               }


### PR DESCRIPTION
## Summary

Fixes the Android live issues from the latest screenshots.

## Problems seen on device

- Character creation returns `failed: invalid_player`.
- Quest preview sits in the middle of the playfield.
- Permanent debug window blocks interaction.
- Old mobile HUD toggles (`FULL/MAP/CHAT`) clutter the top area.
- Mobile movement controls can become hidden/covered by overlays.

## Changes

### Character creation

- Reuses the same guest/playtest player id as the gameplay snapshot fallback.
- Sends the player id through:
  - query `?playerId=guest`
  - `x-player-id` header
  - JSON body `playerId`
- Immediately refetches the gameplay snapshot for the same id after create.

### Mobile HUD cleanup

- Moves the quest preview to a smaller transparent top-right box.
- Hides the permanent debug and ARE heartbeat debug overlays from the public play surface.
- Hides legacy mobile toggles and fullscreen button on mobile.
- Raises the mobile movement pad z-index and pointer priority so it stays reachable.

## Expected result

On Android `/2d/`:

- `Create Character` should no longer fail with `invalid_player`.
- Quest preview no longer blocks the center of the screen.
- Debug panel no longer blocks taps.
- Bottom gameplay dock remains the main menu.
- Movement controls stay visible/reachable.

## Safety

- Client/UI only.
- No schema changes.
- No Docker changes.
- No secrets.
- Does not change server auth precedence.