### PR TITLE
feat: add chat button to HUD and fix NPC dialogue choices

### DIFF
--- a/apps/client-2d/src/ArelorianStitchHud.tsx
+++ b/apps/client-2d/src/ArelorianStitchHud.tsx
@@ -81,6 +81,9 @@ const panels: { id: Exclude<HudPanel, null>; label: string; icon: string; shortc
   { id: "resources", label: "Resources", icon: "⛏", shortcut: "r" },
 ];
 
+// Chat button for side menu
+const chatPanelBtn = { id: "chat" as HudPanel, label: "Chat", icon: "💬", shortcut: "t" };
+
 const overlays: { id: HudOverlay; label: string; short: string }[] = [
   { id: "vitals", label: "Vitals", short: "HP" },
   { id: "radar", label: "Radar", short: "MAP" },
@@ -365,6 +368,16 @@ export function ArelorianStitchHud({
             <small>{panel.label}</small>
           </button>
         ))}
+        {/* Chat button in side menu */}
+        <button
+          className={openOverlays.chat ? "active" : ""}
+          onClick={() => toggleOverlay("chat")}
+          title="Chat [T]"
+          aria-pressed={openOverlays.chat}
+        >
+          <span>{chatPanelBtn.icon}</span>
+          <small>{chatPanelBtn.label}</small>
+        </button>
       </aside>
 
       <section className="stitch-radar" aria-label="Radar Sensor">

--- a/server/src/modules/npc/NPCSystem.ts
+++ b/server/src/modules/npc/NPCSystem.ts
@@ -235,11 +235,109 @@ export class NPCSystem {
     public handleChoice(npcId: string, nodeId: string, choiceId: string, player: any): any {
         const npc = this.getNPC(npcId);
         if (!npc) return null;
+
+        // Process the choice based on choiceId
+        let responseText: string;
+        let newChoices: Array<{ id: string; text: string }> = [];
+
+        switch (choiceId) {
+            case "greet":
+                responseText = "Good to see you, traveler.";
+                newChoices = [
+                    { id: "browse", text: "Browse wares" },
+                    { id: "farewell", text: "Farewell" },
+                ];
+                break;
+            case "farewell":
+                responseText = "Safe travels, friend.";
+                newChoices = [];
+                break;
+            case "browse":
+            case "trade":
+                responseText = "Take a look at what I have.";
+                newChoices = [
+                    { id: "buy", text: "Buy item" },
+                    { id: "sell", text: "Sell item" },
+                    { id: "farewell", text: "Leave" },
+                ];
+                break;
+            case "buy":
+            case "sell":
+                responseText = "What would you like to trade?";
+                newChoices = [
+                    { id: "confirm", text: "Confirm trade" },
+                    { id: "cancel", text: "Cancel" },
+                ];
+                break;
+            case "rest":
+                responseText = "The room is yours for as long as you need.";
+                newChoices = [{ id: "farewell", text: "Leave room" }];
+                break;
+            case "eat":
+                responseText = "Enjoy this meal.";
+                newChoices = [{ id: "farewell", text: "Thank you" }];
+                break;
+            case "gossip":
+                responseText = "Word is there's trouble brewing beyond the village walls.";
+                newChoices = [
+                    { id: "quest", text: "Tell me more" },
+                    { id: "farewell", text: "Farewell" },
+                ];
+                break;
+            case "quest":
+                responseText = "I hear creatures are stirring near the old ruins.";
+                newChoices = [{ id: "accept", text: "I'll investigate" }, { id: "farewell", text: "Not interested" }];
+                break;
+            case "accept":
+                responseText = "Good luck, brave traveler.";
+                newChoices = [];
+                break;
+            case "repair":
+            case "forge":
+            case "upgrade":
+                responseText = "I can work on that for you.";
+                newChoices = [
+                    { id: "confirm", text: "Proceed" },
+                    { id: "farewell", text: "Maybe later" },
+                ];
+                break;
+            case "confirm":
+                responseText = "Consider it done.";
+                newChoices = [{ id: "farewell", text: "Thank you" }];
+                break;
+            case "cancel":
+            case "decline":
+                responseText = "Another time perhaps.";
+                newChoices = [{ id: "farewell", text: "Farewell" }];
+                break;
+            case "heal":
+                responseText = "Let me tend to your wounds.";
+                newChoices = [{ id: "farewell", text: "Thank you" }];
+                break;
+            case "bless":
+            case "pray":
+                responseText = "May the light protect you.";
+                newChoices = [{ id: "farewell", text: "Amen" }];
+                break;
+            case "report":
+                responseText = "Report anything unusual to the guard captain.";
+                newChoices = [{ id: "farewell", text: "Understood" }];
+                break;
+            case "advice":
+                responseText = "Stay away from the dark forest at night.";
+                newChoices = [{ id: "farewell", text: "I will" }];
+                break;
+            default:
+                responseText = "I understand.";
+                newChoices = [{ id: "farewell", text: "Farewell" }];
+        }
+
         return {
             source: npc.name || "NPC",
-            text: "You chose wisely.",
-            choices: [],
-            npcId
+            text: responseText,
+            choices: newChoices,
+            npcId,
+            lastChoice: choiceId,
         };
     }
 


### PR DESCRIPTION
## Summary

### HUD Enhancement
- Added chat button to side menu with icon 💬 and shortcut `T`
- Chat overlay can now be toggled from both the side menu and bottom bar

### NPC Dialogue Fix
- Fixed `NPCSystem.handleChoice` to properly process all dialogue choices
- Added response text and follow-up choices for all NPC interactions:
  - **greet, farewell** - Basic conversation flow
  - **browse, trade, buy, sell** - Merchant interactions
  - **rest, eat, gossip, quest, accept** - Innkeeper/Provisioner interactions
  - **repair, forge, upgrade, confirm, cancel, decline** - Smith interactions
  - **heal, bless, pray** - Healer interactions
  - **report, advice** - Guard interactions

- NPC conversations now have proper flow with contextual responses

## Files Changed
- `apps/client-2d/src/ArelorianStitchHud.tsx` - Added chat button to side menu
- `server/src/modules/npc/NPCSystem.ts` - Fixed handleChoice to process all dialogue choices

## Testing
- Build passes: `pnpm run build`
- Lint passes: `npx eslint server/src apps/client-2d/src`

This ensures NPCs provide meaningful dialogue responses when players interact with them and select choices.

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cdcb0b10-c4b7-410f-a61f-fe7cdd6b7aac)