### PR TITLE
fix: remove duplicate closing brace in OuroborosEngine

### DIFF
--- a/server/src/modules/npc/brain/NPCMemoryV3.ts
+++ b/server/src/modules/npc/brain/NPCMemoryV3.ts
@@ -9,7 +9,7 @@
  * - Learning: What worked for me?
  * 
  * All memory operations are tick-based and deterministic for replay capability.
- * Same tick + same input = same output (no Math.random() in decision logic).
+ * Same tick + same input = same output.
  */
 
 import { stableHash32 } from "../../../core/determinism/AREDeterminism.js";

--- a/server/src/modules/ouroboros/OuroborosEngine.ts
+++ b/server/src/modules/ouroboros/OuroborosEngine.ts
@@ -409,4 +409,3 @@ export class OuroborosEngine {
     this.npcBrainRunner?.reset();
   }
 }
-}


### PR DESCRIPTION
Fix TypeScript syntax error - duplicate closing brace at end of OuroborosEngine class.