### PR TITLE
feat(economy): add resource processing recipes and premium vendor values

### DIFF
--- a/apps/client-2d/src/ui/windows/InventoryPanel.tsx
+++ b/apps/client-2d/src/ui/windows/InventoryPanel.tsx
@@ -79,13 +79,17 @@ const SELLABLE_RESOURCE_IDS = new Set([
 ]);
 
 // Sell prices for resources (in coins)
+// Raw materials: lower prices
+// Processed materials: premium prices for better economy loop
 const RESOURCE_SELL_PRICES: Record<string, number> = {
+  // Raw gathered resources
   wood_log: 1,
   copper_ore: 3,
   raw_fish: 2,
-  wood_plank: 1,
-  copper_ingot: 5,
-  cooked_fish: 3,
+  // Processed resources (premium)
+  wood_plank: 3,
+  copper_ingot: 8,
+  cooked_fish: 4,
 };
 
 export function InventoryPanel({ inventory, equipment, wallet }: Props) {

--- a/docs/ARELOGIC_RESOURCE_PROCESSING_CONTRACT.md
+++ b/docs/ARELOGIC_RESOURCE_PROCESSING_CONTRACT.md
@@ -1,0 +1,345 @@
+# ARELOGIC RESOURCE PROCESSING CONTRACT
+
+## Summary
+
+This contract establishes the resource processing economy loop for Areloria. Players can process raw gathered resources into refined materials that sell for higher prices at the Village Trader. This creates a meaningful progression loop: Gather Raw → Process → Sell Processed → Earn More.
+
+**PR:** #1787  
+**Status:** Implemented  
+**Date:** 2026-06-07
+
+---
+
+## 1. Why Resource Processing Now
+
+After implementing:
+- Resource Gathering (#1777, #1782, #1783)
+- Tool Onboarding (#1784)
+- Resource Selling (#1785)
+- Village Trader Proximity (#1786)
+
+The next logical step is adding value to gathered resources through processing. Benefits:
+1. Creates processing progression loop
+2. Encourages returning to village
+3. Makes gathering more rewarding
+4. Sets foundation for crafting tools from processed materials
+
+---
+
+## 2. Processing Recipe Table
+
+### Resource Processing Recipes
+
+| Recipe ID | Title | Input | Output | Craft Ticks |
+|-----------|-------|-------|--------|-------------|
+| `craft_wood_plank` | Craft Wood Plank | 2× wood_log | 1× wood_plank | 5 |
+| `smelt_copper_ingot` | Smelt Copper Ingot | 2× copper_ore | 1× copper_ingot | 8 |
+| `cook_raw_fish` | Cook Raw Fish | 1× raw_fish | 1× cooked_fish | 4 |
+
+### Tool Crafting Recipes (Future)
+
+| Recipe ID | Title | Input | Output | Craft Ticks |
+|-----------|-------|-------|--------|-------------|
+| `craft_wooden_axe` | Craft Wooden Axe | 2× wood_plank, 1× copper_ingot | 1× wooden_axe | 8 |
+| `craft_copper_pickaxe` | Craft Copper Pickaxe | 1× wood_plank, 2× copper_ingot | 1× copper_pickaxe | 10 |
+| `craft_simple_fishing_rod` | Craft Simple Fishing Rod | 1× wood_plank, 1× raw_fish | 1× simple_fishing_rod | 6 |
+
+---
+
+## 3. Premium Sell Prices
+
+### Price Comparison
+
+| Raw Resource | Raw Price | Processed Item | Processed Price | Profit |
+|--------------|-----------|----------------|-----------------|--------|
+| 2× wood_log | 2 coins | 1× wood_plank | 3 coins | +1 |
+| 2× copper_ore | 6 coins | 1× copper_ingot | 8 coins | +2 |
+| 1× raw_fish | 2 coins | 1× cooked_fish | 4 coins | +2 |
+
+### Full Price Table
+
+```typescript
+export const RESOURCE_SELL_PRICES: Record<string, number> = {
+  // Raw gathered resources
+  wood_log: 1,
+  copper_ore: 3,
+  raw_fish: 2,
+  // Processed resources (premium values)
+  wood_plank: 3,
+  copper_ingot: 8,
+  cooked_fish: 4,
+};
+```
+
+---
+
+## 4. Processing Service Contract
+
+**File:** `server/src/crafting/CraftingService.ts`
+
+### Interface
+
+```typescript
+interface CraftingInput {
+  playerId: string;
+  recipeId: string;
+}
+
+interface CraftingResult {
+  ok: boolean;
+  playerId: string;
+  recipeId: string;
+  reason?: "crafted" | "recipe_not_found" | "level_too_low" | "missing_ingredients" | "inventory_full" | "invalid_player";
+  consumed?: RecipeIngredient[];
+  outputs?: RecipeOutput[];
+  craftingXpReward?: number;
+}
+```
+
+### Validation Rules
+
+1. **Player must be valid**: Invalid/anonymous player returns `invalid_player`
+2. **Recipe must exist**: Unknown recipe ID returns `recipe_not_found`
+3. **Level requirement**: Player must have required crafting level, returns `level_too_low`
+4. **Ingredients available**: Player must have all required items, returns `missing_ingredients`
+5. **Inventory space**: Must have room for outputs, returns `inventory_full`
+
+### Fail-Does-Not-Mutate
+
+If any step fails, the transaction is rolled back:
+- No ingredients consumed
+- No outputs added
+- No XP granted
+
+---
+
+## 5. Server Route
+
+### POST /api/crafting/craft
+
+**Request:**
+```json
+{
+  "recipeId": "craft_wood_plank"
+}
+```
+
+**Headers:**
+- `x-player-id`: Player identifier
+
+**Success Response (200):**
+```json
+{
+  "ok": true,
+  "result": {
+    "ok": true,
+    "playerId": "player1",
+    "recipeId": "craft_wood_plank",
+    "reason": "crafted",
+    "consumed": [{ "itemId": "wood_log", "quantity": 2 }],
+    "outputs": [{ "itemId": "wood_plank", "quantity": 1 }],
+    "craftingXpReward": 20
+  }
+}
+```
+
+**Failure Response (409):**
+```json
+{
+  "ok": false,
+  "result": {
+    "ok": false,
+    "playerId": "player1",
+    "recipeId": "craft_wood_plank",
+    "reason": "missing_ingredients"
+  }
+}
+```
+
+### GET /api/crafting/recipes
+
+Returns all recipes with craftability status for the player.
+
+**Response:**
+```json
+{
+  "ok": true,
+  "playerId": "player1",
+  "recipes": [
+    {
+      "id": "craft_wood_plank",
+      "title": "Craft Wood Plank",
+      "requiredLevel": 1,
+      "craftingXpReward": 20,
+      "ingredients": [{ "itemId": "wood_log", "quantity": 2 }],
+      "outputs": [{ "itemId": "wood_plank", "quantity": 1 }],
+      "craftTicks": 5,
+      "craftable": true
+    }
+  ]
+}
+```
+
+---
+
+## 6. Inventory Mutation Rules
+
+### Successful Craft Flow
+
+1. **Validate all conditions** (player, recipe, level, ingredients, space)
+2. **Consume ingredients** (remove from inventory)
+3. **Add outputs** (add to inventory)
+4. **Grant XP** (add to crafting skill)
+5. **Return result** (with consumed/outputs/XP details)
+
+### Failed Craft Flow
+
+If any validation or operation fails:
+- No inventory changes
+- No XP changes
+- Return failure reason
+
+### No Partial Mutations
+
+The system never partially processes a recipe. Either all ingredients are consumed and all outputs added, or nothing happens.
+
+---
+
+## 7. Client Integration
+
+### Client Actions
+
+**File:** `apps/client-2d/src/game/crafting.ts`
+
+```typescript
+export async function craftRecipe(recipeId: string): Promise<CraftingApiResponse>
+```
+
+### Client UI
+
+**File:** `apps/client-2d/src/ui/windows/CraftingWindow.tsx`
+
+**Features:**
+- Lists all recipes with ingredients/outputs
+- Shows XP reward per recipe
+- Disabled button when not craftable
+- "Missing Items" / "Locked" status
+- Toast notifications on success/failure
+
+**Test IDs:**
+- `data-testid="crafting-row"` (for each recipe)
+- `data-testid="craft-button"` (on each recipe)
+
+---
+
+## 8. NPC Trader Flavor
+
+**File:** `server/src/npc/VendorRoutes.ts`
+
+Village Trader (Mira) dialogue updated:
+
+**Before:**
+> "I buy wood, ore, and fish. Bring me what you gather."
+
+**After:**
+> "I buy wood, ore, and fish. Bring me what you gather. I pay more for planks, ingots, and cooked fish."
+
+This informs players about the premium pricing for processed materials.
+
+---
+
+## 9. Determinism Rules
+
+1. **No Math.random()**: Recipe results are deterministic
+2. **No Date.now()**: Crafting uses server tick, not timestamps
+3. **Stable recipe IDs**: IDs never change
+4. **Fixed prices**: Sell prices are constants, not calculated
+5. **Sorted output**: Recipe lists are sorted by ID for deterministic iteration
+
+---
+
+## 10. Known Limitations
+
+1. **No station proximity**: Players can craft anywhere (no campfire/furnace required)
+2. **Instant crafting**: No tick-based crafting queue (immediate processing)
+3. **No tool durability**: Crafted tools don't degrade
+4. **No dynamic market**: Prices are static
+5. **No NPC inventory**: Unlimited buying capacity
+6. **No recipe discovery**: All recipes visible from start
+
+---
+
+## 11. Next PRs
+
+1. **#1788 Processing Stations / Campfire / Furnace POIs**
+   - Require proximity to campfire for cooking
+   - Require proximity to furnace for smelting
+   - Visual landmarks for processing
+
+2. **#1789 NPC Resource Economy Loop with stock/demand**
+   - NPCs have limited buying capacity
+   - Prices vary by NPC type
+   - Supply affects availability
+
+3. **#1790 Tool Crafting Recipes**
+   - Already exists in StarterRecipes
+   - Test full tool crafting flow
+   - Verify tools work for gathering
+
+4. **#1791 Region-based Pricing**
+   - Different prices in different regions
+   - Travel to remote traders for better deals
+
+---
+
+## 12. Files Changed
+
+### Server (modified files)
+
+| File | Change |
+|------|--------|
+| `server/src/economy/ResourceSellPrices.ts` | Updated prices for premium processed items |
+| `server/src/crafting/StarterRecipes.ts` | Updated copper ingot recipe (3→2 ore) |
+| `server/src/npc/VendorRoutes.ts` | Updated dialogue for premium pricing |
+
+### Client (modified files)
+
+| File | Change |
+|------|--------|
+| `apps/client-2d/src/ui/windows/InventoryPanel.tsx` | Updated client-side sell prices |
+
+### Docs (new file)
+
+| File | Purpose |
+|------|---------|
+| `docs/ARELOGIC_RESOURCE_PROCESSING_CONTRACT.md` | This documentation |
+
+---
+
+## 13. Live Verification
+
+1. Open /2d/ and load a character
+2. Collect resources:
+   - 2× wood_log
+   - 2× copper_ore
+   - 1× raw_fish
+3. Open Crafting window
+4. Verify recipes show:
+   - craft_wood_plank: 2 wood_log → 1 wood_plank
+   - smelt_copper_ingot: 2 copper_ore → 1 copper_ingot
+   - cook_raw_fish: 1 raw_fish → 1 cooked_fish
+5. Craft wood_plank:
+   - wood_log decreases by 2
+   - wood_plank increases by 1
+6. Go to Village Trader
+7. Sell processed items:
+   - wood_plank: 3 coins (vs 2 for raw logs)
+   - copper_ingot: 8 coins (vs 6 for raw ore)
+   - cooked_fish: 4 coins (vs 2 for raw fish)
+8. Verify profit is positive for processing
+9. Reload - inventory persists correctly
+
+---
+
+*Document generated for PR #1787*  
+*Part of the Areloria/WASD Economy Loop effort*

--- a/server/src/crafting/StarterRecipes.ts
+++ b/server/src/crafting/StarterRecipes.ts
@@ -36,7 +36,7 @@ export const STARTER_CRAFTING_RECIPES: readonly CraftingRecipe[] = [
     ingredients: [
       {
         itemId: "copper_ore",
-        quantity: 3,
+        quantity: 2,
       },
     ],
     outputs: [

--- a/server/src/economy/ResourceSellPrices.ts
+++ b/server/src/economy/ResourceSellPrices.ts
@@ -1,9 +1,15 @@
 /**
  * RESOURCE SELL PRICES
  *
- * Deterministic sell prices for gathered resources.
+ * Deterministic sell prices for gathered and processed resources.
  * No Math.random(), no Date.now(), no dynamic market prices.
  * Prices are stable integers in coins.
+ * 
+ * Premium pricing: Processed items are worth more than raw inputs.
+ * This creates the resource processing economy loop:
+ * - wood_log x2 (2 coins) → wood_plank (3 coins) = +1 profit
+ * - copper_ore x2 (6 coins) → copper_ingot (8 coins) = +2 profit
+ * - raw_fish (2 coins) → cooked_fish (4 coins) = +2 profit
  */
 
 import type { InventoryItemId } from "../inventory/InventoryTypes.js";
@@ -11,14 +17,19 @@ import type { InventoryItemId } from "../inventory/InventoryTypes.js";
 /**
  * Sell price in coins per unit.
  * Only resource items are sellable; equipment and quest items are not.
+ * 
+ * Raw materials: wood_log, copper_ore, raw_fish
+ * Processed materials (premium): wood_plank, copper_ingot, cooked_fish
  */
 export const RESOURCE_SELL_PRICES: Record<string, number> = {
+  // Raw gathered resources
   wood_log: 1,
   copper_ore: 3,
   raw_fish: 2,
-  wood_plank: 1,
-  copper_ingot: 5,
-  cooked_fish: 3,
+  // Processed resources (premium values)
+  wood_plank: 3,
+  copper_ingot: 8,
+  cooked_fish: 4,
 } as const;
 
 export interface SellPriceResult {

--- a/server/src/npc/VendorRoutes.ts
+++ b/server/src/npc/VendorRoutes.ts
@@ -90,7 +90,7 @@ router.post("/vendor/:vendorId/interact", async (req, res) => {
 function getVendorDialogue(vendorId: string): string {
   switch (vendorId) {
     case "village_trader_001":
-      return "I buy wood, ore, and fish. Bring me what you gather.";
+      return "I buy wood, ore, and fish. Bring me what you gather. I pay more for planks, ingots, and cooked fish.";
     default:
       return "Welcome, traveler.";
   }

--- a/server/src/tests/economy-service.test.ts
+++ b/server/src/tests/economy-service.test.ts
@@ -360,19 +360,20 @@ describe("EconomyService", () => {
   });
 
   describe("price table", () => {
+    // Define prices in outer scope so both tests can reference it
+    const prices: Record<string, number> = {
+      // Raw gathered resources
+      wood_log: 1,
+      copper_ore: 3,
+      raw_fish: 2,
+      // Processed resources (premium values)
+      wood_plank: 3,
+      copper_ingot: 8,
+      cooked_fish: 4,
+    };
+
     it("should have correct prices for all resources", async () => {
       // Premium pricing: processed items are worth more than raw inputs
-      const prices: Record<string, number> = {
-        // Raw gathered resources
-        wood_log: 1,
-        copper_ore: 3,
-        raw_fish: 2,
-        // Processed resources (premium values)
-        wood_plank: 3,
-        copper_ingot: 8,
-        cooked_fish: 4,
-      };
-
       for (const [itemId, expectedPrice] of Object.entries(prices)) {
         await inventoryService.addItem({ playerId: "player1", itemId, quantity: 1 });
         const result = await economyService.sellResource({

--- a/server/src/tests/economy-service.test.ts
+++ b/server/src/tests/economy-service.test.ts
@@ -361,13 +361,16 @@ describe("EconomyService", () => {
 
   describe("price table", () => {
     it("should have correct prices for all resources", async () => {
+      // Premium pricing: processed items are worth more than raw inputs
       const prices: Record<string, number> = {
+        // Raw gathered resources
         wood_log: 1,
         copper_ore: 3,
         raw_fish: 2,
-        wood_plank: 1,
-        copper_ingot: 5,
-        cooked_fish: 3,
+        // Processed resources (premium values)
+        wood_plank: 3,
+        copper_ingot: 8,
+        cooked_fish: 4,
       };
 
       for (const [itemId, expectedPrice] of Object.entries(prices)) {
@@ -376,10 +379,43 @@ describe("EconomyService", () => {
           playerId: "player1",
           itemId,
           quantity: 1,
+          playerPosition: nearVendorPosition(),
         });
         expect(result.unitPrice).toBe(expectedPrice);
         expect(result.totalCoins).toBe(expectedPrice);
       }
+    });
+
+    it("should have processed items worth more than raw inputs", async () => {
+      // Test the economy loop: processing should be profitable
+      // wood_log x2 = 2 coins raw, wood_plank = 3 coins processed (+1)
+      // copper_ore x2 = 6 coins raw, copper_ingot = 8 coins processed (+2)
+      // raw_fish x1 = 2 coins raw, cooked_fish = 4 coins processed (+2)
+
+      // Sell raw copper_ore x2
+      await inventoryService.addItem({ playerId: "player1", itemId: "copper_ore", quantity: 2 });
+      const rawResult = await economyService.sellResource({
+        playerId: "player1",
+        itemId: "copper_ore",
+        quantity: 2,
+        playerPosition: nearVendorPosition(),
+      });
+      expect(rawResult.totalCoins).toBe(6); // 2 ore x 3 coins
+
+      // Sell raw wood_log x2
+      await inventoryService.addItem({ playerId: "player1", itemId: "wood_log", quantity: 2 });
+      const woodResult = await economyService.sellResource({
+        playerId: "player1",
+        itemId: "wood_log",
+        quantity: 2,
+        playerPosition: nearVendorPosition(),
+      });
+      expect(woodResult.totalCoins).toBe(2); // 2 logs x 1 coin
+
+      // Processed items should be worth more per unit than raw
+      expect(prices.wood_plank).toBeGreaterThan(prices.wood_log);
+      expect(prices.copper_ingot).toBeGreaterThan(prices.copper_ore);
+      expect(prices.cooked_fish).toBeGreaterThan(prices.raw_fish);
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR establishes the resource processing economy loop for Areloria. Players can process raw gathered resources into refined materials that sell for higher prices at the Village Trader.

## Problem

After #1785-#1786, players could sell raw resources anywhere near the village trader, but there was no incentive to process materials before selling. This PR creates the processing loop: Gather Raw → Process → Sell Processed → Earn More.

## Solution

### Premium Sell Prices

Updated prices so processed items are worth more:

| Item | Old Price | New Price | Change |
|------|-----------|-----------|--------|
| wood_log (raw) | 1 | 1 | - |
| wood_plank (processed) | 1 | 3 | +2 |
| copper_ore (raw) | 3 | 3 | - |
| copper_ingot (processed) | 5 | 8 | +3 |
| raw_fish (raw) | 2 | 2 | - |
| cooked_fish (processed) | 3 | 4 | +1 |

### Processing Profit Calculation

- **Wood**: 2× wood_log (2 coins) → 1× wood_plank (3 coins) = **+1 profit**
- **Copper**: 2× copper_ore (6 coins) → 1× copper_ingot (8 coins) = **+2 profit**
- **Fish**: 1× raw_fish (2 coins) → 1× cooked_fish (4 coins) = **+2 profit**

### Recipe Adjustment

Updated `smelt_copper_ingot` recipe from 3× copper_ore → 2× copper_ore to make the economics work properly.

### NPC Trader Dialogue

Updated Mira's dialogue to inform players about premium pricing:
> "I buy wood, ore, and fish. Bring me what you gather. I pay more for planks, ingots, and cooked fish."

## Files Changed

### Server (modified)
- `server/src/economy/ResourceSellPrices.ts` - Updated premium prices
- `server/src/crafting/StarterRecipes.ts` - Fixed copper ingot recipe (3→2 ore)
- `server/src/npc/VendorRoutes.ts` - Updated trader dialogue
- `server/src/tests/economy-service.test.ts` - Updated price tests

### Client (modified)
- `apps/client-2d/src/ui/windows/InventoryPanel.tsx` - Updated client prices

### Docs (new)
- `docs/ARELOGIC_RESOURCE_PROCESSING_CONTRACT.md` - Full documentation

## Existing System Integration

The crafting system already existed with:
- `CraftingService.ts` - Server-side crafting logic
- `craftingRoute.ts` - `/api/crafting/craft` route
- `CraftingWindow.tsx` - Client UI
- `craftRecipe()` - Client action function

This PR just needed to:
1. Adjust prices to make processing profitable
2. Fix copper ore recipe quantity
3. Update dialogue

## Tests

- Updated price table tests to verify premium pricing
- Added test to verify processed items > raw items in value

## Live Verification

1. Open /2d/ and load a character
2. Collect: 2× wood_log, 2× copper_ore, 1× raw_fish
3. Open Crafting window
4. Verify recipes show correct inputs/outputs
5. Craft all processed items
6. Go to Village Trader
7. Sell processed items
8. Verify coins > raw sell value
9. Reload - inventory persists

## Known Limitations

- No station proximity required (crafting works anywhere)
- Instant crafting (no tick-based processing)
- All recipes visible from start
- No recipe discovery

## Next PRs

- #1788 Processing Stations / Campfire / Furnace POIs
- #1789 NPC Resource Economy Loop with stock/demand
- #1790 Tool Crafting Recipes (verify full flow)

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/642f4401-351f-4f33-ace7-6cb9b7712107)