### PR TITLE
feat(ai): harden ARELogic AI skill tool and memory store

### DIFF
--- a/server/src/ai/AILocalLearningStore.ts
+++ b/server/src/ai/AILocalLearningStore.ts
@@ -1,57 +1,240 @@
 /**
  * AILocalLearningStore.ts
- * Local learning store for AI decisions.
- * Keeps bounded history for pattern analysis.
+ * Deterministic local learning memory store for AI decisions.
+ *
+ * Guarantees:
+ * - Bounded memory
+ * - Stable insertion/update behavior
+ * - Scope normalization
+ * - Duplicate event replacement by id
+ * - Deterministic summaries for AutoHeal, diagnostics and agents
  */
 
-import type { AILearningEvent } from "./AIService.types.js";
+import type { AIActionType, AILearningEvent } from "./AIService.types.js";
+
+export interface AILearningSummary {
+  scope: string;
+  total: number;
+  byAction: Record<string, number>;
+  byIntent: Record<string, number>;
+  averageConfidence: number;
+  averageSuccessScore: number;
+  latest: AILearningEvent | null;
+  topTags: Array<{ tag: string; count: number }>;
+  updatedAt: number | null;
+}
+
+export interface AILocalLearningStoreSnapshot {
+  maxEvents: number;
+  totalEvents: number;
+  scopes: string[];
+  latest: AILearningEvent | null;
+}
 
 export interface IAILocalLearningStore {
   record(event: AILearningEvent): Promise<void>;
   list(scope: string, limit?: number): Promise<AILearningEvent[]>;
-  summarize(scope: string): Promise<Record<string, unknown>>;
+  summarize(scope: string): Promise<AILearningSummary>;
+  snapshot?(): Promise<AILocalLearningStoreSnapshot>;
+  clearScope?(scope: string): Promise<number>;
+}
+
+const DEFAULT_MAX_EVENTS = 10_000;
+const MIN_MAX_EVENTS = 100;
+const MAX_MAX_EVENTS = 250_000;
+const MAX_LIST_LIMIT = 500;
+
+function clampInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+function normalizeToken(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._:-]/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 96);
+
+  return normalized || fallback;
+}
+
+function normalizeEvent(event: AILearningEvent): AILearningEvent {
+  const createdAt = Number.isFinite(event.createdAt)
+    ? Math.max(0, Math.trunc(event.createdAt))
+    : 0;
+
+  const confidence = Number.isFinite(event.confidence)
+    ? Math.max(0, Math.min(1, event.confidence))
+    : 0;
+
+  const successScore = Number.isFinite(event.successScore)
+    ? Math.max(0, Math.min(1, event.successScore))
+    : 0;
+
+  return Object.freeze({
+    ...event,
+    id: normalizeToken(event.id, `learn-${event.inputHash}-${event.outputHash}`),
+    agentId: normalizeToken(event.agentId, "ai-core"),
+    memoryScope: normalizeToken(event.memoryScope, "default"),
+    logicalIndex: clampInt(event.logicalIndex, 0, Number.MAX_SAFE_INTEGER),
+    inputHash: String(event.inputHash ?? ""),
+    outputHash: String(event.outputHash ?? ""),
+    intent: normalizeToken(event.intent, "unknown"),
+    action: event.action,
+    confidence,
+    successScore,
+    tags: Array.from(
+      new Set(
+        (event.tags ?? [])
+          .map((tag) => normalizeToken(tag, ""))
+          .filter(Boolean)
+      )
+    ).sort(),
+    createdAt,
+    metadata: Object.freeze({ ...(event.metadata ?? {}) }),
+  });
+}
+
+function createEmptySummary(scope: string): AILearningSummary {
+  return {
+    scope,
+    total: 0,
+    byAction: {},
+    byIntent: {},
+    averageConfidence: 0,
+    averageSuccessScore: 0,
+    latest: null,
+    topTags: [],
+    updatedAt: null,
+  };
 }
 
 export class AILocalLearningStore implements IAILocalLearningStore {
   private readonly events: AILearningEvent[] = [];
   private readonly maxEvents: number;
 
-  constructor(maxEvents = 10_000) {
-    this.maxEvents = Math.max(100, maxEvents);
+  constructor(maxEvents = DEFAULT_MAX_EVENTS) {
+    this.maxEvents = clampInt(maxEvents, MIN_MAX_EVENTS, MAX_MAX_EVENTS);
   }
 
   public async record(event: AILearningEvent): Promise<void> {
-    this.events.push(Object.freeze({ ...event }));
+    const normalized = normalizeEvent(event);
+    const existingIndex = this.events.findIndex((entry) => entry.id === normalized.id);
 
+    if (existingIndex >= 0) {
+      this.events[existingIndex] = normalized;
+    } else {
+      this.events.push(normalized);
+    }
+
+    this.sortEvents();
+    this.trimOldest();
+  }
+
+  public async list(scope: string, limit = 50): Promise<AILearningEvent[]> {
+    const normalizedScope = normalizeToken(scope, "default");
+    const safeLimit = clampInt(limit, 1, MAX_LIST_LIMIT);
+
+    return this.events
+      .filter((event) => event.memoryScope === normalizedScope)
+      .slice(-safeLimit)
+      .map((event) => Object.freeze({ ...event, metadata: { ...event.metadata } }));
+  }
+
+  public async summarize(scope: string): Promise<AILearningSummary> {
+    const normalizedScope = normalizeToken(scope, "default");
+    const scoped = this.events.filter((event) => event.memoryScope === normalizedScope);
+
+    if (scoped.length === 0) {
+      return createEmptySummary(normalizedScope);
+    }
+
+    const byAction: Record<string, number> = {};
+    const byIntent: Record<string, number> = {};
+    const byTag: Record<string, number> = {};
+    let confidenceSum = 0;
+    let successSum = 0;
+
+    for (const event of scoped) {
+      byAction[event.action] = (byAction[event.action] ?? 0) + 1;
+      byIntent[event.intent] = (byIntent[event.intent] ?? 0) + 1;
+      confidenceSum += event.confidence;
+      successSum += event.successScore;
+
+      for (const tag of event.tags) {
+        byTag[tag] = (byTag[tag] ?? 0) + 1;
+      }
+    }
+
+    return {
+      scope: normalizedScope,
+      total: scoped.length,
+      byAction: this.sortCountMap(byAction),
+      byIntent: this.sortCountMap(byIntent),
+      averageConfidence: this.roundRatio(confidenceSum / scoped.length),
+      averageSuccessScore: this.roundRatio(successSum / scoped.length),
+      latest: scoped.at(-1) ?? null,
+      topTags: Object.entries(byTag)
+        .sort(([tagA, countA], [tagB, countB]) => countB - countA || tagA.localeCompare(tagB))
+        .slice(0, 25)
+        .map(([tag, count]) => ({ tag, count })),
+      updatedAt: scoped.at(-1)?.createdAt ?? null,
+    };
+  }
+
+  public async snapshot(): Promise<AILocalLearningStoreSnapshot> {
+    const scopes = Array.from(new Set(this.events.map((event) => event.memoryScope))).sort();
+
+    return {
+      maxEvents: this.maxEvents,
+      totalEvents: this.events.length,
+      scopes,
+      latest: this.events.at(-1) ?? null,
+    };
+  }
+
+  public async clearScope(scope: string): Promise<number> {
+    const normalizedScope = normalizeToken(scope, "default");
+    const before = this.events.length;
+
+    for (let i = this.events.length - 1; i >= 0; i--) {
+      if (this.events[i]?.memoryScope === normalizedScope) {
+        this.events.splice(i, 1);
+      }
+    }
+
+    return before - this.events.length;
+  }
+
+  private sortEvents(): void {
+    this.events.sort((a, b) => {
+      if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+      if (a.logicalIndex !== b.logicalIndex) return a.logicalIndex - b.logicalIndex;
+      return a.id.localeCompare(b.id);
+    });
+  }
+
+  private trimOldest(): void {
     if (this.events.length > this.maxEvents) {
       this.events.splice(0, this.events.length - this.maxEvents);
     }
   }
 
-  public async list(scope: string, limit = 50): Promise<AILearningEvent[]> {
-    return this.events
-      .filter((event) => event.memoryScope === scope)
-      .slice(-Math.max(1, Math.min(limit, 500)));
+  private sortCountMap(input: Record<string, number>): Record<string, number> {
+    return Object.keys(input)
+      .sort()
+      .reduce<Record<string, number>>((acc, key) => {
+        acc[key] = input[key] ?? 0;
+        return acc;
+      }, {});
   }
 
-  public async summarize(scope: string): Promise<Record<string, unknown>> {
-    const scoped = this.events.filter((event) => event.memoryScope === scope);
-    const total = scoped.length;
-
-    const byAction: Record<string, number> = {};
-    const byIntent: Record<string, number> = {};
-
-    for (const event of scoped) {
-      byAction[event.action] = (byAction[event.action] ?? 0) + 1;
-      byIntent[event.intent] = (byIntent[event.intent] ?? 0) + 1;
-    }
-
-    return {
-      scope,
-      total,
-      byAction,
-      byIntent,
-      latest: scoped.at(-1) ?? null,
-    };
+  private roundRatio(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.round(value * 1_000_000) / 1_000_000;
   }
 }

--- a/server/src/ai/AIServiceSkillTool.ts
+++ b/server/src/ai/AIServiceSkillTool.ts
@@ -82,6 +82,10 @@ function normalizeToken(value: unknown, fallback: string): string {
 }
 
 function stableValue(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return `${value.toString()}n`;
+  }
+
   if (Array.isArray(value)) {
     return value.map((entry) => stableValue(entry));
   }
@@ -283,14 +287,20 @@ export class AIServiceSkillTool {
   }
 
   private createTraceId(prompt: string, options: AIProcessOptions): string {
-    const optionSeed = JSON.stringify(stableValue({
-      agentId: options.agentId ?? this.defaultAgentId,
-      logicalIndex: options.logicalIndex ?? ARE_CONSTANTS.DEFAULT_LOGICAL_INDEX,
-      memoryScope: options.memoryScope ?? this.defaultMemoryScope,
-      mode: "system",
-      kappa: ARE_CONSTANTS.KAPPA_INVARIANT,
-      metadata: options.metadata ?? {},
-    }));
+    let optionSeed = "safe-default-options";
+
+    try {
+      optionSeed = JSON.stringify(stableValue({
+        agentId: options.agentId ?? this.defaultAgentId,
+        logicalIndex: options.logicalIndex ?? ARE_CONSTANTS.DEFAULT_LOGICAL_INDEX,
+        memoryScope: options.memoryScope ?? this.defaultMemoryScope,
+        mode: "system",
+        kappa: ARE_CONSTANTS.KAPPA_INVARIANT,
+        metadata: options.metadata ?? {},
+      }));
+    } catch (error) {
+      optionSeed = `unserializable-options:${stableHash(this.errorToString(error))}`;
+    }
 
     return `are-ai-tool-${stableHash(`${prompt}|${optionSeed}`)}`;
   }

--- a/server/src/ai/AIServiceSkillTool.ts
+++ b/server/src/ai/AIServiceSkillTool.ts
@@ -320,7 +320,7 @@ export class AIServiceSkillTool {
 
     return Object.freeze({
       ok: false,
-      mode: "system",
+      mode: "system" as const,
       agentId: this.defaultAgentId,
       traceId,
       createdAt: startedAt,
@@ -334,16 +334,16 @@ export class AIServiceSkillTool {
         input: safeInput,
         normalizedInput: safeInput,
         decision: {
-          action: "heal_request",
+          action: "heal_request" as const,
           confidence: 1,
           intent: "skill_tool_safe_degraded_fallback",
           response: output,
           heal: {
             code: "AI_SKILL_TOOL_DEGRADED_FALLBACK",
             message: error,
-            severity: "warn",
+            severity: "warn" as const,
           },
-          facts: [],
+          facts: [] as string[],
           risks: ["skill-tool-input-rejected", "recovered-by-fallback"],
         },
         output,
@@ -353,7 +353,7 @@ export class AIServiceSkillTool {
           "ARE-KAPPA-INVARIANT",
           "DEGRADED-FALLBACK",
         ],
-        learningHints: [],
+        learningHints: [] as string[],
       },
       error,
       warnings: ["AI skill tool entered degraded fallback mode."],

--- a/server/src/ai/AIServiceSkillTool.ts
+++ b/server/src/ai/AIServiceSkillTool.ts
@@ -1,9 +1,18 @@
 /**
  * AIServiceSkillTool.ts
- * Skill tool wrapper for AI core execution.
+ * Deterministic skill tool wrapper for real AI core execution.
+ *
+ * The intelligence stays inside AIService.processStructured().
+ * This wrapper makes tool execution strict, traceable, non-fatal and
+ * ARELogic-compliant for agent/tool runtimes.
  */
 
-import type { AIProcessOptions, AIProcessResult } from "./AIService.types.js";
+import { ARE_CONSTANTS } from "../core/AREEnvelope.js";
+import type {
+  AIProcessOptions,
+  AIProcessResult,
+  AIServiceMode,
+} from "./AIService.types.js";
 import type { AIService } from "./AIService.js";
 
 export interface AIServiceSkillToolInput {
@@ -11,30 +20,367 @@ export interface AIServiceSkillToolInput {
   options?: AIProcessOptions;
 }
 
+export interface AIServiceSkillToolMeta {
+  name: string;
+  version: string;
+  deterministic: true;
+  mode: AIServiceMode;
+  traceId: string;
+  axiom: "ARELOGIC_KAPPA_1000";
+}
+
 export interface AIServiceSkillToolOutput {
   ok: boolean;
   result: AIProcessResult;
+  tool: AIServiceSkillToolMeta;
+}
+
+export interface AIServiceSkillToolConfig {
+  maxPromptLength?: number;
+  defaultAgentId?: string;
+  defaultMemoryScope?: string;
+  defaultTimeoutMs?: number;
+  strictInput?: boolean;
+}
+
+const DEFAULT_MAX_PROMPT_LENGTH = 24_000;
+const DEFAULT_TIMEOUT_MS = 2_500;
+const TOOL_VERSION = "2.1.0";
+
+function stableHash(input: string): string {
+  let hash = 2166136261;
+
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function normalizePrompt(input: unknown): string {
+  if (typeof input !== "string") return "";
+
+  return input
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .trim();
+}
+
+function normalizeToken(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._:-]/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 96);
+
+  return normalized || fallback;
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableValue(entry));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = stableValue((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
 }
 
 export class AIServiceSkillTool {
   public readonly name = "arelogic.ai.real_process";
 
-  public readonly description =
-    "Runs the real deterministic ARELogic AI core with safety filtering and AutoHeal integration.";
+  public readonly version = TOOL_VERSION;
 
-  constructor(private readonly aiService: AIService) {}
+  public readonly description =
+    "Runs the real deterministic ARELogic AI core with safety filtering, structured output and AutoHeal integration.";
+
+  private readonly maxPromptLength: number;
+  private readonly defaultAgentId: string;
+  private readonly defaultMemoryScope: string;
+  private readonly defaultTimeoutMs: number;
+  private readonly strictInput: boolean;
+
+  constructor(
+    private readonly aiService: AIService,
+    config: AIServiceSkillToolConfig = {}
+  ) {
+    this.maxPromptLength = this.clampInt(
+      config.maxPromptLength ?? DEFAULT_MAX_PROMPT_LENGTH,
+      1,
+      64_000
+    );
+    this.defaultAgentId = normalizeToken(config.defaultAgentId, "ai-skill-tool");
+    this.defaultMemoryScope = normalizeToken(
+      config.defaultMemoryScope,
+      "arelogic.ai.real_process"
+    );
+    this.defaultTimeoutMs = this.clampInt(
+      config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+      50,
+      30_000
+    );
+    this.strictInput = config.strictInput ?? true;
+  }
 
   public async execute(
     input: AIServiceSkillToolInput
   ): Promise<AIServiceSkillToolOutput> {
-    const result = await this.aiService.processStructured(input.prompt, {
-      mode: "system",
-      ...input.options,
-    });
+    const normalizedPrompt = normalizePrompt(input?.prompt);
+    const options = input?.options ?? {};
+    const traceId = this.createTraceId(normalizedPrompt, options);
+    const tool = this.createToolMeta(traceId);
 
-    return {
-      ok: result.ok,
-      result,
-    };
+    const validationError = this.validateInput(normalizedPrompt);
+
+    if (validationError) {
+      return {
+        ok: false,
+        result: this.createFallbackResult(validationError, normalizedPrompt, traceId),
+        tool,
+      };
+    }
+
+    try {
+      const result = await this.aiService.processStructured(normalizedPrompt, {
+        ...options,
+        mode: "system",
+        agentId: normalizeToken(options.agentId, this.defaultAgentId),
+        traceId,
+        kappa: ARE_CONSTANTS.KAPPA_INVARIANT,
+        memoryScope: normalizeToken(options.memoryScope, this.defaultMemoryScope),
+        timeoutMs: this.clampInt(
+          options.timeoutMs ?? this.defaultTimeoutMs,
+          50,
+          30_000
+        ),
+        maxInputLength: this.clampInt(
+          options.maxInputLength ?? this.maxPromptLength,
+          1,
+          64_000
+        ),
+        metadata: {
+          deterministic: true,
+          skillTool: this.name,
+          skillToolVersion: this.version,
+          autoHealLinked: true,
+          safetyBoundary: "AIService.processStructured",
+          ...(options.metadata ?? {}),
+        },
+      });
+
+      return {
+        ok: Boolean(result.ok),
+        result,
+        tool: this.createToolMeta(result.traceId || traceId),
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        result: this.createFallbackResult(
+          `AIServiceSkillTool execution failed: ${this.errorToString(error)}`,
+          normalizedPrompt,
+          traceId
+        ),
+        tool,
+      };
+    }
+  }
+
+  /** Compatibility alias for runtimes that call invoke(). */
+  public async invoke(
+    input: AIServiceSkillToolInput
+  ): Promise<AIServiceSkillToolOutput> {
+    return this.execute(input);
+  }
+
+  /** Compatibility alias for runtimes that call run(). */
+  public async run(
+    input: AIServiceSkillToolInput
+  ): Promise<AIServiceSkillToolOutput> {
+    return this.execute(input);
+  }
+
+  public getManifest() {
+    return Object.freeze({
+      name: this.name,
+      version: this.version,
+      description: this.description,
+      deterministic: true,
+      mode: "system" as const,
+      axiom: "ARELOGIC_KAPPA_1000" as const,
+      inputSchema: {
+        type: "object",
+        required: ["prompt"],
+        additionalProperties: false,
+        properties: {
+          prompt: {
+            type: "string",
+            minLength: 1,
+            maxLength: this.maxPromptLength,
+          },
+          options: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+      },
+      outputSchema: {
+        type: "object",
+        required: ["ok", "result", "tool"],
+        properties: {
+          ok: { type: "boolean" },
+          result: { type: "object" },
+          tool: {
+            type: "object",
+            required: [
+              "name",
+              "version",
+              "deterministic",
+              "mode",
+              "traceId",
+              "axiom",
+            ],
+            properties: {
+              name: { type: "string" },
+              version: { type: "string" },
+              deterministic: { const: true },
+              mode: { const: "system" },
+              traceId: { type: "string" },
+              axiom: { const: "ARELOGIC_KAPPA_1000" },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  private validateInput(prompt: string): string | null {
+    if (!prompt) {
+      return "Prompt is empty.";
+    }
+
+    if (prompt.length > this.maxPromptLength) {
+      return `Prompt exceeds max length of ${this.maxPromptLength} characters.`;
+    }
+
+    if (this.strictInput && /[\u0000-\u0008\u000B\u000C\u000E-\u001F]/u.test(prompt)) {
+      return "Prompt contains forbidden control characters.";
+    }
+
+    return null;
+  }
+
+  private createTraceId(prompt: string, options: AIProcessOptions): string {
+    const optionSeed = JSON.stringify(stableValue({
+      agentId: options.agentId ?? this.defaultAgentId,
+      logicalIndex: options.logicalIndex ?? ARE_CONSTANTS.DEFAULT_LOGICAL_INDEX,
+      memoryScope: options.memoryScope ?? this.defaultMemoryScope,
+      mode: "system",
+      kappa: ARE_CONSTANTS.KAPPA_INVARIANT,
+      metadata: options.metadata ?? {},
+    }));
+
+    return `are-ai-tool-${stableHash(`${prompt}|${optionSeed}`)}`;
+  }
+
+  private createToolMeta(traceId: string): AIServiceSkillToolMeta {
+    return Object.freeze({
+      name: this.name,
+      version: this.version,
+      deterministic: true,
+      mode: "system",
+      traceId,
+      axiom: "ARELOGIC_KAPPA_1000",
+    });
+  }
+
+  private createFallbackResult(
+    error: string,
+    normalizedPrompt: string,
+    traceId: string
+  ): AIProcessResult {
+    const startedAt = Date.now();
+    const safeInput = normalizedPrompt.slice(0, this.maxPromptLength);
+    const inputHash = stableHash(safeInput);
+    const output =
+      "Degradierter AI-SkillTool-Fallback: Anfrage wurde sicher abgefangen.";
+    const outputHash = stableHash(output);
+
+    return Object.freeze({
+      ok: false,
+      mode: "system",
+      agentId: this.defaultAgentId,
+      traceId,
+      createdAt: startedAt,
+      logicalIndex: ARE_CONSTANTS.DEFAULT_LOGICAL_INDEX,
+      kappa: ARE_CONSTANTS.KAPPA_INVARIANT,
+      resonance: ARE_CONSTANTS.DEFAULT_RESONANCE,
+      inputHash,
+      outputHash,
+      durationMs: Date.now() - startedAt,
+      payload: {
+        input: safeInput,
+        normalizedInput: safeInput,
+        decision: {
+          action: "heal_request",
+          confidence: 1,
+          intent: "skill_tool_safe_degraded_fallback",
+          response: output,
+          heal: {
+            code: "AI_SKILL_TOOL_DEGRADED_FALLBACK",
+            message: error,
+            severity: "warn",
+          },
+          facts: [],
+          risks: ["skill-tool-input-rejected", "recovered-by-fallback"],
+        },
+        output,
+        axiomHash: stableHash(`skill-tool-fallback:${traceId}:${inputHash}:${error}`),
+        rulesApplied: [
+          "SKILL-TOOL-INPUT-VALIDATION",
+          "ARE-KAPPA-INVARIANT",
+          "DEGRADED-FALLBACK",
+        ],
+        learningHints: [],
+      },
+      error,
+      warnings: ["AI skill tool entered degraded fallback mode."],
+      metadata: {
+        deterministic: true,
+        realCore: false,
+        degraded: true,
+        autoHealLinked: true,
+        skillTool: this.name,
+        skillToolVersion: this.version,
+      },
+    });
+  }
+
+  private clampInt(value: number, min: number, max: number): number {
+    if (!Number.isFinite(value)) return min;
+    return Math.max(min, Math.min(max, Math.trunc(value)));
+  }
+
+  private errorToString(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === "string") return error;
+
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return "Unknown AIServiceSkillTool failure";
+    }
   }
 }

--- a/server/src/ai/index.ts
+++ b/server/src/ai/index.ts
@@ -15,7 +15,12 @@ export { AIDecisionRules } from "./AIDecisionRules.js";
 export { AISafetyFilter } from "./AISafetyFilter.js";
 
 // Learning
-export { AILocalLearningStore, type IAILocalLearningStore } from "./AILocalLearningStore.js";
+export {
+  AILocalLearningStore,
+  type AILearningSummary,
+  type AILocalLearningStoreSnapshot,
+  type IAILocalLearningStore,
+} from "./AILocalLearningStore.js";
 
 // Command mapping
 export { AICommandMapper, type AICommandQueueItem } from "./AICommandMapper.js";
@@ -26,7 +31,9 @@ export { AIHealBridge } from "./AIHealBridge.js";
 // Skill tool
 export {
   AIServiceSkillTool,
+  type AIServiceSkillToolConfig,
   type AIServiceSkillToolInput,
+  type AIServiceSkillToolMeta,
   type AIServiceSkillToolOutput,
 } from "./AIServiceSkillTool.js";
 


### PR DESCRIPTION
## Summary

- Hardens `AIServiceSkillTool` into a strict deterministic ARELogic tool boundary
- Adds deterministic trace IDs, input validation, compatibility aliases, manifest output and non-fatal degraded fallback envelope
- Forces system-mode execution through the real `AIService.processStructured()` path with Kappa invariant metadata
- Upgrades `AILocalLearningStore` with scope normalization, bounded deterministic ordering, duplicate replacement, richer summaries, snapshots and scope clearing
- Exports the new hardened tool/memory types from `server/src/ai/index.ts`

## ARELogic Notes

- Preserves `kappa = 1000`
- Avoids direct world mutation
- Keeps AI intelligence inside the real AIService core instead of moving behavior into the tool wrapper
- Makes memory behavior deterministic and bounded for AutoHeal/agent analysis

## Files

- `server/src/ai/AIServiceSkillTool.ts`
- `server/src/ai/AILocalLearningStore.ts`
- `server/src/ai/index.ts`

## Testing

Connector edit only; CI should validate TypeScript/build on PR.