### PR TITLE
fix(workflow): add pnpm installation to MiniMax agent jobs

### DIFF
--- a/.github/workflows/minimax-autonomous-agent.yml
+++ b/.github/workflows/minimax-autonomous-agent.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
 
@@ -99,6 +104,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
 
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
@@ -147,6 +157,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
 
@@ -193,6 +208,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
 
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Summary

The MiniMax Autonomous Agent workflow was failing at the "Install Dependencies" step because `pnpm` was not installed on the GitHub Actions runners.

### Fix

Added `pnpm/action-setup@v4` to all jobs that use `pnpm install`:
- `system-health-check`
- `npc-civilization-health`  
- `ui-optimization`
- `arelogic-determinism-audit`

### Root Cause

The `actions/setup-node@v4` action doesn't include pnpm by default. The workflow was trying to run `pnpm install --no-frozen-lockfile` without having pnpm installed first.

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dd8ddb82-7830-492f-bd23-a1f0d7c020c0)