### PR TITLE
feat(npc): add autonomous NPC brain loop and memory observation bus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,7 @@ When working on specific topics, check the skills in `docs/ai-skills/`:
 - `wasd-quest-persistence-ops.md` - Quest persistence implementation & ops (PRs #1697-#1701)
 - `wasd-health-endpoint-verification.md` - Health check patterns for VPS verification
 - `wasd-production-activation-workflow.md` - Complete workflow for production activation
+- `wasd-npc-autonomous-brain.md` - NPC autonomous brain system (memory, decisions, learning)
 
 ### VPS & Deployment Skills
 - `vps-ssh-paramiko-patterns.md` - SSH access to VPS via Paramiko

--- a/docs/ai-skills/wasd-npc-autonomous-brain.md
+++ b/docs/ai-skills/wasd-npc-autonomous-brain.md
@@ -1,0 +1,219 @@
+# WASD NPC Autonomous Brain System
+
+## Overview
+
+The NPC Autonomous Brain System is a deterministic, replay-capable memory and decision system for NPCs in the Ouroboros game world. It provides:
+
+- **5-Layer Memory Model**: Identity, Episodic, Semantic, Relations, Learning
+- **World Event Observation Bus**: All game systems can emit events for NPCs to observe
+- **Deterministic Decision Engine**: Same tick + same input = same output (no Math.random())
+- **Tick-Based Scheduling**: 10Hz movement, 1Hz decisions, 0.1Hz memory compression
+- **Memory Compression**: Prevents unbounded memory growth
+- **Debug Snapshot Support**: For replay verification and admin HUD
+
+## Architecture
+
+```
+NPCBrainRunner
+├── NPCMemoryV3 (Memory types)
+├── NPCObservationBus (World events)
+├── NPCMemoryScoring (Importance calculation)
+├── NPCDecisionEngine (Action selection)
+├── NPCBrainScheduler (Tick phases)
+├── NPCMemoryCompression (State management)
+└── NPCBrainDebugSnapshot (Debug support)
+```
+
+## Memory Layers
+
+### 1. Identity Memory
+Who am I? (profession, role, personality, home region)
+
+### 2. Episodic Memory
+Concrete events: "Player X attacked me at tick 91240"
+
+### 3. Semantic Memory
+Verdichtetes Wissen: "Player X is dangerous" / "Region Y has little iron"
+
+### 4. Relations
+Trust, fear, respect, morale toward entities
+
+### 5. Learning State
+Statistical experience tracking for action success
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `NPCMemoryV3.ts` | Type definitions and memory creation |
+| `NPCObservationBus.ts` | World event emission and subscription |
+| `NPCMemoryScoring.ts` | Memory importance calculation |
+| `NPCDecisionEngine.ts` | Deterministic action selection |
+| `NPCBrainScheduler.ts` | Tick-based phase management |
+| `NPCMemoryCompression.ts` | Memory summarization |
+| `NPCBrainDebugSnapshot.ts` | Debug and replay support |
+| `NPCBrainRunner.ts` | Main integration loop |
+
+## Usage
+
+### Creating NPC Memory
+
+```typescript
+import { createEmptyNPCMemoryV3 } from "./modules/npc/brain/index.js";
+
+const memory = createEmptyNPCMemoryV3(
+  "npc_1",
+  "Bob the Merchant",
+  "region_capital",
+  "merchant",
+  "trader"
+);
+```
+
+### Emitting World Events
+
+```typescript
+import { globalObservationBus, emitCombatEvent } from "./modules/npc/brain/index.js";
+
+// Simple event
+globalObservationBus.emit("player_attack", tick, {
+  actorId: "player_1",
+  targetId: "npc_1",
+  impact: -8,
+  tags: ["combat", "danger"],
+});
+
+// Combat event helper
+emitCombatEvent(globalObservationBus, tick, "player_attack", {
+  actorId: "player_1",
+  targetId: "npc_1",
+  damage: 25,
+  weaponType: "sword",
+});
+```
+
+### Running NPC Brain
+
+```typescript
+import { NPCBrainRunner } from "./modules/npc/brain/index.js";
+
+const runner = new NPCBrainRunner();
+
+const output = runner.runWithContext({
+  npcId: "npc_1",
+  npcName: "Bob",
+  position: { x: 100, y: 200 },
+  homeRegionId: "region_capital",
+  state: "idle",
+  health: 0.8,
+  energy: 0.7,
+  gold: 50,
+  memory,
+  nearbyEntities: [
+    { id: "player_1", name: "Hero", type: "player", position: { x: 105, y: 205 }, hostile: true },
+  ],
+  tick: 1000,
+  worldSnapshot: {
+    tick: 1000,
+    regionId: "region_capital",
+    timeOfDay: 12,
+    dangerLevel: 0.2,
+    resourceAvailability: {},
+    marketPrices: { iron: 30, wood: 15 },
+    nearbyThreats: [],
+    friendlyNPCs: [],
+    hostileNPCs: [],
+  },
+});
+
+console.log(`Decision: ${output.decision.action}`);
+console.log(`Next State: ${output.nextState}`);
+console.log(`Memory Hash: ${output.memoryHash}`);
+```
+
+## Ouroboros Integration
+
+The NPC Brain is integrated into `OuroborosEngine`:
+
+```typescript
+import { OuroborosEngine } from "./modules/ouroboros/OuroborosEngine.js";
+
+const engine = new OuroborosEngine({
+  enableNPCBrain: true,
+  npcBrainInterval: 10, // 1 Hz
+});
+
+// In WorldTick:
+engine.tick(tickCount, npcs, players, memoryCache, relationships, ...);
+
+// Get NPC memory for debugging
+const memory = engine.getNPCMemory("npc_1");
+```
+
+## Decision Actions
+
+| Action | Description |
+|--------|-------------|
+| `idle` | No action |
+| `talk` | Social interaction |
+| `trade` | Buy/sell goods |
+| `flee` | Escape from threat |
+| `attack` | Engage enemy |
+| `patrol` | Guard duty |
+| `work` | Labor activity |
+| `gather` | Collect resources |
+| `craft` | Create items |
+| `explore` | Discover area |
+| `defend` | Protect others |
+| `raise_alarm` | Alert others |
+| `hire_guard` | Employ protection |
+| `social` | Interact with NPCs |
+
+## Brain Phases
+
+| Phase | Frequency | Operations |
+|-------|-----------|------------|
+| TICK | 10 Hz | Movement, danger check |
+| DECISION | 1 Hz | Decision, goal scoring |
+| PLANNING | 0.1 Hz | Memory compression, routine planning |
+
+## Determinism
+
+All decisions use stable hash distribution:
+- `stableHash32()` for deterministic randomness
+- Same NPC always runs brain at same tick offsets
+- Memory hash enables replay verification
+
+## Debug HUD
+
+```typescript
+import { createNPCBrainDebugSnapshot, checkBrainHealth } from "./modules/npc/brain/index.js";
+
+const snapshot = createNPCBrainDebugSnapshot(
+  npcId, tick, state, memory, decision
+);
+
+const health = checkBrainHealth(memory, tick);
+console.log(`NPC Health: ${health.score}/100`);
+```
+
+## Testing
+
+Run tests:
+```bash
+npx vitest run server/src/tests/npc-autonomous-brain.test.ts
+```
+
+Tests verify:
+- Memory creation and migration
+- Observation bus functionality
+- Memory scoring determinism
+- Decision engine determinism
+- Brain scheduler tick distribution
+- Memory compression
+- Replay verification
+
+## Related Skills
+
+- `wasd-ouroboros-system.md` - Ouroboros engine overview
+- `wasd-server-player-stats-sync.md` - Player stats integration

--- a/server/src/modules/npc/brain/NPCBrainDebugSnapshot.ts
+++ b/server/src/modules/npc/brain/NPCBrainDebugSnapshot.ts
@@ -1,0 +1,410 @@
+/**
+ * NPCBrainDebugSnapshot — Debug HUD and Replay Support
+ * 
+ * Provides structured debug information for:
+ * - Admin/Dev HUD visualization
+ * - Replay verification (same tick + same input = same output)
+ * - Memory integrity checking
+ * - NPC behavior debugging
+ */
+
+import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";
+import type {
+  NPCMemoryV3,
+  NPCDecision,
+  NPCGoal,
+  NPCRelation,
+  NPCEpisodicMemory,
+  NPCBrainDebugSnapshot,
+} from "./NPCMemoryV3.js";
+
+// ============================================================================
+// Debug Snapshot Generation
+// ============================================================================
+
+/**
+ * Create debug snapshot for NPC brain state
+ */
+export function createNPCBrainDebugSnapshot(
+  npcId: string,
+  tick: number,
+  state: string,
+  memory: NPCMemoryV3,
+  decision: NPCDecision | null,
+  additionalInfo?: {
+    lastActionResult?: "success" | "failure" | "neutral";
+    dangerLevel?: number;
+    nearbyEntities?: number;
+  }
+): NPCBrainDebugSnapshot {
+  // Get top goal
+  const topGoal = getTopGoal(memory);
+
+  // Get relation highlights (most important relations)
+  const relationHighlights = getRelationHighlights(memory.relations);
+
+  // Get recent events
+  const recentEvents = getRecentEvents(memory.episodic, 10);
+
+  // Calculate learning stats
+  const totalActions = memory.learning.totalActions;
+  const totalSuccesses = memory.learning.totalSuccesses;
+  const successRate = totalActions > 0 ? totalSuccesses / totalActions : 0;
+
+  // Calculate memory hash for replay verification
+  const memoryHash = calculateMemoryHash(memory);
+
+  return {
+    npcId,
+    tick,
+    state,
+    topGoal,
+    decision: decision ?? {
+      action: "idle",
+      reason: "no_decision_made",
+      score: 0,
+      confidence: 0,
+    },
+    relationHighlights,
+    recentEvents,
+    memoryHash,
+    learningStats: {
+      totalActions,
+      totalSuccesses,
+      successRate,
+    },
+  };
+}
+
+/**
+ * Get top goal from memory
+ */
+function getTopGoal(memory: NPCMemoryV3): NPCGoal | undefined {
+  if (memory.goals.length === 0) return undefined;
+  
+  return [...memory.goals]
+    .sort((a, b) => {
+      if (b.priority !== a.priority) return b.priority - a.priority;
+      return a.id.localeCompare(b.id);
+    })[0];
+}
+
+/**
+ * Get most important relations for debugging
+ */
+function getRelationHighlights(relations: Record<string, NPCRelation>): NPCRelation[] {
+  return Object.values(relations)
+    .sort((a, b) => {
+      // Sort by absolute score (most extreme first)
+      const aAbs = Math.abs(a.trust) + Math.abs(a.fear);
+      const bAbs = Math.abs(b.trust) + Math.abs(b.fear);
+      if (aAbs !== bAbs) return bAbs - aAbs;
+      // Then by interaction count
+      return b.interactions - a.interactions;
+    })
+    .slice(0, 5);
+}
+
+/**
+ * Get recent events for debugging
+ */
+function getRecentEvents(episodic: NPCEpisodicMemory[], count: number): NPCEpisodicMemory[] {
+  return [...episodic]
+    .sort((a, b) => b.tick - a.tick)
+    .slice(0, count);
+}
+
+/**
+ * Calculate memory hash for replay verification
+ */
+function calculateMemoryHash(memory: NPCMemoryV3): string {
+  const components = [
+    memory.identity.npcId,
+    memory.identity.homeRegionId,
+    memory.goals.length,
+    memory.episodic.length,
+    memory.semantic.length,
+    Object.keys(memory.relations).length,
+    JSON.stringify(
+      Object.entries(memory.learning.actionScores)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .slice(0, 10)
+    ),
+    JSON.stringify(
+      Object.entries(memory.learning.contextScores)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .slice(0, 10)
+    ),
+  ];
+
+  const hash = stableHash32(components.join("||"));
+  return hash.toString(16).padStart(8, "0");
+}
+
+// ============================================================================
+// Debug Visualization
+// ============================================================================
+
+export interface DebugDisplayInfo {
+  npcName: string;
+  state: string;
+  topGoal: string;
+  goalReason: string;
+  trustPlayer: number;
+  fearPlayer: number;
+  factionMood: string;
+  nextAction: string;
+  decisionReason: string;
+  memoryEvents: number;
+  summaries: number;
+  memoryHash: string;
+  learningSuccessRate: string;
+}
+
+/**
+ * Format debug snapshot for display
+ */
+export function formatDebugDisplay(snapshot: NPCBrainDebugSnapshot): DebugDisplayInfo {
+  const memory = snapshot; // Access through snapshot
+  
+  return {
+    npcName: snapshot.npcId, // Would need name from identity
+    state: snapshot.state,
+    topGoal: snapshot.topGoal?.type ?? "none",
+    goalReason: snapshot.topGoal?.reason ?? "no_goal",
+    trustPlayer: getHighestRelationValue(snapshot.relationHighlights, "trust"),
+    fearPlayer: getHighestRelationValue(snapshot.relationHighlights, "fear"),
+    factionMood: "neutral", // Would calculate from faction memory
+    nextAction: snapshot.decision.action,
+    decisionReason: snapshot.decision.reason,
+    memoryEvents: snapshot.recentEvents.length,
+    summaries: 0, // Would count from memory
+    memoryHash: snapshot.memoryHash,
+    learningSuccessRate: `${(snapshot.learningStats.successRate * 100).toFixed(1)}%`,
+  };
+}
+
+/**
+ * Get highest relation value for specific attribute
+ */
+function getHighestRelationValue(relations: NPCRelation[], attr: "trust" | "fear" | "morale"): number {
+  if (relations.length === 0) return 0;
+  
+  return Math.max(...relations.map((r) => r[attr]));
+}
+
+// ============================================================================
+// Replay Verification
+// ============================================================================
+
+export interface ReplayVerificationResult {
+  verified: boolean;
+  expectedHash: string;
+  actualHash: string;
+  differences: string[];
+}
+
+/**
+ * Verify replay by comparing memory hashes
+ */
+export function verifyReplay(
+  previousSnapshot: NPCBrainDebugSnapshot,
+  currentSnapshot: NPCBrainDebugSnapshot,
+  expectedIdentical: boolean = true
+): ReplayVerificationResult {
+  const differences: string[] = [];
+
+  // Check if memory hash matches
+  if (previousSnapshot.memoryHash !== currentSnapshot.memoryHash) {
+    differences.push(
+      `Memory hash changed: ${previousSnapshot.memoryHash} -> ${currentSnapshot.memoryHash}`
+    );
+  }
+
+  // Check if decision matches
+  if (previousSnapshot.decision.action !== currentSnapshot.decision.action) {
+    differences.push(
+      `Decision changed: ${previousSnapshot.decision.action} -> ${currentSnapshot.decision.action}`
+    );
+  }
+
+  // Check if state matches
+  if (previousSnapshot.state !== currentSnapshot.state) {
+    differences.push(`State changed: ${previousSnapshot.state} -> ${currentSnapshot.state}`);
+  }
+
+  // Verify
+  const isExpectedChange = expectedIdentical 
+    ? differences.length === 0 
+    : differences.length > 0;
+
+  return {
+    verified: isExpectedChange,
+    expectedHash: previousSnapshot.memoryHash,
+    actualHash: currentSnapshot.memoryHash,
+    differences,
+  };
+}
+
+// ============================================================================
+// Brain Health Check
+// ============================================================================
+
+export interface BrainHealthResult {
+  healthy: boolean;
+  score: number;
+  issues: string[];
+  recommendations: string[];
+}
+
+/**
+ * Check NPC brain health
+ */
+export function checkBrainHealth(memory: NPCMemoryV3, tick: number): BrainHealthResult {
+  const issues: string[] = [];
+  const recommendations: string[] = [];
+  let score = 100;
+
+  // Check memory bloat
+  if (memory.episodic.length > 200) {
+    issues.push("Episodic memory growing too large");
+    recommendations.push("Run memory compression more frequently");
+    score -= 10;
+  }
+
+  // Check for stale learning
+  const timeSinceLastOutcome = tick - memory.learning.lastOutcomeTick;
+  if (timeSinceLastOutcome > 500 && memory.learning.totalActions > 10) {
+    issues.push("No learning outcomes for a long time");
+    recommendations.push("Ensure NPC is getting feedback on actions");
+    score -= 15;
+  }
+
+  // Check for low success rate
+  if (memory.learning.totalActions > 5) {
+    const successRate = memory.learning.totalSuccesses / memory.learning.totalActions;
+    if (successRate < 0.3) {
+      issues.push(`Low success rate: ${(successRate * 100).toFixed(0)}%`);
+      recommendations.push("Review decision scoring logic");
+      score -= 20;
+    }
+  }
+
+  // Check for no goals
+  if (memory.goals.length === 0) {
+    issues.push("NPC has no active goals");
+    recommendations.push("Assign goals based on NPC role");
+    score -= 5;
+  }
+
+  // Check for excessive fear
+  const maxFear = Math.max(
+    ...Object.values(memory.relations).map((r) => r.fear),
+    0
+  );
+  if (maxFear > 80) {
+    issues.push("NPC has extreme fear of some entity");
+    recommendations.push("Consider resolving the fear source");
+    score -= 10;
+  }
+
+  // Check for no relations
+  if (Object.keys(memory.relations).length === 0 && tick > 100) {
+    issues.push("NPC has no relations despite being active");
+    recommendations.push("NPC should interact with world entities");
+    score -= 5;
+  }
+
+  return {
+    healthy: issues.length === 0,
+    score: Math.max(0, score),
+    issues,
+    recommendations,
+  };
+}
+
+// ============================================================================
+// Debug Export
+// ============================================================================
+
+export interface ExportedDebugState {
+  timestamp: number;
+  tick: number;
+  npcId: string;
+  snapshot: NPCBrainDebugSnapshot;
+  memorySize: number;
+  relations: string[];
+}
+
+/**
+ * Export debug state for external analysis
+ */
+export function exportDebugState(
+  memory: NPCMemoryV3,
+  tick: number,
+  snapshot: NPCBrainDebugSnapshot
+): ExportedDebugState {
+  return {
+    timestamp: Date.now(),
+    tick,
+    npcId: memory.identity.npcId,
+    snapshot,
+    memorySize: memory.episodic.length + memory.semantic.length,
+    relations: Object.keys(memory.relations),
+  };
+}
+
+/**
+ * Generate summary report for NPC
+ */
+export function generateNPCSummaryReport(
+  npcId: string,
+  memory: NPCMemoryV3,
+  tick: number
+): string {
+  const lines: string[] = [];
+  
+  lines.push(`=== NPC Brain Report: ${npcId} ===`);
+  lines.push(`Tick: ${tick}`);
+  lines.push(`Role: ${memory.identity.role} (${memory.identity.profession})`);
+  lines.push(`Home: ${memory.identity.homeRegionId}`);
+  lines.push("");
+  lines.push("Personality:");
+  lines.push(`  Courage: ${memory.identity.courage}`);
+  lines.push(`  Greed: ${memory.identity.greed}`);
+  lines.push(`  Loyalty: ${memory.identity.loyalty}`);
+  lines.push("");
+  
+  if (memory.goals.length > 0) {
+    lines.push("Active Goals:");
+    for (const goal of memory.goals.slice(0, 5)) {
+      lines.push(`  [${goal.priority}] ${goal.type}: ${goal.reason}`);
+    }
+    lines.push("");
+  }
+  
+  lines.push("Memory Stats:");
+  lines.push(`  Episodic: ${memory.episodic.length}`);
+  lines.push(`  Semantic: ${memory.semantic.length}`);
+  lines.push(`  Relations: ${Object.keys(memory.relations).length}`);
+  lines.push("");
+  
+  lines.push("Learning:");
+  lines.push(`  Total Actions: ${memory.learning.totalActions}`);
+  lines.push(`  Success Rate: ${(memory.learning.totalSuccesses / Math.max(1, memory.learning.totalActions) * 100).toFixed(1)}%`);
+  lines.push("");
+  
+  if (memory.faction.factionId) {
+    lines.push("Faction:");
+    lines.push(`  ${memory.faction.factionId} (Rank: ${memory.faction.factionRank})`);
+    lines.push(`  Loyalty: ${memory.faction.loyaltyToFaction}`);
+    lines.push("");
+  }
+  
+  lines.push("Combat:");
+  lines.push(`  Victories: ${memory.combat.victories}`);
+  lines.push(`  Defeats: ${memory.combat.defeats}`);
+  lines.push(`  Flee Threshold: ${(memory.combat.fleeThreshold * 100).toFixed(0)}%`);
+  
+  return lines.join("\n");
+}

--- a/server/src/modules/npc/brain/NPCBrainRunner.ts
+++ b/server/src/modules/npc/brain/NPCBrainRunner.ts
@@ -1,0 +1,329 @@
+/**
+ * NPCBrainRunner — Main Brain Loop Integration
+ * 
+ * Ties together all brain components:
+ * - NPCMemoryV3: Memory types
+ * - NPCObservationBus: World event input
+ * - NPCMemoryScoring: Memory importance
+ * - NPCDecisionEngine: Action selection
+ * - NPCBrainScheduler: Tick-based phases
+ * - NPCMemoryCompression: State management
+ * - NPCBrainDebugSnapshot: Debug support
+ * 
+ * Usage:
+ *   const runner = new NPCBrainRunner();
+ *   const output = runner.runNPCBrain(input);
+ */
+
+import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";
+import type {
+  NPCDecisionInput,
+  NPCDecision,
+  NPCMemoryV3,
+  NPCObservation,
+  NPCWorldSnapshot,
+  NPCBrainOutput,
+  NPCActionType,
+} from "./NPCMemoryV3.js";
+import { createEmptyNPCMemoryV3 } from "./NPCMemoryV3.js";
+import { NPCObservationBus, globalObservationBus } from "./NPCObservationBus.js";
+import {
+  scoreMemory,
+  shouldStoreMemory,
+  observationToEpisodic,
+  applyObservationsToMemory,
+  updateRelationsFromObservation,
+} from "./NPCMemoryScoring.js";
+import { decideNPCAction, applyActionOutcome, calculateOutcomeScore } from "./NPCDecisionEngine.js";
+import {
+  getActivePhases,
+  getBrainState,
+  updateBrainState,
+  BrainPhase,
+  DEFAULT_SCHEDULER_CONFIG,
+  type NPCBrainSchedulerConfig,
+} from "./NPCBrainScheduler.js";
+import {
+  compressNPCMemory,
+  shouldCompress,
+  DEFAULT_COMPRESSION_CONFIG,
+  type MemoryCompressionConfig,
+} from "./NPCMemoryCompression.js";
+import { createNPCBrainDebugSnapshot, type NPCBrainDebugSnapshot } from "./NPCBrainDebugSnapshot.js";
+
+// ============================================================================
+// NPC Brain Runner
+// ============================================================================
+
+export class NPCBrainRunner {
+  private observationBus: NPCObservationBus;
+  private lastCompressionTicks: Map<string, number> = new Map();
+  private config: NPCBrainSchedulerConfig;
+  private compressionConfig: MemoryCompressionConfig;
+
+  constructor(
+    observationBus: NPCObservationBus = globalObservationBus,
+    config?: Partial<NPCBrainSchedulerConfig>,
+    compressionConfig?: Partial<MemoryCompressionConfig>
+  ) {
+    this.observationBus = observationBus;
+    this.config = { ...DEFAULT_SCHEDULER_CONFIG, ...config };
+    this.compressionConfig = { ...DEFAULT_COMPRESSION_CONFIG, ...compressionConfig };
+  }
+
+  /**
+   * Run NPC brain tick
+   */
+  runNPCBrain(input: NPCDecisionInput): NPCBrainOutput {
+    const { tick, npcId, memory } = input;
+    
+    // Get active phases for this tick
+    const phases = getActivePhases(npcId, tick, this.config);
+    
+    // Track current state
+    const state = getBrainState(npcId);
+
+    // ─── PHASE 1: TICK (10 Hz) ────────────────────────────────────────────────
+    // Light operations: get observations, check danger
+
+    // Get observations for this NPC
+    const observations = this.observationBus.getObservationsForNPC(npcId, memory);
+
+    // Apply observations to memory
+    let updatedMemory = applyObservationsToMemory(memory, observations, tick);
+
+    // Update relations from observations
+    for (const obs of observations) {
+      updatedMemory = {
+        ...updatedMemory,
+        relations: updateRelationsFromObservation(updatedMemory.relations, obs, tick),
+      };
+    }
+
+    // ─── PHASE 2: DECISION (1 Hz) ─────────────────────────────────────────────
+    
+    let decision: NPCDecision | null = null;
+    
+    if (phases.includes(BrainPhase.DECISION)) {
+      // Make decision
+      decision = decideNPCAction(input);
+      
+      // Update brain state
+      updateBrainState(npcId, decision, tick);
+    }
+
+    // ─── PHASE 3: PLANNING (0.1 Hz) ───────────────────────────────────────────
+
+    const lastCompressionTick = this.lastCompressionTicks.get(npcId) ?? 0;
+    
+    if (phases.includes(BrainPhase.PLANNING) && shouldCompress(npcId, tick, lastCompressionTick, this.compressionConfig)) {
+      // Compress memory
+      updatedMemory = compressNPCMemory(updatedMemory, tick, this.compressionConfig);
+      this.lastCompressionTicks.set(npcId, tick);
+    }
+
+    // ─── Calculate Next State ─────────────────────────────────────────────────
+
+    const nextState = decisionToState(decision);
+
+    // ─── Calculate Memory Hash ────────────────────────────────────────────────
+
+    const memoryHash = this.calculateMemoryHash(updatedMemory);
+
+    return {
+      npcId,
+      tick,
+      nextState,
+      decision: decision ?? { action: "idle", reason: "no_decision", score: 0, confidence: 0 },
+      memory: updatedMemory,
+      memoryHash,
+    };
+  }
+
+  /**
+   * Run NPC brain with full context (for Ouroboros integration)
+   */
+  runWithContext(params: {
+    npcId: string;
+    npcName: string;
+    position: { x: number; y: number };
+    homeRegionId: string;
+    factionId?: string;
+    state: string;
+    health: number;
+    energy: number;
+    gold: number;
+    memory: NPCMemoryV3;
+    nearbyEntities: Array<{
+      id: string;
+      name: string;
+      type: "player" | "npc" | "monster";
+      position: { x: number; y: number };
+      faction?: string;
+      hostile?: boolean;
+    }>;
+    tick: number;
+    worldSnapshot: NPCWorldSnapshot;
+  }): NPCBrainOutput {
+    const input: NPCDecisionInput = {
+      tick: params.tick,
+      npcId: params.npcId,
+      npcName: params.npcName,
+      position: params.position,
+      homeRegionId: params.homeRegionId,
+      factionId: params.factionId,
+      state: params.state,
+      health: params.health,
+      energy: params.energy,
+      gold: params.gold,
+      memory: params.memory,
+      world: params.worldSnapshot,
+      nearbyEntities: params.nearbyEntities,
+    };
+
+    return this.runNPCBrain(input);
+  }
+
+  /**
+   * Apply action outcome for learning
+   */
+  applyLearning(
+    memory: NPCMemoryV3,
+    action: NPCActionType,
+    result: {
+      success: boolean;
+      damageDealt?: number;
+      damageTaken?: number;
+      goldGained?: number;
+      goldSpent?: number;
+      socialGain?: number;
+    },
+    contextKey: string,
+    tick: number
+  ): NPCMemoryV3 {
+    const outcomeScore = calculateOutcomeScore(action, result);
+    return applyActionOutcome(memory, action, contextKey, outcomeScore, tick);
+  }
+
+  /**
+   * Get debug snapshot
+   */
+  getDebugSnapshot(
+    npcId: string,
+    tick: number,
+    state: string,
+    memory: NPCMemoryV3,
+    decision: NPCDecision | null
+  ): NPCBrainDebugSnapshot {
+    return createNPCBrainDebugSnapshot(npcId, tick, state, memory, decision);
+  }
+
+  /**
+   * Calculate memory hash for verification
+   */
+  private calculateMemoryHash(memory: NPCMemoryV3): string {
+    const components = [
+      memory.identity.npcId,
+      memory.identity.homeRegionId,
+      memory.goals.length,
+      memory.episodic.length,
+      memory.semantic.length,
+      Object.keys(memory.relations).length,
+      JSON.stringify(
+        Object.entries(memory.learning.actionScores)
+          .sort((a, b) => a[0].localeCompare(b[0]))
+          .slice(0, 10)
+      ),
+    ];
+
+    const hash = stableHash32(components.join("||"));
+    return hash.toString(16).padStart(8, "0");
+  }
+
+  /**
+   * Get scheduler statistics
+   */
+  getStats(): {
+    observationBusStats: ReturnType<NPCObservationBus["getStats"]>;
+    compressionStats: {
+      totalCompressed: number;
+      lastCompressionTicks: number;
+    };
+  } {
+    return {
+      observationBusStats: this.observationBus.getStats(),
+      compressionStats: {
+        totalCompressed: this.lastCompressionTicks.size,
+        lastCompressionTicks: [...this.lastCompressionTicks.values()].length,
+      },
+    };
+  }
+
+  /**
+   * Reset all state (for testing or world reset)
+   */
+  reset(): void {
+    this.lastCompressionTicks.clear();
+    this.observationBus.clearHistory();
+  }
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Convert decision to NPC state string
+ */
+export function decisionToState(decision: NPCDecision | null): string {
+  if (!decision) return "idle";
+
+  const actionStateMap: Record<NPCActionType, string> = {
+    idle: "idle",
+    talk: "social",
+    trade: "trading",
+    flee: "idle",
+    attack: "combat",
+    patrol: "wandering",
+    work: "collecting",
+    gather: "collecting",
+    craft: "collecting",
+    join_guild: "social",
+    vote: "social",
+    raise_alarm: "combat",
+    move_city: "wandering",
+    hire_guard: "social",
+    start_caravan: "trading",
+    explore: "wandering",
+    social: "social",
+    defend: "combat",
+  };
+
+  return actionStateMap[decision.action] ?? "idle";
+}
+
+/**
+ * Create default world snapshot
+ */
+export function createDefaultWorldSnapshot(
+  tick: number,
+  regionId: string
+): NPCWorldSnapshot {
+  return {
+    tick,
+    regionId,
+    timeOfDay: (tick % 1000) / 1000 * 24, // 0-24 hours
+    dangerLevel: 0.1,
+    resourceAvailability: {},
+    marketPrices: {},
+    nearbyThreats: [],
+    friendlyNPCs: [],
+    hostileNPCs: [],
+  };
+}
+
+// ============================================================================
+// Global Runner Instance
+// ============================================================================
+
+export const globalNPCBrainRunner = new NPCBrainRunner();

--- a/server/src/modules/npc/brain/NPCBrainScheduler.ts
+++ b/server/src/modules/npc/brain/NPCBrainScheduler.ts
@@ -1,0 +1,384 @@
+/**
+ * NPCBrainScheduler — Tick-Based Brain Execution Framework
+ * 
+ * Manages NPC brain execution across different tick intervals:
+ * - 10 Hz (every tick): Light movement and danger checks
+ * - 1 Hz (every 10 ticks): Decision updates, goal scoring, relation updates
+ * - 0.1 Hz (every 100 ticks): Memory compression, routine planning, economy/politics
+ * 
+ * Uses stable hash distribution to spread CPU load deterministically:
+ * - Same NPC always runs brain at same ticks
+ * - No random() - fully deterministic for replay
+ */
+
+import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";
+import type { NPCMemoryV3, NPCBrainOutput, NPCDecision } from "./NPCMemoryV3.js";
+
+// ============================================================================
+// Brain Phases
+// ============================================================================
+
+export enum BrainPhase {
+  /** 10 Hz - Light operations: movement, danger check */
+  TICK = 1,
+  /** 1 Hz - Moderate operations: decisions, goals, relations */
+  DECISION = 10,
+  /** 0.1 Hz - Heavy operations: compression, planning, economy */
+  PLANNING = 100,
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+export interface NPCBrainSchedulerConfig {
+  /** Ticks between decision phase runs */
+  decisionInterval: number;
+  /** Ticks between planning phase runs */
+  planningInterval: number;
+  /** Maximum NPCs to process per planning phase */
+  maxPlanningBatch: number;
+  /** Enable debug logging */
+  debug: boolean;
+}
+
+export const DEFAULT_SCHEDULER_CONFIG: NPCBrainSchedulerConfig = {
+  decisionInterval: 10, // 1 Hz at 10 ticks/sec
+  planningInterval: 100, // 0.1 Hz
+  maxPlanningBatch: 50,
+  debug: false,
+};
+
+// ============================================================================
+// NPC Brain State Tracking
+// ============================================================================
+
+export interface NPCBrainState {
+  npcId: string;
+  lastDecisionTick: number;
+  lastPlanningTick: number;
+  currentAction: string;
+  actionStartTick: number;
+  consecutiveIdleTicks: number;
+  phaseModulo: number; // Deterministic offset for load distribution
+}
+
+const brainStates = new Map<string, NPCBrainState>();
+
+// ============================================================================
+// Phase Calculation
+// ============================================================================
+
+/**
+ * Get NPC's deterministic phase offset (0 to interval-1)
+ * This ensures NPCs are distributed across the tick cycle
+ */
+export function getNPCBrainPhase(npcId: string, interval: number): number {
+  const hash = stableHash32(npcId);
+  return hash % interval;
+}
+
+/**
+ * Check if NPC should run brain at current tick
+ * Uses stable hash for deterministic scheduling
+ */
+export function shouldRunBrainPhase(
+  npcId: string,
+  currentTick: number,
+  interval: number
+): boolean {
+  const phase = getNPCBrainPhase(npcId, interval);
+  return currentTick % interval === phase;
+}
+
+/**
+ * Get all phases that should run at current tick
+ */
+export function getActivePhases(
+  npcId: string,
+  currentTick: number,
+  config: NPCBrainSchedulerConfig = DEFAULT_SCHEDULER_CONFIG
+): BrainPhase[] {
+  const phases: BrainPhase[] = [];
+
+  // Always run tick phase (light operations)
+  phases.push(BrainPhase.TICK);
+
+  // Check decision phase
+  if (shouldRunBrainPhase(npcId, currentTick, config.decisionInterval)) {
+    phases.push(BrainPhase.DECISION);
+  }
+
+  // Check planning phase
+  if (shouldRunBrainPhase(npcId, currentTick, config.planningInterval)) {
+    phases.push(BrainPhase.PLANNING);
+  }
+
+  return phases;
+}
+
+// ============================================================================
+// Brain State Management
+// ============================================================================
+
+/**
+ * Get or create brain state for NPC
+ */
+export function getBrainState(npcId: string): NPCBrainState {
+  let state = brainStates.get(npcId);
+  if (!state) {
+    state = {
+      npcId,
+      lastDecisionTick: 0,
+      lastPlanningTick: 0,
+      currentAction: "idle",
+      actionStartTick: 0,
+      consecutiveIdleTicks: 0,
+      phaseModulo: getNPCBrainPhase(npcId, 1000),
+    };
+    brainStates.set(npcId, state);
+  }
+  return state;
+}
+
+/**
+ * Update brain state after decision
+ */
+export function updateBrainState(
+  npcId: string,
+  decision: NPCDecision,
+  currentTick: number
+): void {
+  const state = getBrainState(npcId);
+  
+  if (decision.action === "idle") {
+    state.consecutiveIdleTicks++;
+  } else {
+    state.consecutiveIdleTicks = 0;
+    state.currentAction = decision.action;
+    state.actionStartTick = currentTick;
+  }
+
+  // Check if decision phase just ran
+  if (shouldRunBrainPhase(npcId, currentTick, 10)) {
+    state.lastDecisionTick = currentTick;
+  }
+
+  // Check if planning phase just ran
+  if (shouldRunBrainPhase(npcId, currentTick, 100)) {
+    state.lastPlanningTick = currentTick;
+  }
+}
+
+/**
+ * Remove NPC from brain state tracking
+ */
+export function forgetBrainState(npcId: string): void {
+  brainStates.delete(npcId);
+}
+
+/**
+ * Get all NPC IDs that need planning this tick
+ */
+export function getNPCsForPlanning(
+  currentTick: number,
+  allNPCIds: string[],
+  config: NPCBrainSchedulerConfig = DEFAULT_SCHEDULER_CONFIG
+): string[] {
+  const candidates: string[] = [];
+  
+  for (const npcId of allNPCIds) {
+    if (shouldRunBrainPhase(npcId, currentTick, config.planningInterval)) {
+      candidates.push(npcId);
+    }
+  }
+
+  // Limit batch size
+  return candidates.slice(0, config.maxPlanningBatch);
+}
+
+// ============================================================================
+// Brain Execution
+// ============================================================================
+
+export type BrainTickFn = (
+  npcId: string,
+  tick: number,
+  phase: BrainPhase
+) => void | Promise<void>;
+
+export interface BrainExecutionContext {
+  npcId: string;
+  tick: number;
+  memory: NPCMemoryV3;
+}
+
+/**
+ * Execute brain tick for single NPC
+ */
+export async function executeBrainTick(
+  context: BrainExecutionContext,
+  phases: BrainPhase[],
+  config: NPCBrainSchedulerConfig = DEFAULT_SCHEDULER_CONFIG
+): Promise<{
+  decision: NPCDecision | null;
+  decisionTick: number;
+  planningTick: number;
+}> {
+  const { npcId, tick, memory } = context;
+  const state = getBrainState(npcId);
+
+  let decision: NPCDecision | null = null;
+  const decisionTick = state.lastDecisionTick;
+  const planningTick = state.lastPlanningTick;
+
+  for (const phase of phases) {
+    if (config.debug) {
+      console.log(`[NPCBrain] ${npcId} phase ${phase} at tick ${tick}`);
+    }
+
+    switch (phase) {
+      case BrainPhase.TICK:
+        // Light operations happen every tick
+        // Movement is handled by game systems
+        // Just update state tracking
+        break;
+
+      case BrainPhase.DECISION:
+        // Decision was already calculated, just update state
+        if (state.currentAction) {
+          // Check if action duration exceeded reasonable limit
+          const actionDuration = tick - state.actionStartTick;
+          if (actionDuration > 50) {
+            // Force new decision
+            state.consecutiveIdleTicks++;
+          }
+        }
+        break;
+
+      case BrainPhase.PLANNING:
+        // Heavy operations
+        // Memory compression, routine planning handled externally
+        break;
+    }
+  }
+
+  return { decision, decisionTick, planningTick };
+}
+
+// ============================================================================
+// Scheduling Statistics
+// ============================================================================
+
+export interface SchedulerStats {
+  totalNPCs: number;
+  activeDecisionNPCs: number;
+  activePlanningNPCs: number;
+  idleNPCs: number;
+  averageActionDuration: number;
+}
+
+/**
+ * Get scheduler statistics
+ */
+export function getSchedulerStats(): SchedulerStats {
+  let activeDecisionNPCs = 0;
+  let activePlanningNPCs = 0;
+  let idleNPCs = 0;
+  let totalActionDuration = 0;
+
+  for (const state of brainStates.values()) {
+    if (state.consecutiveIdleTicks > 10) {
+      idleNPCs++;
+    } else if (state.lastPlanningTick > state.lastDecisionTick) {
+      activePlanningNPCs++;
+    } else if (state.lastDecisionTick > 0) {
+      activeDecisionNPCs++;
+    }
+
+    totalActionDuration += Date.now() - state.actionStartTick;
+  }
+
+  return {
+    totalNPCs: brainStates.size,
+    activeDecisionNPCs,
+    activePlanningNPCs,
+    idleNPCs,
+    averageActionDuration: brainStates.size > 0 
+      ? totalActionDuration / brainStates.size 
+      : 0,
+  };
+}
+
+/**
+ * Reset scheduler state (for testing or world reset)
+ */
+export function resetScheduler(): void {
+  brainStates.clear();
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Calculate optimal tick intervals for target Hz
+ */
+export function calculateTickIntervals(targetHz: {
+  tick: number;
+  decision: number;
+  planning: number;
+}): NPCBrainSchedulerConfig {
+  return {
+    decisionInterval: Math.max(1, Math.round(10 / targetHz.decision)),
+    planningInterval: Math.max(10, Math.round(10 / targetHz.planning)),
+    maxPlanningBatch: 50,
+    debug: false,
+  };
+}
+
+/**
+ * Get next tick when NPC will run decision phase
+ */
+export function getNextDecisionTick(npcId: string, currentTick: number): number {
+  const phase = getNPCBrainPhase(npcId, 10);
+  if (currentTick % 10 > phase) {
+    return currentTick + (10 - (currentTick % 10)) + phase;
+  }
+  return currentTick + (phase - (currentTick % 10));
+}
+
+/**
+ * Get next tick when NPC will run planning phase
+ */
+export function getNextPlanningTick(npcId: string, currentTick: number): number {
+  const phase = getNPCBrainPhase(npcId, 100);
+  if (currentTick % 100 > phase) {
+    return currentTick + (100 - (currentTick % 100)) + phase;
+  }
+  return currentTick + (phase - (currentTick % 100));
+}
+
+/**
+ * Estimate CPU load from scheduling
+ */
+export function estimateCPULoad(
+  npcCount: number,
+  config: NPCBrainSchedulerConfig = DEFAULT_SCHEDULER_CONFIG
+): {
+  tickOpsPerSecond: number;
+  decisionOpsPerSecond: number;
+  planningOpsPerSecond: number;
+  totalOpsPerSecond: number;
+} {
+  const tickOpsPerSecond = npcCount * 10; // Every tick
+  const decisionOpsPerSecond = npcCount * (10 / config.decisionInterval);
+  const planningOpsPerSecond = npcCount * (10 / config.planningInterval);
+
+  return {
+    tickOpsPerSecond,
+    decisionOpsPerSecond,
+    planningOpsPerSecond,
+    totalOpsPerSecond: tickOpsPerSecond + decisionOpsPerSecond + planningOpsPerSecond,
+  };
+}

--- a/server/src/modules/npc/brain/NPCDecisionEngine.ts
+++ b/server/src/modules/npc/brain/NPCDecisionEngine.ts
@@ -1,0 +1,765 @@
+/**
+ * NPCDecisionEngine — Deterministic Utility-Based Decision Making
+ * 
+ * NPCs evaluate all possible actions and select the highest-scoring one.
+ * All decisions are deterministic: same tick + same input = same output.
+ * 
+ * Decision flow:
+ * 1. Gather candidates (all possible actions)
+ * 2. Score each action based on context, memory, and personality
+ * 3. Select highest-scoring action (with tie-breaker by alphabetical order)
+ * 4. Return decision with reason and confidence
+ */
+
+import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";
+import type {
+  NPCDecisionInput,
+  NPCDecision,
+  NPCActionType,
+  NPCMemoryV3,
+  NPCWorldSnapshot,
+  NPCGoal,
+  NPCRelation,
+} from "./NPCMemoryV3.js";
+import { calculateRelationScore, calculateThreatLevel } from "./NPCMemoryScoring.js";
+
+// ============================================================================
+// Decision Constants
+// ============================================================================
+
+const DECISION = {
+  // Base scores for actions
+  ATTACK_BASE: 20,
+  FLEE_BASE: 25,
+  TRADE_BASE: 15,
+  WORK_BASE: 10,
+  SOCIAL_BASE: 8,
+  IDLE_BASE: 5,
+  PATROL_BASE: 12,
+  GATHER_BASE: 10,
+  CRAFT_BASE: 10,
+  EXPLORE_BASE: 7,
+  DEFEND_BASE: 18,
+  RAISE_ALARM_BASE: 22,
+  HIRE_GUARD_BASE: 15,
+  START_CARAVAN_BASE: 14,
+  JOIN_GUILD_BASE: 12,
+  VOTE_BASE: 10,
+  MOVE_CITY_BASE: 8,
+  TALK_BASE: 6,
+
+  // Personality modifiers
+  HIGH_COURAGE_MULTIPLIER: 1.5,
+  HIGH_GREED_MULTIPLIER: 1.3,
+  LOW_LOYALTY_THRESHOLD: 30,
+
+  // Relation thresholds
+  HOSTILE_THRESHOLD: -30,
+  FRIENDLY_THRESHOLD: 30,
+  FEAR_THRESHOLD: 60,
+
+  // Context modifiers
+  DANGER_MODIFIER: 0.8,
+  LOW_HEALTH_THRESHOLD: 0.3,
+  LOW_ENERGY_THRESHOLD: 0.3,
+  HIGH_WEALTH_THRESHOLD: 80,
+
+  // Goal priority weights
+  GOAL_MATCH_BONUS: 15,
+  GOAL_MISMATCH_PENALTY: 10,
+};
+
+// ============================================================================
+// Score Calculation Functions
+// ============================================================================
+
+/**
+ * Calculate action score based on context
+ */
+function scoreAction(
+  baseScore: number,
+  context: {
+    memory: NPCMemoryV3;
+    world: NPCWorldSnapshot;
+    health: number;
+    energy: number;
+    gold: number;
+    nearbyHostiles: number;
+    nearbyFriendlies: number;
+    threatLevel: number;
+    safetyLevel: number;
+  }
+): number {
+  let score = baseScore;
+
+  // Health modifier
+  if (context.health < DECISION.LOW_HEALTH_THRESHOLD) {
+    score *= 0.5;
+  }
+
+  // Energy modifier
+  if (context.energy < DECISION.LOW_ENERGY_THRESHOLD) {
+    score *= 0.6;
+  }
+
+  // Personality: courage
+  if (context.memory.identity.courage > 70) {
+    score *= DECISION.HIGH_COURAGE_MULTIPLIER;
+  }
+
+  // Personality: greed
+  if (context.memory.identity.greed > 70) {
+    score *= DECISION.HIGH_GREED_MULTIPLIER;
+  }
+
+  // Danger level modifier
+  score *= (1 - context.threatLevel * DECISION.DANGER_MODIFIER);
+
+  // Safety requirement
+  score *= context.safetyLevel;
+
+  return Math.max(0, Math.trunc(score));
+}
+
+/**
+ * Get top goal from memory
+ */
+function getTopGoal(memory: NPCMemoryV3): NPCGoal | undefined {
+  if (memory.goals.length === 0) return undefined;
+  
+  return [...memory.goals]
+    .sort((a, b) => {
+      if (b.priority !== a.priority) return b.priority - a.priority;
+      return a.id.localeCompare(b.id);
+    })[0];
+}
+
+/**
+ * Get hostile entities in nearby
+ */
+function getHostileEntities(
+  input: NPCDecisionInput
+): Array<{ id: string; name: string; position: { x: number; y: number } }> {
+  return input.nearbyEntities.filter((e) => e.hostile);
+}
+
+/**
+ * Get friendly entities in nearby
+ */
+function getFriendlyEntities(
+  input: NPCDecisionInput
+): Array<{ id: string; name: string; position: { x: number; y: number } }> {
+  return input.nearbyEntities.filter((e) => !e.hostile);
+}
+
+/**
+ * Check if NPC should flee from current threat
+ */
+function shouldFlee(input: NPCDecisionInput, threatLevel: number): boolean {
+  const hostileCount = getHostileEntities(input).length;
+  const npcFear = input.memory.identity.courage < 40;
+  
+  return (
+    threatLevel > 0.5 ||
+    (hostileCount > 2 && npcFear) ||
+    input.health < 0.3
+  );
+}
+
+// ============================================================================
+// Action Scorers
+// ============================================================================
+
+/**
+ * Score flee action
+ */
+function scoreFlee(input: NPCDecisionInput): NPCDecision | null {
+  const hostiles = getHostileEntities(input);
+  if (hostiles.length === 0) return null;
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: hostiles.length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: calculateThreatLevel([], input.npcId),
+    safetyLevel: 0.5,
+  };
+
+  // Calculate distance to safe zone (simplified)
+  const nearestHostile = hostiles[0];
+  const distanceScore = nearestHostile
+    ? Math.max(0, 50 - Math.sqrt(
+        Math.pow(nearestHostile.position.x - input.position.x, 2) +
+        Math.pow(nearestHostile.position.y - input.position.y, 2)
+      ))
+    : 0;
+
+  const baseScore = DECISION.FLEE_BASE + distanceScore;
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "flee",
+    targetId: nearestHostile?.id,
+    reason: `flee_from:${hostiles.length}:hostiles`,
+    score: finalScore,
+    confidence: 0.8,
+  };
+}
+
+/**
+ * Score attack action
+ */
+function scoreAttack(input: NPCDecisionInput): NPCDecision | null {
+  const hostiles = getHostileEntities(input);
+  if (hostiles.length === 0) return null;
+
+  // High courage required for attack
+  if (input.memory.identity.courage < 50) return null;
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: hostiles.length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: calculateThreatLevel([], input.npcId),
+    safetyLevel: 0.7,
+  };
+
+  // Check combat memory - avoid enemies that hurt us before
+  const avoidedEnemies = input.memory.combat.avoidedEnemies;
+  const safeHostiles = hostiles.filter((h) => !avoidedEnemies.includes(h.id));
+
+  if (safeHostiles.length === 0) return null;
+
+  const baseScore = DECISION.ATTACK_BASE - hostiles.length * 3;
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "attack",
+    targetId: safeHostiles[0]?.id,
+    reason: `attack:${safeHostiles[0]?.name ?? "unknown"}`,
+    score: finalScore,
+    confidence: 0.7,
+  };
+}
+
+/**
+ * Score defend action (guard, protect)
+ */
+function scoreDefend(input: NPCDecisionInput): NPCDecision | null {
+  // Only guards and soldiers should defend
+  const validRoles = ["guard", "soldier", "knight", "watchman", "protector"];
+  if (!validRoles.includes(input.memory.identity.role.toLowerCase())) {
+    return null;
+  }
+
+  const hostiles = getHostileEntities(input);
+  const friendlies = getFriendlyEntities(input);
+
+  // Defend if there are friendlies to protect
+  if (friendlies.length === 0 && hostiles.length === 0) return null;
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: hostiles.length,
+    nearbyFriendlies: friendlies.length,
+    threatLevel: input.world.dangerLevel,
+    safetyLevel: 0.8,
+  };
+
+  const baseScore = DECISION.DEFEND_BASE + friendlies.length * 5;
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "defend",
+    targetId: friendlies[0]?.id,
+    reason: `defend:${friendlies[0]?.name ?? "area"}`,
+    score: finalScore,
+    confidence: 0.85,
+  };
+}
+
+/**
+ * Score trade action
+ */
+function scoreTrade(input: NPCDecisionInput): NPCDecision | null {
+  // Merchants and traders prefer trading
+  const merchantRoles = ["merchant", "trader", "shopkeeper", "vendor"];
+  const isMerchant = merchantRoles.some((r) => 
+    input.memory.identity.profession.toLowerCase().includes(r) ||
+    input.memory.identity.role.toLowerCase().includes(r)
+  );
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: getHostileEntities(input).length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: input.world.dangerLevel,
+    safetyLevel: 0.9,
+  };
+
+  let baseScore = DECISION.TRADE_BASE;
+  
+  // Merchants get bonus
+  if (isMerchant) {
+    baseScore *= 1.5;
+  }
+
+  // Low gold increases trade desire
+  if (input.gold < 20) {
+    baseScore *= 1.3;
+  }
+
+  // High gold decreases trade desire
+  if (input.gold > DECISION.HIGH_WEALTH_THRESHOLD) {
+    baseScore *= 0.7;
+  }
+
+  // Check market prices
+  const avgPrice = Object.values(input.world.marketPrices).reduce((a, b) => a + b, 0) / 
+    Math.max(1, Object.keys(input.world.marketPrices).length);
+  if (avgPrice > 50) {
+    baseScore *= 1.2; // Good prices = more trading
+  }
+
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "trade",
+    reason: isMerchant ? "merchant_trade" : "seeking_trade",
+    score: finalScore,
+    confidence: isMerchant ? 0.9 : 0.6,
+  };
+}
+
+/**
+ * Score work action
+ */
+function scoreWork(input: NPCDecisionInput): NPCDecision | null {
+  // Everyone can work, but it's baseline
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: getHostileEntities(input).length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: input.world.dangerLevel,
+    safetyLevel: 0.8,
+  };
+
+  // Low energy = less work
+  if (input.energy < DECISION.LOW_ENERGY_THRESHOLD) {
+    return null;
+  }
+
+  // High wealth = less work motivation
+  const baseScore = input.gold > DECISION.HIGH_WEALTH_THRESHOLD 
+    ? DECISION.WORK_BASE * 0.5 
+    : DECISION.WORK_BASE;
+
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "work",
+    reason: `work_in:${input.memory.identity.homeRegionId}`,
+    score: finalScore,
+    confidence: 0.7,
+  };
+}
+
+/**
+ * Score patrol action
+ */
+function scorePatrol(input: NPCDecisionInput): NPCDecision | null {
+  // Guards and soldiers patrol
+  const validRoles = ["guard", "soldier", "watchman", "ranger", "knight"];
+  if (!validRoles.some((r) => input.memory.identity.role.toLowerCase().includes(r))) {
+    return null;
+  }
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: getHostileEntities(input).length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: input.world.dangerLevel,
+    safetyLevel: 0.7,
+  };
+
+  // High danger = more patrol urgency
+  const baseScore = DECISION.PATROL_BASE + input.world.dangerLevel * 10;
+
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "patrol",
+    reason: `patrol:${input.memory.identity.homeRegionId}`,
+    score: finalScore,
+    confidence: 0.8,
+  };
+}
+
+/**
+ * Score social action
+ */
+function scoreSocial(input: NPCDecisionInput): NPCDecision | null {
+  const friendlies = getFriendlyEntities(input);
+  if (friendlies.length === 0) return null;
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: getHostileEntities(input).length,
+    nearbyFriendlies: friendlies.length,
+    threatLevel: input.world.dangerLevel,
+    safetyLevel: 0.9,
+  };
+
+  const baseScore = DECISION.SOCIAL_BASE + friendlies.length * 2;
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "social",
+    targetId: friendlies[0]?.id,
+    reason: `socialize_with:${friendlies[0]?.name ?? "unknown"}`,
+    score: finalScore,
+    confidence: 0.6,
+  };
+}
+
+/**
+ * Score explore action
+ */
+function scoreExplore(input: NPCDecisionInput): NPCDecision | null {
+  // Only if not too dangerous
+  if (input.world.dangerLevel > 0.5) return null;
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: getHostileEntities(input).length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: input.world.dangerLevel,
+    safetyLevel: 0.6,
+  };
+
+  const baseScore = DECISION.EXPLORE_BASE;
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "explore",
+    reason: `explore_region:${input.world.regionId}`,
+    score: finalScore,
+    confidence: 0.5,
+  };
+}
+
+/**
+ * Score raise alarm action
+ */
+function scoreRaiseAlarm(input: NPCDecisionInput): NPCDecision | null {
+  const hostiles = getHostileEntities(input);
+  
+  // Only raise alarm if there's a real threat
+  if (hostiles.length === 0) return null;
+
+  // Guards and soldiers can raise alarm
+  const validRoles = ["guard", "soldier", "watchman", "knight", "town_crier"];
+  if (!validRoles.some((r) => input.memory.identity.role.toLowerCase().includes(r))) {
+    return null;
+  }
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: hostiles.length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: 1,
+    safetyLevel: 0.9,
+  };
+
+  const baseScore = DECISION.RAISE_ALARM_BASE + hostiles.length * 5;
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "raise_alarm",
+    reason: `alarm:${hostiles.length}:hostiles_detected`,
+    score: finalScore,
+    confidence: 0.95,
+  };
+}
+
+/**
+ * Score hire guard action
+ */
+function scoreHireGuard(input: NPCDecisionInput): NPCDecision | null {
+  // Only if scared and have gold
+  if (input.gold < 30) return null;
+
+  // Check fear level from relations
+  const avgFear = Object.values(input.memory.relations)
+    .reduce((sum, r) => sum + r.fear, 0) / Math.max(1, Object.keys(input.memory.relations).length);
+
+  if (avgFear < DECISION.FEAR_THRESHOLD) return null;
+
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: getHostileEntities(input).length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: input.world.dangerLevel,
+    safetyLevel: 0.5,
+  };
+
+  const baseScore = DECISION.HIRE_GUARD_BASE + avgFear / 10;
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "hire_guard",
+    reason: `hire_guard:fear:${avgFear.toFixed(0)}`,
+    score: finalScore,
+    confidence: 0.7,
+  };
+}
+
+/**
+ * Score idle action (default fallback)
+ */
+function scoreIdle(input: NPCDecisionInput): NPCDecision {
+  const context = {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: getHostileEntities(input).length,
+    nearbyFriendlies: getFriendlyEntities(input).length,
+    threatLevel: input.world.dangerLevel,
+    safetyLevel: 0.6,
+  };
+
+  const baseScore = DECISION.IDLE_BASE;
+  const finalScore = scoreAction(baseScore, context);
+
+  return {
+    action: "idle",
+    reason: "no_better_action_available",
+    score: finalScore,
+    confidence: 0.3,
+  };
+}
+
+// ============================================================================
+// Main Decision Function
+// ============================================================================
+
+/**
+ * Decide NPC action deterministically
+ */
+export function decideNPCAction(input: NPCDecisionInput): NPCDecision {
+  const candidates: NPCDecision[] = [];
+
+  // Collect all possible action candidates
+  const actions = [
+    scoreFlee,
+    scoreAttack,
+    scoreDefend,
+    scoreTrade,
+    scoreWork,
+    scorePatrol,
+    scoreSocial,
+    scoreExplore,
+    scoreRaiseAlarm,
+    scoreHireGuard,
+  ];
+
+  for (const scorer of actions) {
+    const decision = scorer(input);
+    if (decision) {
+      candidates.push(decision);
+    }
+  }
+
+  // Add idle as fallback
+  candidates.push(scoreIdle(input));
+
+  // Sort by score (descending), then by action name (ascending) for determinism
+  candidates.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.action.localeCompare(b.action);
+  });
+
+  // Return highest scoring action
+  return candidates[0] ?? {
+    action: "idle",
+    reason: "fallback",
+    score: 0,
+    confidence: 0,
+  };
+}
+
+/**
+ * Get decision context for scoring
+ */
+export function buildDecisionContext(input: NPCDecisionInput): {
+  memory: NPCMemoryV3;
+  world: NPCWorldSnapshot;
+  health: number;
+  energy: number;
+  gold: number;
+  nearbyHostiles: number;
+  nearbyFriendlies: number;
+  threatLevel: number;
+  safetyLevel: number;
+} {
+  return {
+    memory: input.memory,
+    world: input.world,
+    health: input.health,
+    energy: input.energy,
+    gold: input.gold,
+    nearbyHostiles: input.nearbyEntities.filter((e) => e.hostile).length,
+    nearbyFriendlies: input.nearbyEntities.filter((e) => !e.hostile).length,
+    threatLevel: calculateThreatLevel([], input.npcId),
+    safetyLevel: 0.7,
+  };
+}
+
+/**
+ * Apply learning from action outcome
+ */
+export function applyActionOutcome(
+  memory: NPCMemoryV3,
+  action: NPCActionType,
+  contextKey: string,
+  outcomeScore: number,
+  tick: number
+): NPCMemoryV3 {
+  const actionKey = `action:${action}`;
+  
+  const oldActionScore = memory.learning.actionScores[actionKey] ?? 0;
+  const oldContextScore = memory.learning.contextScores[contextKey] ?? 0;
+
+  // Exponential moving average with 0.85 retention
+  const nextActionScore = Math.trunc(oldActionScore * 0.85 + outcomeScore * 0.15);
+  const nextContextScore = Math.trunc(oldContextScore * 0.85 + outcomeScore * 0.15);
+
+  const updatedLearning = {
+    ...memory.learning,
+    actionScores: {
+      ...memory.learning.actionScores,
+      [actionKey]: nextActionScore,
+    },
+    contextScores: {
+      ...memory.learning.contextScores,
+      [contextKey]: nextContextScore,
+    },
+    successfulActions: outcomeScore > 0
+      ? {
+          ...memory.learning.successfulActions,
+          [actionKey]: (memory.learning.successfulActions[actionKey] ?? 0) + 1,
+        }
+      : memory.learning.successfulActions,
+    failedActions: outcomeScore < 0
+      ? {
+          ...memory.learning.failedActions,
+          [actionKey]: (memory.learning.failedActions[actionKey] ?? 0) + 1,
+        }
+      : memory.learning.failedActions,
+    lastOutcomeTick: tick,
+    totalActions: memory.learning.totalActions + 1,
+    totalSuccesses: outcomeScore > 0 
+      ? memory.learning.totalSuccesses + 1 
+      : memory.learning.totalSuccesses,
+  };
+
+  return {
+    ...memory,
+    learning: updatedLearning,
+  };
+}
+
+/**
+ * Calculate outcome score from action result
+ */
+export function calculateOutcomeScore(
+  action: NPCActionType,
+  result: {
+    success: boolean;
+    damageDealt?: number;
+    damageTaken?: number;
+    goldGained?: number;
+    goldSpent?: number;
+    socialGain?: number;
+  }
+): number {
+  let score = 0;
+
+  if (result.success) score += 10;
+  if (result.damageDealt) score += Math.min(5, result.damageDealt / 10);
+  if (result.damageTaken) score -= Math.min(5, result.damageTaken / 10);
+  if (result.goldGained) score += Math.min(5, result.goldGained / 20);
+  if (result.goldSpent) score -= Math.min(3, result.goldSpent / 30);
+  if (result.socialGain) score += Math.min(4, result.socialGain);
+
+  return Math.max(-10, Math.min(10, score));
+}
+
+/**
+ * Get best action for context based on learning
+ */
+export function getLearnedBestAction(
+  memory: NPCMemoryV3,
+  contextKey: string
+): NPCActionType | null {
+  const contextScore = memory.learning.contextScores[contextKey];
+  if (contextScore === undefined) return null;
+
+  // Find action with highest score
+  let bestAction: NPCActionType | null = null;
+  let bestScore = -Infinity;
+
+  for (const [key, score] of Object.entries(memory.learning.actionScores)) {
+    if (key.startsWith("action:")) {
+      const action = key.slice(7) as NPCActionType;
+      if (score > bestScore) {
+        bestScore = score;
+        bestAction = action;
+      }
+    }
+  }
+
+  return bestAction;
+}

--- a/server/src/modules/npc/brain/NPCMemoryCompression.ts
+++ b/server/src/modules/npc/brain/NPCMemoryCompression.ts
@@ -1,0 +1,436 @@
+/**
+ * NPCMemoryCompression — Memory Summarization and State Management
+ * 
+ * Prevents unbounded memory growth by compressing episodic memories
+ * into semantic summaries. Runs at 0.1 Hz (every 100 ticks).
+ * 
+ * Compression strategy:
+ * 1. Select important events (score >= threshold)
+ * 2. Generate semantic summaries from events
+ * 3. Prune low-importance episodic memories
+ * 4. Update learning statistics
+ */
+
+import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";
+import type {
+  NPCMemoryV3,
+  NPCEpisodicMemory,
+  NPCSemanticMemory,
+  NPCGoal,
+  WorldMemoryEventType,
+} from "./NPCMemoryV3.js";
+
+// ============================================================================
+// Compression Configuration
+// ============================================================================
+
+export interface MemoryCompressionConfig {
+  /** Minimum score to keep episodic memory */
+  minEpisodicScore: number;
+  /** Maximum episodic memories to keep */
+  maxEpisodicMemories: number;
+  /** Maximum semantic memories to keep */
+  maxSemanticMemories: number;
+  /** Ticks between compression runs */
+  compressionInterval: number;
+  /** Minimum events for summary generation */
+  minEventsForSummary: number;
+  /** Importance threshold for summary inclusion */
+  summaryImportanceThreshold: number;
+}
+
+export const DEFAULT_COMPRESSION_CONFIG: MemoryCompressionConfig = {
+  minEpisodicScore: 5,
+  maxEpisodicMemories: 64,
+  maxSemanticMemories: 128,
+  compressionInterval: 100,
+  minEventsForSummary: 3,
+  summaryImportanceThreshold: 8,
+};
+
+// ============================================================================
+// Semantic Summary Generation
+// ============================================================================
+
+/**
+ * Generate semantic summary text from episodic memories
+ */
+export function buildDeterministicSummaryText(
+  events: NPCEpisodicMemory[],
+  npcId: string
+): string {
+  if (events.length === 0) {
+    return `No significant events for ${npcId}`;
+  }
+
+  // Group by type
+  const typeGroups = new Map<WorldMemoryEventType, NPCEpisodicMemory[]>();
+  for (const event of events) {
+    const group = typeGroups.get(event.type) ?? [];
+    group.push(event);
+    typeGroups.set(event.type, group);
+  }
+
+  const summaries: string[] = [];
+
+  // Combat summary
+  const combatEvents = typeGroups.get("player_attack") ?? [];
+  const combatWins = typeGroups.get("combat_won") ?? [];
+  const combatLosses = typeGroups.get("combat_lost") ?? [];
+  
+  if (combatEvents.length > 0) {
+    const playerAttacks = new Set(combatEvents.map((e) => e.actorId)).size;
+    summaries.push(
+      `${combatEvents.length} attacks witnessed, ${combatWins.length} wins, ${combatLosses.length} losses, ${playerAttacks} different attackers`
+    );
+  }
+
+  // Trade summary
+  const tradeEvents = typeGroups.get("player_trade") ?? [];
+  if (tradeEvents.length > 0) {
+    summaries.push(`${tradeEvents.length} trades observed`);
+  }
+
+  // Quest summary
+  const questEvents = [
+    ...(typeGroups.get("quest_completed") ?? []),
+    ...(typeGroups.get("quest_failed") ?? []),
+    ...(typeGroups.get("quest_started") ?? []),
+  ];
+  if (questEvents.length > 0) {
+    const completed = typeGroups.get("quest_completed")?.length ?? 0;
+    const failed = typeGroups.get("quest_failed")?.length ?? 0;
+    summaries.push(`${completed} quests completed, ${failed} failed`);
+  }
+
+  // Resource events
+  const resourceEvents = typeGroups.get("resource_shortage") ?? [];
+  if (resourceEvents.length > 0) {
+    summaries.push(`${resourceEvents.length} resource shortages witnessed`);
+  }
+
+  // Faction events
+  const factionEvents = typeGroups.get("faction_joined") ?? [];
+  const factionLeftEvents = typeGroups.get("faction_left") ?? [];
+  if (factionEvents.length > 0 || factionLeftEvents.length > 0) {
+    summaries.push(
+      `${factionEvents.length} faction joins, ${factionLeftEvents.length} faction leaves`
+    );
+  }
+
+  // Generate summary based on tags
+  const allTags = events.flatMap((e) => e.tags);
+  const tagCounts = new Map<string, number>();
+  for (const tag of allTags) {
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  }
+
+  const topTags = [...tagCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([tag]) => tag);
+
+  if (topTags.length > 0) {
+    summaries.push(`Top interests: ${topTags.join(", ")}`);
+  }
+
+  return summaries.join("; ") || "Routine activity";
+}
+
+/**
+ * Collect all unique tags from events
+ */
+export function collectSortedTags(events: NPCEpisodicMemory[]): string[] {
+  const tagSet = new Set<string>();
+  for (const event of events) {
+    for (const tag of event.tags) {
+      tagSet.add(tag);
+    }
+    // Also add event type as tag
+    tagSet.add(event.type);
+  }
+  return [...tagSet].sort();
+}
+
+/**
+ * Convert summary to semantic memory
+ */
+export function summaryToSemanticMemory(
+  summary: {
+    id: string;
+    tick: number;
+    text: string;
+    weight: number;
+    tags: string[];
+  },
+  category: string = "general"
+): NPCSemanticMemory {
+  return {
+    id: summary.id,
+    tick: summary.tick,
+    text: summary.text,
+    category,
+    confidence: Math.min(1, summary.weight / 50), // Higher weight = more confidence
+    sourceEventIds: [],
+    lastUpdatedTick: summary.tick,
+    weight: summary.weight,
+    tags: summary.tags,
+  };
+}
+
+// ============================================================================
+// Memory Compression
+// ============================================================================
+
+/**
+ * Compress NPC memory to prevent state bloat
+ */
+export function compressNPCMemory(
+  memory: NPCMemoryV3,
+  tick: number,
+  config: MemoryCompressionConfig = DEFAULT_COMPRESSION_CONFIG
+): NPCMemoryV3 {
+  const updatedMemory = { ...memory };
+
+  // ─── Compress Episodic Memory ──────────────────────────────────────────────
+
+  // Filter by importance score
+  const importantEvents = updatedMemory.episodic
+    .filter((event) => (event.score ?? 0) >= config.minEpisodicScore)
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, config.maxEpisodicMemories);
+
+  // ─── Generate Semantic Summary ──────────────────────────────────────────────
+
+  const recentEvents = updatedMemory.episodic.slice(-config.maxEpisodicMemories);
+  
+  if (recentEvents.length >= config.minEventsForSummary) {
+    const summaryText = buildDeterministicSummaryText(recentEvents, memory.identity.npcId);
+    const summaryWeight = recentEvents.reduce((sum, e) => sum + (e.score ?? 0), 0);
+    const summaryTags = collectSortedTags(recentEvents);
+
+    const summaryId = `summary_${tick}_${stableHash32(memory.identity.npcId).toString(16)}`;
+
+    const semantic: NPCSemanticMemory = {
+      id: summaryId,
+      tick,
+      text: summaryText,
+      category: "compressed_summary",
+      confidence: Math.min(1, summaryWeight / 100),
+      sourceEventIds: recentEvents.map((e) => e.id),
+      lastUpdatedTick: tick,
+      weight: summaryWeight,
+      tags: summaryTags,
+    };
+
+    // Add to semantic memory (at start, most recent first)
+    updatedMemory.semantic = [semantic, ...updatedMemory.semantic].slice(
+      0,
+      config.maxSemanticMemories
+    );
+  }
+
+  // ─── Update Episodic Memory ─────────────────────────────────────────────────
+
+  updatedMemory.episodic = importantEvents;
+
+  // ─── Prune Old Goals ────────────────────────────────────────────────────────
+
+  // Keep only active goals with recent activity
+  const activeGoals = updatedMemory.goals.filter((goal) => {
+    if (goal.completed || goal.failed) return false;
+    // Keep goals created within last 1000 ticks
+    return tick - goal.createdAtTick < 1000;
+  });
+
+  // Keep top 10 goals
+  updatedMemory.goals = activeGoals
+    .sort((a, b) => b.priority - a.priority)
+    .slice(0, 10);
+
+  // ─── Update Learning Stats ─────────────────────────────────────────────────
+
+  const totalActions = updatedMemory.learning.totalActions;
+  const totalSuccesses = updatedMemory.learning.totalSuccesses;
+  
+  // Decay old context scores (forgotten knowledge)
+  const decayFactor = 0.95;
+  const now = tick;
+  
+  const updatedContextScores: Record<string, number> = {};
+  for (const [key, score] of Object.entries(updatedMemory.learning.contextScores)) {
+    // Only keep if used recently (within last 500 ticks)
+    if (now - updatedMemory.learning.lastOutcomeTick < 500) {
+      updatedContextScores[key] = Math.trunc(score * decayFactor);
+    }
+  }
+
+  updatedMemory.learning = {
+    ...updatedMemory.learning,
+    contextScores: updatedContextScores,
+  };
+
+  return updatedMemory;
+}
+
+/**
+ * Apply scheduled compression check
+ */
+export function shouldCompress(
+  npcId: string,
+  tick: number,
+  lastCompressionTick: number,
+  config: MemoryCompressionConfig = DEFAULT_COMPRESSION_CONFIG
+): boolean {
+  if (tick - lastCompressionTick < config.compressionInterval) {
+    return false;
+  }
+
+  // Use stable hash for deterministic scheduling
+  const phase = stableHash32(npcId) % config.compressionInterval;
+  return tick % config.compressionInterval === phase;
+}
+
+// ============================================================================
+// Memory Cleanup
+// ============================================================================
+
+/**
+ * Remove stale relations (no interaction for 1000+ ticks)
+ */
+export function pruneStaleRelations(
+  relations: Record<string, { lastInteractionTick: number }>,
+  tick: number,
+  threshold: number = 1000
+): Record<string, { lastInteractionTick: number }> {
+  const pruned: Record<string, { lastInteractionTick: number }> = {};
+  
+  for (const [entityId, relation] of Object.entries(relations)) {
+    if (tick - relation.lastInteractionTick < threshold) {
+      pruned[entityId] = relation;
+    }
+  }
+  
+  return pruned;
+}
+
+/**
+ * Remove low-importance fears (not triggered in a while)
+ */
+export function pruneOldFears(
+  fears: Array<{ lastTriggeredTick: number; triggerCount: number }>,
+  tick: number,
+  threshold: number = 500
+): Array<{ lastTriggeredTick: number; triggerCount: number }> {
+  return fears.filter((fear) => {
+    // Keep if triggered recently
+    if (tick - fear.lastTriggeredTick < threshold) return true;
+    // Keep if triggered many times (strong fear)
+    if (fear.triggerCount >= 3) return true;
+    return false;
+  });
+}
+
+// ============================================================================
+// Memory Verification
+// ============================================================================
+
+export interface MemoryIntegrityResult {
+  valid: boolean;
+  episodicCount: number;
+  semanticCount: number;
+  goalCount: number;
+  relationCount: number;
+  issues: string[];
+}
+
+/**
+ * Verify memory integrity
+ */
+export function verifyMemoryIntegrity(
+  memory: NPCMemoryV3,
+  maxEpisodic: number = 256,
+  maxSemantic: number = 128,
+  maxGoals: number = 20,
+  maxRelations: number = 100
+): MemoryIntegrityResult {
+  const issues: string[] = [];
+
+  // Check episodic memory bounds
+  if (memory.episodic.length > maxEpisodic) {
+    issues.push(`Episodic memory exceeds max (${memory.episodic.length} > ${maxEpisodic})`);
+  }
+
+  // Check semantic memory bounds
+  if (memory.semantic.length > maxSemantic) {
+    issues.push(`Semantic memory exceeds max (${memory.semantic.length} > ${maxSemantic})`);
+  }
+
+  // Check goal bounds
+  if (memory.goals.length > maxGoals) {
+    issues.push(`Goals exceed max (${memory.goals.length} > ${maxGoals})`);
+  }
+
+  // Check relation bounds
+  if (Object.keys(memory.relations).length > maxRelations) {
+    issues.push(`Relations exceed max (${Object.keys(memory.relations).length} > ${maxRelations})`);
+  }
+
+  // Check for duplicate episodic IDs
+  const episodicIds = memory.episodic.map((e) => e.id);
+  const uniqueIds = new Set(episodicIds);
+  if (episodicIds.length !== uniqueIds.size) {
+    issues.push("Duplicate episodic memory IDs detected");
+  }
+
+  // Check for duplicate semantic IDs
+  const semanticIds = memory.semantic.map((s) => s.id);
+  const uniqueSemanticIds = new Set(semanticIds);
+  if (semanticIds.length !== uniqueSemanticIds.size) {
+    issues.push("Duplicate semantic memory IDs detected");
+  }
+
+  return {
+    valid: issues.length === 0,
+    episodicCount: memory.episodic.length,
+    semanticCount: memory.semantic.length,
+    goalCount: memory.goals.length,
+    relationCount: Object.keys(memory.relations).length,
+    issues,
+  };
+}
+
+/**
+ * Get memory statistics
+ */
+export function getMemoryStats(memory: NPCMemoryV3): {
+  totalMemories: number;
+  episodicCount: number;
+  semanticCount: number;
+  eventTypes: Record<string, number>;
+  averageScore: number;
+  topGoals: NPCGoal[];
+} {
+  const eventTypes: Record<string, number> = {};
+  let totalScore = 0;
+
+  for (const event of memory.episodic) {
+    eventTypes[event.type] = (eventTypes[event.type] ?? 0) + 1;
+    totalScore += event.score ?? 0;
+  }
+
+  const topGoals = [...memory.goals]
+    .sort((a, b) => b.priority - a.priority)
+    .slice(0, 5);
+
+  return {
+    totalMemories: memory.episodic.length + memory.semantic.length,
+    episodicCount: memory.episodic.length,
+    semanticCount: memory.semantic.length,
+    eventTypes,
+    averageScore: memory.episodic.length > 0 
+      ? totalScore / memory.episodic.length 
+      : 0,
+    topGoals,
+  };
+}

--- a/server/src/modules/npc/brain/NPCMemoryScoring.ts
+++ b/server/src/modules/npc/brain/NPCMemoryScoring.ts
@@ -1,0 +1,517 @@
+/**
+ * NPCMemoryScoring — Deterministic Memory Importance Calculation
+ * 
+ * NPCs don't remember everything equally. This module calculates
+ * how important each memory is based on:
+ * - Personal relevance (was I involved?)
+ * - Emotional weight (how impactful was it?)
+ * - Recency (how fresh is this memory?)
+ * - Repetition (has this happened before?)
+ * - Faction relevance (is my faction involved?)
+ * 
+ * All calculations are deterministic and tick-based.
+ */
+
+import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";
+import type {
+  NPCObservation,
+  NPCMemoryV3,
+  NPCEpisodicMemory,
+  MemoryScore,
+  NPCRelation,
+  WorldMemoryEventType,
+} from "./NPCMemoryV3.js";
+
+// ============================================================================
+// Score Calculation Constants
+// ============================================================================
+
+const SCORING = {
+  // Personal relevance weights
+  TARGET_SELF: 10,
+  ACTOR_SELF: 8,
+  HOME_REGION: 5,
+  SAME_CITY: 4,
+  SAME_FACTION: 3,
+  OTHER: 1,
+
+  // Emotional weight multiplier
+  EMOTIONAL_MULTIPLIER: 2,
+
+  // Recency decay rate (per tick)
+  RECENCY_DECAY_RATE: 0.001,
+
+  // Repetition bonus cap
+  REPETITION_MAX_BONUS: 5,
+  REPETITION_BONUS_PER_OCCURRENCE: 1,
+
+  // Faction relevance bonus
+  FACTION_MATCH_BONUS: 6,
+
+  // Minimum score threshold for memory storage
+  MIN_SCORE_THRESHOLD: 3,
+
+  // Score normalization range
+  MAX_SCORE: 100,
+  MIN_SCORE: 0,
+};
+
+// ============================================================================
+// Score Calculation
+// ============================================================================
+
+/**
+ * Calculate the importance score for an observation for a specific NPC
+ */
+export function scoreMemory(
+  observation: NPCObservation,
+  npcMemory: NPCMemoryV3,
+  currentTick: number
+): MemoryScore {
+  const npcId = npcMemory.identity.npcId;
+
+  // Personal relevance
+  const personalRelevance = calculatePersonalRelevance(observation, npcId, npcMemory);
+
+  // Emotional weight (absolute impact value)
+  const emotionalWeight = Math.abs(observation.impact);
+
+  // Recency (higher for recent events)
+  const recency = calculateRecency(observation.tick, currentTick);
+
+  // Repetition (how many times has this type of event happened?)
+  const repetition = calculateRepetition(observation, npcMemory);
+
+  // Faction relevance
+  const factionRelevance = calculateFactionRelevance(observation, npcMemory);
+
+  // Final score calculation
+  const finalScore = Math.min(
+    SCORING.MAX_SCORE,
+    Math.max(
+      SCORING.MIN_SCORE,
+      Math.trunc(
+        personalRelevance * SCORING.EMOTIONAL_MULTIPLIER +
+        emotionalWeight * SCORING.EMOTIONAL_MULTIPLIER +
+        factionRelevance +
+        Math.min(repetition * SCORING.REPETITION_BONUS_PER_OCCURRENCE, SCORING.REPETITION_MAX_BONUS) +
+        recency * 2
+      )
+    )
+  );
+
+  return {
+    importance: observation.impact,
+    emotionalWeight,
+    recency,
+    repetition,
+    personalRelevance,
+    factionRelevance,
+    finalScore,
+  };
+}
+
+/**
+ * Calculate personal relevance of an observation to an NPC
+ */
+function calculatePersonalRelevance(
+  observation: NPCObservation,
+  npcId: string,
+  npcMemory: NPCMemoryV3
+): number {
+  // NPC is the target (highest relevance)
+  if (observation.targetId === npcId) {
+    return SCORING.TARGET_SELF;
+  }
+
+  // NPC is the actor (very high relevance)
+  if (observation.actorId === npcId) {
+    return SCORING.ACTOR_SELF;
+  }
+
+  // NPC's home region
+  if (observation.regionId === npcMemory.identity.homeRegionId) {
+    return SCORING.HOME_REGION;
+  }
+
+  // NPC's home city
+  if (
+    npcMemory.identity.homeCityId &&
+    observation.cityId === npcMemory.identity.homeCityId
+  ) {
+    return SCORING.SAME_CITY;
+  }
+
+  // NPC's faction
+  if (
+    npcMemory.faction.factionId &&
+    observation.factionId === npcMemory.faction.factionId
+  ) {
+    return SCORING.SAME_FACTION;
+  }
+
+  return SCORING.OTHER;
+}
+
+/**
+ * Calculate recency score (more recent = higher score)
+ */
+function calculateRecency(tick: number, currentTick: number): number {
+  const ticksAgo = currentTick - tick;
+  
+  // Very recent (within 100 ticks)
+  if (ticksAgo <= 100) {
+    return 10 - ticksAgo / 10;
+  }
+  
+  // Recent (within 1000 ticks)
+  if (ticksAgo <= 1000) {
+    return 5 - (ticksAgo - 100) / 200;
+  }
+  
+  // Older events decay
+  return Math.max(0, 2 - (ticksAgo - 1000) / 1000);
+}
+
+/**
+ * Calculate repetition score (how many similar events?)
+ */
+function calculateRepetition(
+  observation: NPCObservation,
+  npcMemory: NPCMemoryV3
+): number {
+  const count = npcMemory.episodic.filter(
+    (mem) =>
+      mem.type === observation.type &&
+      mem.actorId === observation.actorId
+  ).length;
+
+  return count;
+}
+
+/**
+ * Calculate faction relevance
+ */
+function calculateFactionRelevance(
+  observation: NPCObservation,
+  npcMemory: NPCMemoryV3
+): number {
+  if (
+    observation.factionId &&
+    observation.factionId === npcMemory.faction.factionId
+  ) {
+    return SCORING.FACTION_MATCH_BONUS;
+  }
+  return 0;
+}
+
+// ============================================================================
+// Memory Filtering and Selection
+// ============================================================================
+
+/**
+ * Check if observation should be stored as memory
+ */
+export function shouldStoreMemory(
+  observation: NPCObservation,
+  npcMemory: NPCMemoryV3,
+  currentTick: number
+): boolean {
+  const score = scoreMemory(observation, npcMemory, currentTick);
+  return score.finalScore >= SCORING.MIN_SCORE_THRESHOLD;
+}
+
+/**
+ * Convert observation to episodic memory with score
+ */
+export function observationToEpisodic(
+  observation: NPCObservation,
+  npcMemory: NPCMemoryV3,
+  currentTick: number
+): NPCEpisodicMemory {
+  const score = scoreMemory(observation, npcMemory, currentTick);
+  
+  return {
+    id: observation.id,
+    tick: observation.tick,
+    type: observation.type,
+    actorId: observation.actorId,
+    actorName: observation.actorName,
+    targetId: observation.targetId,
+    targetName: observation.targetName,
+    regionId: observation.regionId,
+    cityId: observation.cityId,
+    factionId: observation.factionId,
+    guildId: observation.guildId,
+    impact: observation.impact,
+    tags: observation.tags,
+    payload: observation.payload,
+    score: score.finalScore,
+    emotionalWeight: score.emotionalWeight,
+  };
+}
+
+/**
+ * Get top N memories by score
+ */
+export function getTopMemories(
+  episodic: NPCEpisodicMemory[],
+  count: number = 10
+): NPCEpisodicMemory[] {
+  return [...episodic]
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, count);
+}
+
+/**
+ * Get memories by type
+ */
+export function getMemoriesByType(
+  episodic: NPCEpisodicMemory[],
+  type: WorldMemoryEventType
+): NPCEpisodicMemory[] {
+  return episodic.filter((mem) => mem.type === type);
+}
+
+/**
+ * Get memories involving specific entity
+ */
+export function getMemoriesInvolvingEntity(
+  episodic: NPCEpisodicMemory[],
+  entityId: string
+): NPCEpisodicMemory[] {
+  return episodic.filter(
+    (mem) => mem.actorId === entityId || mem.targetId === entityId
+  );
+}
+
+// ============================================================================
+// Relation Score Calculation
+// ============================================================================
+
+/**
+ * Calculate relation score for display/debugging
+ */
+export function calculateRelationScore(relation: NPCRelation): number {
+  // Weighted combination of relation components
+  const trustWeight = 0.3;
+  const fearWeight = 0.2;
+  const respectWeight = 0.2;
+  const moraleWeight = 0.3;
+
+  // Fear reduces overall score
+  const fearPenalty = relation.fear / 100 * 0.3;
+
+  const score =
+    (relation.trust / 100 * trustWeight) +
+    ((100 - relation.fear) / 100 * fearWeight) +
+    (relation.respect / 100 * respectWeight) +
+    ((relation.morale + 100) / 200 * moraleWeight) -
+    fearPenalty;
+
+  return Math.max(0, Math.min(1, score));
+}
+
+/**
+ * Determine relation disposition
+ */
+export function getRelationDisposition(relation: NPCRelation): "friendly" | "neutral" | "hostile" {
+  const score = calculateRelationScore(relation);
+  
+  if (score >= 0.6) return "friendly";
+  if (score <= 0.3) return "hostile";
+  return "neutral";
+}
+
+// ============================================================================
+// Fear and Threat Assessment
+// ============================================================================
+
+/**
+ * Calculate threat level from observations
+ */
+export function calculateThreatLevel(
+  observations: NPCObservation[],
+  npcId: string
+): number {
+  const relevantObs = observations.filter(
+    (obs) => obs.targetId === npcId || obs.actorId === npcId
+  );
+
+  if (relevantObs.length === 0) return 0;
+
+  const negativeEvents = relevantObs.filter((obs) => obs.impact < 0);
+  const attackEvents = relevantObs.filter(
+    (obs) => obs.type === "player_attack" || obs.type === "combat_lost"
+  );
+
+  // Threat = negative events + attack frequency
+  const negativeScore = negativeEvents.length * 2;
+  const attackScore = attackEvents.length * 5;
+
+  return Math.min(1, (negativeScore + attackScore) / 20);
+}
+
+/**
+ * Calculate safety level
+ */
+export function calculateSafetyLevel(
+  npcMemory: NPCMemoryV3,
+  threatLevel: number
+): number {
+  // Base safety from combat memory
+  const combatWins = npcMemory.combat.victories;
+  const combatLosses = npcMemory.combat.defeats;
+  
+  // Win ratio
+  const totalCombats = combatWins + combatLosses;
+  const winRatio = totalCombats > 0 ? combatWins / totalCombats : 0.5;
+
+  // Combine with current threat
+  const baseSafety = 0.3 + winRatio * 0.5;
+  const finalSafety = baseSafety - threatLevel * 0.5;
+
+  return Math.max(0, Math.min(1, finalSafety));
+}
+
+// ============================================================================
+// Memory Processing
+// ============================================================================
+
+/**
+ * Apply new observations to NPC memory
+ */
+export function applyObservationsToMemory(
+  memory: NPCMemoryV3,
+  observations: NPCObservation[],
+  currentTick: number
+): NPCMemoryV3 {
+  const updatedMemory = { ...memory };
+  
+  for (const obs of observations) {
+    if (shouldStoreMemory(obs, memory, currentTick)) {
+      const episodic = observationToEpisodic(obs, memory, currentTick);
+      updatedMemory.episodic = [...updatedMemory.episodic, episodic];
+    }
+  }
+
+  // Limit episodic memory size
+  if (updatedMemory.episodic.length > 256) {
+    updatedMemory.episodic = updatedMemory.episodic
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .slice(0, 256);
+  }
+
+  return updatedMemory;
+}
+
+/**
+ * Update relations based on observations
+ */
+export function updateRelationsFromObservation(
+  relations: Record<string, NPCRelation>,
+  observation: NPCObservation,
+  currentTick: number
+): Record<string, NPCRelation> {
+  const updatedRelations = { ...relations };
+
+  // Update actor relation
+  if (observation.actorId) {
+    const actorRelation = updatedRelations[observation.actorId] ?? {
+      entityId: observation.actorId,
+      entityType: "player" as const,
+      trust: 0,
+      fear: 0,
+      respect: 0,
+      greed: 0,
+      morale: 0,
+      interactions: 0,
+      lastInteractionTick: 0,
+      positiveInteractions: 0,
+      negativeInteractions: 0,
+    };
+
+    const isPositive = observation.impact > 0;
+    
+    actorRelation.trust += isPositive ? 5 : -5;
+    actorRelation.trust = Math.max(-100, Math.min(100, actorRelation.trust));
+    
+    actorRelation.morale += isPositive ? 3 : -3;
+    actorRelation.morale = Math.max(-100, Math.min(100, actorRelation.morale));
+    
+    actorRelation.fear += observation.impact < 0 ? Math.abs(observation.impact) * 2 : 0;
+    actorRelation.fear = Math.min(100, actorRelation.fear);
+    
+    actorRelation.interactions++;
+    actorRelation.lastInteractionTick = currentTick;
+    
+    if (isPositive) {
+      actorRelation.positiveInteractions++;
+    } else {
+      actorRelation.negativeInteractions++;
+    }
+
+    updatedRelations[observation.actorId] = actorRelation;
+  }
+
+  // Update target relation
+  if (observation.targetId) {
+    const targetRelation = updatedRelations[observation.targetId] ?? {
+      entityId: observation.targetId,
+      entityType: "player" as const,
+      trust: 0,
+      fear: 0,
+      respect: 0,
+      greed: 0,
+      morale: 0,
+      interactions: 0,
+      lastInteractionTick: 0,
+      positiveInteractions: 0,
+      negativeInteractions: 0,
+    };
+
+    const isPositive = observation.impact > 0;
+    
+    targetRelation.trust += isPositive ? 5 : -5;
+    targetRelation.trust = Math.max(-100, Math.min(100, targetRelation.trust));
+    
+    targetRelation.morale += isPositive ? 3 : -3;
+    targetRelation.morale = Math.max(-100, Math.min(100, targetRelation.morale));
+    
+    targetRelation.fear += observation.impact < 0 ? Math.abs(observation.impact) * 2 : 0;
+    targetRelation.fear = Math.min(100, targetRelation.fear);
+    
+    targetRelation.interactions++;
+    targetRelation.lastInteractionTick = currentTick;
+    
+    if (isPositive) {
+      targetRelation.positiveInteractions++;
+    } else {
+      targetRelation.negativeInteractions++;
+    }
+
+    updatedRelations[observation.targetId] = targetRelation;
+  }
+
+  return updatedRelations;
+}
+
+/**
+ * Calculate memory hash for replay verification
+ */
+export function calculateMemoryFingerprint(memory: NPCMemoryV3): string {
+  const components = [
+    memory.identity.npcId,
+    memory.episodic.length,
+    memory.episodic.slice(-10).map((e) => `${e.type}:${e.tick}:${e.impact}`).join("|"),
+    Object.keys(memory.relations).length,
+    JSON.stringify(
+      Object.entries(memory.learning.actionScores)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .slice(0, 10)
+    ),
+  ];
+
+  const hash = stableHash32(components.join("||"));
+  return hash.toString(16).padStart(8, "0");
+}

--- a/server/src/modules/npc/brain/NPCMemoryV3.ts
+++ b/server/src/modules/npc/brain/NPCMemoryV3.ts
@@ -1,0 +1,622 @@
+/**
+ * NPCMemoryV3 — Autonomous Learning NPC Brain Memory System
+ * 
+ * A 5-layer memory model for deterministic NPC behavior:
+ * - Identity: Who am I?
+ * - Episodic: What happened to me?
+ * - Semantic: What do I know?
+ * - Relations: Who do I know?
+ * - Learning: What worked for me?
+ * 
+ * All memory operations are tick-based and deterministic for replay capability.
+ * Same tick + same input = same output (no Math.random() in decision logic).
+ */
+
+import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";
+
+// ============================================================================
+// World Event Types — All events NPCs can observe
+// ============================================================================
+
+export type WorldMemoryEventType =
+  | "player_attack"
+  | "player_help"
+  | "player_trade"
+  | "npc_death"
+  | "npc_birth"
+  | "resource_shortage"
+  | "market_price_shift"
+  | "city_tax_changed"
+  | "guild_declared_war"
+  | "king_elected"
+  | "building_destroyed"
+  | "building_constructed"
+  | "quest_completed"
+  | "quest_failed"
+  | "quest_started"
+  | "weather_disaster"
+  | "dungeon_opened"
+  | "dungeon_closed"
+  | "boss_spawned"
+  | "boss_defeated"
+  | "caravan_raided"
+  | "caravan_arrived"
+  | "law_changed"
+  | "territory_claimed"
+  | "faction_joined"
+  | "faction_left"
+  | "item_stolen"
+  | "item_gifted"
+  | "combat_won"
+  | "combat_lost"
+  | "social_greeting"
+  | "social_argument"
+  | "crafting_completed"
+  | "exploration_discovered";
+
+// ============================================================================
+// Identity Memory — Who am I?
+// ============================================================================
+
+export interface NPCIdentityMemory {
+  npcId: string;
+  name: string;
+  profession: string;
+  homeCityId?: string;
+  homeRegionId: string;
+  role: string; // guard, merchant, farmer, noble, etc.
+  moralAlignment: number; // -100 to +100
+  courage: number; // 0 to 100
+  greed: number; // 0 to 100
+  loyalty: number; // 0 to 100
+  personalityTraits: string[];
+  birthTick?: number;
+}
+
+// ============================================================================
+// Episodic Memory — Concrete events I experienced
+// ============================================================================
+
+export interface NPCEpisodicMemory {
+  id: string;
+  tick: number;
+  type: WorldMemoryEventType;
+  actorId?: string;
+  actorName?: string;
+  targetId?: string;
+  targetName?: string;
+  regionId?: string;
+  cityId?: string;
+  factionId?: string;
+  guildId?: string;
+  impact: number; // -10 to +10, negative = bad, positive = good
+  tags: string[];
+  payload: Record<string, string | number | boolean>;
+  score?: number; // Calculated memory importance score
+  emotionalWeight?: number;
+}
+
+// ============================================================================
+// Semantic Memory — Verdichtetes Wissen
+// ============================================================================
+
+export interface NPCSemanticMemory {
+  id: string;
+  tick: number;
+  text: string; // "Spieler X ist gefährlich" / "Region Y hat wenig Eisen"
+  category: string;
+  confidence: number; // 0 to 1, how certain is this knowledge
+  sourceEventIds: string[]; // Which episodic memories formed this
+  lastUpdatedTick: number;
+  weight: number; // Importance of this knowledge
+  tags: string[];
+}
+
+// ============================================================================
+// Relations — Who I know and how I feel
+// ============================================================================
+
+export interface NPCRelation {
+  entityId: string;
+  entityType: "player" | "npc" | "faction" | "city" | "guild";
+  trust: number; // -100 to +100
+  fear: number; // 0 to 100, how afraid I am
+  respect: number; // 0 to 100
+  greed: number; // 0 to 100, how much I want their resources
+  morale: number; // -100 to +100, how much I like them
+  interactions: number;
+  lastInteractionTick: number;
+  positiveInteractions: number;
+  negativeInteractions: number;
+  memory?: string; // "They helped me once" / "They attacked my caravan"
+  blocked?: boolean; // Blacklisted
+}
+
+// ============================================================================
+// Goals — What I'm trying to achieve
+// ============================================================================
+
+export interface NPCGoal {
+  id: string;
+  type: NPCGoalType;
+  priority: number; // 0-100, higher = more important
+  createdAtTick: number;
+  targetId?: string;
+  targetPosition?: { x: number; y: number };
+  regionId?: string;
+  reason: string;
+  progress?: number; // 0 to 1
+  completed?: boolean;
+  failed?: boolean;
+}
+
+export type NPCGoalType =
+  | "combat"
+  | "survive"
+  | "collect"
+  | "gather"
+  | "trade"
+  | "social"
+  | "quest_main"
+  | "quest_side"
+  | "explore"
+  | "defend"
+  | "flee"
+  | "rest"
+  | "migrate"
+  | "work"
+  | "craft"
+  | "patrol"
+  | "raise_alarm"
+  | "hire_guard"
+  | "start_caravan"
+  | "join_guild"
+  | "vote"
+  | "idle";
+
+// ============================================================================
+// Routines — Daily schedules
+// ============================================================================
+
+export interface NPCRoutine {
+  id: string;
+  label: string;
+  startTickModulo: number; // Time of day (0-1000 for relative day)
+  endTickModulo: number;
+  preferredRegionId: string;
+  action: NPCRoutineAction;
+  priority: number;
+  safetyRequirement: number; // Minimum safety to execute
+  conditions?: string[];
+}
+
+export type NPCRoutineAction =
+  | "work"
+  | "sleep"
+  | "trade"
+  | "patrol"
+  | "social"
+  | "travel"
+  | "gather"
+  | "craft"
+  | "guard";
+
+// ============================================================================
+// Fears — What I'm afraid of
+// ============================================================================
+
+export interface NPCFearMemory {
+  id: string;
+  trigger: string; // "player_attack", "resource_shortage", etc.
+  fearLevel: number; // 0 to 100
+  lastTriggeredTick: number;
+  triggerCount: number;
+  associatedEntityIds: string[];
+}
+
+// ============================================================================
+// Skills — What I can do
+// ============================================================================
+
+export interface NPCSkillMemory {
+  skillId: string;
+  name: string;
+  level: number;
+  experience: number;
+  lastUsedTick: number;
+  successRate: number; // 0 to 1
+  failureCount: number;
+}
+
+// ============================================================================
+// Economy — Economic knowledge and state
+// ============================================================================
+
+export interface NPCEconomyMemory {
+  wealth: number;
+  debt: number;
+  preferredGoods: string[];
+  avoidedGoods: string[];
+  trustedTradePartners: string[];
+  lastTradeTick: number;
+  priceExpectations: Record<string, number>; // goods -> expected price
+}
+
+// ============================================================================
+// Faction — Faction-related knowledge
+// ============================================================================
+
+export interface NPCFactionMemory {
+  factionId?: string;
+  factionRank: number;
+  loyaltyToFaction: number; // 0 to 100
+  factionContributions: number;
+  factionEnemies: string[];
+  lastFactionActionTick: number;
+}
+
+// ============================================================================
+// Politics — Political knowledge and stances
+// ============================================================================
+
+export interface NPCPoliticalMemory {
+  supportedLeaderId?: string;
+  oppositionIds: string[];
+  lastVoteTick: number;
+  taxTolerance: number; // How high taxes can get before I complain
+  cityMood: number; // -100 to +100, how I feel about my city
+  migrationDesire: number; // 0 to 100, how much I want to leave
+}
+
+// ============================================================================
+// Combat — Combat knowledge and habits
+// ============================================================================
+
+export interface NPCCombatMemory {
+  victories: number;
+  defeats: number;
+  lastCombatTick: number;
+  preferredWeapons: string[];
+  avoidedEnemies: string[];
+  fleeThreshold: number; // HP % at which I flee
+  escortRequests: number; // How often I hired guards
+  killedByPlayer: Record<string, number>; // playerId -> count
+}
+
+// ============================================================================
+// Learning State — Statistical experience tracking
+// ============================================================================
+
+export interface NPCLearningState {
+  actionScores: Record<string, number>; // actionId -> score (higher = more successful)
+  contextScores: Record<string, number>; // contextKey -> score
+  failedActions: Record<string, number>; // actionId -> failure count
+  successfulActions: Record<string, number>; // actionId -> success count
+  lastOutcomeTick: number;
+  totalActions: number;
+  totalSuccesses: number;
+}
+
+// ============================================================================
+// NPC Memory V3 — Full Memory Structure
+// ============================================================================
+
+export interface NPCMemoryV3 {
+  identity: NPCIdentityMemory;
+  episodic: NPCEpisodicMemory[];
+  semantic: NPCSemanticMemory[];
+  relations: Record<string, NPCRelation>;
+  goals: NPCGoal[];
+  routines: NPCRoutine[];
+  fears: NPCFearMemory[];
+  skills: NPCSkillMemory[];
+  economy: NPCEconomyMemory;
+  faction: NPCFactionMemory;
+  politics: NPCPoliticalMemory;
+  combat: NPCCombatMemory;
+  learning: NPCLearningState;
+}
+
+// ============================================================================
+// NPC Observation — Event from world to NPC
+// ============================================================================
+
+export interface NPCObservation {
+  id: string;
+  tick: number;
+  type: WorldMemoryEventType;
+  actorId?: string;
+  actorName?: string;
+  targetId?: string;
+  targetName?: string;
+  regionId?: string;
+  cityId?: string;
+  factionId?: string;
+  guildId?: string;
+  impact: number; // -10 to +10
+  tags: string[];
+  payload: Record<string, string | number | boolean>;
+}
+
+// ============================================================================
+// NPC Decision Types
+// ============================================================================
+
+export interface NPCDecisionInput {
+  tick: number;
+  npcId: string;
+  npcName: string;
+  position: { x: number; y: number };
+  homeRegionId: string;
+  factionId?: string;
+  state: string;
+  health: number;
+  energy: number;
+  gold: number;
+  memory: NPCMemoryV3;
+  world: NPCWorldSnapshot;
+  nearbyEntities: Array<{
+    id: string;
+    name: string;
+    type: "player" | "npc" | "monster";
+    position: { x: number; y: number };
+    faction?: string;
+    hostile?: boolean;
+  }>;
+}
+
+export interface NPCDecision {
+  action: NPCActionType;
+  targetId?: string;
+  targetPosition?: { x: number; y: number };
+  reason: string;
+  score: number;
+  confidence: number; // 0 to 1
+}
+
+export type NPCActionType =
+  | "idle"
+  | "talk"
+  | "trade"
+  | "flee"
+  | "attack"
+  | "patrol"
+  | "work"
+  | "gather"
+  | "craft"
+  | "join_guild"
+  | "vote"
+  | "raise_alarm"
+  | "move_city"
+  | "hire_guard"
+  | "start_caravan"
+  | "explore"
+  | "social"
+  | "defend";
+
+// ============================================================================
+// World Snapshot — What NPCs can perceive
+// ============================================================================
+
+export interface NPCWorldSnapshot {
+  tick: number;
+  regionId: string;
+  timeOfDay: number; // 0-24
+  weather?: string;
+  dangerLevel: number; // 0 to 1
+  resourceAvailability: Record<string, number>;
+  marketPrices: Record<string, number>;
+  nearbyThreats: Array<{
+    id: string;
+    type: string;
+    position: { x: number; y: number };
+    strength: number;
+  }>;
+  friendlyNPCs: string[];
+  hostileNPCs: string[];
+}
+
+// ============================================================================
+// Memory Score — How important is this memory?
+// ============================================================================
+
+export interface MemoryScore {
+  importance: number;
+  emotionalWeight: number;
+  recency: number;
+  repetition: number;
+  personalRelevance: number;
+  factionRelevance: number;
+  finalScore: number;
+}
+
+// ============================================================================
+// Brain Tick Result — Output of NPC brain tick
+// ============================================================================
+
+export interface NPCBrainOutput {
+  npcId: string;
+  tick: number;
+  nextState: string;
+  decision: NPCDecision;
+  memory: NPCMemoryV3;
+  memoryHash: string;
+}
+
+// ============================================================================
+// Brain Debug Snapshot — For debugging HUD
+// ============================================================================
+
+export interface NPCBrainDebugSnapshot {
+  npcId: string;
+  tick: number;
+  state: string;
+  topGoal?: NPCGoal;
+  decision: NPCDecision;
+  relationHighlights: NPCRelation[];
+  recentEvents: NPCEpisodicMemory[];
+  memoryHash: string;
+  learningStats: {
+    totalActions: number;
+    totalSuccesses: number;
+    successRate: number;
+  };
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Generate deterministic episodic memory ID
+ */
+export function generateEpisodicId(npcId: string, tick: number, type: WorldMemoryEventType): string {
+  const hash = stableHash32(`${npcId}:${tick}:${type}`);
+  return `ep_${hash.toString(16)}`;
+}
+
+/**
+ * Generate deterministic goal ID
+ */
+export function generateGoalId(npcId: string, type: NPCGoalType, tick: number): string {
+  const hash = stableHash32(`${npcId}:${type}:${tick}`);
+  return `goal_${hash.toString(16)}`;
+}
+
+/**
+ * Create empty NPCMemoryV3 with defaults
+ */
+export function createEmptyNPCMemoryV3(
+  npcId: string,
+  name: string,
+  homeRegionId: string,
+  profession: string = "worker",
+  role: string = "citizen"
+): NPCMemoryV3 {
+  return {
+    identity: {
+      npcId,
+      name,
+      profession,
+      homeRegionId,
+      role,
+      moralAlignment: 0,
+      courage: 50,
+      greed: 30,
+      loyalty: 50,
+      personalityTraits: [],
+    },
+    episodic: [],
+    semantic: [],
+    relations: {},
+    goals: [],
+    routines: [],
+    fears: [],
+    skills: [],
+    economy: {
+      wealth: 50,
+      debt: 0,
+      preferredGoods: [],
+      avoidedGoods: [],
+      trustedTradePartners: [],
+      lastTradeTick: 0,
+      priceExpectations: {},
+    },
+    faction: {
+      factionRank: 0,
+      loyaltyToFaction: 50,
+      factionContributions: 0,
+      factionEnemies: [],
+      lastFactionActionTick: 0,
+    },
+    politics: {
+      oppositionIds: [],
+      lastVoteTick: 0,
+      taxTolerance: 50,
+      cityMood: 0,
+      migrationDesire: 0,
+    },
+    combat: {
+      victories: 0,
+      defeats: 0,
+      lastCombatTick: 0,
+      preferredWeapons: [],
+      avoidedEnemies: [],
+      fleeThreshold: 0.2,
+      escortRequests: 0,
+      killedByPlayer: {},
+    },
+    learning: {
+      actionScores: {},
+      contextScores: {},
+      failedActions: {},
+      successfulActions: {},
+      lastOutcomeTick: 0,
+      totalActions: 0,
+      totalSuccesses: 0,
+    },
+  };
+}
+
+/**
+ * Convert legacy NPCMemory to NPCMemoryV3 (for compatibility)
+ */
+export function migrateLegacyMemory(
+  legacyMemory: { longTermGoals?: string[]; events?: unknown[]; relations?: unknown[] },
+  npcId: string,
+  name: string,
+  homeRegionId: string
+): NPCMemoryV3 {
+  const base = createEmptyNPCMemoryV3(npcId, name, homeRegionId);
+  
+  // Migrate goals
+  if (legacyMemory.longTermGoals) {
+    base.goals = legacyMemory.longTermGoals.map((goal, idx) => ({
+      id: generateGoalId(npcId, normalizeGoalType(goal), idx),
+      type: normalizeGoalType(goal),
+      priority: 50,
+      createdAtTick: 0,
+      reason: `migrated:${goal}`,
+    }));
+  }
+  
+  return base;
+}
+
+/**
+ * Normalize legacy goal string to goal type
+ */
+function normalizeGoalType(goal: string): NPCGoalType {
+  const g = goal.toLowerCase();
+  if (g.includes("guard") || g.includes("defend")) return "defend";
+  if (g.includes("combat") || g.includes("attack")) return "combat";
+  if (g.includes("collect") || g.includes("gather")) return "collect";
+  if (g.includes("trade") || g.includes("merchant")) return "trade";
+  if (g.includes("quest")) return g.includes("main") ? "quest_main" : "quest_side";
+  if (g.includes("explore")) return "explore";
+  if (g.includes("social") || g.includes("talk")) return "social";
+  if (g.includes("flee") || g.includes("escape")) return "flee";
+  if (g.includes("rest") || g.includes("sleep")) return "rest";
+  if (g.includes("work")) return "work";
+  if (g.includes("craft")) return "craft";
+  return "idle";
+}
+
+/**
+ * Calculate memory hash for replay verification
+ */
+export function calculateMemoryHash(memory: NPCMemoryV3): string {
+  const components = [
+    memory.identity.npcId,
+    memory.identity.homeRegionId,
+    memory.goals.length,
+    memory.episodic.length,
+    memory.semantic.length,
+    Object.keys(memory.relations).length,
+    JSON.stringify(memory.learning.actionScores),
+    JSON.stringify(memory.learning.contextScores),
+  ];
+  
+  const hash = stableHash32(components.join("|"));
+  return hash.toString(16).padStart(8, "0");
+}

--- a/server/src/modules/npc/brain/NPCObservationBus.ts
+++ b/server/src/modules/npc/brain/NPCObservationBus.ts
@@ -1,0 +1,410 @@
+/**
+ * NPCObservationBus — Central Event System for NPC Observations
+ * 
+ * All game systems emit events through this bus. NPCs can subscribe to
+ * relevant event types and receive observations into their memory.
+ * 
+ * Design principles:
+ * - Deterministic observation IDs using stable hash
+ * - Event filtering by NPC relevance criteria
+ * - Type-safe event emission from any game system
+ * 
+ * Usage:
+ *   npcObservationBus.emit({ type: "player_attack", actorId: playerId, targetId: npcId, ... });
+ *   npcObservationBus.subscribe("player_attack", (obs) => npcMemory.addObservation(obs));
+ */
+
+import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";
+import type { 
+  NPCObservation, 
+  WorldMemoryEventType,
+  NPCMemoryV3 
+} from "./NPCMemoryV3.js";
+
+// ============================================================================
+// Observation Bus Core
+// ============================================================================
+
+export type ObservationFilter = {
+  npcId?: string;
+  regionId?: string;
+  factionId?: string;
+  type?: WorldMemoryEventType;
+  actorId?: string;
+  targetId?: string;
+};
+
+export type ObservationCallback = (observation: NPCObservation) => void;
+
+export class NPCObservationBus {
+  private observers: Map<WorldMemoryEventType, Set<ObservationCallback>> = new Map();
+  private globalObservers: Set<ObservationCallback> = new Set();
+  private observationHistory: NPCObservation[] = [];
+  private maxHistorySize = 10000;
+
+  constructor() {
+    // Initialize all event type channels
+    const eventTypes: WorldMemoryEventType[] = [
+      "player_attack", "player_help", "player_trade", "npc_death", "npc_birth",
+      "resource_shortage", "market_price_shift", "city_tax_changed", "guild_declared_war",
+      "king_elected", "building_destroyed", "building_constructed", "quest_completed",
+      "quest_failed", "quest_started", "weather_disaster", "dungeon_opened", "dungeon_closed",
+      "boss_spawned", "boss_defeated", "caravan_raided", "caravan_arrived", "law_changed",
+      "territory_claimed", "faction_joined", "faction_left", "item_stolen", "item_gifted",
+      "combat_won", "combat_lost", "social_greeting", "social_argument", 
+      "crafting_completed", "exploration_discovered",
+    ];
+
+    for (const type of eventTypes) {
+      this.observers.set(type, new Set());
+    }
+  }
+
+  /**
+   * Generate deterministic observation ID
+   */
+  private generateObservationId(
+    tick: number,
+    type: WorldMemoryEventType,
+    actorId?: string,
+    targetId?: string
+  ): string {
+    const components = [tick.toString(), type, actorId ?? "", targetId ?? ""];
+    const hash = stableHash32(components.join("|"));
+    return `obs_${hash.toString(16)}`;
+  }
+
+  /**
+   * Emit an observation event from any game system
+   */
+  emit(
+    type: WorldMemoryEventType,
+    tick: number,
+    data: {
+      actorId?: string;
+      actorName?: string;
+      targetId?: string;
+      targetName?: string;
+      regionId?: string;
+      cityId?: string;
+      factionId?: string;
+      guildId?: string;
+      impact?: number;
+      tags?: string[];
+      payload?: Record<string, string | number | boolean>;
+    }
+  ): NPCObservation {
+    const observation: NPCObservation = {
+      id: this.generateObservationId(tick, type, data.actorId, data.targetId),
+      tick,
+      type,
+      actorId: data.actorId,
+      actorName: data.actorName,
+      targetId: data.targetId,
+      targetName: data.targetName,
+      regionId: data.regionId,
+      cityId: data.cityId,
+      factionId: data.factionId,
+      guildId: data.guildId,
+      impact: data.impact ?? 0,
+      tags: data.tags ?? [],
+      payload: data.payload ?? {},
+    };
+
+    // Store in history
+    this.observationHistory.push(observation);
+    if (this.observationHistory.length > this.maxHistorySize) {
+      this.observationHistory.shift();
+    }
+
+    // Notify type-specific observers
+    const typeObservers = this.observers.get(type);
+    if (typeObservers) {
+      for (const callback of typeObservers) {
+        try {
+          callback(observation);
+        } catch (err) {
+          console.error(`[NPCObservationBus] Observer error for ${type}:`, err);
+        }
+      }
+    }
+
+    // Notify global observers
+    for (const callback of this.globalObservers) {
+      try {
+        callback(observation);
+      } catch (err) {
+        console.error("[NPCObservationBus] Global observer error:", err);
+      }
+    }
+
+    return observation;
+  }
+
+  /**
+   * Subscribe to specific event type
+   */
+  subscribe(type: WorldMemoryEventType, callback: ObservationCallback): () => void {
+    const observers = this.observers.get(type);
+    if (observers) {
+      observers.add(callback);
+    }
+    return () => this.unsubscribe(type, callback);
+  }
+
+  /**
+   * Subscribe to all event types
+   */
+  subscribeAll(callback: ObservationCallback): () => void {
+    this.globalObservers.add(callback);
+    return () => this.globalObservers.delete(callback);
+  }
+
+  /**
+   * Unsubscribe from specific event type
+   */
+  unsubscribe(type: WorldMemoryEventType, callback: ObservationCallback): void {
+    const observers = this.observers.get(type);
+    if (observers) {
+      observers.delete(callback);
+    }
+  }
+
+  /**
+   * Get observations for a specific NPC (filtered by relevance)
+   */
+  getObservationsForNPC(
+    npcId: string,
+    npcMemory: NPCMemoryV3,
+    filter?: ObservationFilter
+  ): NPCObservation[] {
+    return this.observationHistory.filter((obs) => {
+      // Type filter
+      if (filter?.type && obs.type !== filter.type) return false;
+      
+      // Actor filter
+      if (filter?.actorId && obs.actorId !== filter.actorId) return false;
+      
+      // Target filter
+      if (filter?.targetId && obs.targetId !== filter.targetId) return false;
+      
+      // Region filter
+      if (filter?.regionId && obs.regionId !== filter.regionId) return false;
+      
+      // NPC is actor
+      if (obs.actorId === npcId) return true;
+      
+      // NPC is target
+      if (obs.targetId === npcId) return true;
+      
+      // NPC's home region
+      if (obs.regionId === npcMemory.identity.homeRegionId) return true;
+      
+      // NPC's faction
+      if (obs.factionId && obs.factionId === npcMemory.faction.factionId) return true;
+      
+      // NPC is nearby (within same city/region context)
+      if (obs.cityId && npcMemory.identity.homeCityId === obs.cityId) return true;
+      
+      return false;
+    });
+  }
+
+  /**
+   * Get recent observations by type
+   */
+  getRecentObservations(type: WorldMemoryEventType, count: number = 10): NPCObservation[] {
+    return this.observationHistory
+      .filter((obs) => obs.type === type)
+      .slice(-count);
+  }
+
+  /**
+   * Get all observations in time range
+   */
+  getObservationsInRange(startTick: number, endTick: number): NPCObservation[] {
+    return this.observationHistory.filter(
+      (obs) => obs.tick >= startTick && obs.tick <= endTick
+    );
+  }
+
+  /**
+   * Get observation statistics
+   */
+  getStats(): {
+    totalObservations: number;
+    byType: Record<string, number>;
+    historySize: number;
+  } {
+    const byType: Record<string, number> = {};
+    for (const obs of this.observationHistory) {
+      byType[obs.type] = (byType[obs.type] ?? 0) + 1;
+    }
+    return {
+      totalObservations: this.observationHistory.length,
+      byType,
+      historySize: this.observationHistory.length,
+    };
+  }
+
+  /**
+   * Clear observation history
+   */
+  clearHistory(): void {
+    this.observationHistory = [];
+  }
+}
+
+// ============================================================================
+// Pre-built Event Emitters for Common Game Systems
+// ============================================================================
+
+/**
+ * Combat event emitter helper
+ */
+export function emitCombatEvent(
+  bus: NPCObservationBus,
+  tick: number,
+  event: "player_attack" | "combat_won" | "combat_lost" | "npc_death",
+  data: {
+    actorId: string;
+    actorName?: string;
+    targetId: string;
+    targetName?: string;
+    regionId?: string;
+    damage?: number;
+    weaponType?: string;
+  }
+): NPCObservation {
+  return bus.emit(event, tick, {
+    actorId: data.actorId,
+    actorName: data.actorName,
+    targetId: data.targetId,
+    targetName: data.targetName,
+    regionId: data.regionId,
+    impact: event === "player_attack" ? -8 : event === "combat_won" ? 5 : -5,
+    tags: ["combat", "danger", ...(data.weaponType ? [data.weaponType] : [])],
+    payload: {
+      damage: data.damage ?? 0,
+      weaponType: data.weaponType ?? "unknown",
+    },
+  });
+}
+
+/**
+ * Trade event emitter helper
+ */
+export function emitTradeEvent(
+  bus: NPCObservationBus,
+  tick: number,
+  event: "player_trade" | "market_price_shift",
+  data: {
+    actorId?: string;
+    targetId?: string;
+    regionId?: string;
+    goods?: string;
+    price?: number;
+    quantity?: number;
+  }
+): NPCObservation {
+  return bus.emit(event, tick, {
+    actorId: data.actorId,
+    targetId: data.targetId,
+    regionId: data.regionId,
+    impact: event === "player_trade" ? 3 : 0,
+    tags: ["trade", "economy", ...(data.goods ? [data.goods] : [])],
+    payload: {
+      goods: data.goods ?? "unknown",
+      price: data.price ?? 0,
+      quantity: data.quantity ?? 0,
+    },
+  });
+}
+
+/**
+ * Quest event emitter helper
+ */
+export function emitQuestEvent(
+  bus: NPCObservationBus,
+  tick: number,
+  event: "quest_completed" | "quest_failed" | "quest_started",
+  data: {
+    actorId: string;
+    targetId?: string;
+    questId?: string;
+    questName?: string;
+    regionId?: string;
+    reward?: number;
+  }
+): NPCObservation {
+  return bus.emit(event, tick, {
+    actorId: data.actorId,
+    targetId: data.targetId,
+    regionId: data.regionId,
+    impact: event === "quest_completed" ? 6 : event === "quest_failed" ? -3 : 1,
+    tags: ["quest", "adventure"],
+    payload: {
+      questId: data.questId ?? "unknown",
+      questName: data.questName ?? "Unknown Quest",
+      reward: data.reward ?? 0,
+    },
+  });
+}
+
+/**
+ * Faction event emitter helper
+ */
+export function emitFactionEvent(
+  bus: NPCObservationBus,
+  tick: number,
+  event: "faction_joined" | "faction_left" | "guild_declared_war",
+  data: {
+    actorId: string;
+    factionId: string;
+    factionName?: string;
+    regionId?: string;
+  }
+): NPCObservation {
+  return bus.emit(event, tick, {
+    actorId: data.actorId,
+    factionId: data.factionId,
+    regionId: data.regionId,
+    impact: event === "faction_joined" ? 4 : event === "faction_left" ? -2 : -6,
+    tags: ["faction", "politics"],
+    payload: {
+      factionName: data.factionName ?? data.factionId,
+    },
+  });
+}
+
+/**
+ * Economy event emitter helper
+ */
+export function emitEconomyEvent(
+  bus: NPCObservationBus,
+  tick: number,
+  event: "resource_shortage" | "caravan_raided" | "caravan_arrived",
+  data: {
+    regionId: string;
+    goods?: string;
+    quantity?: number;
+    actorId?: string;
+  }
+): NPCObservation {
+  return bus.emit(event, tick, {
+    actorId: data.actorId,
+    regionId: data.regionId,
+    impact: event === "resource_shortage" ? -4 : event === "caravan_raided" ? -5 : 3,
+    tags: ["economy", "trade", ...(data.goods ? [data.goods] : [])],
+    payload: {
+      goods: data.goods ?? "unknown",
+      quantity: data.quantity ?? 0,
+    },
+  });
+}
+
+// ============================================================================
+// Global Singleton (for easy access across game systems)
+// ============================================================================
+
+export const globalObservationBus = new NPCObservationBus();

--- a/server/src/modules/npc/brain/index.ts
+++ b/server/src/modules/npc/brain/index.ts
@@ -1,0 +1,17 @@
+/**
+ * NPC Brain Module — Autonomous Learning NPC System
+ * 
+ * Exports all brain components for easy imports.
+ * 
+ * Usage:
+ *   import { NPCBrainRunner, globalObservationBus } from "./brain/index.js";
+ */
+
+export * from "./NPCMemoryV3.js";
+export * from "./NPCObservationBus.js";
+export * from "./NPCMemoryScoring.js";
+export * from "./NPCDecisionEngine.js";
+export * from "./NPCBrainScheduler.js";
+export * from "./NPCMemoryCompression.js";
+export * from "./NPCBrainDebugSnapshot.js";
+export * from "./NPCBrainRunner.js";

--- a/server/src/modules/ouroboros/OuroborosEngine.ts
+++ b/server/src/modules/ouroboros/OuroborosEngine.ts
@@ -4,6 +4,11 @@
  * Past → Legend → Belief → Action → History → Past
  *
  * Wired into WorldTick.tick() to run alongside existing systems.
+ * 
+ * Integrates NPC Brain System for autonomous learning:
+ * - NPCMemoryV3 for structured memory
+ * - NPCObservationBus for world events
+ * - NPCBrainRunner for decision making
  */
 
 import { WorldEventBus, type WorldEvent } from "./WorldEventBus.js";
@@ -16,11 +21,31 @@ import { type NPCRelationshipSystem } from "../npc/NPCRelationshipSystem.js";
 import { type ChatChannelRouter, type ChatRecipient, type SendToPlayerFn, type BroadcastFn, type ResolveSocketIdFn } from "../chat/ChatChannelRouter.js";
 import { type StatusEmitter } from "../chat/StatusEmitter.js";
 
+// Import NPC Brain System
+import {
+  NPCBrainRunner,
+  globalObservationBus,
+  createEmptyNPCMemoryV3,
+  type NPCMemoryV3,
+  type NPCDecision,
+  type NPCWorldSnapshot,
+  type NPCObservation,
+  emitCombatEvent,
+  emitTradeEvent,
+  emitQuestEvent,
+  emitFactionEvent,
+  emitEconomyEvent,
+} from "../npc/brain/index.js";
+
 export interface OuroborosEngineConfig extends OuroborosConfig {
   /** How many world ticks between Ouroboros cycles. */
   tickInterval: number;
   /** How many world ticks between conflict resolution checks. */
   conflictCheckInterval: number;
+  /** Enable NPC Brain autonomous learning system */
+  enableNPCBrain: boolean;
+  /** How many world ticks between NPC brain runs */
+  npcBrainInterval: number;
 }
 
 const DEFAULT_ENGINE_CONFIG: OuroborosEngineConfig = {
@@ -30,6 +55,8 @@ const DEFAULT_ENGINE_CONFIG: OuroborosEngineConfig = {
   familyFormChance: 0.005,
   tickInterval: 10,
   conflictCheckInterval: 100,
+  enableNPCBrain: true,
+  npcBrainInterval: 10, // 1 Hz at 10 ticks/sec
 };
 
 export class OuroborosEngine {
@@ -39,6 +66,10 @@ export class OuroborosEngine {
   public readonly factions: DynamicFactions;
   private config: OuroborosEngineConfig;
   private readonly SPATIAL_CHUNK_SIZE = 64;
+  
+  // NPC Brain System integration
+  private npcBrainRunner: NPCBrainRunner;
+  private npcMemories: Map<string, NPCMemoryV3> = new Map();
 
   constructor(config?: Partial<OuroborosEngineConfig>) {
     this.config = { ...DEFAULT_ENGINE_CONFIG, ...config };
@@ -46,6 +77,11 @@ export class OuroborosEngine {
     this.history = new WorldHistory();
     this.market = new EmergentMarket();
     this.factions = new DynamicFactions();
+    
+    // Initialize NPC Brain Runner
+    if (this.config.enableNPCBrain) {
+      this.npcBrainRunner = new NPCBrainRunner(globalObservationBus);
+    }
 
     this.eventBus.onAll((event) => {
       this.history.record(event);
@@ -163,6 +199,12 @@ export class OuroborosEngine {
           statusEmitter.emitNpcThinking(npc.name, `[${action.type}]`, npc.position);
         }
       }
+
+      // ─── NPC Brain Integration ────────────────────────────────────────────────
+      // Run NPC brain for autonomous learning (every npcBrainInterval ticks)
+      if (this.config.enableNPCBrain && this.npcBrainRunner && tickCount % this.config.npcBrainInterval === 0) {
+        this.runNPCBrainTick(npc, ctx, tickCount, nearby);
+      }
     }
 
     // Resolve faction conflicts periodically
@@ -220,6 +262,151 @@ export class OuroborosEngine {
       families: this.factions.getAllFamilies().length,
       marketRegions: this.market.getRegions().length,
       tradeRoutes: this.market.getEstablishedRoutes().length,
+      // NPC Brain System stats
+      npcBrainEnabled: this.config.enableNPCBrain,
+      npcBrainInterval: this.config.npcBrainInterval,
+      trackedNPCs: this.npcMemories.size,
+      npcBrainStats: this.npcBrainRunner?.getStats() ?? null,
     };
   }
+
+  // ─── NPC Brain Helper Methods ───────────────────────────────────────────────
+
+  /**
+   * Run NPC brain tick for single NPC
+   */
+  private runNPCBrainTick(
+    npc: { id: string; name: string; position: { x: number; y: number }; faction?: string },
+    ctx: AgentContext,
+    tickCount: number,
+    nearby: Array<{ id: string; name: string; type: "npc" | "player"; position: { x: number; y: number }; faction?: string }>
+  ): void {
+    if (!this.npcBrainRunner) return;
+
+    // Get or create NPC memory
+    let memory = this.npcMemories.get(npc.id);
+    if (!memory) {
+      memory = createEmptyNPCMemoryV3(
+        npc.id,
+        npc.name,
+        ctx.regionId,
+        "worker", // Default profession
+        "citizen" // Default role
+      );
+      this.npcMemories.set(npc.id, memory);
+    }
+
+    // Build world snapshot
+    const worldSnapshot: NPCWorldSnapshot = {
+      tick: tickCount,
+      regionId: ctx.regionId,
+      timeOfDay: (tickCount % 1000) / 1000 * 24,
+      dangerLevel: nearby.some((e) => e.type === "player" || e.type === "npc") ? 0.3 : 0.1,
+      resourceAvailability: {},
+      marketPrices: {},
+      nearbyThreats: [],
+      friendlyNPCs: nearby.filter((e) => e.type === "npc").map((e) => e.id),
+      hostileNPCs: [],
+    };
+
+    // Build nearby entities for brain
+    const brainNearbyEntities = nearby.map((e) => ({
+      id: e.id,
+      name: e.name,
+      type: e.type as "player" | "npc" | "monster",
+      position: e.position,
+      faction: e.faction,
+      hostile: e.type !== "npc", // Players are hostile by default in this simplified model
+    }));
+
+    // Run NPC brain
+    const output = this.npcBrainRunner.runWithContext({
+      npcId: npc.id,
+      npcName: npc.name,
+      position: npc.position,
+      homeRegionId: ctx.regionId,
+      factionId: npc.faction,
+      state: "idle",
+      health: 0.8, // TODO: Get from actual NPC state
+      energy: 0.7,
+      gold: 50,
+      memory,
+      nearbyEntities: brainNearbyEntities,
+      tick: tickCount,
+      worldSnapshot,
+    });
+
+    // Store updated memory
+    this.npcMemories.set(npc.id, output.memory);
+
+    // Emit world events based on NPC decisions
+    this.emitNPCCognitiveEvents(npc, output.decision, tickCount);
+  }
+
+  /**
+   * Emit world events from NPC decisions
+   */
+  private emitNPCCognitiveEvents(
+    npc: { id: string; name: string; position: { x: number; y: number } },
+    decision: NPCDecision,
+    tickCount: number
+  ): void {
+    switch (decision.action) {
+      case "raise_alarm":
+        globalObservationBus.emit("player_attack", tickCount, {
+          actorId: npc.id,
+          actorName: npc.name,
+          regionId: `region_${Math.floor(npc.position.x / 100)}_${Math.floor(npc.position.y / 100)}`,
+          impact: -2,
+          tags: ["alarm", "danger"],
+          payload: { reason: decision.reason },
+        });
+        break;
+
+      case "flee":
+        globalObservationBus.emit("player_attack", tickCount, {
+          actorId: npc.id,
+          actorName: npc.name,
+          regionId: `region_${Math.floor(npc.position.x / 100)}_${Math.floor(npc.position.y / 100)}`,
+          impact: 1,
+          tags: ["flee", "evasion"],
+          payload: { reason: decision.reason },
+        });
+        break;
+
+      case "trade":
+        globalObservationBus.emit("player_trade", tickCount, {
+          actorId: npc.id,
+          actorName: npc.name,
+          regionId: `region_${Math.floor(npc.position.x / 100)}_${Math.floor(npc.position.y / 100)}`,
+          impact: 3,
+          tags: ["trade", "economy"],
+          payload: { reason: decision.reason },
+        });
+        break;
+    }
+  }
+
+  /**
+   * Get NPC memory by ID
+   */
+  getNPCMemory(npcId: string): NPCMemoryV3 | undefined {
+    return this.npcMemories.get(npcId);
+  }
+
+  /**
+   * Get all NPC memories (for debugging)
+   */
+  getAllNPCMemories(): Map<string, NPCMemoryV3> {
+    return this.npcMemories;
+  }
+
+  /**
+   * Reset NPC brain state (for world reset)
+   */
+  resetNPCBrains(): void {
+    this.npcMemories.clear();
+    this.npcBrainRunner?.reset();
+  }
+}
 }

--- a/server/src/tests/npc-autonomous-brain.test.ts
+++ b/server/src/tests/npc-autonomous-brain.test.ts
@@ -1,0 +1,1187 @@
+/**
+ * NPC Autonomous Brain Tests — Deterministic Replay Verification
+ * 
+ * Tests for:
+ * - Memory V3 structure and creation
+ * - Observation bus functionality
+ * - Memory scoring and importance calculation
+ * - Decision engine deterministic behavior
+ * - Brain scheduler tick distribution
+ * - Memory compression
+ * - Debug snapshot generation
+ * - Replay verification (same tick + same input = same output)
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  // Types and creation
+  createEmptyNPCMemoryV3,
+  migrateLegacyMemory,
+  calculateMemoryHash,
+  generateGoalId,
+  generateEpisodicId,
+  type NPCMemoryV3,
+  type NPCObservation,
+  type NPCDecisionInput,
+  type WorldMemoryEventType,
+  // Observation Bus
+  NPCObservationBus,
+  emitCombatEvent,
+  emitTradeEvent,
+  emitQuestEvent,
+  // Memory Scoring
+  scoreMemory,
+  shouldStoreMemory,
+  observationToEpisodic,
+  getTopMemories,
+  calculateRelationScore,
+  getRelationDisposition,
+  applyObservationsToMemory,
+  updateRelationsFromObservation,
+  calculateMemoryFingerprint,
+  // Decision Engine
+  decideNPCAction,
+  applyActionOutcome,
+  calculateOutcomeScore,
+  getLearnedBestAction,
+  // Brain Scheduler
+  getNPCBrainPhase,
+  shouldRunBrainPhase,
+  getActivePhases,
+  getBrainState,
+  updateBrainState,
+  getNextDecisionTick,
+  getNextPlanningTick,
+  estimateCPULoad,
+  resetScheduler,
+  BrainPhase,
+  DEFAULT_SCHEDULER_CONFIG,
+  // Memory Compression
+  compressNPCMemory,
+  shouldCompress,
+  verifyMemoryIntegrity,
+  getMemoryStats,
+  DEFAULT_COMPRESSION_CONFIG,
+  // Debug Snapshot
+  createNPCBrainDebugSnapshot,
+  verifyReplay,
+  checkBrainHealth,
+  generateNPCSummaryReport,
+  // Brain Runner
+  NPCBrainRunner,
+  decisionToState,
+  createDefaultWorldSnapshot,
+} from "../modules/npc/brain/index.js";
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+function createTestMemory(npcId: string = "test_npc_1"): NPCMemoryV3 {
+  return createEmptyNPCMemoryV3(
+    npcId,
+    "Test NPC",
+    "region_test",
+    "merchant",
+    "trader"
+  );
+}
+
+function createTestObservation(
+  tick: number = 100,
+  type: WorldMemoryEventType = "player_attack",
+  overrides: Partial<NPCObservation> = {}
+): NPCObservation {
+  return {
+    id: `obs_${tick}_${type}`,
+    tick,
+    type,
+    actorId: "player_1",
+    actorName: "Test Player",
+    targetId: "test_npc_1",
+    targetName: "Test NPC",
+    regionId: "region_test",
+    impact: type === "player_attack" ? -8 : 3,
+    tags: [type],
+    payload: {},
+    ...overrides,
+  };
+}
+
+function createTestDecisionInput(
+  memory: NPCMemoryV3,
+  tick: number = 100
+): NPCDecisionInput {
+  return {
+    tick,
+    npcId: memory.identity.npcId,
+    npcName: memory.identity.name,
+    position: { x: 100, y: 200 },
+    homeRegionId: memory.identity.homeRegionId,
+    state: "idle",
+    health: 0.8,
+    energy: 0.7,
+    gold: 50,
+    memory,
+    world: {
+      tick,
+      regionId: "region_test",
+      timeOfDay: 12,
+      dangerLevel: 0.2,
+      resourceAvailability: {},
+      marketPrices: { iron: 30, wood: 15 },
+      nearbyThreats: [],
+      friendlyNPCs: [],
+      hostileNPCs: [],
+    },
+    nearbyEntities: [
+      { id: "player_1", name: "Player One", type: "player" as const, position: { x: 105, y: 205 }, hostile: true },
+      { id: "npc_2", name: "Friend NPC", type: "npc" as const, position: { x: 95, y: 195 }, hostile: false },
+    ],
+  };
+}
+
+// ============================================================================
+// NPCMemoryV3 Tests
+// ============================================================================
+
+describe("NPCMemoryV3", () => {
+  describe("createEmptyNPCMemoryV3", () => {
+    it("creates memory with correct identity", () => {
+      const memory = createEmptyNPCMemoryV3("npc_1", "Bob", "region_a", "guard", "soldier");
+      
+      expect(memory.identity.npcId).toBe("npc_1");
+      expect(memory.identity.name).toBe("Bob");
+      expect(memory.identity.profession).toBe("guard");
+      expect(memory.identity.role).toBe("soldier");
+      expect(memory.identity.homeRegionId).toBe("region_a");
+    });
+
+    it("creates memory with default values", () => {
+      const memory = createEmptyNPCMemoryV3("npc_1", "Bob", "region_a");
+      
+      expect(memory.identity.courage).toBe(50);
+      expect(memory.identity.greed).toBe(30);
+      expect(memory.identity.loyalty).toBe(50);
+      expect(memory.identity.moralAlignment).toBe(0);
+    });
+
+    it("creates memory with empty collections", () => {
+      const memory = createEmptyNPCMemoryV3("npc_1", "Bob", "region_a");
+      
+      expect(memory.episodic).toEqual([]);
+      expect(memory.semantic).toEqual([]);
+      expect(memory.goals).toEqual([]);
+      expect(memory.relations).toEqual({});
+      expect(memory.routines).toEqual([]);
+      expect(memory.fears).toEqual([]);
+      expect(memory.skills).toEqual([]);
+    });
+  });
+
+  describe("migrateLegacyMemory", () => {
+    it("migrates string goals to structured goals", () => {
+      const legacy = {
+        longTermGoals: ["guard_the_village", "trade_with_merchants"],
+      };
+      
+      const memory = migrateLegacyMemory(legacy, "npc_1", "Bob", "region_a");
+      
+      expect(memory.goals.length).toBe(2);
+      expect(memory.goals[0]!.type).toBe("defend");
+      expect(memory.goals[1]!.type).toBe("trade");
+    });
+
+    it("handles empty legacy memory", () => {
+      const legacy = {};
+      const memory = migrateLegacyMemory(legacy, "npc_1", "Bob", "region_a");
+      
+      expect(memory.goals).toEqual([]);
+    });
+  });
+
+  describe("generateGoalId", () => {
+    it("generates deterministic goal IDs", () => {
+      const id1 = generateGoalId("npc_1", "combat", 100);
+      const id2 = generateGoalId("npc_1", "combat", 100);
+      
+      expect(id1).toBe(id2);
+      expect(id1).toMatch(/^goal_[a-f0-9]+$/);
+    });
+
+    it("generates different IDs for different inputs", () => {
+      const id1 = generateGoalId("npc_1", "combat", 100);
+      const id2 = generateGoalId("npc_1", "trade", 100);
+      const id3 = generateGoalId("npc_2", "combat", 100);
+      
+      expect(id1).not.toBe(id2);
+      expect(id1).not.toBe(id3);
+    });
+  });
+
+  describe("calculateMemoryHash", () => {
+    it("generates consistent hash for same memory", () => {
+      const memory = createTestMemory();
+      const hash1 = calculateMemoryHash(memory);
+      const hash2 = calculateMemoryHash(memory);
+      
+      expect(hash1).toBe(hash2);
+    });
+
+    it("generates different hash for different memory", () => {
+      const memory1 = createTestMemory("npc_1");
+      const memory2 = createTestMemory("npc_2");
+      
+      const hash1 = calculateMemoryHash(memory1);
+      const hash2 = calculateMemoryHash(memory2);
+      
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+});
+
+// ============================================================================
+// NPCObservationBus Tests
+// ============================================================================
+
+describe("NPCObservationBus", () => {
+  let bus: NPCObservationBus;
+
+  beforeEach(() => {
+    bus = new NPCObservationBus();
+  });
+
+  describe("emit", () => {
+    it("creates observation with generated ID", () => {
+      const obs = bus.emit("player_attack", 100, {
+        actorId: "player_1",
+        targetId: "npc_1",
+        impact: -8,
+      });
+
+      expect(obs.id).toMatch(/^obs_[a-f0-9]+$/);
+      expect(obs.tick).toBe(100);
+      expect(obs.type).toBe("player_attack");
+      expect(obs.actorId).toBe("player_1");
+      expect(obs.targetId).toBe("npc_1");
+      expect(obs.impact).toBe(-8);
+    });
+
+    it("stores observation in history", () => {
+      bus.emit("player_attack", 100, { actorId: "player_1", targetId: "npc_1" });
+      bus.emit("combat_won", 101, { actorId: "npc_1", targetId: "monster_1" });
+
+      const stats = bus.getStats();
+      expect(stats.totalObservations).toBe(2);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("receives type-specific events", () => {
+      const received: NPCObservation[] = [];
+      bus.subscribe("player_attack", (obs) => received.push(obs));
+
+      bus.emit("player_attack", 100, { actorId: "player_1", targetId: "npc_1" });
+      bus.emit("combat_won", 101, { actorId: "npc_1" });
+
+      expect(received.length).toBe(1);
+      expect(received[0]!.type).toBe("player_attack");
+    });
+
+    it("allows unsubscribe", () => {
+      const received: NPCObservation[] = [];
+      const unsubscribe = bus.subscribe("player_attack", (obs) => received.push(obs));
+
+      bus.emit("player_attack", 100, { actorId: "player_1", targetId: "npc_1" });
+      unsubscribe();
+      bus.emit("player_attack", 101, { actorId: "player_1", targetId: "npc_1" });
+
+      expect(received.length).toBe(1);
+    });
+  });
+
+  describe("subscribeAll", () => {
+    it("receives all events", () => {
+      const received: NPCObservation[] = [];
+      bus.subscribeAll((obs) => received.push(obs));
+
+      bus.emit("player_attack", 100, { actorId: "player_1" });
+      bus.emit("combat_won", 101, { actorId: "npc_1" });
+
+      expect(received.length).toBe(2);
+    });
+  });
+
+  describe("getObservationsForNPC", () => {
+    it("filters observations by NPC relevance", () => {
+      const memory = createTestMemory("npc_1");
+      
+      bus.emit("player_attack", 100, { 
+        actorId: "player_1", 
+        targetId: "npc_1",
+        regionId: "region_test",
+      });
+      bus.emit("player_attack", 101, { 
+        actorId: "player_1", 
+        targetId: "npc_2",
+        regionId: "region_other",
+      });
+
+      const obs = bus.getObservationsForNPC("npc_1", memory);
+      expect(obs.length).toBe(1);
+    });
+  });
+});
+
+// ============================================================================
+// NPCMemoryScoring Tests
+// ============================================================================
+
+describe("NPCMemoryScoring", () => {
+  describe("scoreMemory", () => {
+    it("scores higher for self-targeted events", () => {
+      const memory = createTestMemory("npc_1");
+      const obs = createTestObservation(100, "player_attack", {
+        targetId: "npc_1",
+        impact: -8,
+      });
+
+      const score = scoreMemory(obs, memory, 100);
+
+      expect(score.finalScore).toBeGreaterThan(0);
+      expect(score.personalRelevance).toBe(10); // TARGET_SELF
+    });
+
+    it("scores higher for home region events", () => {
+      const memory = createTestMemory("npc_1");
+      const obs = createTestObservation(100, "resource_shortage", {
+        regionId: "region_test",
+        impact: -4,
+      });
+
+      const score = scoreMemory(obs, memory, 100);
+
+      expect(score.personalRelevance).toBe(5); // HOME_REGION
+    });
+
+    it("applies emotional weight to score", () => {
+      const memory = createTestMemory("npc_1");
+      
+      const lowImpact = createTestObservation(100, "player_trade", { impact: 2 });
+      const highImpact = createTestObservation(100, "player_attack", { impact: -8 });
+
+      const scoreLow = scoreMemory(lowImpact, memory, 100);
+      const scoreHigh = scoreMemory(highImpact, memory, 100);
+
+      expect(scoreHigh.finalScore).toBeGreaterThan(scoreLow.finalScore);
+    });
+  });
+
+  describe("shouldStoreMemory", () => {
+    it("returns true for high-scoring observations", () => {
+      const memory = createTestMemory("npc_1");
+      const obs = createTestObservation(100, "player_attack", {
+        targetId: "npc_1",
+        impact: -8,
+      });
+
+      expect(shouldStoreMemory(obs, memory, 100)).toBe(true);
+    });
+
+    it("returns false for low-scoring observations", () => {
+      const memory = createTestMemory("npc_1");
+      const obs = createTestObservation(100, "exploration_discovered", {
+        impact: 1,
+        actorId: "npc_other",
+        targetId: "npc_other",
+      });
+
+      expect(shouldStoreMemory(obs, memory, 100)).toBe(false);
+    });
+  });
+
+  describe("getTopMemories", () => {
+    it("returns memories sorted by score", () => {
+      const memory = createTestMemory("npc_1");
+      memory.episodic = [
+        { id: "e1", tick: 100, type: "player_attack", impact: -8, tags: [], score: 5 },
+        { id: "e2", tick: 101, type: "player_trade", impact: 3, tags: [], score: 15 },
+        { id: "e3", tick: 102, type: "quest_completed", impact: 6, tags: [], score: 25 },
+      ];
+
+      const top = getTopMemories(memory.episodic, 2);
+
+      expect(top.length).toBe(2);
+      expect(top[0]!.id).toBe("e3");
+      expect(top[1]!.id).toBe("e2");
+    });
+  });
+
+  describe("calculateRelationScore", () => {
+    it("returns 0.5 for neutral relation", () => {
+      const relation = {
+        entityId: "player_1",
+        entityType: "player" as const,
+        trust: 0,
+        fear: 0,
+        respect: 0,
+        greed: 0,
+        morale: 0,
+        interactions: 0,
+        lastInteractionTick: 0,
+        positiveInteractions: 0,
+        negativeInteractions: 0,
+      };
+
+      const score = calculateRelationScore(relation);
+      expect(score).toBeCloseTo(0.5, 1);
+    });
+
+    it("returns higher score for positive relation", () => {
+      const relation = {
+        entityId: "player_1",
+        entityType: "player" as const,
+        trust: 80,
+        fear: 0,
+        respect: 70,
+        greed: 0,
+        morale: 80,
+        interactions: 10,
+        lastInteractionTick: 0,
+        positiveInteractions: 10,
+        negativeInteractions: 0,
+      };
+
+      const score = calculateRelationScore(relation);
+      expect(score).toBeGreaterThan(0.6);
+    });
+
+    it("returns lower score for fearful relation", () => {
+      const relation = {
+        entityId: "player_1",
+        entityType: "player" as const,
+        trust: 50,
+        fear: 90,
+        respect: 0,
+        greed: 0,
+        morale: -30,
+        interactions: 5,
+        lastInteractionTick: 0,
+        positiveInteractions: 2,
+        negativeInteractions: 3,
+      };
+
+      const score = calculateRelationScore(relation);
+      expect(score).toBeLessThan(0.4);
+    });
+  });
+
+  describe("getRelationDisposition", () => {
+    it("returns 'friendly' for high score", () => {
+      const relation = {
+        entityId: "player_1",
+        entityType: "player" as const,
+        trust: 70,
+        fear: 10,
+        respect: 60,
+        greed: 20,
+        morale: 60,
+        interactions: 10,
+        lastInteractionTick: 0,
+        positiveInteractions: 9,
+        negativeInteractions: 1,
+      };
+
+      expect(getRelationDisposition(relation)).toBe("friendly");
+    });
+
+    it("returns 'hostile' for low score", () => {
+      const relation = {
+        entityId: "player_1",
+        entityType: "player" as const,
+        trust: -60,
+        fear: 80,
+        respect: 10,
+        greed: 50,
+        morale: -70,
+        interactions: 10,
+        lastInteractionTick: 0,
+        positiveInteractions: 2,
+        negativeInteractions: 8,
+      };
+
+      expect(getRelationDisposition(relation)).toBe("hostile");
+    });
+
+    it("returns 'neutral' for middle score", () => {
+      const relation = {
+        entityId: "player_1",
+        entityType: "player" as const,
+        trust: 0,
+        fear: 30,
+        respect: 30,
+        greed: 30,
+        morale: 0,
+        interactions: 5,
+        lastInteractionTick: 0,
+        positiveInteractions: 3,
+        negativeInteractions: 2,
+      };
+
+      expect(getRelationDisposition(relation)).toBe("neutral");
+    });
+  });
+
+  describe("applyObservationsToMemory", () => {
+    it("adds high-scoring observations to episodic memory", () => {
+      const memory = createTestMemory("npc_1");
+      const obs = createTestObservation(100, "player_attack", {
+        targetId: "npc_1",
+        impact: -8,
+      });
+
+      const updated = applyObservationsToMemory(memory, [obs], 100);
+
+      expect(updated.episodic.length).toBeGreaterThan(0);
+    });
+
+    it("limits episodic memory size", () => {
+      const memory = createTestMemory("npc_1");
+      const observations: NPCObservation[] = [];
+      
+      // Add 300 observations
+      for (let i = 0; i < 300; i++) {
+        observations.push(createTestObservation(100 + i, "player_attack", {
+          targetId: "npc_1",
+          impact: -8,
+        }));
+      }
+
+      const updated = applyObservationsToMemory(memory, observations, 400);
+
+      expect(updated.episodic.length).toBeLessThanOrEqual(256);
+    });
+  });
+
+  describe("updateRelationsFromObservation", () => {
+    it("updates actor relation on positive interaction", () => {
+      const relations: Record<string, any> = {};
+      const obs = createTestObservation(100, "player_trade", {
+        actorId: "player_1",
+        targetId: "npc_1",
+        impact: 3,
+      });
+
+      const updated = updateRelationsFromObservation(relations, obs, 100);
+
+      expect(updated["player_1"]).toBeDefined();
+      expect(updated["player_1"]!.trust).toBeGreaterThan(0);
+      expect(updated["player_1"]!.morale).toBeGreaterThan(0);
+    });
+
+    it("updates actor relation on negative interaction", () => {
+      const relations: Record<string, any> = {};
+      const obs = createTestObservation(100, "player_attack", {
+        actorId: "player_1",
+        targetId: "npc_1",
+        impact: -8,
+      });
+
+      const updated = updateRelationsFromObservation(relations, obs, 100);
+
+      expect(updated["player_1"]).toBeDefined();
+      expect(updated["player_1"]!.trust).toBeLessThan(0);
+      expect(updated["player_1"]!.fear).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ============================================================================
+// NPCDecisionEngine Tests
+// ============================================================================
+
+describe("NPCDecisionEngine", () => {
+  describe("decideNPCAction", () => {
+    it("returns flee when hostiles are near and NPC is scared", () => {
+      const memory = createTestMemory("npc_1");
+      memory.identity.courage = 30; // Low courage = scared
+
+      const input = createTestDecisionInput(memory, 100);
+      input.nearbyEntities = [
+        { id: "monster_1", name: "Wolf", type: "monster", position: { x: 105, y: 205 }, hostile: true },
+      ];
+
+      const decision = decideNPCAction(input);
+
+      expect(decision.action).toBe("flee");
+      expect(decision.score).toBeGreaterThan(0);
+    });
+
+    it("returns idle when no nearby entities", () => {
+      const memory = createTestMemory("npc_1");
+      const input = createTestDecisionInput(memory, 100);
+      input.nearbyEntities = [];
+
+      const decision = decideNPCAction(input);
+
+      expect(decision.action).toBe("idle");
+    });
+
+    it("merchant prefers trade action", () => {
+      const memory = createTestMemory("npc_1");
+      memory.identity.profession = "merchant";
+      memory.identity.role = "trader";
+
+      const input = createTestDecisionInput(memory, 100);
+      input.nearbyEntities = [
+        { id: "player_1", name: "Player", type: "player", position: { x: 105, y: 205 }, hostile: false },
+      ];
+      input.gold = 10; // Low gold increases trade desire
+
+      const decision = decideNPCAction(input);
+
+      expect(decision.action).toBe("trade");
+    });
+
+    it("guard prefers patrol when no threat", () => {
+      const memory = createTestMemory("npc_1");
+      memory.identity.role = "guard";
+
+      const input = createTestDecisionInput(memory, 100);
+      input.nearbyEntities = [];
+      input.world.dangerLevel = 0.1;
+
+      const decision = decideNPCAction(input);
+
+      expect(["patrol", "work", "idle"]).toContain(decision.action);
+    });
+
+    it("returns deterministic result for same input", () => {
+      const memory = createTestMemory("npc_1");
+      const input = createTestDecisionInput(memory, 100);
+
+      const decision1 = decideNPCAction(input);
+      const decision2 = decideNPCAction(input);
+
+      expect(decision1.action).toBe(decision2.action);
+      expect(decision1.score).toBe(decision2.score);
+      expect(decision1.reason).toBe(decision2.reason);
+    });
+  });
+
+  describe("applyActionOutcome", () => {
+    it("updates action scores on success", () => {
+      const memory = createTestMemory("npc_1");
+
+      const updated = applyActionOutcome(memory, "trade", "context_trade_1", 10, 100);
+
+      expect(updated.learning.actionScores["action:trade"]).toBe(10);
+      expect(updated.learning.successfulActions["action:trade"]).toBe(1);
+      expect(updated.learning.totalActions).toBe(1);
+      expect(updated.learning.totalSuccesses).toBe(1);
+    });
+
+    it("updates action scores on failure", () => {
+      const memory = createTestMemory("npc_1");
+
+      const updated = applyActionOutcome(memory, "attack", "context_attack_1", -5, 100);
+
+      expect(updated.learning.actionScores["action:attack"]).toBeLessThan(0);
+      expect(updated.learning.failedActions["action:attack"]).toBe(1);
+      expect(updated.learning.totalSuccesses).toBe(0);
+    });
+
+    it("uses exponential moving average", () => {
+      let memory = createTestMemory("npc_1");
+
+      // First outcome
+      memory = applyActionOutcome(memory, "trade", "context_trade", 10, 100);
+      expect(memory.learning.actionScores["action:trade"]).toBe(10);
+
+      // Second outcome (should be weighted average)
+      memory = applyActionOutcome(memory, "trade", "context_trade", 10, 101);
+      // 10 * 0.85 + 10 * 0.15 = 10
+      expect(memory.learning.actionScores["action:trade"]).toBe(10);
+
+      // Third outcome with different score
+      memory = applyActionOutcome(memory, "trade", "context_trade", -5, 102);
+      // 10 * 0.85 + (-5) * 0.15 = 8.5 - 0.75 = 7.75 -> 7
+      expect(memory.learning.actionScores["action:trade"]).toBe(7);
+    });
+  });
+
+  describe("calculateOutcomeScore", () => {
+    it("scores positive for success", () => {
+      const score = calculateOutcomeScore("trade", { success: true, goldGained: 50 });
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it("scores negative for failure", () => {
+      const score = calculateOutcomeScore("attack", { success: false, damageTaken: 50 });
+      expect(score).toBeLessThan(0);
+    });
+
+    it("considers multiple factors", () => {
+      const score = calculateOutcomeScore("combat", {
+        success: true,
+        damageDealt: 100,
+        damageTaken: 20,
+        goldGained: 10,
+      });
+      expect(score).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ============================================================================
+// NPCBrainScheduler Tests
+// ============================================================================
+
+describe("NPCBrainScheduler", () => {
+  beforeEach(() => {
+    resetScheduler();
+  });
+
+  describe("getNPCBrainPhase", () => {
+    it("returns consistent phase for same NPC", () => {
+      const phase1 = getNPCBrainPhase("npc_1", 10);
+      const phase2 = getNPCBrainPhase("npc_1", 10);
+      expect(phase1).toBe(phase2);
+    });
+
+    it("distributes NPCs across phases", () => {
+      const phases = new Set<number>();
+      for (let i = 0; i < 100; i++) {
+        phases.add(getNPCBrainPhase(`npc_${i}`, 10));
+      }
+      // Should have multiple phases represented
+      expect(phases.size).toBeGreaterThan(1);
+    });
+  });
+
+  describe("shouldRunBrainPhase", () => {
+    it("returns true at correct tick intervals", () => {
+      const npcId = "npc_test";
+      const phase = getNPCBrainPhase(npcId, 10);
+
+      // Should be true when tick % interval equals phase
+      expect(shouldRunBrainPhase(npcId, phase, 10)).toBe(true);
+      expect(shouldRunBrainPhase(npcId, phase + 10, 10)).toBe(true);
+    });
+
+    it("returns false at incorrect tick intervals", () => {
+      const npcId = "npc_test";
+      const phase = getNPCBrainPhase(npcId, 10);
+
+      expect(shouldRunBrainPhase(npcId, phase + 1, 10)).toBe(false);
+      expect(shouldRunBrainPhase(npcId, phase + 5, 10)).toBe(false);
+    });
+  });
+
+  describe("getActivePhases", () => {
+    it("always includes TICK phase", () => {
+      const phases = getActivePhases("npc_1", 100, DEFAULT_SCHEDULER_CONFIG);
+      expect(phases).toContain(BrainPhase.TICK);
+    });
+
+    it("includes DECISION phase at correct intervals", () => {
+      const npcId = "npc_1";
+      const phase = getNPCBrainPhase(npcId, 10);
+      
+      const phases = getActivePhases(npcId, phase, DEFAULT_SCHEDULER_CONFIG);
+      expect(phases).toContain(BrainPhase.DECISION);
+    });
+  });
+
+  describe("getNextDecisionTick", () => {
+    it("returns future tick", () => {
+      const npcId = "npc_test";
+      const currentTick = 100;
+      const nextTick = getNextDecisionTick(npcId, currentTick);
+
+      expect(nextTick).toBeGreaterThanOrEqual(currentTick);
+    });
+  });
+
+  describe("estimateCPULoad", () => {
+    it("calculates operations per second", () => {
+      const load = estimateCPULoad(100, DEFAULT_SCHEDULER_CONFIG);
+
+      expect(load.tickOpsPerSecond).toBe(1000); // 100 * 10
+      expect(load.decisionOpsPerSecond).toBe(100); // 100 * (10/10)
+      expect(load.planningOpsPerSecond).toBe(10); // 100 * (10/100)
+    });
+  });
+});
+
+// ============================================================================
+// NPCMemoryCompression Tests
+// ============================================================================
+
+describe("NPCMemoryCompression", () => {
+  describe("compressNPCMemory", () => {
+    it("keeps important memories", () => {
+      const memory = createTestMemory("npc_1");
+      memory.episodic = [
+        { id: "e1", tick: 50, type: "player_attack", impact: -8, tags: [], score: 20 },
+        { id: "e2", tick: 51, type: "player_trade", impact: 3, tags: [], score: 3 },
+        { id: "e3", tick: 52, type: "quest_completed", impact: 6, tags: [], score: 12 },
+      ];
+
+      const compressed = compressNPCMemory(memory, 200, {
+        minEpisodicScore: 5,
+        maxEpisodicMemories: 64,
+        maxSemanticMemories: 128,
+        compressionInterval: 100,
+        minEventsForSummary: 3,
+        summaryImportanceThreshold: 8,
+      });
+
+      expect(compressed.episodic.length).toBeLessThanOrEqual(64);
+      // Should keep e1 and e3 (score >= 5), may drop e2
+    });
+
+    it("generates semantic summary", () => {
+      const memory = createTestMemory("npc_1");
+      memory.episodic = [
+        { id: "e1", tick: 50, type: "player_attack", impact: -8, tags: ["combat"], score: 20 },
+        { id: "e2", tick: 51, type: "player_trade", impact: 3, tags: ["trade"], score: 10 },
+        { id: "e3", tick: 52, type: "quest_completed", impact: 6, tags: ["quest"], score: 15 },
+      ];
+
+      const compressed = compressNPCMemory(memory, 200, {
+        minEpisodicScore: 3,
+        maxEpisodicMemories: 64,
+        maxSemanticMemories: 128,
+        compressionInterval: 100,
+        minEventsForSummary: 3,
+        summaryImportanceThreshold: 8,
+      });
+
+      expect(compressed.semantic.length).toBeGreaterThan(0);
+      expect(compressed.semantic[0]!.text).toContain("attacks");
+    });
+
+    it("limits semantic memories", () => {
+      const memory = createTestMemory("npc_1");
+      // Add 200 semantic memories
+      memory.semantic = Array.from({ length: 200 }, (_, i) => ({
+        id: `sem_${i}`,
+        tick: 100 + i,
+        text: `Summary ${i}`,
+        category: "test",
+        confidence: 0.8,
+        sourceEventIds: [],
+        lastUpdatedTick: 100 + i,
+        weight: 10,
+        tags: [],
+      }));
+
+      const compressed = compressNPCMemory(memory, 300, DEFAULT_COMPRESSION_CONFIG);
+
+      expect(compressed.semantic.length).toBeLessThanOrEqual(128);
+    });
+  });
+
+  describe("verifyMemoryIntegrity", () => {
+    it("returns valid for healthy memory", () => {
+      const memory = createTestMemory("npc_1");
+
+      const result = verifyMemoryIntegrity(memory);
+
+      expect(result.valid).toBe(true);
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it("detects memory bloat", () => {
+      const memory = createTestMemory("npc_1");
+      memory.episodic = Array.from({ length: 300 }, (_, i) => ({
+        id: `e_${i}`,
+        tick: 100 + i,
+        type: "player_attack" as const,
+        impact: -5,
+        tags: [],
+        score: 5,
+      }));
+
+      const result = verifyMemoryIntegrity(memory, 256, 128, 20, 100);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues.some(i => i.includes("Episodic"))).toBe(true);
+    });
+  });
+
+  describe("getMemoryStats", () => {
+    it("returns correct statistics", () => {
+      const memory = createTestMemory("npc_1");
+      memory.episodic = [
+        { id: "e1", tick: 100, type: "player_attack", impact: -8, tags: [], score: 10 },
+        { id: "e2", tick: 101, type: "player_trade", impact: 3, tags: [], score: 5 },
+      ];
+      memory.semantic = [
+        { id: "s1", tick: 100, text: "Test", category: "test", confidence: 0.8, sourceEventIds: [], lastUpdatedTick: 100, weight: 10, tags: [] },
+      ];
+      memory.goals = [
+        { id: "g1", type: "combat" as const, priority: 80, createdAtTick: 100, reason: "defend" },
+        { id: "g2", type: "trade" as const, priority: 60, createdAtTick: 100, reason: "earn" },
+      ];
+
+      const stats = getMemoryStats(memory);
+
+      expect(stats.totalMemories).toBe(3);
+      expect(stats.episodicCount).toBe(2);
+      expect(stats.semanticCount).toBe(1);
+      expect(stats.goalCount).toBe(2);
+      expect(stats.averageScore).toBe(7.5);
+    });
+  });
+});
+
+// ============================================================================
+// NPCBrainDebugSnapshot Tests
+// ============================================================================
+
+describe("NPCBrainDebugSnapshot", () => {
+  describe("createNPCBrainDebugSnapshot", () => {
+    it("creates snapshot with all fields", () => {
+      const memory = createTestMemory("npc_1");
+      memory.episodic = [
+        { id: "e1", tick: 100, type: "player_attack", impact: -8, tags: [], score: 10 },
+      ];
+      memory.goals = [
+        { id: "g1", type: "combat" as const, priority: 80, createdAtTick: 100, reason: "defend" },
+      ];
+
+      const snapshot = createNPCBrainDebugSnapshot(
+        "npc_1",
+        100,
+        "combat",
+        memory,
+        { action: "attack", reason: "hostile_nearby", score: 25, confidence: 0.8 }
+      );
+
+      expect(snapshot.npcId).toBe("npc_1");
+      expect(snapshot.tick).toBe(100);
+      expect(snapshot.state).toBe("combat");
+      expect(snapshot.topGoal).toBeDefined();
+      expect(snapshot.decision.action).toBe("attack");
+      expect(snapshot.memoryHash).toBeDefined();
+    });
+  });
+
+  describe("checkBrainHealth", () => {
+    it("returns healthy for good memory", () => {
+      const memory = createTestMemory("npc_1");
+      memory.learning.totalActions = 10;
+      memory.learning.totalSuccesses = 7;
+
+      const health = checkBrainHealth(memory, 200);
+
+      expect(health.healthy).toBe(true);
+      expect(health.score).toBeGreaterThan(50);
+    });
+
+    it("detects issues", () => {
+      const memory = createTestMemory("npc_1");
+      memory.episodic = Array.from({ length: 250 }, (_, i) => ({
+        id: `e_${i}`,
+        tick: 100 + i,
+        type: "player_attack" as const,
+        impact: -5,
+        tags: [],
+        score: 5,
+      }));
+      memory.learning.totalActions = 10;
+      memory.learning.totalSuccesses = 2; // Low success rate
+
+      const health = checkBrainHealth(memory, 200);
+
+      expect(health.healthy).toBe(false);
+      expect(health.issues.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("generateNPCSummaryReport", () => {
+    it("generates formatted report", () => {
+      const memory = createTestMemory("npc_1");
+      memory.learning.totalActions = 50;
+      memory.learning.totalSuccesses = 35;
+
+      const report = generateNPCSummaryReport("npc_1", memory, 100);
+
+      expect(report).toContain("NPC Brain Report: npc_1");
+      expect(report).toContain("Tick: 100");
+      expect(report).toContain("Role: trader");
+      expect(report).toContain("Success Rate:");
+    });
+  });
+});
+
+// ============================================================================
+// NPCBrainRunner Tests
+// ============================================================================
+
+describe("NPCBrainRunner", () => {
+  let runner: NPCBrainRunner;
+
+  beforeEach(() => {
+    runner = new NPCBrainRunner();
+  });
+
+  describe("runNPCBrain", () => {
+    it("runs brain tick and returns output", () => {
+      const memory = createTestMemory("npc_1");
+      const input = createTestDecisionInput(memory, 100);
+
+      const output = runner.runNPCBrain(input);
+
+      expect(output.npcId).toBe("npc_1");
+      expect(output.tick).toBe(100);
+      expect(output.decision).toBeDefined();
+      expect(output.memoryHash).toBeDefined();
+    });
+
+    it("applies observations to memory", () => {
+      const memory = createTestMemory("npc_1");
+      const input = createTestDecisionInput(memory, 100);
+
+      // Add observation before running
+      runner.runNPCBrain(input);
+
+      // Add new observation
+      const obs = createTestObservation(101, "player_attack", {
+        targetId: "npc_1",
+        impact: -8,
+      });
+      runner["observationBus"].emit("player_attack", 101, {
+        actorId: "player_1",
+        targetId: "npc_1",
+        impact: -8,
+      });
+
+      const input2 = createTestDecisionInput(memory, 102);
+      const output = runner.runNPCBrain(input2);
+
+      // Memory should be updated with observation
+      expect(output.memory.episodic.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("applyLearning", () => {
+    it("applies outcome to learning state", () => {
+      const memory = createTestMemory("npc_1");
+
+      const updated = runner.applyLearning(
+        memory,
+        "trade",
+        { success: true, goldGained: 50 },
+        "trade_at_market",
+        100
+      );
+
+      expect(updated.learning.totalActions).toBe(1);
+      expect(updated.learning.totalSuccesses).toBe(1);
+    });
+  });
+
+  describe("getDebugSnapshot", () => {
+    it("creates debug snapshot", () => {
+      const memory = createTestMemory("npc_1");
+      const decision = { action: "trade" as const, reason: "merchant", score: 20, confidence: 0.8 };
+
+      const snapshot = runner.getDebugSnapshot("npc_1", 100, "trading", memory, decision);
+
+      expect(snapshot.npcId).toBe("npc_1");
+      expect(snapshot.state).toBe("trading");
+      expect(snapshot.decision.action).toBe("trade");
+    });
+  });
+});
+
+// ============================================================================
+// Determinism/Replay Tests
+// ============================================================================
+
+describe("Determinism and Replay", () => {
+  let runner: NPCBrainRunner;
+
+  beforeEach(() => {
+    runner = new NPCBrainRunner();
+  });
+
+  it("same tick + same input = same output (memory scoring)", () => {
+    const memory1 = createTestMemory("npc_1");
+    const memory2 = createTestMemory("npc_1");
+    
+    const obs = createTestObservation(100, "player_attack", {
+      targetId: "npc_1",
+      impact: -8,
+    });
+
+    const updated1 = applyObservationsToMemory(memory1, [obs], 100);
+    const updated2 = applyObservationsToMemory(memory2, [obs], 100);
+
+    expect(updated1.episodic.length).toBe(updated2.episodic.length);
+  });
+
+  it("same tick + same input = same output (decision)", () => {
+    const memory = createTestMemory("npc_1");
+    const input = createTestDecisionInput(memory, 100);
+
+    const output1 = runner.runNPCBrain(input);
+    const output2 = runner.runNPCBrain(input);
+
+    expect(output1.decision.action).toBe(output2.decision.action);
+    expect(output1.decision.score).toBe(output2.decision.score);
+    expect(output1.memoryHash).toBe(output2.memoryHash);
+  });
+
+  it("memory hash changes with different input", () => {
+    const memory1 = createTestMemory("npc_1");
+    const memory2 = createTestMemory("npc_1");
+    memory2.episodic = [
+      { id: "e1", tick: 100, type: "player_attack", impact: -8, tags: [], score: 10 },
+    ];
+
+    const hash1 = calculateMemoryHash(memory1);
+    const hash2 = calculateMemoryHash(memory2);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("decision varies with different context", () => {
+    const memory = createTestMemory("npc_1");
+
+    // Scenario 1: No hostiles
+    const input1 = createTestDecisionInput(memory, 100);
+    input1.nearbyEntities = [];
+    const decision1 = decideNPCAction(input1);
+
+    // Scenario 2: Hostile present
+    const input2 = createTestDecisionInput(memory, 101);
+    input2.nearbyEntities = [
+      { id: "monster", name: "Wolf", type: "monster", position: { x: 105, y: 205 }, hostile: true },
+    ];
+    const decision2 = decideNPCAction(input2);
+
+    // Decisions should differ
+    expect(decision1.action).not.toBe(decision2.action);
+  });
+
+  it("replay verification detects changes", () => {
+    const memory = createTestMemory("npc_1");
+    const input = createTestDecisionInput(memory, 100);
+
+    const output1 = runner.runNPCBrain(input);
+    const snapshot1 = runner.getDebugSnapshot("npc_1", 100, "idle", memory, output1.decision);
+
+    // Run again
+    const output2 = runner.runNPCBrain(input);
+    const snapshot2 = runner.getDebugSnapshot("npc_1", 100, "idle", memory, output2.decision);
+
+    const verification = verifyReplay(snapshot1, snapshot2, true);
+    
+    expect(verification.verified).toBe(true);
+    expect(verification.differences).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Implements Phase 1 of the NPC learning system - a deterministic, replay-capable memory and decision system for NPCs in the Ouroboros game world.

## New Module: server/src/modules/npc/brain/

- NPCMemoryV3.ts - 5-layer memory types
- NPCObservationBus.ts - Central event system
- NPCMemoryScoring.ts - Memory importance calculation
- NPCDecisionEngine.ts - Utility-based action selection
- NPCBrainScheduler.ts - Tick-based phase management
- NPCMemoryCompression.ts - Memory summarization
- NPCBrainDebugSnapshot.ts - Debug HUD support
- NPCBrainRunner.ts - Main integration loop

## Key Features

1. 5-Layer Memory Model
2. World Event Observation Bus
3. Deterministic Decisions
4. Tick-Based Scheduling (10Hz/1Hz/0.1Hz)
5. Memory Compression
6. Debug Snapshot Support