### PR TITLE
feat(economy): add server-authoritative resource selling contract

### DIFF
--- a/apps/client-2d/src/game/gameplayActions.ts
+++ b/apps/client-2d/src/game/gameplayActions.ts
@@ -221,3 +221,108 @@ export async function refreshSnapshot(playerId?: string): Promise<void> {
     liveGameplayStore.setSnapshot(next);
   }
 }
+
+export interface SellResourceResult {
+  ok: boolean;
+  result?: {
+    itemId: string;
+    quantitySold: number;
+    unitPrice: number;
+    totalCoins: number;
+    newBalance: number;
+  };
+  error?: string;
+}
+
+/**
+ * Dispatch sell resource action and refresh the live snapshot.
+ */
+export async function dispatchSellResource(input: {
+  playerId?: string;
+  itemId: string;
+  quantity: number;
+}): Promise<SellResourceResult> {
+  const pid = input.playerId ?? DEFAULT_GAMEPLAY_PLAYER_ID;
+
+  try {
+    const response = await fetch("/api/economy/sell-resource", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-player-id": pid,
+      },
+      body: JSON.stringify({
+        playerId: pid,
+        itemId: input.itemId,
+        quantity: input.quantity,
+      }),
+    });
+
+    const json = await response.json().catch(() => null);
+
+    if (!response.ok || !json?.ok) {
+      return { ok: false, error: String(json?.error ?? "sell_failed") };
+    }
+
+    // Refetch snapshot to update inventory and wallet
+    const next = await fetchGameplaySnapshot(pid);
+    if (next) {
+      liveGameplayStore.setSnapshot(next);
+    }
+
+    return { ok: true, result: json.result };
+  } catch (error) {
+    console.error("[dispatchSellResource] failed:", error);
+    return { ok: false, error: "network_error" };
+  }
+}
+
+export interface SellAllResourcesResult {
+  ok: boolean;
+  result?: {
+    sold: Array<{
+      itemId: string;
+      quantitySold: number;
+      unitPrice: number;
+      totalCoins: number;
+    }>;
+    totalCoins: number;
+    newBalance: number;
+  };
+  error?: string;
+}
+
+/**
+ * Dispatch sell all resources action and refresh the live snapshot.
+ */
+export async function dispatchSellAllResources(playerId?: string): Promise<SellAllResourcesResult> {
+  const pid = playerId ?? DEFAULT_GAMEPLAY_PLAYER_ID;
+
+  try {
+    const response = await fetch("/api/economy/sell-all-resources", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-player-id": pid,
+      },
+      body: JSON.stringify({ playerId: pid }),
+    });
+
+    const json = await response.json().catch(() => null);
+
+    if (!response.ok || !json?.ok) {
+      return { ok: false, error: String(json?.error ?? "sell_all_failed") };
+    }
+
+    // Refetch snapshot to update inventory and wallet
+    const next = await fetchGameplaySnapshot(pid);
+    if (next) {
+      liveGameplayStore.setSnapshot(next);
+    }
+
+    return { ok: true, result: json.result };
+  } catch (error) {
+    console.error("[dispatchSellAllResources] failed:", error);
+    return { ok: false, error: "network_error" };
+  }
+}

--- a/apps/client-2d/src/game/liveGameplaySnapshot.ts
+++ b/apps/client-2d/src/game/liveGameplaySnapshot.ts
@@ -180,6 +180,13 @@ export interface PaperdollSnapshot {
   slots: PaperdollSlotSnapshot[];
 }
 
+/**
+ * Wallet Snapshot shape (coin balance)
+ */
+export interface WalletSnapshot {
+  coin: number;
+}
+
 export interface LiveGameplaySnapshot {
   status: LiveDataStatus;
   serverTick: number | null;
@@ -194,6 +201,7 @@ export interface LiveGameplaySnapshot {
   guild: GuildSnapshot;
   factions: FactionStandingSnapshot[];
   map: MapSnapshot;
+  wallet: WalletSnapshot;
 }
 
 // Default empty snapshot - honest waiting state
@@ -233,6 +241,9 @@ export const EMPTY_LIVE_GAMEPLAY_SNAPSHOT: LiveGameplaySnapshot = {
     chunkZ: null,
     visibleChunks: null,
     biome: null,
+  },
+  wallet: {
+    coin: 0,
   },
 };
 
@@ -279,6 +290,9 @@ export function normalizeLiveGameplaySnapshot(
             ? input.map.visibleChunks
             : null,
         biome: input.map?.biome ?? null,
+      },
+      wallet: {
+        coin: typeof input.wallet?.coin === "number" ? Math.max(0, Math.floor(input.wallet.coin)) : 0,
       },
     };
   } catch (error) {

--- a/apps/client-2d/src/ui/GameplayWindowsLayer.tsx
+++ b/apps/client-2d/src/ui/GameplayWindowsLayer.tsx
@@ -72,7 +72,10 @@ export function GameplayWindowsLayer({ snapshot, openPanels }: Props) {
 
       {openPanels.has("inventory") && (
         <WindowFrame id="inventory" title="Inventory">
-          <InventoryPanel inventory={snapshot.inventory ?? null} />
+          <InventoryPanel
+            inventory={snapshot.inventory ?? null}
+            wallet={snapshot.wallet}
+          />
         </WindowFrame>
       )}
 

--- a/apps/client-2d/src/ui/windows/InventoryPanel.tsx
+++ b/apps/client-2d/src/ui/windows/InventoryPanel.tsx
@@ -4,6 +4,7 @@
  * Displays server-authoritative player inventory from LiveGameplaySnapshot.
  * Shows gathered resource items with quantities.
  * Includes Gathering Tools section for equipped tools.
+ * Supports selling resources to the vendor.
  *
  * Rules:
  * - No Math.random() for display
@@ -11,20 +12,24 @@
  * - Shows server-provided values only
  * - Client cannot set inventory directly
  * - After equip, refetches snapshot to update equipment/paperdoll display
+ * - After sell, refetches snapshot to update inventory and wallet
  */
 
 import React, { useCallback } from "react";
 import type {
   PlayerInventorySnapshot,
   PlayerEquipmentSnapshot,
+  WalletSnapshot,
 } from "../../game/liveGameplaySnapshot";
 import { equipGatheringTool } from "../../game/equipment";
 import { fetchGameplaySnapshot, liveGameplayStore, DEFAULT_GAMEPLAY_PLAYER_ID } from "../../game/liveGameplayStore";
 import { getGatheringToolIcon, isGatheringTool } from "../utils/ItemIconMapper";
+import { dispatchSellResource, dispatchSellAllResources } from "../../game/gameplayActions";
 
 interface Props {
   inventory: PlayerInventorySnapshot;
   equipment?: PlayerEquipmentSnapshot | null;
+  wallet?: WalletSnapshot;
 }
 
 // Tool item IDs for gathering
@@ -62,10 +67,31 @@ const categoryIcons: Record<string, string> = {
   equipment: "⚔️",
 };
 
-export function InventoryPanel({ inventory, equipment }: Props) {
+// Resource item IDs that are sellable
+const SELLABLE_RESOURCE_IDS = new Set([
+  "wood_log",
+  "copper_ore",
+  "raw_fish",
+  "wood_plank",
+  "copper_ingot",
+  "cooked_fish",
+]);
+
+// Sell prices for resources (in coins)
+const RESOURCE_SELL_PRICES: Record<string, number> = {
+  wood_log: 1,
+  copper_ore: 3,
+  raw_fish: 2,
+  wood_plank: 1,
+  copper_ingot: 5,
+  cooked_fish: 3,
+};
+
+export function InventoryPanel({ inventory, equipment, wallet }: Props) {
   const slots = inventory?.slots ?? [];
   const equipped = equipment?.slots ?? [];
   const tools = slots.filter((slot) => GATHERING_TOOL_IDS.has(slot.itemId));
+  const resources = slots.filter((slot) => SELLABLE_RESOURCE_IDS.has(slot.itemId));
 
   const handleEquip = useCallback(
     async (itemId: string) => {
@@ -100,6 +126,61 @@ export function InventoryPanel({ inventory, equipment }: Props) {
     [],
   );
 
+  const handleSell = useCallback(
+    async (itemId: string, quantity: number) => {
+      const result = await dispatchSellResource({ itemId, quantity });
+
+      if (result.ok && result.result) {
+        const price = RESOURCE_SELL_PRICES[itemId] ?? 0;
+        window.dispatchEvent(
+          new CustomEvent("wasd:toast", {
+            detail: {
+              type: "success",
+              message: `Sold ${quantity} for ${result.result.totalCoins} coins`,
+            },
+          }),
+        );
+      } else {
+        window.dispatchEvent(
+          new CustomEvent("wasd:toast", {
+            detail: {
+              type: "error",
+              message: `Sell failed: ${result.error ?? "unknown"}`,
+            },
+          }),
+        );
+      }
+    },
+    [],
+  );
+
+  const handleSellAll = useCallback(
+    async () => {
+      const result = await dispatchSellAllResources();
+
+      if (result.ok && result.result) {
+        window.dispatchEvent(
+          new CustomEvent("wasd:toast", {
+            detail: {
+              type: "success",
+              message: `Sold all resources for ${result.result.totalCoins} coins`,
+            },
+          }),
+        );
+      } else {
+        window.dispatchEvent(
+          new CustomEvent("wasd:toast", {
+            detail: {
+              type: "error",
+              message: result.error ?? "Nothing to sell",
+            },
+          }),
+        );
+      }
+    },
+    [],
+  );
+
   if (!slots.length && !equipped.length) {
     return (
       <section data-testid="inventory-panel-empty" className="are-window">
@@ -115,6 +196,12 @@ export function InventoryPanel({ inventory, equipment }: Props) {
   return (
     <section data-testid="inventory-panel-live" className="are-window">
       <h2>Inventory</h2>
+
+      {/* Wallet Section */}
+      <div className="wallet-section" data-testid="wallet-balance">
+        <span className="wallet-label">💰 Coins:</span>
+        <span className="wallet-value">{wallet?.coin ?? 0}</span>
+      </div>
 
       {/* Gathering Tools Section */}
       <div className="gathering-tools-section">
@@ -170,10 +257,25 @@ export function InventoryPanel({ inventory, equipment }: Props) {
         {slots.length} / {inventory.capacity} slots used
       </p>
 
+      {/* Sell All Resources Button */}
+      {resources.length > 0 && (
+        <button
+          type="button"
+          className="sell-all-button"
+          onClick={handleSellAll}
+          data-testid="sell-all-resources-button"
+        >
+          Sell All Resources
+        </button>
+      )}
+
       <div className="inventory-grid">
         {slots.map((slot) => {
           const iconPath = getGatheringToolIcon(slot.itemId);
           const rarity = TOOL_RARITY[slot.itemId] ?? slot.category;
+          const isSellable = SELLABLE_RESOURCE_IDS.has(slot.itemId);
+          const sellPrice = RESOURCE_SELL_PRICES[slot.itemId];
+
           return (
             <article key={slot.slotId} className={`inventory-slot rarity-${rarity}`}>
               <div className="inventory-slot__icon">
@@ -189,7 +291,21 @@ export function InventoryPanel({ inventory, equipment }: Props) {
                   x{slot.quantity}
                 </span>
                 <small className="inventory-slot__category">{slot.category}</small>
+                {isSellable && sellPrice !== undefined && (
+                  <small className="inventory-slot__price">{sellPrice} coin(s) each</small>
+                )}
               </div>
+              {isSellable && (
+                <button
+                  type="button"
+                  className="sell-button"
+                  onClick={() => handleSell(slot.itemId, slot.quantity)}
+                  data-testid="sell-resource-button"
+                  title={`Sell ${slot.name} for ${sellPrice * slot.quantity} coins`}
+                >
+                  SELL
+                </button>
+              )}
             </article>
           );
         })}

--- a/docs/ARELOGIC_RESOURCE_VENDOR_CONTRACT.md
+++ b/docs/ARELOGIC_RESOURCE_VENDOR_CONTRACT.md
@@ -1,0 +1,265 @@
+# ARELOGIC RESOURCE VENDOR CONTRACT
+
+## Summary
+
+This contract establishes server-authoritative resource selling functionality, enabling players to sell gathered resources for coins. The first completed economy loop in Areloria: Gather Resources → Sell → Gain Currency.
+
+## Why Resource Selling Now
+
+After implementing:
+- Character Name/Persistence (#1776)
+- Resource Gather Intent Adapter (#1777)
+- Resource Gather Position Bridge (#1778)
+- Resource Node Contract V2 (#1782)
+- Worldgen Outside Starter Village (#1783)
+- Tool Onboarding / Starter Tool Acquisition (#1784)
+
+The next logical step is enabling players to use gathered resources. Resource selling provides:
+1. First meaningful economy loop
+2. Reason to gather more resources
+3. Currency for future crafting/progression
+4. Validation that the gathering system works
+
+## Sellable Resources
+
+| Item ID       | Sell Price (coins) |
+|---------------|-------------------|
+| wood_log      | 1                 |
+| copper_ore    | 3                 |
+| raw_fish      | 2                 |
+| wood_plank    | 1                 |
+| copper_ingot  | 5                 |
+| cooked_fish   | 3                 |
+
+**Non-sellable items:**
+- Tools (wooden_axe, copper_pickaxe, simple_fishing_rod)
+- Quest items
+- Unknown items
+
+## Price Table Rules
+
+- Prices are deterministic and static
+- No Math.random() for prices
+- No Date.now() for prices
+- No dynamic market pricing
+- Prices are integers (coins are whole units)
+- Price table defined in: `server/src/economy/ResourceSellPrices.ts`
+
+## Server Routes
+
+### POST /api/economy/sell-resource
+
+**Request:**
+```json
+{
+  "playerId": "string",
+  "itemId": "string",
+  "quantity": number
+}
+```
+
+**Headers:**
+- `x-player-id`: Player identifier
+
+**Success Response (200):**
+```json
+{
+  "ok": true,
+  "result": {
+    "itemId": "wood_log",
+    "quantitySold": 3,
+    "unitPrice": 1,
+    "totalCoins": 3,
+    "newBalance": 3
+  }
+}
+```
+
+**Failure Response (400):**
+```json
+{
+  "ok": false,
+  "error": "invalid_quantity"
+}
+```
+
+### POST /api/economy/sell-all-resources
+
+**Request:**
+```json
+{
+  "playerId": "string"
+}
+```
+
+**Headers:**
+- `x-player-id`: Player identifier
+
+**Success Response (200):**
+```json
+{
+  "ok": true,
+  "result": {
+    "sold": [
+      { "itemId": "wood_log", "quantitySold": 5, "unitPrice": 1, "totalCoins": 5 },
+      { "itemId": "copper_ore", "quantitySold": 2, "unitPrice": 3, "totalCoins": 6 }
+    ],
+    "totalCoins": 11,
+    "newBalance": 11
+  }
+}
+```
+
+**Failure Response (400):**
+```json
+{
+  "ok": false,
+  "error": "nothing_to_sell"
+}
+```
+
+## Wallet / Currency Contract
+
+**Server-side:**
+- `server/src/economy/WalletTypes.ts` - WalletState type
+- `server/src/economy/WalletStore.ts` - In-memory wallet storage
+- `server/src/economy/WalletService.ts` - Wallet operations with persistence
+- `server/src/economy/WalletPersistence.ts` - Persistence interface
+
+**Wallet State:**
+```typescript
+interface WalletState {
+  playerId: string;
+  schemaVersion: 1;
+  balances: {
+    coin: number;  // Always initialized to 0
+  };
+}
+```
+
+**Snapshot shape (for client):**
+```typescript
+interface WalletSnapshot {
+  coin: number;
+}
+```
+
+## Fail-Does-Not-Mutate Rules
+
+1. **Invalid player**: No inventory or wallet changes
+2. **Invalid item**: No changes
+3. **Invalid quantity**: No changes
+4. **Not sellable**: No changes
+5. **Insufficient quantity**: No changes
+
+The server validates all conditions before making any state changes. If any validation fails, the operation is rejected and the player's state remains unchanged.
+
+## Client Actions
+
+**File:** `apps/client-2d/src/game/gameplayActions.ts`
+
+```typescript
+// Sell specific resource
+dispatchSellResource({ itemId: string, quantity: number, playerId?: string })
+
+// Sell all resources
+dispatchSellAllResources(playerId?: string)
+```
+
+Both actions:
+- POST to server route
+- Include `x-player-id` header
+- Refetch snapshot on success
+- Return ActionResult with details
+
+## Client UI
+
+**File:** `apps/client-2d/src/ui/windows/InventoryPanel.tsx`
+
+**Features:**
+- Wallet balance display (Coins: X)
+- "SELL" button on each sellable resource slot
+- "Sell All Resources" button at top of inventory
+- Toast feedback on sell success/failure
+
+**Test IDs:**
+- `data-testid="wallet-balance"`
+- `data-testid="sell-resource-button"`
+- `data-testid="sell-all-resources-button"`
+
+**Sell button behavior:**
+- Sells entire stack (quantity from slot)
+- Shows tooltip with total value
+- Only visible for sellable resources
+
+## Snapshot Integration
+
+**Server:** `server/src/routes/gameplaySnapshot.ts`
+- Wallet state included in snapshot
+- Coin balance returned with each snapshot
+
+**Client:** `apps/client-2d/src/game/liveGameplaySnapshot.ts`
+- `wallet.coin` field added to LiveGameplaySnapshot
+- Normalizes to 0 if missing (backwards compatible)
+
+## Known Limitations
+
+1. **Static prices**: No dynamic market or NPC-specific pricing
+2. **No NPC vendor location**: Items can be sold anywhere (MVP)
+3. **No vendor inventory**: Unlimited buying capacity assumed
+4. **No player trading**: Cannot trade coins/items with other players
+5. **No real-money**: Coins are game currency only
+6. **No partial sell**: Must sell entire stack or all resources
+
+## Next PRs
+
+1. **#1786 NPC Vendor Location / Village Trader**
+   - Add physical NPC vendor in village
+   - Require player to be near vendor to sell
+   - NPC-specific pricing (future)
+
+2. **#1787 NPC Resource Economy Loop**
+   - NPCs that buy processed items for more
+   - Smelting copper_ore → copper_ingot → sell
+   - Cooking raw_fish → cooked_fish → sell
+
+3. **#1788 Tool Crafting Recipes**
+   - Better tools from gathered resources
+   - Copper axe, iron pickaxe, etc.
+   - Use coins to craft
+
+4. **#1789 Mining/Fishing Camps as World POIs**
+   - Named locations with bonus rewards
+   - Visual landmarks for gathering
+   - Respawn rate modifiers
+
+## Files Changed
+
+### Server (new files)
+- `server/src/economy/WalletTypes.ts`
+- `server/src/economy/WalletStore.ts`
+- `server/src/economy/WalletService.ts`
+- `server/src/economy/WalletPersistence.ts`
+- `server/src/economy/JsonWalletPersistenceAdapter.ts`
+- `server/src/economy/ResourceSellPrices.ts`
+- `server/src/economy/EconomyService.ts`
+- `server/src/economy/economyRoute.ts`
+- `server/src/economy/economyRuntime.ts`
+- `server/src/economy/index.ts`
+- `server/src/tests/economy-service.test.ts`
+
+### Server (modified files)
+- `server/src/core/ServerBootstrap.ts` - Added economyRouter
+- `server/src/gameplay/LiveGameplaySnapshotTypes.ts` - Added wallet
+- `server/src/gameplay/LiveGameplaySnapshotComposer.ts` - Added getWallet
+- `server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts` - Added wallet
+- `server/src/tests/LiveGameplaySnapshotComposer.test.ts` - Updated tests
+
+### Client (modified files)
+- `apps/client-2d/src/game/liveGameplaySnapshot.ts` - Added wallet types
+- `apps/client-2d/src/game/gameplayActions.ts` - Added sell actions
+- `apps/client-2d/src/ui/windows/InventoryPanel.tsx` - Added sell UI
+- `apps/client-2d/src/ui/GameplayWindowsLayer.tsx` - Added wallet prop
+
+### Docs (new file)
+- `docs/ARELOGIC_RESOURCE_VENDOR_CONTRACT.md`

--- a/server/src/core/ServerBootstrap.ts
+++ b/server/src/core/ServerBootstrap.ts
@@ -40,6 +40,7 @@ import { default as craftingRouter } from "../routes/craftingRoute.js";
 import { default as equipmentRouter } from "../routes/equipmentRoute.js";
 import { default as onboardingRouter } from "../routes/onboardingRoute.js";
 import { default as characterRouter } from "../character/characterRoute.js";
+import { default as economyRouter } from "../economy/economyRoute.js";
 import { PlaytesterConfig } from "../config/PlaytesterConfig.js";
 import { PlaytesterMonitorStream } from "../modules/playtester/PlaytesterMonitorStream.js";
 import { PlaytesterWebRTCSignaling } from "../modules/playtester/PlaytesterWebRTCSignaling.js";
@@ -204,6 +205,7 @@ export class ServerBootstrap {
     app.use("/api/equipment", equipmentRouter);
     app.use("/api/character", characterRouter);
     app.use("/api/onboarding", onboardingRouter);
+    app.use("/api/economy", economyRouter);
     app.use("/api/self-healing", createSelfHealWorkshopRouter());
     app.use("/api/manifest", createManifestResyncRouter(tick));
     app.use("/api/finance", express.json({ limit: "1mb" }), financeRouter());

--- a/server/src/economy/EconomyService.ts
+++ b/server/src/economy/EconomyService.ts
@@ -1,0 +1,245 @@
+/**
+ * ECONOMY SERVICE
+ *
+ * Server-authoritative economy operations for resource selling.
+ * Deterministic: No Math.random(), no Date.now(), stable ordering.
+ * Fail-close: failed operations do not mutate state.
+ */
+
+import { InventoryService } from "../inventory/InventoryService.js";
+import { WalletService } from "./WalletService.js";
+import { getSellPrice, isSellable } from "./ResourceSellPrices.js";
+import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+
+export interface SellResourceInput {
+  playerId: string;
+  itemId: InventoryItemId | string;
+  quantity: number;
+}
+
+export interface SellResourceResult {
+  ok: boolean;
+  itemId: string;
+  quantitySold: number;
+  unitPrice: number;
+  totalCoins: number;
+  newBalance: number;
+  reason?:
+    | "sold"
+    | "invalid_player"
+    | "invalid_item"
+    | "invalid_quantity"
+    | "not_sellable"
+    | "insufficient_quantity";
+}
+
+export interface SellAllResourcesInput {
+  playerId: string;
+}
+
+export interface SellAllResourcesResult {
+  ok: boolean;
+  sold: Array<{
+    itemId: string;
+    quantitySold: number;
+    unitPrice: number;
+    totalCoins: number;
+  }>;
+  totalCoins: number;
+  newBalance: number;
+  reason?: "sold" | "nothing_to_sell" | "invalid_player";
+}
+
+export class EconomyService {
+  constructor(
+    private readonly inventoryService: InventoryService,
+    private readonly walletService: WalletService,
+  ) {}
+
+  async sellResource(input: SellResourceInput): Promise<SellResourceResult> {
+    // Validate player
+    if (!input.playerId || input.playerId === "anonymous") {
+      return {
+        ok: false,
+        itemId: String(input.itemId),
+        quantitySold: 0,
+        unitPrice: 0,
+        totalCoins: 0,
+        newBalance: 0,
+        reason: "invalid_player",
+      };
+    }
+
+    // Validate quantity
+    const quantity = Math.floor(Number(input.quantity));
+    if (quantity <= 0 || !Number.isFinite(quantity)) {
+      return {
+        ok: false,
+        itemId: String(input.itemId),
+        quantitySold: 0,
+        unitPrice: 0,
+        totalCoins: 0,
+        newBalance: 0,
+        reason: "invalid_quantity",
+      };
+    }
+
+    // Check if item is sellable
+    const priceResult = getSellPrice(input.itemId);
+    if (!priceResult.sellable) {
+      return {
+        ok: false,
+        itemId: String(input.itemId),
+        quantitySold: 0,
+        unitPrice: 0,
+        totalCoins: 0,
+        newBalance: 0,
+        reason: "not_sellable",
+      };
+    }
+
+    // Check if player has enough
+    const inventory = await this.inventoryService.getPlayerInventory(input.playerId);
+    const slot = inventory.slots.find((s) => s.itemId === input.itemId);
+
+    if (!slot || slot.quantity < quantity) {
+      return {
+        ok: false,
+        itemId: String(input.itemId),
+        quantitySold: 0,
+        unitPrice: priceResult.price,
+        totalCoins: 0,
+        newBalance: 0,
+        reason: "insufficient_quantity",
+      };
+    }
+
+    // All validations passed - perform the transaction
+    // Remove items from inventory
+    const removeResult = await this.inventoryService.removeItem({
+      playerId: input.playerId,
+      itemId: input.itemId,
+      quantity,
+    });
+
+    if (!removeResult.ok) {
+      // Should not happen if we checked correctly, but fail-safe
+      return {
+        ok: false,
+        itemId: String(input.itemId),
+        quantitySold: 0,
+        unitPrice: priceResult.price,
+        totalCoins: 0,
+        newBalance: 0,
+        reason: "insufficient_quantity",
+      };
+    }
+
+    // Add coins to wallet
+    const totalCoins = quantity * priceResult.price;
+    const updatedWallet = await this.walletService.addCoins({
+      playerId: input.playerId,
+      amount: totalCoins,
+    });
+
+    return {
+      ok: true,
+      itemId: String(input.itemId),
+      quantitySold: quantity,
+      unitPrice: priceResult.price,
+      totalCoins,
+      newBalance: updatedWallet.balances.coin,
+      reason: "sold",
+    };
+  }
+
+  async sellAllResources(input: SellAllResourcesInput): Promise<SellAllResourcesResult> {
+    // Validate player
+    if (!input.playerId || input.playerId === "anonymous") {
+      return {
+        ok: false,
+        sold: [],
+        totalCoins: 0,
+        newBalance: 0,
+        reason: "invalid_player",
+      };
+    }
+
+    // Get inventory
+    const inventory = await this.inventoryService.getPlayerInventory(input.playerId);
+
+    // Find all sellable resource slots
+    const sellableSlots = inventory.slots.filter((slot) => isSellable(slot.itemId));
+
+    if (sellableSlots.length === 0) {
+      return {
+        ok: false,
+        sold: [],
+        totalCoins: 0,
+        newBalance: 0,
+        reason: "nothing_to_sell",
+      };
+    }
+
+    // Calculate what can be sold
+    const sellOps: Array<{
+      itemId: string;
+      quantity: number;
+      price: number;
+      totalCoins: number;
+    }> = [];
+
+    let totalCoins = 0;
+
+    for (const slot of sellableSlots) {
+      const priceResult = getSellPrice(slot.itemId);
+      if (!priceResult.sellable) continue;
+
+      const slotTotal = slot.quantity * priceResult.price;
+      totalCoins += slotTotal;
+      sellOps.push({
+        itemId: slot.itemId,
+        quantity: slot.quantity,
+        price: priceResult.price,
+        totalCoins: slotTotal,
+      });
+    }
+
+    if (sellOps.length === 0) {
+      return {
+        ok: false,
+        sold: [],
+        totalCoins: 0,
+        newBalance: 0,
+        reason: "nothing_to_sell",
+      };
+    }
+
+    // Remove all items and add coins in a transaction
+    for (const op of sellOps) {
+      await this.inventoryService.removeItem({
+        playerId: input.playerId,
+        itemId: op.itemId,
+        quantity: op.quantity,
+      });
+    }
+
+    const updatedWallet = await this.walletService.addCoins({
+      playerId: input.playerId,
+      amount: totalCoins,
+    });
+
+    return {
+      ok: true,
+      sold: sellOps.map((op) => ({
+        itemId: op.itemId,
+        quantitySold: op.quantity,
+        unitPrice: op.price,
+        totalCoins: op.totalCoins,
+      })),
+      totalCoins,
+      newBalance: updatedWallet.balances.coin,
+      reason: "sold",
+    };
+  }
+}

--- a/server/src/economy/JsonWalletPersistenceAdapter.ts
+++ b/server/src/economy/JsonWalletPersistenceAdapter.ts
@@ -1,0 +1,86 @@
+/**
+ * JSON WALLET PERSISTENCE ADAPTER
+ *
+ * File-based wallet persistence for development/testing.
+ * Atomic writes ensure data integrity.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  createPersistedWalletState,
+  type WalletPersistenceAdapter,
+  type PersistedWalletState,
+} from "./WalletPersistence.js";
+import { type WalletState } from "./WalletTypes.js";
+
+interface WalletFile {
+  schemaVersion: 1;
+  players: PersistedWalletState[];
+}
+
+function stableFile(wallets: PersistedWalletState[]): WalletFile {
+  return {
+    schemaVersion: 1,
+    players: [...wallets].sort((a, b) => a.playerId.localeCompare(b.playerId)),
+  };
+}
+
+export function resolveWalletStateFilePath(): string {
+  return process.env.WALLET_STATE_FILE
+    ? path.resolve(process.env.WALLET_STATE_FILE)
+    : path.resolve(process.cwd(), "data", "wallet-state.json");
+}
+
+export class JsonWalletPersistenceAdapter implements WalletPersistenceAdapter {
+  constructor(private readonly filePath = resolveWalletStateFilePath()) {}
+
+  async loadWallet(playerId: string): Promise<PersistedWalletState | null> {
+    const file = await this.readFileSafe();
+    const found = file.players.find((player) => player.playerId === playerId);
+    return found ?? null;
+  }
+
+  async saveWallet(state: PersistedWalletState): Promise<void> {
+    const file = await this.readFileSafe();
+    const normalized = createPersistedWalletState(state.playerId, state);
+    const withoutPlayer = file.players.filter((player) => player.playerId !== normalized.playerId);
+    await this.writeFileAtomic(stableFile([...withoutPlayer, normalized]));
+  }
+
+  async health(): Promise<{ ok: boolean; driver: string; error?: string }> {
+    try {
+      await mkdir(path.dirname(this.filePath), { recursive: true });
+      return { ok: true, driver: "json" };
+    } catch (error) {
+      return {
+        ok: false,
+        driver: "json",
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async readFileSafe(): Promise<WalletFile> {
+    try {
+      const raw = await readFile(this.filePath, "utf8");
+      const parsed = JSON.parse(raw) as Partial<WalletFile>;
+
+      return stableFile(
+        Array.isArray(parsed.players)
+          ? parsed.players.map((player) => createPersistedWalletState(player.playerId, player as WalletState))
+          : [],
+      );
+    } catch {
+      return stableFile([]);
+    }
+  }
+
+  private async writeFileAtomic(file: WalletFile): Promise<void> {
+    await mkdir(path.dirname(this.filePath), { recursive: true });
+
+    const tmp = `${this.filePath}.tmp`;
+    await writeFile(tmp, `${JSON.stringify(file, null, 2)}\n`, "utf8");
+    await rename(tmp, this.filePath);
+  }
+}

--- a/server/src/economy/ResourceSellPrices.ts
+++ b/server/src/economy/ResourceSellPrices.ts
@@ -1,0 +1,61 @@
+/**
+ * RESOURCE SELL PRICES
+ *
+ * Deterministic sell prices for gathered resources.
+ * No Math.random(), no Date.now(), no dynamic market prices.
+ * Prices are stable integers in coins.
+ */
+
+import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+
+/**
+ * Sell price in coins per unit.
+ * Only resource items are sellable; equipment and quest items are not.
+ */
+export const RESOURCE_SELL_PRICES: Record<string, number> = {
+  wood_log: 1,
+  copper_ore: 3,
+  raw_fish: 2,
+  wood_plank: 1,
+  copper_ingot: 5,
+  cooked_fish: 3,
+} as const;
+
+export interface SellPriceResult {
+  sellable: true;
+  price: number;
+}
+
+export interface NotSellableResult {
+  sellable: false;
+  reason: "not_sellable";
+}
+
+export type GetSellPriceResult = SellPriceResult | NotSellableResult;
+
+/**
+ * Get the sell price for an item ID.
+ * Returns sellable=true and price if the item can be sold.
+ * Returns sellable=false if the item is equipment, quest item, or unknown.
+ */
+export function getSellPrice(itemId: string): GetSellPriceResult {
+  const price = RESOURCE_SELL_PRICES[itemId];
+  if (price === undefined) {
+    return { sellable: false, reason: "not_sellable" };
+  }
+  return { sellable: true, price: Number(price) };
+}
+
+/**
+ * Check if an item ID is sellable (has a price in the table).
+ */
+export function isSellable(itemId: string): boolean {
+  return itemId in RESOURCE_SELL_PRICES;
+}
+
+/**
+ * Get all sellable resource item IDs.
+ */
+export function getSellableItemIds(): string[] {
+  return Object.keys(RESOURCE_SELL_PRICES);
+}

--- a/server/src/economy/WalletPersistence.ts
+++ b/server/src/economy/WalletPersistence.ts
@@ -1,0 +1,29 @@
+/**
+ * WALLET PERSISTENCE INTERFACE
+ *
+ * Defines the contract for wallet persistence adapters.
+ * Supports JSON file-based and Postgres backends.
+ */
+
+import { type WalletState } from "./WalletTypes.js";
+
+export interface PersistedWalletState extends WalletState {
+  schemaVersion: 1;
+}
+
+export interface WalletPersistenceAdapter {
+  loadWallet(playerId: string): Promise<PersistedWalletState | null>;
+  saveWallet(state: PersistedWalletState): Promise<void>;
+  health?(): Promise<{ ok: boolean; driver: string; error?: string }>;
+}
+
+export function createPersistedWalletState(
+  playerId: string,
+  state: WalletState,
+): PersistedWalletState {
+  return {
+    playerId,
+    schemaVersion: 1,
+    balances: { ...state.balances },
+  };
+}

--- a/server/src/economy/WalletService.ts
+++ b/server/src/economy/WalletService.ts
@@ -1,0 +1,58 @@
+/**
+ * WALLET SERVICE
+ *
+ * Server-authoritative wallet service with persistence hydration.
+ * Deterministic: No Math.random(), no Date.now(), stable ordering.
+ */
+
+import { WalletStore } from "./WalletStore.js";
+import {
+  createPersistedWalletState,
+  type WalletPersistenceAdapter,
+} from "./WalletPersistence.js";
+import type { WalletState } from "./WalletTypes.js";
+
+export class WalletService {
+  private readonly hydratedPlayers = new Set<string>();
+
+  constructor(
+    private readonly store: WalletStore,
+    private readonly persistence: WalletPersistenceAdapter,
+  ) {}
+
+  async getWallet(playerId: string): Promise<WalletState> {
+    await this.hydratePlayer(playerId);
+    return this.store.getWallet(playerId);
+  }
+
+  async addCoins(input: {
+    playerId: string;
+    amount: number;
+  }): Promise<WalletState> {
+    await this.hydratePlayer(input.playerId);
+    const result = this.store.addCoins(input.playerId, input.amount);
+
+    if (result) {
+      await this.persistence.saveWallet(
+        createPersistedWalletState(input.playerId, result),
+      );
+    }
+
+    return result;
+  }
+
+  async hydratePlayer(playerId: string): Promise<void> {
+    if (this.hydratedPlayers.has(playerId)) return;
+
+    const persisted = await this.persistence.loadWallet(playerId);
+    if (persisted) {
+      this.store.replaceWallet(playerId, persisted);
+    }
+
+    this.hydratedPlayers.add(playerId);
+  }
+
+  clearForTests(): void {
+    this.hydratedPlayers.clear();
+  }
+}

--- a/server/src/economy/WalletStore.ts
+++ b/server/src/economy/WalletStore.ts
@@ -1,0 +1,76 @@
+/**
+ * WALLET STORE
+ *
+ * Server-authoritative in-memory wallet store.
+ * Deterministic: No Math.random(), stable ordering, no Date.now().
+ */
+
+import {
+  createDefaultWalletState,
+  normalizeWalletBalance,
+  type WalletState,
+  type CurrencyId,
+} from "./WalletTypes.js";
+
+export class WalletStore {
+  private readonly wallets = new Map<string, WalletState>();
+
+  getWallet(playerId: string): WalletState {
+    const existing = this.wallets.get(playerId);
+    if (existing) return existing;
+
+    const created = createDefaultWalletState(playerId);
+    this.wallets.set(playerId, created);
+    return created;
+  }
+
+  addCoins(playerId: string, amount: number): WalletState {
+    const state = this.getWallet(playerId);
+    const normalized = normalizeWalletBalance(amount);
+    if (normalized <= 0) return state;
+
+    const nextState: WalletState = {
+      ...state,
+      balances: {
+        ...state.balances,
+        coin: state.balances.coin + normalized,
+      },
+    };
+
+    this.wallets.set(playerId, nextState);
+    return nextState;
+  }
+
+  subtractCoins(playerId: string, amount: number): WalletState {
+    const state = this.getWallet(playerId);
+    const normalized = normalizeWalletBalance(amount);
+    if (normalized <= 0) return state;
+
+    const current = state.balances.coin;
+    const next = Math.max(0, current - normalized);
+
+    const nextState: WalletState = {
+      ...state,
+      balances: {
+        ...state.balances,
+        coin: next,
+      },
+    };
+
+    this.wallets.set(playerId, nextState);
+    return nextState;
+  }
+
+  hasCoins(playerId: string, amount: number): boolean {
+    const state = this.getWallet(playerId);
+    return state.balances.coin >= normalizeWalletBalance(amount);
+  }
+
+  replaceWallet(playerId: string, state: WalletState): void {
+    this.wallets.set(playerId, state);
+  }
+
+  clearForTests(): void {
+    this.wallets.clear();
+  }
+}

--- a/server/src/economy/WalletTypes.ts
+++ b/server/src/economy/WalletTypes.ts
@@ -1,0 +1,44 @@
+/**
+ * WALLET TYPES
+ *
+ * Server-authoritative player currency/wallet types.
+ * Deterministic: No Date.now(), no Math.random(), stable coin IDs and ordering.
+ */
+
+export type CurrencyId = "coin";
+
+export interface WalletState {
+  playerId: string;
+  schemaVersion: 1;
+  balances: Record<CurrencyId, number>;
+}
+
+export interface WalletSnapshot {
+  playerId: string;
+  coin: number;
+}
+
+export const DEFAULT_WALLET_BALANCES: Record<CurrencyId, number> = {
+  coin: 0,
+};
+
+export function createDefaultWalletState(playerId: string): WalletState {
+  return {
+    playerId,
+    schemaVersion: 1,
+    balances: { ...DEFAULT_WALLET_BALANCES },
+  };
+}
+
+export function normalizeWalletBalance(value: unknown): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, n);
+}
+
+export function toWalletSnapshot(state: WalletState): WalletSnapshot {
+  return {
+    playerId: state.playerId,
+    coin: state.balances.coin,
+  };
+}

--- a/server/src/economy/economyRoute.ts
+++ b/server/src/economy/economyRoute.ts
@@ -1,0 +1,122 @@
+/**
+ * ECONOMY API ROUTE
+ *
+ * Server-authoritative economy API for resource selling.
+ * No Date.now(), no Math.random(), stable ordering.
+ */
+
+import express, { Router } from "express";
+import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
+import { economyService } from "./economyRuntime.js";
+
+const router = Router();
+
+router.use(express.json());
+
+function parseItemId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!/^[a-zA-Z0-9_]{1,64}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+function parseQuantity(value: unknown): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n) || n < 0) return -1;
+  return n;
+}
+
+/**
+ * POST /api/economy/sell-resource
+ *
+ * Sell a specific quantity of a resource item.
+ * Consumes items from inventory, adds coins to wallet.
+ */
+router.post("/sell-resource", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+
+  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    res.status(401).json({
+      ok: false,
+      error: "authenticated_player_required",
+    });
+    return;
+  }
+
+  const itemId = parseItemId(req.body?.itemId);
+  const quantity = parseQuantity(req.body?.quantity);
+
+  if (!itemId) {
+    res.status(400).json({
+      ok: false,
+      error: "invalid_item_id",
+    });
+    return;
+  }
+
+  if (quantity <= 0) {
+    res.status(400).json({
+      ok: false,
+      error: "invalid_quantity",
+    });
+    return;
+  }
+
+  try {
+    const result = await economyService.sellResource({
+      playerId: identity.playerId,
+      itemId,
+      quantity,
+    });
+
+    const statusCode = result.ok ? 200 : 400;
+    res.status(statusCode).json({
+      ok: result.ok,
+      result,
+    });
+  } catch (error) {
+    console.error("[economy-sell-resource] Failed to sell resource:", error);
+    res.status(500).json({
+      ok: false,
+      error: "internal_error",
+    });
+  }
+});
+
+/**
+ * POST /api/economy/sell-all-resources
+ *
+ * Sell all sellable resource items in the player's inventory.
+ * Consumes all resource items, adds coins to wallet.
+ */
+router.post("/sell-all-resources", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+
+  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    res.status(401).json({
+      ok: false,
+      error: "authenticated_player_required",
+    });
+    return;
+  }
+
+  try {
+    const result = await economyService.sellAllResources({
+      playerId: identity.playerId,
+    });
+
+    const statusCode = result.ok ? 200 : 400;
+    res.status(statusCode).json({
+      ok: result.ok,
+      result,
+    });
+  } catch (error) {
+    console.error("[economy-sell-all-resources] Failed to sell resources:", error);
+    res.status(500).json({
+      ok: false,
+      error: "internal_error",
+    });
+  }
+});
+
+export default router;

--- a/server/src/economy/economyRuntime.ts
+++ b/server/src/economy/economyRuntime.ts
@@ -1,0 +1,50 @@
+/**
+ * ECONOMY RUNTIME
+ *
+ * Singleton economy service instances for the server.
+ * Provides lazy initialization and access to EconomyService and WalletService.
+ */
+
+import { EconomyService } from "./EconomyService.js";
+import { WalletService } from "./WalletService.js";
+import { WalletStore } from "./WalletStore.js";
+import { JsonWalletPersistenceAdapter } from "./JsonWalletPersistenceAdapter.js";
+import { getInventoryService } from "../inventory/inventoryRuntime.js";
+
+const store = new WalletStore();
+const adapter = new JsonWalletPersistenceAdapter();
+const walletService = new WalletService(store, adapter);
+
+let servicePromise: Promise<EconomyService> | null = null;
+
+async function getOrCreateService(): Promise<EconomyService> {
+  if (servicePromise) return servicePromise;
+
+  const inventoryService = await getInventoryService();
+  servicePromise = Promise.resolve(new EconomyService(inventoryService, walletService));
+  return servicePromise;
+}
+
+export async function getEconomyService(): Promise<EconomyService> {
+  return getOrCreateService();
+}
+
+export async function getWalletService(): Promise<WalletService> {
+  return walletService;
+}
+
+export { walletService };
+export { store as walletStore };
+
+// Singleton economyService interface for route handlers
+// Uses lazy initialization to avoid circular dependency issues
+export const economyService = {
+  sellResource: async (input: { playerId: string; itemId: string; quantity: number }) => {
+    const service = await getEconomyService();
+    return service.sellResource(input);
+  },
+  sellAllResources: async (input: { playerId: string }) => {
+    const service = await getEconomyService();
+    return service.sellAllResources(input);
+  },
+};

--- a/server/src/economy/index.ts
+++ b/server/src/economy/index.ts
@@ -1,0 +1,11 @@
+/**
+ * ECONOMY MODULE
+ *
+ * Server-authoritative economy for resource selling and currency management.
+ */
+
+export { EconomyService } from "./EconomyService.js";
+export { WalletService } from "./WalletService.js";
+export { WalletStore } from "./WalletStore.js";
+export { type WalletState, type WalletSnapshot } from "./WalletTypes.js";
+export { RESOURCE_SELL_PRICES, getSellPrice, isSellable, getSellableItemIds } from "./ResourceSellPrices.js";

--- a/server/src/gameplay/LiveGameplaySnapshotComposer.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotComposer.ts
@@ -24,6 +24,7 @@ export interface LiveGameplaySnapshotComposerDeps {
   readonly getEquipmentSlots: (playerId: string) => readonly LiveGameplayEquipmentSlot[] | Promise<readonly LiveGameplayEquipmentSlot[]>;
   readonly getSkillStates: (playerId: string) => readonly LiveGameplaySkillState[] | Promise<readonly LiveGameplaySkillState[]>;
   readonly getResourceNodes: (playerId: string) => readonly LiveGameplayResourceNode[] | Promise<readonly LiveGameplayResourceNode[]>;
+  readonly getWallet: (playerId: string) => { readonly coin: number } | Promise<{ readonly coin: number }>;
 }
 
 export class LiveGameplaySnapshotComposer {
@@ -37,6 +38,8 @@ export class LiveGameplaySnapshotComposer {
       this.deps.getResourceNodes(playerId),
     ]);
 
+    const wallet = await this.deps.getWallet(playerId);
+
     return Object.freeze({
       schemaVersion: "live-gameplay-snapshot.v1" as const,
       playerId,
@@ -47,6 +50,7 @@ export class LiveGameplaySnapshotComposer {
       equipment: Object.freeze([...equipment].sort((a, b) => a.slot.localeCompare(b.slot))),
       skills: Object.freeze([...skills].sort((a, b) => a.skillId.localeCompare(b.skillId))),
       resourceNodes: Object.freeze([...resourceNodes].sort((a, b) => a.nodeId.localeCompare(b.nodeId))),
+      wallet: Object.freeze(wallet),
     });
   }
 

--- a/server/src/gameplay/LiveGameplaySnapshotTypes.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotTypes.ts
@@ -36,6 +36,10 @@ export interface LiveGameplayResourceNode {
   readonly available: boolean;
 }
 
+export interface LiveGameplayWallet {
+  readonly coin: number;
+}
+
 export interface LiveGameplaySnapshot {
   readonly schemaVersion: "live-gameplay-snapshot.v1";
   readonly playerId: string;
@@ -46,6 +50,7 @@ export interface LiveGameplaySnapshot {
   readonly equipment: readonly LiveGameplayEquipmentSlot[];
   readonly skills: readonly LiveGameplaySkillState[];
   readonly resourceNodes: readonly LiveGameplayResourceNode[];
+  readonly wallet: LiveGameplayWallet;
 }
 
 export interface GatherResult {

--- a/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
+++ b/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
@@ -2,6 +2,7 @@ import { LiveGameplaySnapshotComposer } from "./LiveGameplaySnapshotComposer.js"
 import type { LiveGameplaySnapshot } from "./LiveGameplaySnapshotTypes.js";
 import { toLiveEquipmentSlots } from "./adapters/EquipmentSnapshotAdapter.js";
 import { toLiveInventoryItems } from "./adapters/InventorySnapshotAdapter.js";
+import { getWalletService } from "../economy/economyRuntime.js";
 
 interface LegacyInventorySlot {
   readonly itemId?: string;
@@ -81,6 +82,11 @@ export function composeLiveGameplaySnapshotFromLegacy(
       y: Number(node.y ?? node.position?.y ?? 0),
       available: node.available === true || node.status === "available",
     })),
+    getWallet: async (playerId: string) => {
+      const walletService = await getWalletService();
+      const wallet = await walletService.getWallet(playerId);
+      return { coin: wallet.balances.coin };
+    },
   });
 
   return composer.compose(input.playerId, input.logicalIndex);

--- a/server/src/tests/LiveGameplaySnapshotComposer.test.ts
+++ b/server/src/tests/LiveGameplaySnapshotComposer.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { LiveGameplaySnapshotComposer } from "./LiveGameplaySnapshotComposer.js";
+import { LiveGameplaySnapshotComposer } from "../gameplay/LiveGameplaySnapshotComposer.js";
 
 describe("LiveGameplaySnapshotComposer", () => {
   it("composes deterministic sorted snapshot", async () => {
@@ -31,6 +31,7 @@ describe("LiveGameplaySnapshotComposer", () => {
       getResourceNodes: () => [
         { nodeId: "node_tree_001", resourceId: "tree", skillId: "woodcutting", x: 10, y: 20, available: true },
       ],
+      getWallet: () => ({ coin: 0 }),
     });
 
     const snapshot = await composer.compose("player_test", 42);
@@ -53,6 +54,7 @@ describe("LiveGameplaySnapshotComposer", () => {
       getEquipmentSlots: () => [],
       getSkillStates: () => [],
       getResourceNodes: () => [],
+      getWallet: () => ({ coin: 0 }),
     });
 
     const snapshot = await composer.compose("player_test", -1);
@@ -65,6 +67,7 @@ describe("LiveGameplaySnapshotComposer", () => {
       getEquipmentSlots: () => [],
       getSkillStates: () => [],
       getResourceNodes: () => [],
+      getWallet: () => ({ coin: 0 }),
     });
 
     const snapshot = await composer.compose("player_test", Infinity);
@@ -77,6 +80,7 @@ describe("LiveGameplaySnapshotComposer", () => {
       getEquipmentSlots: () => [],
       getSkillStates: () => [],
       getResourceNodes: () => [],
+      getWallet: () => ({ coin: 0 }),
     });
 
     const snapshot = await composer.compose("player_empty", 0);
@@ -85,6 +89,7 @@ describe("LiveGameplaySnapshotComposer", () => {
     expect(snapshot.equipment).toEqual([]);
     expect(snapshot.skills).toEqual([]);
     expect(snapshot.resourceNodes).toEqual([]);
+    expect(snapshot.wallet.coin).toBe(0);
   });
 
   it("returns frozen snapshot object", async () => {
@@ -93,6 +98,7 @@ describe("LiveGameplaySnapshotComposer", () => {
       getEquipmentSlots: () => [],
       getSkillStates: () => [],
       getResourceNodes: () => [],
+      getWallet: () => ({ coin: 42 }),
     });
 
     const snapshot = await composer.compose("player_test", 0);
@@ -102,6 +108,8 @@ describe("LiveGameplaySnapshotComposer", () => {
     expect(Object.isFrozen(snapshot.equipment)).toBe(true);
     expect(Object.isFrozen(snapshot.skills)).toBe(true);
     expect(Object.isFrozen(snapshot.resourceNodes)).toBe(true);
+    expect(Object.isFrozen(snapshot.wallet)).toBe(true);
+    expect(snapshot.wallet.coin).toBe(42);
   });
 
   it("sorts multiple inventory items by itemId", async () => {
@@ -114,6 +122,7 @@ describe("LiveGameplaySnapshotComposer", () => {
       getEquipmentSlots: () => [],
       getSkillStates: () => [],
       getResourceNodes: () => [],
+      getWallet: () => ({ coin: 0 }),
     });
 
     const snapshot = await composer.compose("player_test", 0);
@@ -127,6 +136,7 @@ describe("LiveGameplaySnapshotComposer", () => {
       getEquipmentSlots: async () => [{ slot: "tool", itemId: "axe" }],
       getSkillStates: async () => [{ skillId: "woodcutting", xp: 100, level: 2 }],
       getResourceNodes: async () => [{ nodeId: "node_1", resourceId: "tree", skillId: "woodcutting", x: 0, y: 0, available: true }],
+      getWallet: async () => ({ coin: 100 }),
     });
 
     const snapshot = await composer.compose("async_player", 10);
@@ -134,5 +144,6 @@ describe("LiveGameplaySnapshotComposer", () => {
     expect(snapshot.inventory).toHaveLength(1);
     expect(snapshot.inventory[0].itemId).toBe("async_item");
     expect(snapshot.skills[0].skillId).toBe("woodcutting");
+    expect(snapshot.wallet.coin).toBe(100);
   });
 });

--- a/server/src/tests/economy-service.test.ts
+++ b/server/src/tests/economy-service.test.ts
@@ -1,0 +1,262 @@
+/**
+ * ECONOMY SERVICE TESTS
+ *
+ * Server-authoritative resource selling contract tests.
+ * Tests sell-resource and sell-all-resources operations.
+ * Ensures fail-does-not-mutate behavior.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { EconomyService } from "../economy/EconomyService.js";
+import { WalletStore } from "../economy/WalletStore.js";
+import { InventoryStore } from "../inventory/InventoryStore.js";
+import { InventoryService } from "../inventory/InventoryService.js";
+
+// Mock persistence adapter
+const mockPersistence = {
+  async loadWallet() { return null; },
+  async saveWallet() {},
+  async loadPlayerInventory() { return null; },
+  async savePlayerInventory() {},
+};
+
+describe("EconomyService", () => {
+  let economyService: EconomyService;
+  let inventoryService: InventoryService;
+  let walletStore: WalletStore;
+
+  beforeEach(() => {
+    walletStore = new WalletStore();
+    const inventoryStore = new InventoryStore();
+    inventoryService = new InventoryService(inventoryStore, mockPersistence);
+    economyService = new EconomyService(inventoryService, {
+      getWallet: async (playerId: string) => walletStore.getWallet(playerId),
+      addCoins: async (input: { playerId: string; amount: number }) => {
+        const state = walletStore.getWallet(input.playerId);
+        const normalized = Math.max(0, Math.floor(Number(input.amount)));
+        const next = { ...state, balances: { ...state.balances, coin: state.balances.coin + normalized } };
+        walletStore.wallets.set(input.playerId, next);
+        return next;
+      },
+      hydratePlayer: async () => {},
+    } as any);
+  });
+
+  describe("sellResource", () => {
+    it("should sell resource successfully", async () => {
+      // Add wood_log to inventory
+      await inventoryService.addItem({ playerId: "player1", itemId: "wood_log", quantity: 5 });
+
+      const result = await economyService.sellResource({
+        playerId: "player1",
+        itemId: "wood_log",
+        quantity: 3,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.reason).toBe("sold");
+      expect(result.quantitySold).toBe(3);
+      expect(result.unitPrice).toBe(1);
+      expect(result.totalCoins).toBe(3);
+      expect(result.newBalance).toBe(3);
+
+      // Verify inventory was reduced
+      const inventory = await inventoryService.getPlayerInventory("player1");
+      const woodSlot = inventory.slots.find((s) => s.itemId === "wood_log");
+      expect(woodSlot?.quantity).toBe(2);
+    });
+
+    it("should fail for invalid player", async () => {
+      const result = await economyService.sellResource({
+        playerId: "",
+        itemId: "wood_log",
+        quantity: 1,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_player");
+    });
+
+    it("should fail for invalid quantity", async () => {
+      const result = await economyService.sellResource({
+        playerId: "player1",
+        itemId: "wood_log",
+        quantity: 0,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_quantity");
+    });
+
+    it("should fail for not_sellable item (tool)", async () => {
+      // Add a tool to inventory
+      await inventoryService.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+
+      const result = await economyService.sellResource({
+        playerId: "player1",
+        itemId: "wooden_axe",
+        quantity: 1,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("not_sellable");
+    });
+
+    it("should fail for insufficient quantity", async () => {
+      // Add only 1 wood_log
+      await inventoryService.addItem({ playerId: "player1", itemId: "wood_log", quantity: 1 });
+
+      const result = await economyService.sellResource({
+        playerId: "player1",
+        itemId: "wood_log",
+        quantity: 5,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("insufficient_quantity");
+    });
+
+    it("should not mutate inventory on failure", async () => {
+      // Add 1 wood_log
+      await inventoryService.addItem({ playerId: "player1", itemId: "wood_log", quantity: 1 });
+
+      // Try to sell 5 (more than available)
+      const result = await economyService.sellResource({
+        playerId: "player1",
+        itemId: "wood_log",
+        quantity: 5,
+      });
+
+      expect(result.ok).toBe(false);
+
+      // Verify inventory is unchanged
+      const inventory = await inventoryService.getPlayerInventory("player1");
+      const woodSlot = inventory.slots.find((s) => s.itemId === "wood_log");
+      expect(woodSlot?.quantity).toBe(1);
+    });
+  });
+
+  describe("sellAllResources", () => {
+    it("should sell all resources successfully", async () => {
+      // Add multiple resource types
+      await inventoryService.addItem({ playerId: "player1", itemId: "wood_log", quantity: 5 });
+      await inventoryService.addItem({ playerId: "player1", itemId: "copper_ore", quantity: 2 });
+      await inventoryService.addItem({ playerId: "player1", itemId: "raw_fish", quantity: 1 });
+
+      const result = await economyService.sellAllResources({
+        playerId: "player1",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.reason).toBe("sold");
+      // 5*1 + 2*3 + 1*2 = 5 + 6 + 2 = 13
+      expect(result.totalCoins).toBe(13);
+      expect(result.sold).toHaveLength(3);
+
+      // Verify inventory is empty
+      const inventory = await inventoryService.getPlayerInventory("player1");
+      expect(inventory.slots.length).toBe(0);
+    });
+
+    it("should fail for nothing_to_sell", async () => {
+      const result = await economyService.sellAllResources({
+        playerId: "player1",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("nothing_to_sell");
+    });
+
+    it("should not sell tools", async () => {
+      // Add tools and resources
+      await inventoryService.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      await inventoryService.addItem({ playerId: "player1", itemId: "wood_log", quantity: 5 });
+
+      const result = await economyService.sellAllResources({
+        playerId: "player1",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.sold).toHaveLength(1); // Only wood_log
+      expect(result.totalCoins).toBe(5); // 5 * 1
+
+      // Verify tool is still in inventory
+      const inventory = await inventoryService.getPlayerInventory("player1");
+      const toolSlot = inventory.slots.find((s) => s.itemId === "wooden_axe");
+      expect(toolSlot).toBeDefined();
+      expect(toolSlot?.quantity).toBe(1);
+    });
+
+    it("should not mutate inventory on failure", async () => {
+      // Add some resources
+      await inventoryService.addItem({ playerId: "player1", itemId: "wood_log", quantity: 5 });
+
+      // Create another service instance and try to sell from non-existent player
+      const result = await economyService.sellAllResources({
+        playerId: "nonexistent",
+      });
+
+      expect(result.ok).toBe(false);
+
+      // Verify original inventory is unchanged
+      const inventory = await inventoryService.getPlayerInventory("player1");
+      const woodSlot = inventory.slots.find((s) => s.itemId === "wood_log");
+      expect(woodSlot?.quantity).toBe(5);
+    });
+  });
+
+  describe("price table", () => {
+    it("should have correct prices for all resources", async () => {
+      const prices: Record<string, number> = {
+        wood_log: 1,
+        copper_ore: 3,
+        raw_fish: 2,
+        wood_plank: 1,
+        copper_ingot: 5,
+        cooked_fish: 3,
+      };
+
+      for (const [itemId, expectedPrice] of Object.entries(prices)) {
+        await inventoryService.addItem({ playerId: "player1", itemId, quantity: 1 });
+        const result = await economyService.sellResource({
+          playerId: "player1",
+          itemId,
+          quantity: 1,
+        });
+        expect(result.unitPrice).toBe(expectedPrice);
+        expect(result.totalCoins).toBe(expectedPrice);
+      }
+    });
+  });
+});
+
+describe("WalletStore", () => {
+  it("should create default wallet with 0 coins", () => {
+    const store = new WalletStore();
+    const wallet = store.getWallet("player1");
+    expect(wallet.balances.coin).toBe(0);
+  });
+
+  it("should add coins", () => {
+    const store = new WalletStore();
+    store.addCoins("player1", 10);
+    const wallet = store.getWallet("player1");
+    expect(wallet.balances.coin).toBe(10);
+  });
+
+  it("should accumulate coins", () => {
+    const store = new WalletStore();
+    store.addCoins("player1", 5);
+    store.addCoins("player1", 3);
+    const wallet = store.getWallet("player1");
+    expect(wallet.balances.coin).toBe(8);
+  });
+
+  it("should clear for tests", () => {
+    const store = new WalletStore();
+    store.addCoins("player1", 10);
+    store.clearForTests();
+    const wallet = store.getWallet("player1");
+    expect(wallet.balances.coin).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements resource selling for the first economy loop: **Gather Resources → Sell → Gain Coins**

This PR adds server-authoritative resource selling with deterministic pricing, enabling players to sell gathered resources for coins.

## Server Routes

### `POST /api/economy/sell-resource`
- Input: `{ playerId, itemId, quantity }`
- Validates player, item, quantity, sellability, and inventory
- On success: removes items from inventory, adds coins to wallet
- Fail-does-not-mutate: failed operations leave state unchanged

### `POST /api/economy/sell-all-resources`
- Input: `{ playerId }`
- Sells all sellable resource stacks in inventory
- Returns summary of sold items and total coins

## Currency / Wallet Contract

- `WalletState` with `balances.coin` (initialized to 0)
- `WalletStore` for in-memory state
- `WalletService` with persistence hydration
- JSON file persistence adapter
- Wallet included in LiveGameplaySnapshot as `wallet.coin`

## Deterministic Price Table

| Item ID       | Price (coins) |
|---------------|---------------|
| wood_log      | 1             |
| copper_ore    | 3             |
| raw_fish      | 2             |
| wood_plank    | 1             |
| copper_ingot  | 5             |
| cooked_fish   | 3             |

Tools and quest items are **not sellable**.

## Client Actions

- `dispatchSellResource({ itemId, quantity, playerId? })`
- `dispatchSellAllResources(playerId?)`
- Both refetch snapshot on success

## Client UI

- `InventoryPanel.tsx`: Wallet balance display, SELL button per resource, "Sell All Resources" button
- Test IDs: `wallet-balance`, `sell-resource-button`, `sell-all-resources-button`
- Toast feedback on success/failure

## Tests

- **15 economy service tests**: sell success, invalid player/item/quantity, insufficient quantity, not_sellable, price table verification
- **7 LiveGameplaySnapshotComposer tests**: Updated to include `getWallet` dependency and verify wallet in snapshot

## Files Changed

**New server files:**
- `server/src/economy/` - Wallet types, store, service, persistence, EconomyService, route, runtime

**Modified server files:**
- `server/src/core/ServerBootstrap.ts` - Added economyRouter
- `server/src/gameplay/` - Added wallet to snapshot types and composer

**New client files:**
- None (actions added to existing files)

**Modified client files:**
- `apps/client-2d/src/game/gameplayActions.ts` - Added sell actions
- `apps/client-2d/src/game/liveGameplaySnapshot.ts` - Added wallet types
- `apps/client-2d/src/ui/windows/InventoryPanel.tsx` - Added sell UI
- `apps/client-2d/src/ui/GameplayWindowsLayer.tsx` - Added wallet prop

**Docs:**
- `docs/ARELOGIC_RESOURCE_VENDOR_CONTRACT.md` - Full contract documentation

## Live Verification Steps

1. Start server with `pnpm -C server dev`
2. Open client at `/2d/`
3. Create character and claim starter tools
4. Gather some resources (wood, copper ore, fish)
5. Open inventory panel
6. Verify wallet shows "Coins: 0"
7. Click SELL on a resource
8. Verify toast shows "Sold X for Y coins"
9. Verify wallet balance increased
10. Verify resource quantity decreased
11. Click "Sell All Resources" to sell remaining
12. Verify all sellable resources are gone but tools remain
13. Reload and verify coins persist

## Known Limitations

- Static prices (no dynamic market)
- No vendor location requirement (MVP)
- No player trading
- No real-money currency

## Next PRs

- #1786: NPC Vendor Location / Village Trader
- #1787: NPC Resource Economy Loop
- #1788: Tool Crafting Recipes
- #1789: Mining/Fishing Camps as World POIs

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/605135fa-974e-4aae-a147-ab1b8db7539d)