### PR TITLE
refactor(worldtick): use typed null gameplay ports

### DIFF
--- a/server/src/core/WorldTick.ts
+++ b/server/src/core/WorldTick.ts
@@ -45,6 +45,8 @@ import { PersistentPlaytesterNPC, type PlaytesterWorldPort, type PlaytesterNpcSp
 import { PlaytesterJsonlLogger } from "../modules/playtester/PlaytesterJsonlLogger.js";
 import { handleGameplayQuestEvent } from "../quests/QuestGameplayEventBridge.js";
 import { gatheringService } from "../resources/GatheringService.js";
+import type { CraftingPort, SkillPort, PlacementPort } from "./ports/GameplayPorts.js";
+import { NullCraftingPort, NullSkillPort, NullPlacementPort } from "./ports/NullGameplayPorts.js";
 
 // Phase 5: Gameplay Contract imports
 import { 
@@ -332,6 +334,7 @@ export class WorldTick {
     return persistenceDirector.getStats(); 
   }
   public placementEngine: any = {};
+  public readonly placementEnginePort: PlacementPort = new NullPlacementPort();
   public listActiveVoteBanners(): any { return []; }
   public handleVoteProviderCallback(data: any): any { return { ok: true }; }
   public getAdminVoteBanners(): any { return []; }
@@ -340,8 +343,8 @@ export class WorldTick {
   public setVoteBannerOrder(data: any): any { return { ok: true }; }
   public getVoteAdminDiagnostics(): any { return {}; }
   public debouncedSave(): void {}
-  public craftingSystem: any = {};
-  public skillSystem: any = {};
+  public readonly craftingSystem: CraftingPort = new NullCraftingPort();
+  public readonly skillSystem: SkillPort = new NullSkillPort();
   public worldState: any = { customDialogues: {} };
   public createNPC(id: any, name: any, x: any, y: any): void {}
   public playerToSocket: Map<string, string> = new Map();

--- a/server/src/core/ports/GameplayPorts.ts
+++ b/server/src/core/ports/GameplayPorts.ts
@@ -1,0 +1,11 @@
+export interface CraftingPort {
+  craft(playerId: string, recipeId: string, logicalIndex: number): { ok: true; result: unknown } | { ok: false; reason: string };
+}
+
+export interface SkillPort {
+  useSkill(playerId: string, skillId: string, logicalIndex: number): { ok: true; result: unknown } | { ok: false; reason: string };
+}
+
+export interface PlacementPort {
+  place(playerId: string, blockId: string, x: number, y: number, logicalIndex: number): { ok: true; result: unknown } | { ok: false; reason: string };
+}

--- a/server/src/core/ports/NullGameplayPorts.test.ts
+++ b/server/src/core/ports/NullGameplayPorts.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { NullCraftingPort, NullPlacementPort, NullSkillPort } from "./NullGameplayPorts.js";
+
+describe("NullGameplayPorts", () => {
+  it("return explicit deterministic failures", () => {
+    expect(new NullCraftingPort().craft("p1", "r1", 1)).toEqual({
+      ok: false,
+      reason: "crafting_not_connected",
+    });
+
+    expect(new NullSkillPort().useSkill("p1", "s1", 1)).toEqual({
+      ok: false,
+      reason: "skill_not_connected",
+    });
+
+    expect(new NullPlacementPort().place("p1", "b1", 1, 2, 3)).toEqual({
+      ok: false,
+      reason: "placement_not_connected",
+    });
+  });
+});

--- a/server/src/core/ports/NullGameplayPorts.ts
+++ b/server/src/core/ports/NullGameplayPorts.ts
@@ -1,0 +1,19 @@
+import type { CraftingPort, SkillPort, PlacementPort } from "./GameplayPorts.js";
+
+export class NullCraftingPort implements CraftingPort {
+  craft(_playerId: string, _recipeId: string, _logicalIndex: number): { ok: false; reason: string } {
+    return { ok: false, reason: "crafting_not_connected" };
+  }
+}
+
+export class NullSkillPort implements SkillPort {
+  useSkill(_playerId: string, _skillId: string, _logicalIndex: number): { ok: false; reason: string } {
+    return { ok: false, reason: "skill_not_connected" };
+  }
+}
+
+export class NullPlacementPort implements PlacementPort {
+  place(_playerId: string, _blockId: string, _x: number, _y: number, _logicalIndex: number): { ok: false; reason: string } {
+    return { ok: false, reason: "placement_not_connected" };
+  }
+}


### PR DESCRIPTION
## Summary

Replaces silent gameplay `{}` placeholders in WorldTick with explicit typed null ports.

## Scope

- Adds typed null gameplay ports
- Wires WorldTick to use explicit CraftingPort / SkillPort / PlacementPort
- Does not change snapshot schema
- Does not touch client behavior
- Does not include SelfHeal signal work

## Determinism

- No Math.random
- No Date.now for gameplay progression
- Explicit null results instead of silent empty objects
- All calls require logicalIndex

## Validation

- `pnpm --filter @wasd/server typecheck`
- `pnpm exec vitest run server/src/core/ports/NullGameplayPorts.test.ts`
- `pnpm guard:worldtick`

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b0fb2b3b-438a-46ea-b8e0-8f61eb5535a7)