### PR TITLE
fix(loot): convert CommonJS require() to ESM import

### DIFF
--- a/server/src/loot/DeterministicRng.ts
+++ b/server/src/loot/DeterministicRng.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-const crypto = require('node:crypto');
+import crypto from 'node:crypto';
 
 class DeterministicRng {
   private state: number;

--- a/server/src/loot/LootAxioms.ts
+++ b/server/src/loot/LootAxioms.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-const crypto = require('node:crypto');
+import crypto from 'node:crypto';
 
 const LootAxioms = Object.freeze({
   VERSION: 'ARE_LOOT_AXIOMS_V3_MUTATION',


### PR DESCRIPTION
## Summary

Fixes **502 Bad Gateway** on `arelorian.de/2d/` — the game engine container was crash-looping with `ERR_AMBIGUOUS_MODULE_SYNTAX`.

## Root Cause

`DeterministicRng.ts` and `LootAxioms.ts` used CommonJS `require('node:crypto')` but were transpiled as ESM format (`format: 'esm'` in esbuild). When `characterRuntime.ts` added top-level `await` (commit `9082d66b`), Node.js could no longer determine the module format, causing the crash loop.

## Fix

Converted both files from:
```typescript
const crypto = require('node:crypto');
```
to:
```typescript
import crypto from 'node:crypto';
```

## Files Changed
- `server/src/loot/DeterministicRng.ts`
- `server/src/loot/LootAxioms.ts`

## Verification

1. Check container no longer crash-loops: `docker ps` should show `Up X minutes`
2. Health endpoint responds: `curl http://127.0.0.1:3001/health`
3. Site `arelorian.de/2d/` loads without 502

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bd2f0b34-5594-4075-b96e-ce92241072a8)