### PR TITLE
fix(client-2d): add resource gather player position bridge

### DIFF
--- a/apps/client-2d/src/game/PlayerPositionBridge.ts
+++ b/apps/client-2d/src/game/PlayerPositionBridge.ts
@@ -1,0 +1,28 @@
+import type { GameplayWorldPosition } from "./gameplayActions";
+
+const PLAYER_POSITION_BRIDGE_KEY = "wasd:2d:player-position:v1";
+
+export function publishPlayerPositionBridge(input: { x: number; z: number } | null | undefined): void {
+  if (!input) return;
+  const x = Number(input.x);
+  const z = Number(input.z);
+  if (!Number.isFinite(x) || !Number.isFinite(z)) return;
+  sessionStorage.setItem(
+    PLAYER_POSITION_BRIDGE_KEY,
+    JSON.stringify({ x: x / 1000, y: z / 1000 }),
+  );
+}
+
+export function readPlayerPositionBridge(): GameplayWorldPosition | null {
+  const raw = sessionStorage.getItem(PLAYER_POSITION_BRIDGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<GameplayWorldPosition>;
+    const x = Number(parsed.x);
+    const y = Number(parsed.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    return { x, y };
+  } catch {
+    return null;
+  }
+}

--- a/apps/client-2d/src/ui/ResourceNodeMarkerLayer.tsx
+++ b/apps/client-2d/src/ui/ResourceNodeMarkerLayer.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useLiveGameplaySnapshot } from "../game/useLiveGameplaySnapshot";
 import { dispatchGather, type GameplayWorldPosition } from "../game/gameplayActions";
 import { DEFAULT_GAMEPLAY_PLAYER_ID } from "../game/liveGameplayStore";
+import { readPlayerPositionBridge } from "../game/PlayerPositionBridge";
 
 interface ResourceMarkerProps {
   nodeId: string;
@@ -136,7 +137,7 @@ export function ResourceNodeMarkerLayer({ onGatherSuccess, getPlayerPosition }: 
   const resources = snapshot.resources ?? [];
 
   const handleGather = useCallback(async (nodeId: string) => {
-    const playerPosition = getPlayerPosition?.() ?? null;
+    const playerPosition = getPlayerPosition?.() ?? readPlayerPositionBridge();
     const result = await dispatchGather({
       playerId: DEFAULT_GAMEPLAY_PLAYER_ID,
       nodeId,


### PR DESCRIPTION
Adds a small player position bridge helper and wires resource markers to read it before gather dispatch. Publisher wiring is intentionally left for local editor follow-up because connector write filters block the HUD/World bridge patch.