### PR TITLE
fix: allow Stitch UI blueprint validation

### DIFF
--- a/scripts/validate-pixi-assets.mjs
+++ b/scripts/validate-pixi-assets.mjs
@@ -85,6 +85,17 @@ function isAllowedPackDocumentation(relative, extension) {
   );
 }
 
+function isAllowedStitchUiBlueprint(relative, extension) {
+  const basename = path.basename(relative).toLowerCase();
+  return (
+    relative.startsWith('game-assets/')
+    && (
+      (basename === 'code.html' && extension === '.html')
+      || extension === '.md'
+    )
+  );
+}
+
 function assertUrlDrift(pack, metadata, allowlist, errors) {
   if (!metadata) {
     errors.push(`Missing source metadata for pack ${pack.id}`);
@@ -149,7 +160,7 @@ async function main() {
       continue;
     }
 
-    if (isIgnoredStagingFile(relative) || isAllowedPackDocumentation(relative, extension)) {
+    if (isIgnoredStagingFile(relative) || isAllowedPackDocumentation(relative, extension) || isAllowedStitchUiBlueprint(relative, extension)) {
       continue;
     }
 


### PR DESCRIPTION
Fixes the Pixi asset validation failure after the Stitch asset import.

The validator still blocks arbitrary unsupported files, but now allows Stitch UI blueprint files only under game-assets:
- code.html
- markdown docs

This keeps HTML out of world spawning while letting the imported UI blueprints exist as preview/reference assets.