### PR TITLE
feat(client-2d): make inventory and paperdoll server-backed

### DIFF
--- a/apps/client-2d/src/game/equipment.ts
+++ b/apps/client-2d/src/game/equipment.ts
@@ -97,6 +97,30 @@ export async function equipGatheringTool(itemId: string): Promise<{
 }
 
 /**
+ * Unequip a gathering tool from a slot.
+ * Server validates ownership.
+ */
+export async function unequipGatheringTool(slotId: string): Promise<{
+  ok: boolean;
+  result?: {
+    ok: boolean;
+    playerId: string;
+    slotId: string;
+    reason?: string;
+  };
+}> {
+  const response = await fetch("/api/equipment/unequip", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ slotId }),
+  });
+
+  return response.json();
+}
+
+/**
  * Get current player equipment state from server.
  */
 export async function fetchEquipmentState(): Promise<{

--- a/apps/client-2d/src/ui/windows/InventoryPanel.tsx
+++ b/apps/client-2d/src/ui/windows/InventoryPanel.tsx
@@ -14,6 +14,7 @@
  * - Client cannot set inventory directly
  * - After equip, refetches snapshot to update equipment/paperdoll display
  * - After sell, refetches snapshot to update inventory and wallet
+ * - After unequip, refetches snapshot to update inventory and equipment
  */
 
 import React, { useCallback, useMemo } from "react";
@@ -25,7 +26,7 @@ import type {
   VendorPriceItemSnapshot,
 } from "../../game/liveGameplaySnapshot";
 import { getVendorPriceForItem } from "../../game/liveGameplaySnapshot";
-import { equipGatheringTool } from "../../game/equipment";
+import { equipGatheringTool, unequipGatheringTool } from "../../game/equipment";
 import { fetchGameplaySnapshot, liveGameplayStore, DEFAULT_GAMEPLAY_PLAYER_ID } from "../../game/liveGameplayStore";
 import { getGatheringToolIcon, isGatheringTool } from "../utils/ItemIconMapper";
 import { dispatchSellResource, dispatchSellAllResources } from "../../game/gameplayActions";
@@ -140,6 +141,16 @@ export function InventoryPanel({ inventory, equipment, wallet, vendorEconomy }: 
     [getPriceInfo],
   );
 
+  /**
+   * Refetch snapshot after mutating actions.
+   */
+  const refetchSnapshot = useCallback(async () => {
+    const next = await fetchGameplaySnapshot(DEFAULT_GAMEPLAY_PLAYER_ID);
+    if (next) {
+      liveGameplayStore.setSnapshot(next);
+    }
+  }, []);
+
   const handleEquip = useCallback(
     async (itemId: string) => {
       const result = await equipGatheringTool(itemId);
@@ -155,10 +166,7 @@ export function InventoryPanel({ inventory, equipment, wallet, vendorEconomy }: 
         );
 
         // Refetch snapshot to update equipment/paperdoll display
-        const next = await fetchGameplaySnapshot(DEFAULT_GAMEPLAY_PLAYER_ID);
-        if (next) {
-          liveGameplayStore.setSnapshot(next);
-        }
+        await refetchSnapshot();
       } else {
         window.dispatchEvent(
           new CustomEvent("wasd:toast", {
@@ -170,7 +178,37 @@ export function InventoryPanel({ inventory, equipment, wallet, vendorEconomy }: 
         );
       }
     },
-    [],
+    [refetchSnapshot],
+  );
+
+  const handleUnequip = useCallback(
+    async (slotId: string) => {
+      const result = await unequipGatheringTool(slotId);
+
+      if (result.ok && result.result?.ok) {
+        window.dispatchEvent(
+          new CustomEvent("wasd:toast", {
+            detail: {
+              type: "success",
+              message: "Tool unequipped",
+            },
+          }),
+        );
+
+        // Refetch snapshot to update equipment/paperdoll display
+        await refetchSnapshot();
+      } else {
+        window.dispatchEvent(
+          new CustomEvent("wasd:toast", {
+            detail: {
+              type: "error",
+              message: `Unequip failed: ${result.result?.reason ?? "unknown"}`,
+            },
+          }),
+        );
+      }
+    },
+    [refetchSnapshot],
   );
 
   const handleSell = useCallback(
@@ -275,12 +313,21 @@ export function InventoryPanel({ inventory, equipment, wallet, vendorEconomy }: 
               {equipped.map((slot) => {
                 const iconPath = getGatheringToolIcon(slot.itemId);
                 return (
-                  <div key={slot.slotId} className={`equipped-slot rarity-${TOOL_RARITY[slot.itemId] ?? "common"}`}>
+                  <div key={slot.slotId} className={`equipped-slot rarity-${TOOL_RARITY[slot.itemId] ?? "common"}`} data-testid={`equipment-slot-${slot.slotId}`}>
                     {iconPath && (
                       <img src={iconPath} alt={slot.title} className="tool-svg-icon" />
                     )}
                     <span className="slot-label">{SLOT_LABELS[slot.slotId] ?? slot.slotId}:</span>
                     <span className="item-name">{slot.title}</span>
+                    <button
+                      type="button"
+                      className="unequip-button"
+                      onClick={() => handleUnequip(slot.slotId)}
+                      data-testid={`unequip-slot-${slot.slotId}`}
+                      title={`Unequip ${slot.title}`}
+                    >
+                      ✕
+                    </button>
                   </div>
                 );
               })}
@@ -300,6 +347,7 @@ export function InventoryPanel({ inventory, equipment, wallet, vendorEconomy }: 
                     type="button"
                     className={`tool-button rarity-${TOOL_RARITY[slot.itemId] ?? "common"}`}
                     onClick={() => handleEquip(slot.itemId)}
+                    data-testid={`equip-item-${slot.itemId}`}
                     title={`Equip ${slot.name}`}
                   >
                     {iconPath && (

--- a/docs/CHARACTER_PAPERDOLL.md
+++ b/docs/CHARACTER_PAPERDOLL.md
@@ -160,3 +160,129 @@ Character and paperdoll are included in `/api/gameplay/snapshot`:
 
 - `server/src/tests/character-store.test.ts` - Unit tests
 - `e2e/character-profile.spec.ts` - E2E tests
+
+## Equipment System (2026-06-09)
+
+The equipment system provides server-authoritative equip/unequip functionality.
+
+### API Endpoints
+
+#### GET /api/equipment/state
+
+Get current player equipment state.
+
+**Response:**
+```json
+{
+  "ok": true,
+  "playerId": "player_123",
+  "equipment": {
+    "playerId": "player_123",
+    "schemaVersion": 1,
+    "slots": [
+      { "slotId": "woodcutting_tool", "itemId": "wooden_axe", "title": "Wooden Axe", "tier": 1 }
+    ]
+  }
+}
+```
+
+#### POST /api/equipment/equip
+
+Equip an item from inventory.
+
+**Request:**
+```json
+{ "itemId": "wooden_axe" }
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "result": {
+    "ok": true,
+    "playerId": "player_123",
+    "itemId": "wooden_axe",
+    "reason": "equipped",
+    "equipment": { ... }
+  }
+}
+```
+
+#### POST /api/equipment/unequip
+
+Unequip an item from a slot.
+
+**Request:**
+```json
+{ "slotId": "woodcutting_tool" }
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "result": {
+    "ok": true,
+    "playerId": "player_123",
+    "slotId": "woodcutting_tool",
+    "reason": "unequipped",
+    "equipment": { ... }
+  }
+}
+```
+
+### Fail Reasons
+
+| Reason | Description |
+|--------|-------------|
+| `invalid_item` | Item ID is not a valid equipment item |
+| `item_not_owned` | Player does not own this item in inventory |
+| `invalid_player` | Player ID is invalid (anonymous) |
+| `invalid_slot` | Slot ID is not a valid equipment slot |
+| `slot_empty` | No item equipped in the specified slot |
+
+### Equipment Slots
+
+| Slot ID | Skill | Example Items |
+|---------|-------|----------------|
+| `woodcutting_tool` | Woodcutting | wooden_axe, copper_axe |
+| `mining_tool` | Mining | copper_pickaxe, reinforced_pickaxe |
+| `fishing_tool` | Fishing | simple_fishing_rod, reinforced_fishing_rod |
+
+### Client Integration
+
+```typescript
+import { equipGatheringTool, unequipGatheringTool, fetchEquipmentState } from "./game/equipment";
+
+// Equip a tool
+const result = await equipGatheringTool("wooden_axe");
+
+// Unequip a tool
+const result = await unequipGatheringTool("woodcutting_tool");
+
+// Fetch current equipment state
+const result = await fetchEquipmentState();
+```
+
+### Test IDs
+
+| Test ID | Element |
+|---------|---------|
+| `inventory-panel-live` | Main inventory panel |
+| `inventory-panel-empty` | Empty inventory state |
+| `wallet-balance` | Coin balance display |
+| `equipment-slot-{slotId}` | Equipped item in slot |
+| `unequip-slot-{slotId}` | Unequip button for slot |
+| `equip-item-{itemId}` | Equip button for item |
+| `sell-resource-button` | Sell individual resource |
+| `sell-all-resources-button` | Sell all resources |
+
+### Files
+
+- `server/src/routes/equipmentRoute.ts` - REST endpoints
+- `server/src/equipment/EquipmentService.ts` - Equipment service
+- `server/src/equipment/EquipmentStore.ts` - In-memory store
+- `server/src/equipment/EquipmentTypes.ts` - Types and definitions
+- `apps/client-2d/src/game/equipment.ts` - Client API functions
+- `apps/client-2d/src/ui/windows/InventoryPanel.tsx` - Inventory UI

--- a/server/src/routes/equipmentRoute.ts
+++ b/server/src/routes/equipmentRoute.ts
@@ -15,6 +15,7 @@ import { Router } from "express";
 import { json } from "express";
 import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
 import { equipmentService } from "../equipment/equipmentRuntime.js";
+import { EQUIPMENT_DEFINITIONS } from "../equipment/EquipmentTypes.js";
 
 const router = Router();
 
@@ -93,6 +94,56 @@ router.post("/equip", async (req, res) => {
     });
   } catch (error) {
     console.error("[equipment-equip] Failed to equip item:", error);
+    res.status(500).json({
+      ok: false,
+      error: "internal_error",
+    });
+  }
+});
+
+/**
+ * POST /api/equipment/unequip
+ *
+ * Unequip an item from a slot.
+ * Requires authenticated player in production.
+ */
+router.post("/unequip", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+
+  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    res.status(401).json({ ok: false, error: "authenticated_player_required" });
+    return;
+  }
+
+  const slotId = parseItemId(req.body?.slotId);
+
+  if (!slotId) {
+    res.status(400).json({ ok: false, error: "invalid_slot_id" });
+    return;
+  }
+
+  // Validate slotId is a known equipment slot
+  const validSlots = Object.keys(EQUIPMENT_DEFINITIONS).map(
+    (itemId) => EQUIPMENT_DEFINITIONS[itemId as keyof typeof EQUIPMENT_DEFINITIONS].slotId
+  );
+  const uniqueSlots = [...new Set(validSlots)];
+  if (!uniqueSlots.includes(slotId as any)) {
+    res.status(400).json({ ok: false, error: "invalid_slot" });
+    return;
+  }
+
+  try {
+    const result = await equipmentService.unequipItem({
+      playerId: identity.playerId,
+      slotId: slotId as any,
+    });
+
+    res.status(result.ok ? 200 : 409).json({
+      ok: result.ok,
+      result,
+    });
+  } catch (error) {
+    console.error("[equipment-unequip] Failed to unequip item:", error);
     res.status(500).json({
       ok: false,
       error: "internal_error",


### PR DESCRIPTION
## Summary

Make inventory and paperdoll fully playable with server-authoritative equip/unequip.

## Changes

### Server

- **server/src/routes/equipmentRoute.ts**: Added `POST /api/equipment/unequip` endpoint
  - Validates slot ID against known equipment slots
  - Calls `equipmentService.unequipItem()`
  - Returns result with updated equipment state

### Client

- **apps/client-2d/src/game/equipment.ts**: Added `unequipGatheringTool()` function
  - POSTs to `/api/equipment/unequip` with slotId
  - Returns result object with success/failure

- **apps/client-2d/src/ui/windows/InventoryPanel.tsx**: Added unequip functionality
  - Added unequip buttons next to equipped items
  - Added `handleUnequip()` callback
  - Added `refetchSnapshot()` helper for consistent state updates
  - Added test IDs: `equipment-slot-{slotId}`, `unequip-slot-{slotId}`, `equip-item-{itemId}`

### Docs

- **docs/CHARACTER_PAPERDOLL.md**: Documented equipment system API
  - Equipment slots table
  - API endpoint specifications
  - Fail reasons
  - Client integration example
  - Test IDs

## Features

- ✅ Open inventory and see real items
- ✅ See equipment slots with equipped items
- ✅ Equip a gathering tool through server-backed intent
- ✅ Unequip a gathering tool through server-backed intent
- ✅ See paperdoll update after equip/unequip
- ✅ Test IDs for E2E verification

## Server Contract

```
POST /api/equipment/unequip
Body: { "slotId": "woodcutting_tool" }

Response:
{
  "ok": true,
  "result": {
    "ok": true,
    "playerId": "player_123",
    "slotId": "woodcutting_tool",
    "reason": "unequipped",
    "equipment": { ... }
  }
}
```

## Test IDs

| Test ID | Element |
|---------|---------|
| `inventory-panel-live` | Main inventory panel |
| `inventory-panel-empty` | Empty inventory state |
| `equipment-slot-{slotId}` | Equipped item display |
| `unequip-slot-{slotId}` | Unequip button |
| `equip-item-{itemId}` | Equip button |

## Determinism

- No Math.random()
- No Date.now()
- Server-authoritative mutations
- Validation before mutation
- Stable slot ordering

## Verification

- Build: `pnpm --filter @wasd/shared build`
- CI: `pnpm run ci:verify`
- E2E: `pnpm run test:e2e:ci`

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/56a13281-b4b8-4a28-9bb0-cf6d9de00b39)