### PR TITLE
feat(world): require processing stations for resource recipes

### DIFF
--- a/apps/client-2d/src/game/crafting.ts
+++ b/apps/client-2d/src/game/crafting.ts
@@ -5,6 +5,8 @@
  * Server-authoritative: client cannot create or consume items.
  */
 
+import { readPlayerPositionBridge } from "./PlayerPositionBridge";
+
 export interface CraftingApiResponse {
   ok: boolean;
   result: {
@@ -21,14 +23,20 @@ export interface CraftingApiResponse {
 /**
  * Craft a recipe.
  * Server-authoritative: consumes ingredients, adds outputs, grants XP.
+ * Requires player position for station-bound recipes.
  */
 export async function craftRecipe(recipeId: string): Promise<CraftingApiResponse> {
+  const playerPosition = readPlayerPositionBridge();
+
   const response = await fetch("/api/crafting/craft", {
     method: "POST",
     headers: {
       "content-type": "application/json",
     },
-    body: JSON.stringify({ recipeId }),
+    body: JSON.stringify({
+      recipeId,
+      playerPosition: playerPosition ?? undefined,
+    }),
   });
 
   return response.json();

--- a/apps/client-2d/src/ui/windows/CraftingWindow.tsx
+++ b/apps/client-2d/src/ui/windows/CraftingWindow.tsx
@@ -5,6 +5,7 @@
  * Server-authoritative display only - client cannot craft directly.
  * Uses LiveGameplaySnapshot for reactive updates.
  * After crafting, refetches snapshot to update inventory and quest progress.
+ * Shows station requirements and proximity feedback.
  */
 
 import { useCallback } from "react";
@@ -16,6 +17,40 @@ import type { CraftingSnapshot } from "../../game/liveGameplaySnapshot";
 interface CraftingWindowProps {
   readonly isOpen?: boolean;
   readonly onClose?: () => void;
+}
+
+const STATION_EMOJI: Record<string, string> = {
+  campfire: "🔥",
+  furnace: "🧱",
+  workbench: "🛠",
+};
+
+const STATION_NAME: Record<string, string> = {
+  campfire: "Campfire",
+  furnace: "Furnace",
+  workbench: "Workbench",
+};
+
+function getBlockedMessage(blockedReason?: string): string {
+  switch (blockedReason) {
+    case "missing_ingredients":
+      return "Missing Items";
+    case "station_too_far":
+      return "Move to Station";
+    case "missing_player_position":
+      return "Waiting for position";
+    case "level_too_low":
+      return "Level Locked";
+    default:
+      return "Locked";
+  }
+}
+
+function getStationRequirement(recipe: { stationType?: string }): string | null {
+  if (!recipe.stationType) return null;
+  const emoji = STATION_EMOJI[recipe.stationType] ?? "⚙️";
+  const name = STATION_NAME[recipe.stationType] ?? recipe.stationType;
+  return `${emoji} ${name} required`;
 }
 
 export function CraftingWindow({ isOpen = true, onClose }: CraftingWindowProps) {
@@ -42,11 +77,23 @@ export function CraftingWindow({ isOpen = true, onClose }: CraftingWindowProps) 
         liveGameplayStore.setSnapshot(next);
       }
     } else {
+      const reason = result.result?.reason;
+      let message = "Craft failed";
+      if (reason === "station_too_far") {
+        message = "Move near a station to craft this";
+      } else if (reason === "missing_player_position") {
+        message = "Waiting for position sync...";
+      } else if (reason === "missing_ingredients") {
+        message = "Missing required items";
+      } else if (reason) {
+        message = `Craft failed: ${reason}`;
+      }
+
       window.dispatchEvent(
         new CustomEvent("wasd:toast", {
           detail: {
             type: "error",
-            message: `Craft failed: ${result.result?.reason ?? "unknown"}`,
+            message,
           },
         }),
       );
@@ -75,50 +122,52 @@ export function CraftingWindow({ isOpen = true, onClose }: CraftingWindowProps) 
           </div>
         ) : (
           <div className="crafting-list">
-            {recipes.map((recipe) => (
-              <article key={recipe.id} className="crafting-row">
-                <div className="crafting-row__header">
-                  <strong>{recipe.title}</strong>
-                  <span className="crafting-row__xp">+{recipe.craftingXpReward} XP</span>
-                </div>
-
-                <div className="crafting-row__meta">
-                  Requires Crafting Lv. {recipe.requiredLevel}
-                </div>
-
-                <div className="crafting-row__items">
-                  <div className="crafting-row__ingredients">
-                    <span className="crafting-row__label">Input:</span>
-                    <span>
-                      {recipe.ingredients
-                        .map((item) => `${item.quantity}× ${item.itemId}`)
-                        .join(", ")}
-                    </span>
+            {recipes.map((recipe) => {
+              const stationReq = getStationRequirement(recipe);
+              return (
+                <article key={recipe.id} className="crafting-row">
+                  <div className="crafting-row__header">
+                    <strong>{recipe.title}</strong>
+                    <span className="crafting-row__xp">+{recipe.craftingXpReward} XP</span>
                   </div>
-                  <div className="crafting-row__outputs">
-                    <span className="crafting-row__label">Output:</span>
-                    <span>
-                      {recipe.outputs
-                        .map((item) => `${item.quantity}× ${item.itemId}`)
-                        .join(", ")}
-                    </span>
-                  </div>
-                </div>
 
-                <button
-                  type="button"
-                  className="crafting-row__button"
-                  disabled={!recipe.craftable}
-                  onClick={() => handleCraft(recipe.id)}
-                >
-                  {recipe.craftable
-                    ? "Craft"
-                    : recipe.blockedReason === "missing_ingredients"
-                      ? "Missing Items"
-                      : "Locked"}
-                </button>
-              </article>
-            ))}
+                  <div className="crafting-row__meta">
+                    Requires Crafting Lv. {recipe.requiredLevel}
+                    {stationReq && (
+                      <span className="crafting-row__station">{stationReq}</span>
+                    )}
+                  </div>
+
+                  <div className="crafting-row__items">
+                    <div className="crafting-row__ingredients">
+                      <span className="crafting-row__label">Input:</span>
+                      <span>
+                        {recipe.ingredients
+                          .map((item) => `${item.quantity}× ${item.itemId}`)
+                          .join(", ")}
+                      </span>
+                    </div>
+                    <div className="crafting-row__outputs">
+                      <span className="crafting-row__label">Output:</span>
+                      <span>
+                        {recipe.outputs
+                          .map((item) => `${item.quantity}× ${item.itemId}`)
+                          .join(", ")}
+                      </span>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    className="crafting-row__button"
+                    disabled={!recipe.craftable}
+                    onClick={() => handleCraft(recipe.id)}
+                  >
+                    {getBlockedMessage(recipe.blockedReason)}
+                  </button>
+                </article>
+              );
+            })}
           </div>
         )}
       </div>

--- a/docs/ARELOGIC_PROCESSING_STATIONS_CONTRACT.md
+++ b/docs/ARELOGIC_PROCESSING_STATIONS_CONTRACT.md
@@ -1,0 +1,262 @@
+# ARELOGIC PROCESSING STATIONS CONTRACT
+
+## Summary
+
+This contract establishes processing station requirements for crafting recipes in Areloria. Players must be near specific processing stations (campfire, furnace, workbench) to craft certain recipes. This creates the world loop: Go Out → Gather Resources → Return to Village → Use Station → Process → Sell.
+
+**PR:** #1788  
+**Status:** Implemented  
+**Date:** 2026-06-07
+
+---
+
+## 1. Why Processing Stations After #1787
+
+After #1787, players could process resources anywhere on the map, which felt abstract. Processing stations add physical context to crafting and give villages a purpose beyond just the vendor.
+
+Benefits:
+1. Creates physical world loop: gather → station → process → sell
+2. Gives villages meaningful POIs
+3. Makes processing feel grounded in the world
+4. Sets foundation for future station POIs (mining camp, fishing pier)
+
+---
+
+## 2. Station Types
+
+### Starter Village Processing Stations
+
+| Station ID | Type | Title | Position | Interaction Radius |
+|------------|------|-------|----------|-------------------|
+| `campfire_001` | campfire | Village Campfire | { x: 465, y: 506 } | 32 |
+| `furnace_001` | furnace | Village Furnace | { x: 470, y: 506 } | 32 |
+| `workbench_001` | workbench | Village Workbench | { x: 468, y: 500 } | 32 |
+
+### Station Properties
+
+```typescript
+interface ProcessingStation {
+  id: string;                    // Deterministic ID
+  type: "campfire" | "furnace" | "workbench";
+  title: string;                // Display name
+  position: { x: number; y: number };
+  interactionRadius: number;     // Distance in world units
+}
+```
+
+---
+
+## 3. Recipe Station Requirements
+
+### Resource Processing Recipes
+
+| Recipe ID | Title | Station Required | Input | Output |
+|-----------|-------|-----------------|-------|--------|
+| `cook_raw_fish` | Cook Raw Fish | campfire | 1× raw_fish | 1× cooked_fish |
+| `smelt_copper_ingot` | Smelt Copper Ingot | furnace | 2× copper_ore | 1× copper_ingot |
+| `craft_wood_plank` | Craft Wood Plank | workbench | 2× wood_log | 1× wood_plank |
+
+### Tool Crafting Recipes
+
+| Recipe ID | Title | Station Required | Input | Output |
+|-----------|-------|-----------------|-------|--------|
+| `craft_wooden_axe` | Craft Wooden Axe | workbench | 2× wood_plank, 1× copper_ingot | 1× wooden_axe |
+| `craft_copper_pickaxe` | Craft Copper Pickaxe | workbench | 1× wood_plank, 2× copper_ingot | 1× copper_pickaxe |
+| `craft_simple_fishing_rod` | Craft Simple Fishing Rod | workbench | 1× wood_plank, 1× raw_fish | 1× simple_fishing_rod |
+
+---
+
+## 4. Server Crafting Contract
+
+### POST /api/crafting/craft
+
+**Request:**
+```json
+{
+  "recipeId": "cook_raw_fish",
+  "playerPosition": { "x": 465, "y": 506 }
+}
+```
+
+**Success Response (200):**
+```json
+{
+  "ok": true,
+  "result": {
+    "ok": true,
+    "playerId": "player1",
+    "recipeId": "cook_raw_fish",
+    "reason": "crafted",
+    "consumed": [{ "itemId": "raw_fish", "quantity": 1 }],
+    "outputs": [{ "itemId": "cooked_fish", "quantity": 1 }],
+    "craftingXpReward": 15
+  }
+}
+```
+
+**Failure Response (409):**
+```json
+{
+  "ok": false,
+  "result": {
+    "ok": false,
+    "playerId": "player1",
+    "recipeId": "cook_raw_fish",
+    "reason": "station_too_far"
+  }
+}
+```
+
+---
+
+## 5. Player Position / Proximity Check
+
+### Validation Flow
+
+1. **Recipe has stationType?**
+   - No: Skip station check, proceed with crafting
+   - Yes: Continue to position validation
+
+2. **Player position provided?**
+   - No: Return `missing_player_position`
+   - Yes: Continue to position validation
+
+3. **Player position finite?**
+   - No: Return `invalid_player_position`
+   - Yes: Continue to proximity check
+
+4. **Player within station radius?**
+   - No: Return `station_too_far`
+   - Yes: Proceed with crafting
+
+### Failure Reasons
+
+| Error | Description | Inventory Mutated? |
+|-------|-------------|-------------------|
+| `missing_player_position` | No position provided for station-required recipe | No |
+| `invalid_player_position` | Position contains NaN/Infinity | No |
+| `station_too_far` | Player outside station interaction radius | No |
+
+---
+
+## 6. Client UI
+
+- Shows station requirement per recipe (e.g., "🔥 Campfire required")
+- Button shows "Move to Station" when `blockedReason === "station_too_far"`
+- Toast shows user-friendly message: "Move near a station to craft this"
+
+---
+
+## 7. Determinism Rules
+
+1. **No Math.random()**: Station positions and IDs are deterministic
+2. **No Date.now()**: All validation uses current state, not timestamps
+3. **Stable station IDs**: Always `campfire_001`, `furnace_001`, `workbench_001`
+4. **Fixed positions**: Stations never move
+5. **Fixed radius**: Always 32 units
+
+---
+
+## 8. Known Limitations
+
+1. **Only starter village stations**: No remote processing locations
+2. **No player-built stations**: Stations are world fixtures only
+3. **No station durability**: Stations don't degrade
+4. **No tick-based processing**: Instant crafting
+5. **Emoji/fallback rendering**: No custom sprites for stations yet
+
+---
+
+## 9. Next PRs
+
+1. **#1789 Mining/Fishing/Logging Camp POIs**
+   - Named locations with bonus resources
+   - Visual landmarks for gathering
+
+2. **#1790 NPC Resource Economy Stock/Demand**
+   - NPCs have limited buying capacity
+   - Prices vary by NPC type
+
+3. **#1791 Tool Crafting Recipes**
+   - Verify full tool crafting flow works
+   - Tools function for gathering
+
+4. **#1792 Player-built Stations / Housing Foundation**
+   - Players can place their own stations
+   - Housing system foundation
+
+---
+
+## 10. Files Changed
+
+### Server (new files)
+
+| File | Purpose |
+|------|---------|
+| `server/src/crafting/ProcessingStations.ts` | Station definitions and proximity checking |
+
+### Server (modified files)
+
+| File | Change |
+|------|--------|
+| `server/src/crafting/CraftingTypes.ts` | Added stationType to recipes and results |
+| `server/src/crafting/StarterRecipes.ts` | Added stationType to all recipes |
+| `server/src/crafting/CraftingService.ts` | Added station proximity validation |
+| `server/src/routes/craftingRoute.ts` | Added playerPosition and stationId parsing |
+
+### Client (modified files)
+
+| File | Change |
+|------|--------|
+| `apps/client-2d/src/game/crafting.ts` | Added playerPosition to craft requests |
+| `apps/client-2d/src/ui/windows/CraftingWindow.tsx` | Added station display and feedback |
+
+### Docs (new file)
+
+| File | Purpose |
+|------|---------|
+| `docs/ARELOGIC_PROCESSING_STATIONS_CONTRACT.md` | This documentation |
+
+---
+
+## 11. Live Verification
+
+1. Open /2d/ and load a character
+2. Collect: 1× raw_fish, 2× copper_ore, 2× wood_log
+3. Open Crafting window far from village
+4. Try to craft - should show "Move to Station"
+5. Return to village
+6. Near campfire: cook raw_fish → cooked_fish succeeds
+7. Near furnace: smelt copper_ore → copper_ingot succeeds
+8. Near workbench: craft wood_plank succeeds
+9. Go to Village Trader, sell processed items
+10. Verify premium prices work
+11. Reload - inventory persists correctly
+
+---
+
+## 12. Processing Loop
+
+The full player loop now looks like:
+
+```
+Go Outside → Gather Resources → Return to Village
+                                       ↓
+                  ┌────────────────────┼────────────────────┐
+                  ↓                    ↓                    ↓
+             Campfire           Furnace            Workbench
+                  ↓                    ↓                    ↓
+            Cook Fish         Smelt Ore          Make Planks
+                  ↓                    ↓                    ↓
+                  └────────────────────┼────────────────────┘
+                                       ↓
+                             Village Trader
+                                       ↓
+                              Sell Processed Items
+                              (Premium Prices ✓)
+```
+
+---
+
+*Document generated for PR #1788*
+*Part of the Areloria/WASD World POI effort*

--- a/server/src/crafting/CraftingService.ts
+++ b/server/src/crafting/CraftingService.ts
@@ -3,12 +3,17 @@
  *
  * Server-authoritative crafting service.
  * Deterministic: No Math.random(), no Date.now(), stable recipe ordering.
+ * Station proximity required for recipes with stationType.
  */
 
 import { getInventoryService } from "../inventory/inventoryRuntime.js";
 import { getSkillProgressionService } from "../skills/skillRuntime.js";
 import type { SkillSnapshot } from "../skills/SkillTypes.js";
 import { STARTER_CRAFTING_RECIPES } from "./StarterRecipes.js";
+import {
+  isWithinAnyStationOfType,
+  getProcessingStationById,
+} from "./ProcessingStations.js";
 import type {
   CraftingRecipe,
   CraftingRecipeSnapshot,
@@ -66,6 +71,8 @@ export class CraftingService {
   async craft(input: {
     playerId: string;
     recipeId: string;
+    playerPosition?: { x: number; y: number };
+    stationId?: string;
   }): Promise<CraftingResult> {
     if (!input.playerId || input.playerId === "anonymous") {
       return {
@@ -84,6 +91,74 @@ export class CraftingService {
         recipeId: input.recipeId,
         reason: "recipe_not_found",
       };
+    }
+
+    // Station proximity check for recipes that require a station
+    if (recipe.stationType) {
+      // Player position is required for station-bound recipes
+      if (!input.playerPosition) {
+        return {
+          ok: false,
+          playerId: input.playerId,
+          recipeId: recipe.id,
+          reason: "missing_player_position",
+        };
+      }
+
+      // Validate player position is finite
+      if (
+        !Number.isFinite(input.playerPosition.x) ||
+        !Number.isFinite(input.playerPosition.y)
+      ) {
+        return {
+          ok: false,
+          playerId: input.playerId,
+          recipeId: recipe.id,
+          reason: "invalid_player_position",
+        };
+      }
+
+      // If stationId provided, verify it matches the required station type
+      if (input.stationId) {
+        const station = getProcessingStationById(input.stationId);
+        if (!station) {
+          return {
+            ok: false,
+            playerId: input.playerId,
+            recipeId: recipe.id,
+            reason: "station_too_far",
+          };
+        }
+        if (station.type !== recipe.stationType) {
+          return {
+            ok: false,
+            playerId: input.playerId,
+            recipeId: recipe.id,
+            reason: "station_type_mismatch",
+          };
+        }
+        // Check if player is within this station's radius
+        const distanceResult = isWithinAnyStationOfType(input.playerPosition, recipe.stationType);
+        if (!distanceResult.withinRange || distanceResult.station?.id !== input.stationId) {
+          return {
+            ok: false,
+            playerId: input.playerId,
+            recipeId: recipe.id,
+            reason: "station_too_far",
+          };
+        }
+      } else {
+        // No stationId provided - find nearest station of required type
+        const distanceResult = isWithinAnyStationOfType(input.playerPosition, recipe.stationType);
+        if (!distanceResult.withinRange) {
+          return {
+            ok: false,
+            playerId: input.playerId,
+            recipeId: recipe.id,
+            reason: "station_too_far",
+          };
+        }
+      }
     }
 
     const skillService = await getSkillProgressionService();

--- a/server/src/crafting/CraftingTypes.ts
+++ b/server/src/crafting/CraftingTypes.ts
@@ -6,6 +6,7 @@
  */
 
 import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+import type { ProcessingStationType } from "./ProcessingStations.js";
 
 export type RecipeId =
   | "craft_wood_plank"
@@ -33,19 +34,26 @@ export interface CraftingRecipe {
   ingredients: RecipeIngredient[];
   outputs: RecipeOutput[];
   craftTicks: number;
+  stationType?: ProcessingStationType;
 }
+
+export type CraftingFailureReason =
+  | "crafted"
+  | "recipe_not_found"
+  | "level_too_low"
+  | "missing_ingredients"
+  | "inventory_full"
+  | "invalid_player"
+  | "missing_player_position"
+  | "invalid_player_position"
+  | "station_too_far"
+  | "station_type_mismatch";
 
 export interface CraftingResult {
   ok: boolean;
   playerId: string;
   recipeId: RecipeId | string;
-  reason?:
-    | "crafted"
-    | "recipe_not_found"
-    | "level_too_low"
-    | "missing_ingredients"
-    | "inventory_full"
-    | "invalid_player";
+  reason?: CraftingFailureReason;
   consumed?: RecipeIngredient[];
   outputs?: RecipeOutput[];
   craftingXpReward?: number;
@@ -59,6 +67,7 @@ export interface CraftingRecipeSnapshot {
   ingredients: RecipeIngredient[];
   outputs: RecipeOutput[];
   craftTicks: number;
+  stationType?: ProcessingStationType;
   craftable: boolean;
-  blockedReason?: "level_too_low" | "missing_ingredients";
+  blockedReason?: "level_too_low" | "missing_ingredients" | "station_too_far" | "missing_player_position";
 }

--- a/server/src/crafting/ProcessingStations.ts
+++ b/server/src/crafting/ProcessingStations.ts
@@ -1,0 +1,161 @@
+/**
+ * PROCESSING STATIONS
+ *
+ * Deterministic processing station definitions for the crafting system.
+ * Stations are world POIs that players must be near to craft certain recipes.
+ *
+ * Rules:
+ * - No Math.random()
+ * - No Date.now()
+ * - Deterministic IDs and positions
+ * - Sorted by ID for deterministic iteration
+ */
+
+export type ProcessingStationType = "campfire" | "furnace" | "workbench";
+
+export interface ProcessingStation {
+  id: string;
+  type: ProcessingStationType;
+  title: string;
+  position: {
+    x: number;
+    y: number;
+  };
+  interactionRadius: number;
+}
+
+export interface StationDistanceResult {
+  withinRange: boolean;
+  distance: number;
+  requiredDistance: number;
+}
+
+/**
+ * Calculate Euclidean distance between two positions.
+ */
+export function calculateDistance(
+  posA: { x: number; y: number },
+  posB: { x: number; y: number }
+): number {
+  const dx = posA.x - posB.x;
+  const dy = posA.y - posB.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Starter Village Processing Stations
+ *
+ * Stations are placed near the starter village center (chunk 0/0).
+ * Position coordinates derived from village layout.
+ */
+export const STARTER_PROCESSING_STATIONS: readonly ProcessingStation[] = [
+  {
+    id: "campfire_001",
+    type: "campfire",
+    title: "Village Campfire",
+    position: {
+      x: 465,
+      y: 506,
+    },
+    interactionRadius: 32,
+  },
+  {
+    id: "furnace_001",
+    type: "furnace",
+    title: "Village Furnace",
+    position: {
+      x: 470,
+      y: 506,
+    },
+    interactionRadius: 32,
+  },
+  {
+    id: "workbench_001",
+    type: "workbench",
+    title: "Village Workbench",
+    position: {
+      x: 468,
+      y: 500,
+    },
+    interactionRadius: 32,
+  },
+] as const;
+
+/**
+ * Get all starter processing stations.
+ */
+export function getStarterProcessingStations(): ProcessingStation[] {
+  return [...STARTER_PROCESSING_STATIONS].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Get a processing station by ID.
+ * Returns undefined if not found.
+ */
+export function getProcessingStationById(stationId: string): ProcessingStation | undefined {
+  return STARTER_PROCESSING_STATIONS.find((s) => s.id === stationId);
+}
+
+/**
+ * Find the nearest processing station of a specific type.
+ * Returns undefined if no station of that type exists.
+ */
+export function findNearestProcessingStation(
+  position: { x: number; y: number },
+  type: ProcessingStationType
+): ProcessingStation | undefined {
+  const stationsOfType = STARTER_PROCESSING_STATIONS.filter((s) => s.type === type);
+  if (stationsOfType.length === 0) return undefined;
+
+  let nearest: ProcessingStation | undefined;
+  let nearestDistance = Infinity;
+
+  for (const station of stationsOfType) {
+    const distance = calculateDistance(position, station.position);
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = station;
+    }
+  }
+
+  return nearest;
+}
+
+/**
+ * Check if a player position is within a station's interaction radius.
+ */
+export function isWithinProcessingStationRadius(
+  playerPosition: { x: number; y: number },
+  station: ProcessingStation
+): StationDistanceResult {
+  const distance = calculateDistance(playerPosition, station.position);
+  return {
+    withinRange: distance <= station.interactionRadius,
+    distance: Math.round(distance * 100) / 100,
+    requiredDistance: station.interactionRadius,
+  };
+}
+
+/**
+ * Check if a player position is within range of any station of a specific type.
+ */
+export function isWithinAnyStationOfType(
+  playerPosition: { x: number; y: number },
+  type: ProcessingStationType
+): StationDistanceResult & { station?: ProcessingStation } {
+  const station = findNearestProcessingStation(playerPosition, type);
+  if (!station) {
+    return {
+      withinRange: false,
+      distance: Infinity,
+      requiredDistance: 32,
+      station: undefined,
+    };
+  }
+
+  const distanceResult = isWithinProcessingStationRadius(playerPosition, station);
+  return {
+    ...distanceResult,
+    station,
+  };
+}

--- a/server/src/crafting/StarterRecipes.ts
+++ b/server/src/crafting/StarterRecipes.ts
@@ -14,6 +14,7 @@ export const STARTER_CRAFTING_RECIPES: readonly CraftingRecipe[] = [
     requiredLevel: 1,
     craftingXpReward: 20,
     craftTicks: 5,
+    stationType: "workbench",
     ingredients: [
       {
         itemId: "wood_log",
@@ -33,6 +34,7 @@ export const STARTER_CRAFTING_RECIPES: readonly CraftingRecipe[] = [
     requiredLevel: 1,
     craftingXpReward: 30,
     craftTicks: 8,
+    stationType: "furnace",
     ingredients: [
       {
         itemId: "copper_ore",
@@ -52,6 +54,7 @@ export const STARTER_CRAFTING_RECIPES: readonly CraftingRecipe[] = [
     requiredLevel: 1,
     craftingXpReward: 15,
     craftTicks: 4,
+    stationType: "campfire",
     ingredients: [
       {
         itemId: "raw_fish",
@@ -71,6 +74,7 @@ export const STARTER_CRAFTING_RECIPES: readonly CraftingRecipe[] = [
     requiredLevel: 1,
     craftingXpReward: 35,
     craftTicks: 8,
+    stationType: "workbench",
     ingredients: [
       { itemId: "wood_plank", quantity: 2 },
       { itemId: "copper_ingot", quantity: 1 },
@@ -85,6 +89,7 @@ export const STARTER_CRAFTING_RECIPES: readonly CraftingRecipe[] = [
     requiredLevel: 1,
     craftingXpReward: 40,
     craftTicks: 10,
+    stationType: "workbench",
     ingredients: [
       { itemId: "wood_plank", quantity: 1 },
       { itemId: "copper_ingot", quantity: 2 },
@@ -99,6 +104,7 @@ export const STARTER_CRAFTING_RECIPES: readonly CraftingRecipe[] = [
     requiredLevel: 1,
     craftingXpReward: 25,
     craftTicks: 6,
+    stationType: "workbench",
     ingredients: [
       { itemId: "wood_plank", quantity: 1 },
       { itemId: "raw_fish", quantity: 1 },

--- a/server/src/routes/craftingRoute.ts
+++ b/server/src/routes/craftingRoute.ts
@@ -3,6 +3,7 @@
  *
  * Server-authoritative crafting API.
  * No Date.now(), no Math.random(), stable recipe ordering.
+ * Requires station proximity for recipes with stationType.
  */
 
 import express, { Router } from "express";
@@ -17,6 +18,21 @@ function parseRecipeId(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   if (!/^[a-zA-Z0-9_-]{1,96}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+function parsePlayerPosition(value: unknown): { x: number; y: number } | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const pos = value as { x?: unknown; y?: unknown };
+  if (typeof pos.x !== "number" || typeof pos.y !== "number") return undefined;
+  if (!Number.isFinite(pos.x) || !Number.isFinite(pos.y)) return undefined;
+  return { x: pos.x, y: pos.y };
+}
+
+function parseStationId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
   return trimmed;
 }
 
@@ -58,6 +74,7 @@ router.get("/recipes", async (req, res) => {
  *
  * Attempt to craft a recipe.
  * Consumes ingredients, adds outputs, grants crafting XP.
+ * Requires playerPosition and stationId for station-bound recipes.
  */
 router.post("/craft", async (req, res) => {
   const identity = resolveHttpPlayerIdentity(req);
@@ -80,10 +97,15 @@ router.post("/craft", async (req, res) => {
     return;
   }
 
+  const playerPosition = parsePlayerPosition(req.body?.playerPosition);
+  const stationId = parseStationId(req.body?.stationId);
+
   try {
     const result = await craftingService.craft({
       playerId: identity.playerId,
       recipeId,
+      playerPosition,
+      stationId,
     });
 
     res.status(result.ok ? 200 : 409).json({

--- a/server/src/routes/gameplaySnapshotUtils.ts
+++ b/server/src/routes/gameplaySnapshotUtils.ts
@@ -148,8 +148,9 @@ export interface CraftingRecipeSnapshot {
   ingredients: CraftingRecipeIngredientSnapshot[];
   outputs: CraftingRecipeOutputSnapshot[];
   craftTicks: number;
+  stationType?: "campfire" | "furnace" | "workbench";
   craftable: boolean;
-  blockedReason?: "level_too_low" | "missing_ingredients";
+  blockedReason?: "level_too_low" | "missing_ingredients" | "station_too_far" | "missing_player_position";
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements processing station requirements for crafting recipes. Players must now be near specific processing stations (campfire, furnace, workbench) to craft certain recipes.

## Changes

### New Files
- `server/src/crafting/ProcessingStations.ts` - Station definitions and proximity checking functions
- `docs/ARELOGIC_PROCESSING_STATIONS_CONTRACT.md` - Full documentation

### Modified Files
- `server/src/crafting/CraftingTypes.ts` - Added `stationType` to recipes and `CraftingFailureReason` types
- `server/src/crafting/StarterRecipes.ts` - Added `stationType` to all recipes
- `server/src/crafting/CraftingService.ts` - Added station proximity validation in the craft method
- `server/src/routes/craftingRoute.ts` - Added `playerPosition` and `stationId` parsing
- `apps/client-2d/src/game/crafting.ts` - Added `playerPosition` to craft requests
- `apps/client-2d/src/ui/windows/CraftingWindow.tsx` - Added station display and feedback

## Station Definitions

| Station ID | Type | Title | Position | Radius |
|------------|------|-------|----------|--------|
| `campfire_001` | campfire | Village Campfire | { x: 465, y: 506 } | 32 |
| `furnace_001` | furnace | Village Furnace | { x: 470, y: 506 } | 32 |
| `workbench_001` | workbench | Village Workbench | { x: 468, y: 500 } | 32 |

## Recipe Station Requirements

| Recipe | Station Required |
|--------|-----------------|
| `cook_raw_fish` | campfire |
| `smelt_copper_ingot` | furnace |
| `craft_wood_plank` | workbench |
| `craft_wooden_axe` | workbench |
| `craft_copper_pickaxe` | workbench |
| `craft_simple_fishing_rod` | workbench |

## Verification

After this PR:
1. Crafting far from stations fails with `station_too_far`
2. Crafting near correct station succeeds
3. Client shows station requirements per recipe
4. Fail does not mutate inventory/wallet/quest state

## PRs in Chain
- Follows #1787 (Resource Processing Economy Loop)
- Part of the World POI effort (see docs/ROADMAP_TO_RELEASE.md)

---

*PR created by OpenHands from conversation #642f4401351f4f33ace76cb9b7712107*

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9e848973-ca4a-4fb5-ac60-96fc842eb118)