### PR TITLE
fix(npc-brain): remove Math.random reference from comment

### DIFF
--- a/server/src/modules/npc/brain/NPCMemoryV3.ts
+++ b/server/src/modules/npc/brain/NPCMemoryV3.ts
@@ -9,7 +9,7 @@
  * - Learning: What worked for me?
  * 
  * All memory operations are tick-based and deterministic for replay capability.
- * Same tick + same input = same output (no Math.random() in decision logic).
+ * Same tick + same input = same output.
  */
 
 import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";


### PR DESCRIPTION
Fix ARE determinism scanner false positive by removing Math.random reference from comment in NPCMemoryV3.ts.