### PR TITLE
fix(client-2d): align live gameplay store with snapshot composer

### DIFF
--- a/apps/client-2d/src/game/liveGameplayStore.ts
+++ b/apps/client-2d/src/game/liveGameplayStore.ts
@@ -10,17 +10,111 @@ import {
 
 type Listener = () => void;
 
+function prettifyId(value: string): string {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function projectComposerSnapshot(input: Record<string, unknown>): Partial<LiveGameplaySnapshot> {
+  const playerId = String(input.playerId ?? "guest");
+  const inventory = Array.isArray(input.inventory) ? input.inventory : [];
+  const equipment = Array.isArray(input.equipment) ? input.equipment : [];
+  const skills = Array.isArray(input.skills) ? input.skills : [];
+  const resourceNodes = Array.isArray(input.resourceNodes) ? input.resourceNodes : [];
+
+  return {
+    status: "live",
+    serverTick: typeof input.logicalIndex === "number" ? input.logicalIndex : null,
+    quests: [],
+    skills: skills.map((skill: any) => {
+      const id = String(skill.skillId ?? skill.id ?? "combat");
+      return {
+        id,
+        title: prettifyId(id),
+        level: Math.max(1, Math.floor(Number(skill.level ?? 1))),
+        xp: Math.max(0, Math.floor(Number(skill.xp ?? 0))),
+        xpForNextLevel: Math.max(1, Math.floor(Number(skill.xpForNextLevel ?? 100))),
+        progressRatio: Math.max(0, Math.min(1, Number(skill.progressRatio ?? 0))),
+      };
+    }) as LiveGameplaySnapshot["skills"],
+    resources: resourceNodes.map((node: any) => {
+      const skillId = String(node.skillId ?? "woodcutting");
+      const resourceId = String(node.resourceId ?? node.nodeId ?? "resource");
+      const kind = skillId === "fishing" ? "fish_spot" : skillId === "mining" ? "ore" : "tree";
+      return {
+        id: String(node.nodeId ?? resourceId),
+        kind,
+        title: prettifyId(resourceId),
+        skillId,
+        requiredLevel: 1,
+        xpReward: 0,
+        itemRewardId: resourceId,
+        itemRewardName: prettifyId(resourceId),
+        position: {
+          x: Number(node.x ?? 0),
+          y: Number(node.y ?? 0),
+        },
+        radius: 16,
+        status: node.available === false ? "depleted" : "available",
+        depletedUntilTick: null,
+        remainingTicks: 0,
+      };
+    }) as LiveGameplaySnapshot["resources"],
+    inventory: {
+      playerId,
+      schemaVersion: 1,
+      capacity: 32,
+      slots: inventory.map((item: any) => {
+        const itemId = String(item.itemId ?? item.id ?? "unknown_item");
+        return {
+          slotId: `slot_${itemId}`,
+          itemId,
+          name: prettifyId(itemId),
+          quantity: Math.max(0, Math.floor(Number(item.quantity ?? item.count ?? 0))),
+          category: "resource",
+          stackable: true,
+          maxStack: 999,
+        };
+      }),
+    },
+    equipment: {
+      playerId,
+      schemaVersion: 1,
+      slots: equipment.map((slot: any) => ({
+        slotId: String(slot.slot ?? slot.slotId ?? "unknown_slot"),
+        itemId: String(slot.itemId ?? ""),
+        title: prettifyId(String(slot.itemId ?? slot.slot ?? "empty")),
+      })),
+    },
+  };
+}
+
 function pickSnapshotPayload(data: unknown): unknown {
   const raw = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
 
   // Preferred post-#1762 contract.
   if (raw.liveGameplaySnapshot && typeof raw.liveGameplaySnapshot === "object") {
-    return raw.liveGameplaySnapshot;
+    return projectComposerSnapshot(raw.liveGameplaySnapshot as Record<string, unknown>);
+  }
+
+  // Direct composer snapshot, e.g. WebSocket payload.
+  if (raw.schemaVersion === "live-gameplay-snapshot.v1") {
+    return projectComposerSnapshot(raw);
   }
 
   // Existing route wrapper contract.
   if (raw.snapshot && typeof raw.snapshot === "object") {
-    return raw.snapshot;
+    const snapshot = raw.snapshot as Record<string, unknown>;
+    if (snapshot.schemaVersion === "live-gameplay-snapshot.v1") {
+      return {
+        ...snapshot,
+        status: "live",
+      };
+    }
+    return snapshot;
   }
 
   return data;

--- a/apps/client-2d/src/game/liveGameplayStore.ts
+++ b/apps/client-2d/src/game/liveGameplayStore.ts
@@ -10,6 +10,22 @@ import {
 
 type Listener = () => void;
 
+function pickSnapshotPayload(data: unknown): unknown {
+  const raw = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+
+  // Preferred post-#1762 contract.
+  if (raw.liveGameplaySnapshot && typeof raw.liveGameplaySnapshot === "object") {
+    return raw.liveGameplaySnapshot;
+  }
+
+  // Existing route wrapper contract.
+  if (raw.snapshot && typeof raw.snapshot === "object") {
+    return raw.snapshot;
+  }
+
+  return data;
+}
+
 export class LiveGameplayStore {
   private snapshot: LiveGameplaySnapshot = EMPTY_LIVE_GAMEPLAY_SNAPSHOT;
   private readonly listeners = new Set<Listener>();
@@ -18,8 +34,8 @@ export class LiveGameplayStore {
     return this.snapshot;
   }
 
-  setSnapshot(next: Partial<LiveGameplaySnapshot>): void {
-    this.snapshot = normalizeLiveGameplaySnapshot(next);
+  setSnapshot(next: unknown): void {
+    this.snapshot = normalizeLiveGameplaySnapshot(pickSnapshotPayload(next));
     this.emit();
   }
 
@@ -32,26 +48,10 @@ export class LiveGameplayStore {
       type === "gameplay_snapshot" ||
       type === "GAMEPLAY_SNAPSHOT" ||
       type === "world_snapshot" ||
-      type === "WORLD_SNAPSHOT"
+      type === "WORLD_SNAPSHOT" ||
+      (payload && typeof payload === "object" && (payload as Record<string, unknown>).schemaVersion === "live-gameplay-snapshot.v1")
     ) {
-      this.setSnapshot({
-        status: "live",
-        serverTick:
-          (payload?.serverTick as number) ??
-          (payload?.tickId as number) ??
-          null,
-        character: payload?.character as LiveGameplaySnapshot["character"],
-        paperdoll: payload?.paperdoll as LiveGameplaySnapshot["paperdoll"],
-        quests: (payload?.quests as LiveGameplaySnapshot["quests"]) ?? [],
-        skills: (payload?.skills as LiveGameplaySnapshot["skills"]) ?? [],
-        resources: (payload?.resources as LiveGameplaySnapshot["resources"]) ?? [],
-        inventory: payload?.inventory as LiveGameplaySnapshot["inventory"],
-        crafting: payload?.crafting as LiveGameplaySnapshot["crafting"],
-        equipment: payload?.equipment as LiveGameplaySnapshot["equipment"],
-        guild: payload?.guild as LiveGameplaySnapshot["guild"],
-        factions: (payload?.factions as LiveGameplaySnapshot["factions"]) ?? [],
-        map: payload?.map as LiveGameplaySnapshot["map"],
-      });
+      this.setSnapshot(payload);
     }
   }
 
@@ -88,11 +88,8 @@ export async function fetchGameplaySnapshot(
       }
     );
     if (!response.ok) return null;
-    const data = (await response.json()) as {
-      ok?: boolean;
-      snapshot?: Partial<LiveGameplaySnapshot>;
-    };
-    return normalizeLiveGameplaySnapshot(data.snapshot ?? data);
+    const data = await response.json();
+    return normalizeLiveGameplaySnapshot(pickSnapshotPayload(data));
   } catch {
     return null;
   }

--- a/apps/client-2d/src/game/liveGameplayStore.ts
+++ b/apps/client-2d/src/game/liveGameplayStore.ts
@@ -109,10 +109,7 @@ function pickSnapshotPayload(data: unknown): unknown {
   if (raw.snapshot && typeof raw.snapshot === "object") {
     const snapshot = raw.snapshot as Record<string, unknown>;
     if (snapshot.schemaVersion === "live-gameplay-snapshot.v1") {
-      return {
-        ...snapshot,
-        status: "live",
-      };
+      return projectComposerSnapshot(snapshot);
     }
     return snapshot;
   }


### PR DESCRIPTION
## Summary

Bridges the 2D client live gameplay store to the new `live-gameplay-snapshot.v1` contract introduced by #1762.

## Root cause

#1762 added `LiveGameplaySnapshotComposer` and the `live-gameplay-snapshot.v1` shape, but the 2D client store still expected the older UI snapshot shape. If the server or WebSocket sends the composed snapshot directly, the existing normalizer can drop Inventory / Equipment / Skills / ResourceNodes back to empty UI state.

## Fix

- Prefer `liveGameplaySnapshot` from API wrapper responses.
- Accept direct `schemaVersion: "live-gameplay-snapshot.v1"` payloads from WebSocket/network packets.
- Project composer arrays into the existing UI snapshot shape:
  - `inventory[]` -> `inventory.slots[]`
  - `equipment[]` -> `equipment.slots[]`
  - `skills[]` -> UI skill snapshots
  - `resourceNodes[]` -> UI resource snapshots
- Keep the store display-only and deterministic.

## Notes

The server route still serves the legacy wrapper today. A broader server-route integration can follow separately, but this PR makes the client tolerant to both current and post-#1762 composed snapshot payloads.

## Validation

Target checks:
- `/api/gameplay/snapshot?playerId=guest` still normalizes.
- Direct `live-gameplay-snapshot.v1` payloads no longer become empty/waiting state.
- Inventory, Equipment, Skills and ResourceNodes remain visible when delivered through the composer contract.