### PR TITLE
feat: harden live system contract and client entrypoints

### DIFF
--- a/apps/client-2d/src/net/liveGameplaySnapshot.ts
+++ b/apps/client-2d/src/net/liveGameplaySnapshot.ts
@@ -1,0 +1,71 @@
+/**
+ * LIVE GAMEPLAY SNAPSHOT CLIENT VALIDATION
+ *
+ * Client-side type validation for server-authoritative snapshots.
+ * The client validates before applying and may display degraded fallback UI if invalid.
+ *
+ * Rules:
+ * - Client validates snapshots before applying
+ * - Client does not invent authoritative state
+ * - Client may display degraded fallback UI if snapshot invalid
+ * - Client render loop may interpolate visuals, but not alter server truth
+ */
+
+export interface LiveGameplaySnapshotClient {
+  readonly schemaVersion: "live-gameplay-snapshot.v2";
+  readonly playerId: string;
+  readonly logicalIndex: number;
+  readonly tickRateHz: 10;
+  readonly tickMs: 100;
+  readonly inventory: readonly unknown[];
+  readonly equipment: readonly unknown[];
+  readonly skills: readonly unknown[];
+  readonly resourceNodes: readonly unknown[];
+  readonly combat: {
+    readonly hp: number;
+    readonly maxHp: number;
+    readonly stamina: number;
+    readonly maxStamina: number;
+    readonly targetId: string | null;
+    readonly cooldowns: readonly unknown[];
+  };
+  readonly crafting: {
+    readonly knownRecipes: readonly unknown[];
+    readonly activeCraft: unknown | null;
+  };
+  readonly faction: {
+    readonly guildId: string | null;
+    readonly factionId: string | null;
+    readonly reputation: readonly unknown[];
+  };
+  readonly world: {
+    readonly chunkId: string;
+    readonly biomeId: string;
+    readonly safeZone: boolean;
+  };
+}
+
+export function isLiveGameplaySnapshot(value: unknown): value is LiveGameplaySnapshotClient {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Partial<LiveGameplaySnapshotClient>;
+
+  return (
+    v.schemaVersion === "live-gameplay-snapshot.v2" &&
+    typeof v.playerId === "string" &&
+    typeof v.logicalIndex === "number" &&
+    v.tickRateHz === 10 &&
+    v.tickMs === 100 &&
+    Array.isArray(v.inventory) &&
+    Array.isArray(v.equipment) &&
+    Array.isArray(v.skills) &&
+    Array.isArray(v.resourceNodes) &&
+    typeof v.combat === "object" &&
+    v.combat !== null &&
+    typeof v.crafting === "object" &&
+    v.crafting !== null &&
+    typeof v.faction === "object" &&
+    v.faction !== null &&
+    typeof v.world === "object" &&
+    v.world !== null
+  );
+}

--- a/docs/ARCHITECTURE_CLIENT_ENTRYPOINTS.md
+++ b/docs/ARCHITECTURE_CLIENT_ENTRYPOINTS.md
@@ -1,0 +1,109 @@
+# Arelorian Client Entrypoints
+
+## Source Truth
+
+The playable 2D client source is:
+
+```
+apps/client-2d/
+```
+
+**There is no root-level `2d/` source directory.**
+
+## Public Routes
+
+| Route | Description |
+|-------|-------------|
+| `/2d` | Playable PIXI 2D client |
+| `/3d` | Experimental 3D client |
+| `/portal` | Portal shell |
+
+## Build Artifacts
+
+| Path | Description |
+|------|-------------|
+| `apps/client-2d/dist/` | Direct Vite output |
+| `client/dist/2d/` | Runtime static output |
+| `server/client/dist/2d/` | Copied runtime static output inside server container |
+
+## Rule
+
+**Never patch generated build output as source.**
+
+### Correct:
+```
+apps/client-2d/src/...
+```
+
+### Wrong:
+```
+client/dist/2d/...
+server/client/dist/2d/...
+2d/...
+```
+
+## Deterministic Boundary
+
+The server is authoritative. The client renders state; it does not decide truth.
+
+### Server Owns:
+- Movement validation
+- Combat outcome
+- Resource gathering result
+- Crafting result
+- Item changes
+- Quest changes
+- Guild/faction state
+
+### Client Owns:
+- Input collection
+- Rendering
+- Interpolation
+- UI projection
+- Degraded/offline display
+
+## Client Entrypoint Health
+
+The `/health` endpoint exposes `clientEntrypoints` with:
+
+```typescript
+interface ClientEntrypointHealth {
+  source: {
+    client2d: "apps/client-2d";
+    client3d: "client";
+    portal: "portal";
+  };
+  runtime: {
+    root: string;        // e.g., /path/to/client/dist
+    client2d: string;   // e.g., /path/to/client/dist/2d/index.html
+    client3d: string;
+    portal: string;
+  };
+  route: {
+    client2d: "/2d";
+    client3d: "/3d";
+    portal: "/portal";
+  };
+  available: {
+    client2d: boolean;
+    client3d: boolean;
+    portal: boolean;
+  };
+}
+```
+
+## Guard Script
+
+Run `pnpm guard:entrypoints` to validate:
+
+1. Required source paths exist:
+   - `apps/client-2d/package.json`
+   - `apps/client-2d/index.html`
+   - `apps/client-2d/src/main.tsx`
+   - `server/src/core/ServerBootstrap.ts`
+   - `Dockerfile.vps`
+
+2. Forbidden fake 2d paths do NOT exist:
+   - `2d/package.json`
+   - `2d/index.html`
+   - `src/2d/index.html`

--- a/docs/ARELOGIC_LIVE_SYSTEM_CONTRACT.md
+++ b/docs/ARELOGIC_LIVE_SYSTEM_CONTRACT.md
@@ -1,0 +1,146 @@
+# ARELogic Live System Contract
+
+## Goal
+
+The live system contract connects WorldTick, LiveGameplaySnapshot, client rendering, SelfHeal and health diagnostics without violating deterministic simulation rules.
+
+## Core ARELogic Rules
+
+1. **The server is authoritative.**
+2. **WorldTick runs at 10Hz / 100ms.**
+3. **Gameplay state must be reproducible from explicit inputs.**
+4. **Simulation paths must not use:**
+   - `Math.random()`
+   - `Date.now()`
+   - `new Date()`
+   - `randomUUID()`
+   - `host/container identity`
+5. **Operational telemetry may use wall-clock time only if it never feeds gameplay decisions.**
+6. **Snapshot arrays must be sorted by stable ids.**
+7. **Missing systems return explicit null-port responses, not silent `{}` placeholders.**
+8. **SelfHeal may observe and repair infrastructure, but must not invent gameplay outcomes.**
+9. **Client renders state; it does not decide truth.**
+
+## Snapshot v2
+
+The v2 live gameplay snapshot includes:
+
+- `inventory` - Player inventory items
+- `equipment` - Equipped gear slots
+- `skills` - Skill states with XP/levels
+- `resourceNodes` - Available gathering nodes
+- `combat` - HP, stamina, cooldowns, target
+- `crafting` - Known recipes, active job
+- `faction` - Guild, faction, reputation
+- `world` - Chunk, biome, safe zone
+
+### Schema Version
+
+```
+live-gameplay-snapshot.v2
+```
+
+## Null Port Principle
+
+A missing subsystem must say:
+
+```json
+{
+  "ok": false,
+  "reason": "system_not_connected"
+}
+```
+
+**It must not silently return `{}`.**
+
+### Defined Ports
+
+| Port | Interface | Null Response |
+|------|-----------|---------------|
+| Crafting | `CraftingPort` | `{ ok: false, reason: "crafting_not_connected" }` |
+| Skill | `SkillPort` | `{ ok: false, reason: "skill_not_connected" }` |
+| Placement | `PlacementPort` | `{ ok: false, reason: "placement_not_connected" }` |
+
+## SelfHeal Integration
+
+SelfHeal signals are typed and logged through deterministic patch entries.
+
+### Defined Signals
+
+| Signal | Description |
+|--------|-------------|
+| `BOOT_CONFIG_MISSING` | Bootstrap configuration not found |
+| `CLIENT_ASSET_MISSING` | Required client asset absent |
+| `WORLD_TICK_DRIFT` | Tick timing deviation detected |
+| `PERSISTENCE_WRITE_FAILED` | Database/file write error |
+| `REDIS_UNAVAILABLE` | Redis connection failed |
+| `ARE_INVARIANT_VIOLATION` | Determinism guard triggered |
+| `SNAPSHOT_COMPOSITION_FAILED` | Snapshot composer error |
+| `GLB_ASSET_INVALID` | 3D asset validation failed |
+| `ENTRYPOINT_CONTRACT_DRIFT` | Client source/route mismatch |
+
+### Patch Log Entry
+
+Each repair produces a hashable, deterministic log entry:
+
+```typescript
+interface HealPatchLogEntry {
+  id: string;           // SHA-256 hash
+  tick: number;
+  signal: SelfHealSignal;
+  subsystem: string;
+  action: string;
+  beforeHash: string;   // SHA-256 of before state
+  afterHash: string;    // SHA-256 of after state
+  ok: boolean;
+}
+```
+
+## Client Snapshot Validation
+
+The client validates server snapshots before applying:
+
+```typescript
+function isLiveGameplaySnapshot(value: unknown): value is LiveGameplaySnapshotClient {
+  return (
+    value.schemaVersion === "live-gameplay-snapshot.v2" &&
+    typeof value.playerId === "string" &&
+    typeof value.logicalIndex === "number" &&
+    value.tickRateHz === 10 &&
+    value.tickMs === 100 &&
+    // ... other field validations
+  );
+}
+```
+
+If validation fails, the client displays degraded fallback UI.
+
+## Validation Commands
+
+```bash
+# Verify entrypoints
+pnpm guard:entrypoints
+
+# Run all guards
+pnpm guard:all
+
+# Type check server
+pnpm --filter @wasd/server typecheck
+
+# Build client-2d
+pnpm --filter @wasd/client-2d build
+
+# Build server
+pnpm --filter @wasd/server build
+```
+
+## Expected Results
+
+After implementation:
+
+- `/health` reports real client entrypoints
+- `/2d` remains public route
+- `apps/client-2d` remains source
+- `LiveGameplaySnapshot v2` is stable and sorted
+- Missing systems are explicit null ports
+- `SelfHeal` has typed signal contracts

--- a/docs/skills/live-system-contract-hardening.skill.md
+++ b/docs/skills/live-system-contract-hardening.skill.md
@@ -1,0 +1,139 @@
+# Skill: Live System Contract Hardening
+
+## Purpose
+
+Hardens the WASD live gameplay path by connecting existing systems through deterministic contracts.
+
+## Scope
+
+This skill may modify:
+- `server/src/gameplay/**` - Extended LiveGameplaySnapshot types
+- `server/src/core/ports/**` - Typed gameplay port interfaces
+- `server/src/selfhealing/**` - SelfHeal signal contracts
+- `server/src/core/ServerBootstrap.ts` - ClientEntrypointHealth
+- `apps/client-2d/src/net/**` - Client snapshot validation
+- `scripts/verify-client-entrypoints.mjs` - Entry point guard
+- `e2e/live-system-contract.spec.ts` - Contract tests
+- `docs/**` - Architecture and skill docs
+
+**This skill must not treat `2d/` as a source directory.**
+
+## Deterministic Requirements
+
+- **No `Math.random`** in simulation
+- **No `Date.now`** in gameplay decisions
+- **No mutation** of source snapshot arrays
+- **Stable sorting** for arrays
+- **Explicit `logicalIndex`** on gameplay operations
+- **Null ports** instead of placeholder objects
+- **Health telemetry** cannot affect simulation
+
+## Key Types
+
+### Gameplay Ports
+
+```typescript
+interface CraftingPort {
+  readonly kind: "crafting";
+  craft(playerId: string, recipeId: string, logicalIndex: number): CraftingResult;
+}
+
+interface SkillPort {
+  readonly kind: "skill";
+  useSkill(playerId: string, skillId: string, logicalIndex: number): SkillUseResult;
+}
+
+interface PlacementPort {
+  readonly kind: "placement";
+  place(playerId: string, blueprintId: string, tileX: number, tileZ: number, logicalIndex: number): PlacementResult;
+}
+```
+
+### SelfHeal Signals
+
+```typescript
+type SelfHealSignal =
+  | "BOOT_CONFIG_MISSING"
+  | "CLIENT_ASSET_MISSING"
+  | "WORLD_TICK_DRIFT"
+  | "PERSISTENCE_WRITE_FAILED"
+  | "REDIS_UNAVAILABLE"
+  | "ARE_INVARIANT_VIOLATION"
+  | "SNAPSHOT_COMPOSITION_FAILED"
+  | "GLB_ASSET_INVALID"
+  | "ENTRYPOINT_CONTRACT_DRIFT";
+```
+
+### Snapshot v2
+
+```typescript
+interface LiveGameplaySnapshot {
+  readonly schemaVersion: "live-gameplay-snapshot.v2";
+  readonly playerId: string;
+  readonly logicalIndex: number;
+  readonly tickRateHz: 10;
+  readonly tickMs: 100;
+  readonly inventory: readonly LiveGameplayInventoryItem[];
+  readonly equipment: readonly LiveGameplayEquipmentSlot[];
+  readonly skills: readonly LiveGameplaySkillState[];
+  readonly resourceNodes: readonly LiveGameplayResourceNode[];
+  readonly combat: LiveGameplayCombatView;
+  readonly crafting: LiveGameplayCraftingView;
+  readonly faction: LiveGameplayFactionView;
+  readonly world: LiveGameplayWorldView;
+}
+```
+
+## Validation
+
+Run:
+
+```bash
+# Verify entrypoints guard
+pnpm guard:entrypoints
+
+# Run all guards
+pnpm guard:all
+
+# Type check server
+pnpm --filter @wasd/server typecheck
+
+# Run server tests
+pnpm --filter @wasd/server test -- --run
+
+# Build client-2d
+pnpm --filter @wasd/client-2d build
+```
+
+## Expected Result
+
+- `/health` reports real client entrypoints
+- `/2d` remains public route
+- `apps/client-2d` remains source
+- `LiveGameplaySnapshot v2` is stable and sorted
+- Missing systems are explicit null ports
+- `SelfHeal` has typed signal contracts
+
+## Files Created
+
+| File | Description |
+|------|-------------|
+| `scripts/verify-client-entrypoints.mjs` | Guard script for client entrypoint truth |
+| `server/src/core/ports/GameplayPorts.ts` | Typed port interfaces |
+| `server/src/core/ports/NullGameplayPorts.ts` | Explicit null implementations |
+| `server/src/selfhealing/SelfHealSignals.ts` | Typed signal contracts |
+| `server/src/selfhealing/SelfHealPatchLog.ts` | Deterministic patch logging |
+| `apps/client-2d/src/net/liveGameplaySnapshot.ts` | Client validation types |
+| `e2e/live-system-contract.spec.ts` | E2E contract tests |
+| `docs/ARCHITECTURE_CLIENT_ENTRYPOINTS.md` | Client entrypoint docs |
+| `docs/ARELOGIC_LIVE_SYSTEM_CONTRACT.md` | ARELogic contract docs |
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `package.json` | Added `guard:entrypoints` and updated `guard:all` |
+| `server/src/gameplay/LiveGameplaySnapshotTypes.ts` | Extended v2 types |
+| `server/src/gameplay/LiveGameplaySnapshotComposer.ts` | Extended composer |
+| `server/src/core/ServerBootstrap.ts` | Added `ClientEntrypointHealth` |
+| `server/src/core/WorldTick.ts` | Replaced placeholders with typed ports |

--- a/e2e/live-system-contract.spec.ts
+++ b/e2e/live-system-contract.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * LIVE SYSTEM CONTRACT E2E TEST
+ *
+ * Verifies the live system contract exposes /2d route and no fake root source assumption.
+ * Tests route /2d - does not test source path 2d/.
+ *
+ * Rules:
+ * - Test route /2d
+ * - Do not test source path 2d/
+ * - The test should prove visible runtime, not fake filesystem assumptions
+ */
+
+import { test, expect } from "@playwright/test";
+
+test("live system contract exposes 2d route and no fake root source assumption", async ({ request, page }) => {
+  const health = await request.get("/health");
+  expect([200, 503]).toContain(health.status());
+
+  const body = await health.json();
+  expect(body).toBeTruthy();
+
+  // Verify clientEntrypoints in health response
+  if (body.clientEntrypoints) {
+    expect(body.clientEntrypoints.source.client2d).toBe("apps/client-2d");
+    expect(body.clientEntrypoints.route.client2d).toBe("/2d");
+  }
+
+  // Navigate to /2d route
+  await page.goto("/2d", {
+    waitUntil: "domcontentloaded",
+    timeout: 60_000,
+  });
+
+  await expect(page.locator("body")).toBeVisible();
+
+  // Check for console errors
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+
+  // No errors should be present
+  expect(errors).toEqual([]);
+});
+
+test("health endpoint reports clientEntrypoints with source truth", async ({ request }) => {
+  const health = await request.get("/health");
+  const status = health.status();
+  expect([200, 503]).toContain(status);
+
+  const body = await health.json();
+
+  // Verify clientEntrypoints structure
+  expect(body.clientEntrypoints).toBeDefined();
+  expect(body.clientEntrypoints.source).toBeDefined();
+  expect(body.clientEntrypoints.runtime).toBeDefined();
+  expect(body.clientEntrypoints.route).toBeDefined();
+  expect(body.clientEntrypoints.available).toBeDefined();
+
+  // Verify source truth
+  expect(body.clientEntrypoints.source.client2d).toBe("apps/client-2d");
+  expect(body.clientEntrypoints.source.client3d).toBe("client");
+  expect(body.clientEntrypoints.source.portal).toBe("portal");
+
+  // Verify routes
+  expect(body.clientEntrypoints.route.client2d).toBe("/2d");
+  expect(body.clientEntrypoints.route.client3d).toBe("/3d");
+  expect(body.clientEntrypoints.route.portal).toBe("/portal");
+});
+
+test("guard:entrypoints script validates real source paths", () => {
+  // This test verifies the guard script exists and can be invoked
+  // In CI, this would be run via: pnpm guard:entrypoints
+  // Here we just verify the script exists in the expected location
+  const { existsSync } = require("fs");
+  expect(existsSync("scripts/verify-client-entrypoints.mjs")).toBe(true);
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "guard:monorepo:frozen": "MONOREPO_GUARD_RUN_PNPM=1 node scripts/monorepo-guard.mjs",
     "guard:architecture": "node scripts/arelorian-architecture-lint.mjs",
     "guard:worldtick": "pnpm --filter @wasd/server guard:worldtick",
-    "guard:all": "pnpm guard:monorepo && pnpm guard:architecture && pnpm guard:worldtick",
+    "guard:entrypoints": "node scripts/verify-client-entrypoints.mjs",
+    "guard:all": "pnpm guard:monorepo && pnpm guard:architecture && pnpm guard:worldtick && pnpm guard:entrypoints",
     "clean": "pnpm -r exec rm -rf dist node_modules"
   },
   "engines": {

--- a/scripts/verify-client-entrypoints.mjs
+++ b/scripts/verify-client-entrypoints.mjs
@@ -1,0 +1,51 @@
+/**
+ * VERIFY CLIENT ENTRYPOINTS
+ * 
+ * Guards the real client source truth: apps/client-2d is source, /2d is route only.
+ * No root-level 2d/ source directory exists.
+ * 
+ * @usage pnpm guard:entrypoints
+ */
+
+import { existsSync } from "node:fs";
+
+const requiredSourcePaths = [
+  "apps/client-2d/package.json",
+  "apps/client-2d/index.html",
+  "apps/client-2d/src/main.tsx",
+  "server/src/core/ServerBootstrap.ts",
+  "Dockerfile.vps",
+];
+
+const forbiddenSourceAssumptions = [
+  "2d/package.json",
+  "2d/index.html",
+  "src/2d/index.html",
+];
+
+let hasError = false;
+
+for (const path of requiredSourcePaths) {
+  if (!existsSync(path)) {
+    console.error(`[entrypoints] missing required path: ${path}`);
+    hasError = true;
+  } else {
+    console.log(`[entrypoints] ✓ ${path}`);
+  }
+}
+
+for (const path of forbiddenSourceAssumptions) {
+  if (existsSync(path)) {
+    console.error(`[entrypoints] ERROR: forbidden fake 2d source path exists: ${path}`);
+    hasError = true;
+  } else {
+    console.log(`[entrypoints] ✓ no fake 2d source at ${path}`);
+  }
+}
+
+if (hasError) {
+  console.error("[entrypoints] FAILED: Client entrypoint contract violated");
+  process.exit(1);
+}
+
+console.log("[entrypoints] OK: apps/client-2d is source, /2d is route only.");

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -50,6 +50,60 @@ const currentDir = typeof __dirname !== 'undefined' ? __dirname : path.dirname(f
 type HealthContentSummary = { mode: "published" | "pack_dir" | "legacy" | "unknown"; root: string | null };
 type HealthSupabaseSummary = ReturnType<typeof getSupabaseSummary> | { status: "unknown" };
 
+export interface ClientEntrypointHealth {
+  readonly source: {
+    readonly client2d: string;
+    readonly client3d: string;
+    readonly portal: string;
+  };
+  readonly runtime: {
+    readonly root: string;
+    readonly client2d: string;
+    readonly client3d: string;
+    readonly portal: string;
+  };
+  readonly route: {
+    readonly client2d: "/2d";
+    readonly client3d: "/3d";
+    readonly portal: "/portal";
+  };
+  readonly available: {
+    readonly client2d: boolean;
+    readonly client3d: boolean;
+    readonly portal: boolean;
+  };
+}
+
+export function buildClientEntrypointHealth(clientRoot: string, clientDistPath: string): ClientEntrypointHealth {
+  const client2dRuntime = path.join(clientDistPath, "2d", "index.html");
+  const client3dRuntime = path.join(clientDistPath, "3d", "index.html");
+  const portalRuntime = path.join(clientDistPath, "portal", "index.html");
+
+  return Object.freeze({
+    source: Object.freeze({
+      client2d: "apps/client-2d",
+      client3d: "client",
+      portal: "portal",
+    }),
+    runtime: Object.freeze({
+      root: clientDistPath,
+      client2d: client2dRuntime,
+      client3d: client3dRuntime,
+      portal: portalRuntime,
+    }),
+    route: Object.freeze({
+      client2d: "/2d" as const,
+      client3d: "/3d" as const,
+      portal: "/portal" as const,
+    }),
+    available: Object.freeze({
+      client2d: existsSync(client2dRuntime),
+      client3d: existsSync(client3dRuntime),
+      portal: existsSync(portalRuntime),
+    }),
+  });
+}
+
 function resolveClientRoot(): string {
   const fromEnv = process.env.CLIENT_ROOT_DIR?.trim();
   if (fromEnv) return path.isAbsolute(fromEnv) ? fromEnv : path.resolve(process.cwd(), fromEnv);
@@ -144,6 +198,9 @@ export class ServerBootstrap {
     app.get("/health", (_req, res) => {
       const tick = (this as any)._tick as WorldTick | undefined;
       const selfHealingStatus = safeHealthValue(() => selfHealingRuntime.getStatus(), { active: false, config: {}, totalErrors: 0, totalHealed: 0, healingRate: 0, featuresProtected: 0 } as any);
+      const clientRoot = resolveClientRoot();
+      const clientPath = path.join(clientRoot, "dist");
+      const clientEntrypoints = buildClientEntrypointHealth(clientRoot, clientPath);
       res.status(this.initializing ? 503 : 200).json({
         ok: !this.initializing,
         status: this.initializing ? "initializing" : "ok",
@@ -151,6 +208,7 @@ export class ServerBootstrap {
         version: "0.2.0",
         uptimeSeconds: Math.round(process.uptime()),
         port: Number(process.env.PORT || 3000),
+        clientEntrypoints,
         persistence: safeHealthValue(() => tick?.getPersistenceStats?.() ?? { status: "unknown" }, { status: "unknown" }),
         content: safeHealthValue<HealthContentSummary>(() => { const content = getContentDataSourceLabel(); return { mode: content.mode, root: content.root }; }, { mode: "unknown", root: null }),
         supabase: safeHealthValue<HealthSupabaseSummary>(() => getSupabaseSummary(), { status: "unknown" }),

--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -47,6 +47,9 @@ import { handleGameplayQuestEvent } from "../quests/QuestGameplayEventBridge.js"
 import { gatheringService } from "../resources/GatheringService.js";
 
 // Phase 5: Gameplay Contract imports
+import type { CraftingPort, SkillPort, PlacementPort } from "./ports/GameplayPorts.js";
+import { NullCraftingPort, NullSkillPort, NullPlacementPort } from "./ports/NullGameplayPorts.js";
+
 import { 
   SERVER_PROTOCOL_VERSION,
   safeJsonParse,
@@ -340,8 +343,11 @@ export class WorldTick {
   public setVoteBannerOrder(data: any): any { return { ok: true }; }
   public getVoteAdminDiagnostics(): any { return {}; }
   public debouncedSave(): void {}
-  public craftingSystem: any = {};
-  public skillSystem: any = {};
+
+  // Phase 4: Typed gameplay ports - replace placeholders with explicit null ports
+  public readonly craftingSystem: CraftingPort = new NullCraftingPort();
+  public readonly skillSystem: SkillPort = new NullSkillPort();
+  public readonly placementEnginePort: PlacementPort = new NullPlacementPort();
   public worldState: any = { customDialogues: {} };
   public createNPC(id: any, name: any, x: any, y: any): void {}
   public playerToSocket: Map<string, string> = new Map();

--- a/server/src/core/ports/GameplayPorts.ts
+++ b/server/src/core/ports/GameplayPorts.ts
@@ -1,0 +1,45 @@
+/**
+ * GAMEPLAY PORTS
+ *
+ * Typed port interfaces for gameplay systems connected to WorldTick.
+ * All operations require logicalIndex for deterministic tracking.
+ *
+ * Rules:
+ * - No Math.random() in port implementations
+ * - No Date.now() for gameplay decisions
+ * - All operations require logicalIndex
+ * - Null ports must return explicit failure, not silent {}
+ */
+
+export interface CraftingResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+  readonly jobId?: string;
+}
+
+export interface CraftingPort {
+  readonly kind: "crafting";
+  craft(playerId: string, recipeId: string, logicalIndex: number): CraftingResult;
+}
+
+export interface SkillUseResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+  readonly cooldownTicks?: number;
+}
+
+export interface SkillPort {
+  readonly kind: "skill";
+  useSkill(playerId: string, skillId: string, logicalIndex: number): SkillUseResult;
+}
+
+export interface PlacementResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+  readonly structureId?: string;
+}
+
+export interface PlacementPort {
+  readonly kind: "placement";
+  place(playerId: string, blueprintId: string, tileX: number, tileZ: number, logicalIndex: number): PlacementResult;
+}

--- a/server/src/core/ports/NullGameplayPorts.ts
+++ b/server/src/core/ports/NullGameplayPorts.ts
@@ -1,0 +1,59 @@
+/**
+ * NULL GAMEPLAY PORTS
+ *
+ * Explicit null/placeholder implementations for unconnected gameplay systems.
+ * These provide honest, typed responses instead of silent {} placeholders.
+ *
+ * Rules:
+ * - Null ports must be explicit and honest
+ * - All methods require logicalIndex
+ * - No direct mutation hidden inside port contracts
+ */
+
+import type {
+  CraftingPort,
+  CraftingResult,
+  SkillPort,
+  SkillUseResult,
+  PlacementPort,
+  PlacementResult,
+} from "./GameplayPorts.js";
+
+export class NullCraftingPort implements CraftingPort {
+  public readonly kind = "crafting" as const;
+
+  public craft(_playerId: string, _recipeId: string, _logicalIndex: number): CraftingResult {
+    return Object.freeze({
+      ok: false,
+      reason: "crafting_not_connected",
+    });
+  }
+}
+
+export class NullSkillPort implements SkillPort {
+  public readonly kind = "skill" as const;
+
+  public useSkill(_playerId: string, _skillId: string, _logicalIndex: number): SkillUseResult {
+    return Object.freeze({
+      ok: false,
+      reason: "skill_not_connected",
+    });
+  }
+}
+
+export class NullPlacementPort implements PlacementPort {
+  public readonly kind = "placement" as const;
+
+  public place(
+    _playerId: string,
+    _blueprintId: string,
+    _tileX: number,
+    _tileZ: number,
+    _logicalIndex: number,
+  ): PlacementResult {
+    return Object.freeze({
+      ok: false,
+      reason: "placement_not_connected",
+    });
+  }
+}

--- a/server/src/gameplay/LiveGameplaySnapshotComposer.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotComposer.ts
@@ -17,28 +17,50 @@ import type {
   LiveGameplayEquipmentSlot,
   LiveGameplaySkillState,
   LiveGameplayResourceNode,
+  LiveGameplayCombatView,
+  LiveGameplayCraftingView,
+  LiveGameplayFactionView,
+  LiveGameplayWorldView,
 } from "./LiveGameplaySnapshotTypes.js";
 
+// Phase 3: Extended deps for v2 snapshot
 export interface LiveGameplaySnapshotComposerDeps {
   readonly getInventoryItems: (playerId: string) => readonly LiveGameplayInventoryItem[] | Promise<readonly LiveGameplayInventoryItem[]>;
   readonly getEquipmentSlots: (playerId: string) => readonly LiveGameplayEquipmentSlot[] | Promise<readonly LiveGameplayEquipmentSlot[]>;
   readonly getSkillStates: (playerId: string) => readonly LiveGameplaySkillState[] | Promise<readonly LiveGameplaySkillState[]>;
   readonly getResourceNodes: (playerId: string) => readonly LiveGameplayResourceNode[] | Promise<readonly LiveGameplayResourceNode[]>;
+  readonly getCombatView: (playerId: string) => LiveGameplayCombatView | Promise<LiveGameplayCombatView>;
+  readonly getCraftingView: (playerId: string) => LiveGameplayCraftingView | Promise<LiveGameplayCraftingView>;
+  readonly getFactionView: (playerId: string) => LiveGameplayFactionView | Promise<LiveGameplayFactionView>;
+  readonly getWorldView: (playerId: string) => LiveGameplayWorldView | Promise<LiveGameplayWorldView>;
 }
 
 export class LiveGameplaySnapshotComposer {
   public constructor(private readonly deps: LiveGameplaySnapshotComposerDeps) {}
 
   public async compose(playerId: string, logicalIndex: number): Promise<LiveGameplaySnapshot> {
-    const [inventory, equipment, skills, resourceNodes] = await Promise.all([
+    const [
+      inventory,
+      equipment,
+      skills,
+      resourceNodes,
+      combat,
+      crafting,
+      faction,
+      world,
+    ] = await Promise.all([
       this.deps.getInventoryItems(playerId),
       this.deps.getEquipmentSlots(playerId),
       this.deps.getSkillStates(playerId),
       this.deps.getResourceNodes(playerId),
+      this.deps.getCombatView(playerId),
+      this.deps.getCraftingView(playerId),
+      this.deps.getFactionView(playerId),
+      this.deps.getWorldView(playerId),
     ]);
 
     return Object.freeze({
-      schemaVersion: "live-gameplay-snapshot.v1" as const,
+      schemaVersion: "live-gameplay-snapshot.v2" as const,
       playerId,
       logicalIndex: this.safeIndex(logicalIndex),
       tickRateHz: 10 as const,
@@ -47,6 +69,19 @@ export class LiveGameplaySnapshotComposer {
       equipment: Object.freeze([...equipment].sort((a, b) => a.slot.localeCompare(b.slot))),
       skills: Object.freeze([...skills].sort((a, b) => a.skillId.localeCompare(b.skillId))),
       resourceNodes: Object.freeze([...resourceNodes].sort((a, b) => a.nodeId.localeCompare(b.nodeId))),
+      combat: Object.freeze({
+        ...combat,
+        cooldowns: Object.freeze([...combat.cooldowns].sort((a, b) => a.id.localeCompare(b.id))),
+      }),
+      crafting: Object.freeze({
+        knownRecipes: Object.freeze([...crafting.knownRecipes].sort((a, b) => a.recipeId.localeCompare(b.recipeId))),
+        activeCraft: crafting.activeCraft ? Object.freeze({ ...crafting.activeCraft }) : null,
+      }),
+      faction: Object.freeze({
+        ...faction,
+        reputation: Object.freeze([...faction.reputation].sort((a, b) => a.factionId.localeCompare(b.factionId))),
+      }),
+      world: Object.freeze({ ...world }),
     });
   }
 

--- a/server/src/gameplay/LiveGameplaySnapshotTypes.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotTypes.ts
@@ -36,8 +36,59 @@ export interface LiveGameplayResourceNode {
   readonly available: boolean;
 }
 
+// Phase 3: Extended types for v2 snapshot
+export interface LiveGameplayCooldownView {
+  readonly id: string;
+  readonly remainingTicks: number;
+  readonly totalTicks: number;
+}
+
+export interface LiveGameplayCombatView {
+  readonly hp: number;
+  readonly maxHp: number;
+  readonly stamina: number;
+  readonly maxStamina: number;
+  readonly targetId: string | null;
+  readonly cooldowns: readonly LiveGameplayCooldownView[];
+}
+
+export interface LiveGameplayCraftingRecipeView {
+  readonly recipeId: string;
+  readonly outputItemId: string;
+  readonly known: boolean;
+}
+
+export interface LiveGameplayCraftingJobView {
+  readonly jobId: string;
+  readonly recipeId: string;
+  readonly startedAtTick: number;
+  readonly completesAtTick: number;
+}
+
+export interface LiveGameplayCraftingView {
+  readonly knownRecipes: readonly LiveGameplayCraftingRecipeView[];
+  readonly activeCraft: LiveGameplayCraftingJobView | null;
+}
+
+export interface LiveGameplayReputationView {
+  readonly factionId: string;
+  readonly value: number;
+}
+
+export interface LiveGameplayFactionView {
+  readonly guildId: string | null;
+  readonly factionId: string | null;
+  readonly reputation: readonly LiveGameplayReputationView[];
+}
+
+export interface LiveGameplayWorldView {
+  readonly chunkId: string;
+  readonly biomeId: string;
+  readonly safeZone: boolean;
+}
+
 export interface LiveGameplaySnapshot {
-  readonly schemaVersion: "live-gameplay-snapshot.v1";
+  readonly schemaVersion: "live-gameplay-snapshot.v2";
   readonly playerId: string;
   readonly logicalIndex: number;
   readonly tickRateHz: 10;
@@ -46,6 +97,10 @@ export interface LiveGameplaySnapshot {
   readonly equipment: readonly LiveGameplayEquipmentSlot[];
   readonly skills: readonly LiveGameplaySkillState[];
   readonly resourceNodes: readonly LiveGameplayResourceNode[];
+  readonly combat: LiveGameplayCombatView;
+  readonly crafting: LiveGameplayCraftingView;
+  readonly faction: LiveGameplayFactionView;
+  readonly world: LiveGameplayWorldView;
 }
 
 export interface GatherResult {

--- a/server/src/selfhealing/SelfHealPatchLog.ts
+++ b/server/src/selfhealing/SelfHealPatchLog.ts
@@ -1,0 +1,84 @@
+/**
+ * SELF HEAL PATCH LOG
+ *
+ * Deterministic patch logging for SelfHeal repairs.
+ * All entries are hashable and reproducible.
+ *
+ * Rules:
+ * - SelfHeal may observe runtime
+ * - SelfHeal must not create random gameplay outcomes
+ * - Repairs must produce hashable logs
+ * - Patch logs must be deterministic from signal + before + after
+ * - If repair is unsafe, report degraded mode instead of mutating
+ */
+
+import { createHash } from "node:crypto";
+import type { SelfHealSignal } from "./SelfHealSignals.js";
+
+export interface HealPatchLogEntry {
+  readonly id: string;
+  readonly tick: number;
+  readonly signal: SelfHealSignal;
+  readonly subsystem: string;
+  readonly action: string;
+  readonly beforeHash: string;
+  readonly afterHash: string;
+  readonly ok: boolean;
+}
+
+export function stableHealHash(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(value)))
+    .digest("hex");
+}
+
+export function createHealPatchLogEntry(input: {
+  readonly tick: number;
+  readonly signal: SelfHealSignal;
+  readonly subsystem: string;
+  readonly action: string;
+  readonly before: unknown;
+  readonly after: unknown;
+  readonly ok: boolean;
+}): HealPatchLogEntry {
+  const beforeHash = stableHealHash(input.before);
+  const afterHash = stableHealHash(input.after);
+  const id = stableHealHash({
+    tick: input.tick,
+    signal: input.signal,
+    subsystem: input.subsystem,
+    action: input.action,
+    beforeHash,
+    afterHash,
+  });
+
+  return Object.freeze({
+    id,
+    tick: input.tick,
+    signal: input.signal,
+    subsystem: input.subsystem,
+    action: input.action,
+    beforeHash,
+    afterHash,
+    ok: input.ok,
+  });
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null) return null;
+  if (typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+
+  for (const key of Object.keys(input).sort()) {
+    const child = input[key];
+    if (typeof child === "undefined") continue;
+    if (typeof child === "function") continue;
+    if (typeof child === "symbol") continue;
+    output[key] = canonicalize(child);
+  }
+
+  return output;
+}

--- a/server/src/selfhealing/SelfHealSignals.ts
+++ b/server/src/selfhealing/SelfHealSignals.ts
@@ -1,0 +1,33 @@
+/**
+ * SELF HEAL SIGNALS
+ *
+ * Typed signal contracts for SelfHeal system monitoring.
+ * All signals are deterministic and traceable.
+ *
+ * Rules:
+ * - SelfHeal may observe runtime
+ * - SelfHeal must not create random gameplay outcomes
+ * - Repairs must produce hashable logs
+ * - Patch logs must be deterministic from signal + before + after
+ * - If repair is unsafe, report degraded mode instead of mutating
+ */
+
+export type SelfHealSignal =
+  | "BOOT_CONFIG_MISSING"
+  | "CLIENT_ASSET_MISSING"
+  | "WORLD_TICK_DRIFT"
+  | "PERSISTENCE_WRITE_FAILED"
+  | "REDIS_UNAVAILABLE"
+  | "ARE_INVARIANT_VIOLATION"
+  | "SNAPSHOT_COMPOSITION_FAILED"
+  | "GLB_ASSET_INVALID"
+  | "ENTRYPOINT_CONTRACT_DRIFT";
+
+export interface SelfHealSignalEnvelope {
+  readonly signal: SelfHealSignal;
+  readonly subsystem: string;
+  readonly logicalIndex: number;
+  readonly severity: "info" | "warn" | "error" | "critical";
+  readonly message: string;
+  readonly metadata: Readonly<Record<string, unknown>>;
+}


### PR DESCRIPTION
## Summary

Integrates real client entrypoint truth, deterministic LiveGameplaySnapshot v2, typed WorldTick null ports, SelfHeal signals, docs, skills and guards.

## Changes

### Phase 1 - Client Entrypoint Truth Guard
- Added `scripts/verify-client-entrypoints.mjs` - guards real client source (`apps/client-2d`) vs fake root `2d/`
- Updated `package.json` with `guard:entrypoints` and updated `guard:all`

### Phase 2 - Health Report: Real Client Routes
- Added `ClientEntrypointHealth` interface and `buildClientEntrypointHealth()` function to `ServerBootstrap.ts`
- Extended `/health` endpoint with `clientEntrypoints` showing source, runtime, route, and availability

### Phase 3 - Live Gameplay Snapshot v2
- Extended `LiveGameplaySnapshotTypes.ts` with:
  - `LiveGameplayCooldownView`
  - `LiveGameplayCombatView`
  - `LiveGameplayCraftingRecipeView`
  - `LiveGameplayCraftingJobView`
  - `LiveGameplayCraftingView`
  - `LiveGameplayReputationView`
  - `LiveGameplayFactionView`
  - `LiveGameplayWorldView`
- Updated `LiveGameplaySnapshotComposer.ts` with extended deps and v2 schema

### Phase 4 - WorldTick Ports Instead of Placeholders
- Created `server/src/core/ports/GameplayPorts.ts` with typed interfaces:
  - `CraftingPort`, `CraftingResult`
  - `SkillPort`, `SkillUseResult`
  - `PlacementPort`, `PlacementResult`
- Created `server/src/core/ports/NullGameplayPorts.ts` with explicit null implementations
- Updated `WorldTick.ts` to use typed ports instead of `{}` placeholders

### Phase 5 - SelfHeal Signal Contract
- Created `server/src/selfhealing/SelfHealSignals.ts` with typed signals
- Created `server/src/selfhealing/SelfHealPatchLog.ts` with deterministic patch logging

### Phase 6 - Client Snapshot Render Contract
- Added `apps/client-2d/src/net/liveGameplaySnapshot.ts` with client-side validation

### Phase 7 - E2E Contract Test
- Added `e2e/live-system-contract.spec.ts` to verify `/2d` route and health contract

### Phase 8 - Documentation
- `docs/ARCHITECTURE_CLIENT_ENTRYPOINTS.md` - Client entrypoint architecture
- `docs/ARELOGIC_LIVE_SYSTEM_CONTRACT.md` - ARELogic contract documentation
- `docs/skills/live-system-contract-hardening.skill.md` - Skill documentation

## Key Rules Enforced

- `apps/client-2d` is the only real 2D client source (no root `2d/`)
- `/2d` is the public route only
- `LiveGameplaySnapshot v2` is deterministic and sorted
- Missing systems return explicit null-port responses, not `{}`
- SelfHeal signals are typed and logged deterministically

## Validation

```bash
pnpm guard:entrypoints  # Verify client source truth
pnpm guard:all           # Run all guards
```

## Commit History

1. `test(entrypoints): guard real client source and route contract`
2. `feat(server): expose client entrypoint health`
3. `feat(gameplay): extend deterministic live gameplay snapshot to v2`
4. `refactor(worldtick): replace placeholder systems with typed null ports`
5. `feat(selfheal): add typed deterministic heal signal contract and patch log`
6. `feat(client-2d): validate live gameplay snapshot contract`
7. `test(e2e): verify live system route contract`
8. `docs: document ARELogic live system contract and client entrypoints`

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/322baf90-ff54-4bf4-955c-0ee1530e1ab8)