### PR TITLE
fix(api): emit composed live gameplay snapshot

### DIFF
--- a/apps/client-2d/src/game/liveGameplayStore.ts
+++ b/apps/client-2d/src/game/liveGameplayStore.ts
@@ -92,10 +92,42 @@ function projectComposerSnapshot(input: Record<string, unknown>): Partial<LiveGa
   };
 }
 
+function mergeComposerIntoLegacy(
+  legacy: Record<string, unknown>,
+  composer: Record<string, unknown>,
+): unknown {
+  const projected = projectComposerSnapshot(composer) as Record<string, unknown>;
+
+  return {
+    ...legacy,
+    status: projected.status ?? legacy.status,
+    serverTick: projected.serverTick ?? legacy.serverTick,
+    skills: projected.skills ?? legacy.skills,
+    resources: projected.resources ?? legacy.resources,
+    inventory: projected.inventory ?? legacy.inventory,
+    equipment: projected.equipment ?? legacy.equipment,
+  };
+}
+
 function pickSnapshotPayload(data: unknown): unknown {
   const raw = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
 
-  // Preferred post-#1762 contract.
+  // Existing route wrapper contract with post-#1762 sibling composer data.
+  // Keep legacy as the base so Quest Journal, Character, Paperdoll, Crafting,
+  // Guild/Faction and Map data are not lost.
+  if (
+    raw.snapshot &&
+    typeof raw.snapshot === "object" &&
+    raw.liveGameplaySnapshot &&
+    typeof raw.liveGameplaySnapshot === "object"
+  ) {
+    return mergeComposerIntoLegacy(
+      raw.snapshot as Record<string, unknown>,
+      raw.liveGameplaySnapshot as Record<string, unknown>,
+    );
+  }
+
+  // Preferred post-#1762 contract when it is the only available payload.
   if (raw.liveGameplaySnapshot && typeof raw.liveGameplaySnapshot === "object") {
     return projectComposerSnapshot(raw.liveGameplaySnapshot as Record<string, unknown>);
   }

--- a/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
+++ b/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
@@ -1,0 +1,87 @@
+import { LiveGameplaySnapshotComposer } from "./LiveGameplaySnapshotComposer.js";
+import type { LiveGameplaySnapshot } from "./LiveGameplaySnapshotTypes.js";
+import { toLiveEquipmentSlots } from "./adapters/EquipmentSnapshotAdapter.js";
+import { toLiveInventoryItems } from "./adapters/InventorySnapshotAdapter.js";
+
+interface LegacyInventorySlot {
+  readonly itemId?: string;
+  readonly id?: string;
+  readonly quantity?: number;
+  readonly count?: number;
+}
+
+interface LegacyInventorySnapshot {
+  readonly slots?: readonly LegacyInventorySlot[];
+}
+
+interface LegacyEquipmentSlot {
+  readonly slot?: string;
+  readonly slotId?: string;
+  readonly itemId?: string | null;
+}
+
+interface LegacyEquipmentSnapshot {
+  readonly slots?: readonly LegacyEquipmentSlot[];
+}
+
+interface LegacySkillSnapshot {
+  readonly id?: string;
+  readonly skillId?: string;
+  readonly xp?: number;
+  readonly level?: number;
+}
+
+interface LegacyResourceNodeSnapshot {
+  readonly id?: string;
+  readonly nodeId?: string;
+  readonly kind?: string;
+  readonly resourceId?: string;
+  readonly itemRewardId?: string;
+  readonly skillId?: string;
+  readonly x?: number;
+  readonly y?: number;
+  readonly position?: {
+    readonly x?: number;
+    readonly y?: number;
+  };
+  readonly available?: boolean;
+  readonly status?: string;
+}
+
+export interface ComposeLiveGameplaySnapshotFromLegacyInput {
+  readonly playerId: string;
+  readonly logicalIndex: number;
+  readonly inventory: LegacyInventorySnapshot;
+  readonly equipment: LegacyEquipmentSnapshot | null;
+  readonly skills: readonly LegacySkillSnapshot[];
+  readonly resourceNodes: readonly LegacyResourceNodeSnapshot[];
+}
+
+export function composeLiveGameplaySnapshotFromLegacy(
+  input: ComposeLiveGameplaySnapshotFromLegacyInput,
+): Promise<LiveGameplaySnapshot> {
+  const composer = new LiveGameplaySnapshotComposer({
+    getInventoryItems: () => toLiveInventoryItems(input.inventory.slots ?? []),
+    getEquipmentSlots: () => toLiveEquipmentSlots(
+      (input.equipment?.slots ?? []).map((slot) => ({
+        slot: String(slot.slot ?? slot.slotId ?? ""),
+        itemId: slot.itemId ?? null,
+      })),
+    ),
+    getSkillStates: () => input.skills.map((skill) => ({
+      skillId: String(skill.skillId ?? skill.id ?? "unknown_skill"),
+      xp: Math.max(0, Math.floor(Number(skill.xp ?? 0))),
+      level: Math.max(1, Math.floor(Number(skill.level ?? 1))),
+    })),
+    getResourceNodes: () => input.resourceNodes.map((node) => ({
+      nodeId: String(node.nodeId ?? node.id ?? "unknown_node"),
+      resourceId: String(node.resourceId ?? node.itemRewardId ?? node.kind ?? "resource"),
+      skillId: String(node.skillId ?? "unknown_skill"),
+      x: Number(node.x ?? node.position?.x ?? 0),
+      y: Number(node.y ?? node.position?.y ?? 0),
+      available: node.available === true || node.status === "available",
+    })),
+  });
+
+  return composer.compose(input.playerId, input.logicalIndex);
+}

--- a/server/src/routes/gameplaySnapshot.ts
+++ b/server/src/routes/gameplaySnapshot.ts
@@ -28,6 +28,7 @@ import { characterService } from "../character/characterRuntime.js";
 import { toCharacterProfileSnapshot } from "../character/CharacterTypes.js";
 import { createPaperdollSnapshot } from "../character/PaperdollTypes.js";
 import { createStartPathQuestSnapshot } from "../character/StartPathQuestLine.js";
+import { composeLiveGameplaySnapshotFromLegacy } from "../gameplay/composeLiveGameplaySnapshotFromLegacy.js";
 
 /**
  * Get current tick ID from WorldTick instance.
@@ -141,12 +142,22 @@ export function createGameplaySnapshotRouter(tick: WorldTick) {
       map: {},
     });
 
+    const liveGameplaySnapshot = await composeLiveGameplaySnapshotFromLegacy({
+      playerId: identity.playerId,
+      logicalIndex: serverTick,
+      inventory,
+      equipment,
+      skills: skillState.skills,
+      resourceNodes: resources,
+    });
+
     res.json({
       ok: true,
       playerId: identity.playerId,
       playerIdentitySource: identity.source,
       authenticated: identity.authenticated,
       snapshot,
+      liveGameplaySnapshot,
     });
   });
 


### PR DESCRIPTION
## Summary

Wires the post-#1762 `LiveGameplaySnapshotComposer` into `/api/gameplay/snapshot` without removing the legacy UI snapshot.

## What changed

- Adds `composeLiveGameplaySnapshotFromLegacy()` bridge.
- Keeps existing `snapshot` response untouched for Quest Journal, Character, Paperdoll and legacy panels.
- Adds sibling `liveGameplaySnapshot` response using `schemaVersion: "live-gameplay-snapshot.v1"`.
- Reuses existing server-authoritative inventory, equipment, skills and resource node data.
- Preserves deterministic sorting through the composer and existing adapters.

## Why

#1762 introduced the deterministic composer contract, and #1764 made the 2D client understand it. This PR officially exposes the composed contract from the snapshot API while keeping the current UI safe.

## Expected API shape

```json
{
  "ok": true,
  "snapshot": { "status": "live" },
  "liveGameplaySnapshot": {
    "schemaVersion": "live-gameplay-snapshot.v1",
    "tickRateHz": 10,
    "tickMs": 100,
    "inventory": [],
    "equipment": [],
    "skills": [],
    "resourceNodes": []
  }
}
```

## Validation

- `/api/gameplay/snapshot?playerId=guest` still returns legacy `snapshot`.
- Response also includes `liveGameplaySnapshot`.
- Client from #1764 prefers/normalizes the composed sibling safely.
- No client-side gameplay decisions introduced.