### PR TITLE
fix(client-2d): wire player position bridge and fix mobile chat toggle

### DIFF
--- a/apps/client-2d/src/ArelorianStitchHud.tsx
+++ b/apps/client-2d/src/ArelorianStitchHud.tsx
@@ -13,6 +13,7 @@ import { useLiveGameplaySnapshot } from "./game/useLiveGameplaySnapshot";
 import { GameplayWindowDock } from "./ui/GameplayWindowDock";
 import { GameplayWindowsLayer } from "./ui/GameplayWindowsLayer";
 import { useGameplayPanels } from "./ui/useGameplayPanels";
+import { publishPlayerPositionBridge } from "./game/PlayerPositionBridge";
 import "./areHeartbeat.css";
 
 type Msg = { from: string; txt: string };
@@ -136,6 +137,11 @@ export function ArelorianStitchHud({
   // Live gameplay snapshot from server (display-only, no game logic)
   const liveGameplay = useLiveGameplaySnapshot();
 
+  // Publish player position to PlayerPositionBridge so ResourceNodeMarkerLayer can read it
+  useEffect(() => {
+    publishPlayerPositionBridge(debugPlayerPos);
+  }, [debugPlayerPos?.x, debugPlayerPos?.z]);
+
   // Deterministic vitals from server (no Math.random, no Date.now)
   const hpPercent = vitals ? Math.round((vitals.hp / vitals.maxHp) * 100) : 86;
   const manaPercent = vitals ? Math.round((vitals.mana / vitals.maxMana) * 100) : 64;
@@ -255,6 +261,7 @@ export function ArelorianStitchHud({
           <button
             key={overlay.id}
             type="button"
+            data-testid={overlay.id === "chat" ? "mobile-chat-toggle" : undefined}
             className={openOverlays[overlay.id] ? "active" : ""}
             onClick={() => toggleOverlay(overlay.id)}
             aria-pressed={openOverlays[overlay.id]}


### PR DESCRIPTION
## Fixes

### Mobile chat toggle was in wrong location (P2 review finding)
- The `.stitch-bottom-right` section is hidden on mobile via `@media (max-width: 920px)` in `theme.css:226`
- The original PR added CHAT button to `.stitch-bottom-right` which would be invisible on mobile
- **Fix**: CHAT already exists in `.stitch-mobile-toggles` nav (lines 259-272) which has no mobile hiding rule
- Added `data-testid="mobile-chat-toggle"` to the existing CHAT button for testability

### Player position bridge publisher wired
- `ArelorianStitchHud.tsx` now calls `publishPlayerPositionBridge(debugPlayerPos)` in a `useEffect`
- This completes the data flow from server heartbeat → HUD → sessionStorage → ResourceNodeMarkerLayer

## Changes

| File | Change |
|---|---|
| `apps/client-2d/src/ArelorianStitchHud.tsx` | +7 lines |

## Testing

```bash
pnpm --filter @wasd/client-2d typecheck
```

## Related

- Fixes a bug in #1780 (merged as `d5ca9b0f`) where mobile chat toggle was placed in a hidden section
- Closes #1778 (player position publisher was missing)

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/70c135ef-5f73-4a80-a94f-0fc669bfb41c)