### PR TITLE
feat(quests): add NPC resource economy quest loop

### DIFF
--- a/apps/client-2d/src/theme.css
+++ b/apps/client-2d/src/theme.css
@@ -269,3 +269,389 @@ canvas { display: block; filter: saturate(1.16) contrast(1.08); touch-action: no
     height: 48px;
   }
 }
+
+/* ─── Cyber-Zen NPC Dialogue Panel ──────────────────────────────────────────── */
+
+.cz-npc-panel {
+  width: 100%;
+  max-width: 380px;
+  border: 1px solid rgba(0, 229, 255, 0.28);
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(4, 8, 14, 0.92), rgba(13, 18, 33, 0.88));
+  box-shadow: 0 0 28px rgba(0, 229, 255, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(12px);
+  overflow: hidden;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* NPC Memory Block */
+.cz-npc-memory {
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(0, 229, 255, 0.18);
+  background: linear-gradient(135deg, rgba(0, 229, 255, 0.08), rgba(103, 92, 255, 0.06));
+}
+
+.cz-npc-memory-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--st-aether);
+}
+
+.cz-npc-sigil {
+  font-size: 14px;
+  color: var(--cz-aura);
+}
+
+.cz-npc-label {
+  font-weight: 800;
+}
+
+.cz-npc-memory-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cz-npc-identity {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.cz-npc-name {
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cz-text);
+  text-shadow: 0 0 12px rgba(0, 229, 255, 0.3);
+}
+
+/* Trust Tier Badges */
+.cz-trust-badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.trust-tier--honored {
+  border: 1px solid rgba(139, 92, 246, 0.6);
+  background: rgba(139, 92, 246, 0.2);
+  color: #a78bfa;
+  box-shadow: 0 0 14px rgba(139, 92, 246, 0.3);
+}
+
+.trust-tier--trusted {
+  border: 1px solid rgba(57, 255, 20, 0.5);
+  background: rgba(57, 255, 20, 0.15);
+  color: var(--st-emerald);
+  box-shadow: 0 0 10px rgba(57, 255, 20, 0.2);
+}
+
+.trust-tier--neutral {
+  border: 1px solid rgba(0, 229, 255, 0.4);
+  background: rgba(0, 229, 255, 0.1);
+  color: var(--st-aether);
+}
+
+.trust-tier--cold {
+  border: 1px solid rgba(100, 116, 139, 0.5);
+  background: rgba(100, 116, 139, 0.15);
+  color: #94a3b8;
+}
+
+.trust-tier--hostile {
+  border: 1px solid rgba(255, 63, 111, 0.5);
+  background: rgba(255, 63, 111, 0.15);
+  color: var(--st-ruby);
+  box-shadow: 0 0 10px rgba(255, 63, 111, 0.2);
+}
+
+/* Reputation Row */
+.cz-npc-rep-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--cz-muted);
+}
+
+.cz-npc-rep-label {
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  color: rgba(244, 247, 255, 0.5);
+}
+
+.cz-npc-rep-value {
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--st-aether);
+  text-shadow: 0 0 14px rgba(0, 229, 255, 0.4);
+}
+
+.cz-npc-quest-count {
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(139, 92, 246, 0.2);
+  border: 1px solid rgba(139, 92, 246, 0.4);
+  font-size: 10px;
+  color: #a78bfa;
+}
+
+/* Memory Note */
+.cz-npc-memory-note {
+  margin-top: 6px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: rgba(244, 247, 255, 0.7);
+  text-transform: uppercase;
+}
+
+/* Dialogue State */
+.cz-npc-dialogue-state {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  border-bottom: 1px solid rgba(0, 229, 255, 0.1);
+  background: rgba(0, 0, 0, 0.2);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.cz-npc-dialogue-label {
+  color: rgba(244, 247, 255, 0.5);
+  font-weight: 600;
+}
+
+.cz-npc-dialogue-value {
+  color: var(--st-gold);
+  font-weight: 700;
+}
+
+/* NPC Dialogue Line */
+.cz-npc-line {
+  padding: 14px 16px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: rgba(244, 247, 255, 0.85);
+  border-bottom: 1px solid rgba(0, 229, 255, 0.1);
+}
+
+.cz-npc-line p {
+  margin: 0;
+}
+
+/* Quest Tracker */
+.cz-quest-tracker {
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(0, 229, 255, 0.1);
+}
+
+.cz-quest-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.cz-quest-label {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(0, 229, 255, 0.15);
+  border: 1px solid rgba(0, 229, 255, 0.3);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  color: var(--st-aether);
+}
+
+.cz-quest-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cz-text);
+}
+
+/* Quest Objectives */
+.cz-quest-objectives {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cz-quest-objective {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 11px;
+}
+
+.cz-quest-objective.completed {
+  background: rgba(57, 255, 20, 0.08);
+  border-color: rgba(57, 255, 20, 0.25);
+}
+
+.cz-quest-check {
+  font-size: 14px;
+  color: var(--st-emerald);
+  text-shadow: 0 0 8px var(--st-emerald);
+}
+
+.cz-quest-objective:not(.completed) .cz-quest-check {
+  color: rgba(244, 247, 255, 0.4);
+  text-shadow: none;
+}
+
+.cz-quest-objective-title {
+  flex: 1;
+  color: rgba(244, 247, 255, 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cz-quest-objective.completed .cz-quest-objective-title {
+  color: var(--st-emerald);
+}
+
+.cz-quest-progress {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--st-aether);
+  font-family: ui-monospace, monospace;
+}
+
+/* Quest Rewards */
+.cz-quest-reward {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(255, 215, 106, 0.08), rgba(0, 229, 255, 0.06));
+  border: 1px solid rgba(255, 215, 106, 0.2);
+}
+
+.cz-reward-label {
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  color: var(--st-gold);
+}
+
+.cz-reward-item {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(244, 247, 255, 0.75);
+}
+
+.cz-reward-rep {
+  background: rgba(139, 92, 246, 0.15);
+  color: #a78bfa;
+}
+
+/* Action Buttons */
+.cz-npc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 16px;
+}
+
+.cz-action-btn {
+  flex: 1;
+  min-width: 100px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.cz-action-btn--accept {
+  border: 1px solid rgba(0, 229, 255, 0.5);
+  background: linear-gradient(135deg, rgba(0, 229, 255, 0.2), rgba(103, 92, 255, 0.15));
+  color: var(--st-aether);
+  box-shadow: 0 0 14px rgba(0, 229, 255, 0.15);
+}
+
+.cz-action-btn--accept:hover {
+  background: linear-gradient(135deg, rgba(0, 229, 255, 0.35), rgba(103, 92, 255, 0.25));
+  box-shadow: 0 0 20px rgba(0, 229, 255, 0.3);
+  transform: translateY(-1px);
+}
+
+.cz-action-btn--complete {
+  border: 1px solid rgba(57, 255, 20, 0.5);
+  background: linear-gradient(135deg, rgba(57, 255, 20, 0.2), rgba(0, 229, 255, 0.15));
+  color: var(--st-emerald);
+  box-shadow: 0 0 14px rgba(57, 255, 20, 0.2);
+}
+
+.cz-action-btn--complete:hover {
+  background: linear-gradient(135deg, rgba(57, 255, 20, 0.35), rgba(0, 229, 255, 0.25));
+  box-shadow: 0 0 20px rgba(57, 255, 20, 0.35);
+  transform: translateY(-1px);
+}
+
+.cz-action-btn--talk {
+  border: 1px solid rgba(255, 215, 106, 0.4);
+  background: linear-gradient(135deg, rgba(255, 215, 106, 0.15), rgba(139, 92, 246, 0.1));
+  color: var(--st-gold);
+}
+
+.cz-action-btn--talk:hover {
+  background: linear-gradient(135deg, rgba(255, 215, 106, 0.25), rgba(139, 92, 246, 0.2));
+  box-shadow: 0 0 16px rgba(255, 215, 106, 0.25);
+}
+
+.cz-action-btn:active {
+  transform: scale(0.97);
+}
+
+/* Mobile Responsive */
+@media (max-width: 520px) {
+  .cz-npc-panel {
+    max-width: 100%;
+    border-radius: 14px;
+  }
+
+  .cz-npc-actions {
+    flex-direction: column;
+  }
+
+  .cz-action-btn {
+    width: 100%;
+  }
+}

--- a/apps/client-2d/src/ui/windows/NpcDialoguePanel.tsx
+++ b/apps/client-2d/src/ui/windows/NpcDialoguePanel.tsx
@@ -1,7 +1,8 @@
 /**
  * NPC Dialogue Panel
  *
- * Displays NPC dialogue and quest interactions for the resource economy loop.
+ * Displays NPC dialogue, quest interactions, and memory/reputation for the resource economy loop.
+ * Cyber-Zen styled panel using Arelorian Stitch design system.
  * Server-authoritative, display-only.
  * Uses test IDs for E2E testing.
  */
@@ -21,6 +22,45 @@ interface NpcDialoguePanelProps {
   onCompleteQuest?: (questId: string) => void;
   /** Called when player wants to talk to NPC */
   onTalkToNpc?: (npcId: string) => void;
+}
+
+/**
+ * Trust tier based on reputation value.
+ * Maps reputation number to visual trust state.
+ */
+function getTrustTier(reputation: number): { tier: string; cssClass: string; label: string } {
+  if (reputation >= 5) return { tier: "honored", cssClass: "trust-tier--honored", label: "HONORED" };
+  if (reputation >= 3) return { tier: "trusted", cssClass: "trust-tier--trusted", label: "TRUSTED" };
+  if (reputation >= 1) return { tier: "neutral", cssClass: "trust-tier--neutral", label: "NEUTRAL" };
+  if (reputation <= -1) return { tier: "cold", cssClass: "trust-tier--cold", label: "COLD" };
+  if (reputation <= -3) return { tier: "hostile", cssClass: "trust-tier--hostile", label: "HOSTILE" };
+  return { tier: "unknown", cssClass: "trust-tier--neutral", label: "UNKNOWN" };
+}
+
+/**
+ * Get memory note based on dialogue state.
+ * Deterministic: no random text, uses server state.
+ */
+function getMemoryNote(dialogueState: string, completedQuestIds: readonly string[]): string {
+  if (completedQuestIds.includes("village_supply_order_001")) {
+    return "VALUED SUPPLIER // COMPLETED ORDER";
+  }
+  switch (dialogueState) {
+    case "quest_ready_to_complete":
+      return "AWAITING COMPLETION // SUPPLY READY";
+    case "quest_active_ready_to_sell":
+      return "PROCESSING ACTIVE // PLANK PENDING";
+    case "quest_active_ready_to_process":
+      return "GATHERING COMPLETE // PROCESSING NEEDED";
+    case "quest_active_missing_wood":
+      return "ORDER PENDING // WOOD NEEDED";
+    case "quest_available":
+      return "TRADE ACTIVE // OPEN TO BUSINESS";
+    case "quest_completed":
+      return "VERIFIED TRUSTWORTHY // MEMORY LOCKED";
+    default:
+      return "STANDBY // STATE SYNC";
+  }
 }
 
 export function NpcDialoguePanel({
@@ -52,83 +92,107 @@ export function NpcDialoguePanel({
   const showAcceptButton = miraAvailableQuest !== undefined;
   const showCompleteButton = miraActiveQuest?.state === "ready_to_complete";
 
+  // Get trust tier for visual state
+  const trustInfo = getTrustTier(miraReputation?.reputation ?? 0);
+  const memoryNote = getMemoryNote(miraDialogue?.dialogueState ?? "quest_available", completedQuestIds);
+
   return (
-    <div className="npc-dialogue-panel" data-testid="npc-dialogue-village_trader_001">
-      {/* NPC Name and Reputation */}
-      <header className="npc-dialogue-header">
-        <h3 data-testid="npc-name-village_trader_001">
-          {miraDialogue?.displayName ?? "Mira the Quartermaster"}
-        </h3>
-        {miraReputation && (
-          <span
-            className="npc-reputation-badge"
-            data-testid={`npc-reputation-village_trader_001`}
-            title={`Reputation: ${miraReputation.reputation}`}
-          >
-            ★ {miraReputation.reputation}
-          </span>
-        )}
-      </header>
+    <div className="cz-npc-panel" data-testid="npc-dialogue-village_trader_001">
+      {/* NPC Memory Block - Cyber-Zen styled */}
+      <div className="cz-npc-memory" data-testid={`npc-memory-village_trader_001`}>
+        <div className="cz-npc-memory-header">
+          <span className="cz-npc-sigil">◈</span>
+          <span className="cz-npc-label">MEMORY</span>
+        </div>
+        <div className="cz-npc-memory-content">
+          <div className="cz-npc-identity">
+            <span className="cz-npc-name" data-testid="npc-name-village_trader_001">
+              {miraDialogue?.displayName ?? "MIRA THE QUARTERMASTER"}
+            </span>
+            <span className={`cz-trust-badge ${trustInfo.cssClass}`} data-testid={`npc-trust-tier-village_trader_001`}>
+              {trustInfo.label}
+            </span>
+          </div>
+          <div className="cz-npc-rep-row">
+            <span className="cz-npc-rep-label">REP</span>
+            <span className="cz-npc-rep-value" data-testid={`npc-reputation-village_trader_001`}>
+              {miraReputation?.reputation ?? 0}
+            </span>
+            {miraReputation && miraReputation.completedQuestIds.length > 0 && (
+              <span className="cz-npc-quest-count">
+                [{miraReputation.completedQuestIds.length}]
+              </span>
+            )}
+          </div>
+          <div className="cz-npc-memory-note" data-testid={`npc-memory-note-village_trader_001`}>
+            {memoryNote}
+          </div>
+        </div>
+      </div>
+
+      {/* Dialogue State Indicator */}
+      {miraDialogue && (
+        <div className="cz-npc-dialogue-state" data-testid={`npc-dialogue-memory-state-village_trader_001`}>
+          <span className="cz-npc-dialogue-label">DIALOGUE</span>
+          <span className="cz-npc-dialogue-value">{miraDialogue.dialogueState}</span>
+        </div>
+      )}
 
       {/* NPC Dialogue Line */}
       {miraDialogue && (
-        <div
-          className="npc-dialogue-line"
-          data-testid={`npc-dialogue-line-village_trader_001`}
-        >
+        <div className="cz-npc-line" data-testid={`npc-dialogue-line-village_trader_001`}>
           <p>{miraDialogue.line}</p>
         </div>
       )}
 
-      {/* Quest Tracker */}
+      {/* Quest Tracker - Cyber-Zen styled */}
       {showQuestTracker && miraActiveQuest && (
-        <div
-          className="quest-tracker"
-          data-testid={`quest-tracker-village_supply_order_001`}
-        >
-          <h4>{miraActiveQuest.questId.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())}</h4>
+        <div className="cz-quest-tracker" data-testid={`quest-tracker-village_supply_order_001`}>
+          <div className="cz-quest-header">
+            <span className="cz-quest-label">QUEST</span>
+            <span className="cz-quest-title">
+              {miraActiveQuest.questId.replace(/_/g, "_").replace(/\b\w/g, (l) => l.toUpperCase())}
+            </span>
+          </div>
 
-          <ul className="quest-objectives">
+          <ul className="cz-quest-objectives">
             {miraActiveQuest.objectives.map((obj) => (
               <li
                 key={obj.objectiveId}
-                className={`quest-objective ${obj.completed ? "completed" : ""}`}
+                className={`cz-quest-objective ${obj.completed ? "completed" : ""}`}
                 data-testid={`quest-objective-${obj.objectiveId}`}
               >
-                <span className="objective-check">{obj.completed ? "✓" : "○"}</span>
-                <span className="objective-title">{obj.title}</span>
-                <span className="objective-progress">
+                <span className="cz-quest-check">{obj.completed ? "◉" : "○"}</span>
+                <span className="cz-quest-objective-title">{obj.title}</span>
+                <span className="cz-quest-progress">
                   {obj.current}/{obj.required}
                 </span>
               </li>
             ))}
           </ul>
 
-          {/* Reward Preview */}
-          <div
-            className="quest-reward-preview"
-            data-testid={`quest-reward-village_supply_order_001`}
-          >
-            <span>Rewards:</span>
-            <span>10 coins</span>
-            <span>25 gathering XP</span>
-            <span>25 crafting XP</span>
-            <span>+1 reputation</span>
+          {/* Reward Preview - Cyber-Zen styled */}
+          <div className="cz-quest-reward" data-testid={`quest-reward-village_supply_order_001`}>
+            <span className="cz-reward-label">REWARD</span>
+            <span className="cz-reward-item">+10 COINS</span>
+            <span className="cz-reward-item">+25 GATH XP</span>
+            <span className="cz-reward-item">+25 CRFT XP</span>
+            <span className="cz-reward-item cz-reward-rep">+1 REP</span>
           </div>
         </div>
       )}
 
-      {/* Action Buttons */}
-      <div className="npc-dialogue-actions">
+      {/* Action Buttons - Cyber-Zen styled */}
+      <div className="cz-npc-actions">
         {/* Accept Quest Button */}
         {showAcceptButton && miraAvailableQuest && (
           <button
             type="button"
-            className="accept-quest-button"
+            className="cz-action-btn cz-action-btn--accept"
             data-testid={`accept-quest-village_supply_order_001`}
             onClick={() => onAcceptQuest?.("village_supply_order_001")}
           >
-            Accept Quest
+            ACCEPT ORDER
           </button>
         )}
 
@@ -136,11 +200,11 @@ export function NpcDialoguePanel({
         {showCompleteButton && (
           <button
             type="button"
-            className="complete-quest-button"
+            className="cz-action-btn cz-action-btn--complete"
             data-testid={`complete-quest-village_supply_order_001`}
             onClick={() => onCompleteQuest?.("village_supply_order_001")}
           >
-            Complete Quest
+            COMPLETE ORDER
           </button>
         )}
 
@@ -148,10 +212,10 @@ export function NpcDialoguePanel({
         {miraActiveQuest && (
           <button
             type="button"
-            className="talk-to-npc-button"
+            className="cz-action-btn cz-action-btn--talk"
             onClick={() => onTalkToNpc?.("village_trader_001")}
           >
-            Talk to Mira
+            TALK TO MIRA
           </button>
         )}
       </div>

--- a/docs/CLIENT_2D_LIVE_RENDER_AUDIT.md
+++ b/docs/CLIENT_2D_LIVE_RENDER_AUDIT.md
@@ -269,3 +269,73 @@ pnpm --filter @wasd/client-2d test -- --run uiRuntimeManifest
 The `uiRuntimeManifest.ts` file provides a machine-readable version of this audit.
 
 See: `apps/client-2d/src/ui/uiRuntimeManifest.ts`
+
+## Update (2026-06-09): NPC Dialogue Panel Cyber-Zen Update
+
+The `NpcDialoguePanel` component has been updated with full Cyber-Zen styling:
+
+### Component Status
+
+| Component | Path | Status | Notes |
+|-----------|------|--------|-------|
+| NpcDialoguePanel | `src/ui/windows/NpcDialoguePanel.tsx` | LIVE | Cyber-Zen styled, NPC memory/reputation |
+
+### Cyber-Zen Features Added
+
+1. **NPC Memory Block** - Shows NPC identity, trust tier badge, reputation value, and deterministic memory note
+2. **Trust Tier Badges** - Visual states for hostile/cold/neutral/trusted/honored based on reputation
+3. **Dialogue State Indicator** - Shows current dialogue state in monospace format
+4. **Quest Tracker** - Cyber-Zen styled with emerald checkmarks for completed objectives
+5. **Action Buttons** - Accept (cyan), Complete (green), Talk (gold) styled consistently
+
+### Test IDs Added
+
+| Test ID | Element |
+|---------|---------|
+| `npc-memory-village_trader_001` | NPC memory block |
+| `npc-trust-tier-village_trader_001` | Trust tier badge |
+| `npc-reputation-village_trader_001` | Reputation value |
+| `npc-memory-note-village_trader_001` | Memory/lore text |
+| `npc-dialogue-memory-state-village_trader_001` | Dialogue state indicator |
+
+### CSS Classes
+
+New Cyber-Zen classes in `theme.css`:
+
+| Class | Purpose |
+|-------|---------|
+| `.cz-npc-panel` | Main NPC dialogue panel |
+| `.cz-npc-memory` | NPC memory block |
+| `.cz-trust-badge` | Trust tier badge |
+| `.trust-tier--honored` | Honored tier (violet) |
+| `.trust-tier--trusted` | Trusted tier (green) |
+| `.trust-tier--neutral` | Neutral tier (cyan) |
+| `.trust-tier--cold` | Cold tier (grey-blue) |
+| `.trust-tier--hostile` | Hostile tier (ruby) |
+| `.cz-npc-rep-value` | Reputation number display |
+| `.cz-npc-memory-note` | Deterministic memory text |
+| `.cz-action-btn` | Action buttons |
+
+### Visual Design Source
+
+Cyber-Zen design vocabulary from `theme.css`:
+
+```css
+--cz-bg: #05060b
+--cz-panel: rgba(13, 17, 28, 0.86)
+--cz-cyan / --st-aether: #00e5ff
+--cz-green / --st-emerald: #39ff14
+--cz-gold / --st-gold: #ffd76a
+--st-ruby: #ff3f6f
+--st-violet: #8b5cf6
+```
+
+### Data Source
+
+All NPC memory/reputation values come from `LiveGameplaySnapshot`:
+
+- `snapshot.npcDialogues[]` - NPC dialogue state and line
+- `snapshot.npcReputations[]` - NPC reputation and completed quests
+- `snapshot.activeQuests[]` - Active quest with objectives
+- `snapshot.availableQuests[]` - Available quests
+- `snapshot.completedQuestIds[]` - Completed quest IDs

--- a/docs/NPC_MEMORY_REPUTATION.md
+++ b/docs/NPC_MEMORY_REPUTATION.md
@@ -1,0 +1,145 @@
+# NPC Memory and Reputation System
+
+> Documentation Date: 2026-06-09
+> Branch: `feat/npc-resource-quest-loop`
+
+## Overview
+
+The NPC Memory and Reputation System provides deterministic, server-authoritative tracking of player-NPC relationships. It uses the Cyber-Zen design language from the Arelorian Stitch design system.
+
+## Cyber-Zen Visual Source
+
+The NPC Memory UI uses the existing Cyber-Zen design vocabulary from:
+
+- `apps/client-2d/src/theme.css` - CSS variables and base tokens
+- `apps/client-2d/src/ui/windows/NpcDialoguePanel.tsx` - Component implementation
+- Pattern: dark radial cyber background, thin neon borders, monospace status labels, deterministic HUD panels
+
+## Reused UI Components/Classes
+
+### CSS Variables (from theme.css)
+
+| Variable | Value | Usage |
+|----------|-------|-------|
+| `--cz-bg` | `#05060b` | Base background |
+| `--cz-panel` | `rgba(13, 17, 28, 0.86)` | Panel background |
+| `--cz-cyan` / `--st-aether` | `#00e5ff` | Cyan accent, trust tier neutral |
+| `--cz-green` / `--st-emerald` | `#39ff14` | Green accent, completed states |
+| `--cz-gold` / `--st-gold` | `#ffd76a` | Gold accent, dialogue state |
+| `--st-ruby` | `#ff3f6f` | Ruby accent, hostile state |
+| `--st-violet` | `#8b5cf6` | Violet accent, honored state |
+
+### Component Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.cz-npc-panel` | Main NPC dialogue panel container |
+| `.cz-npc-memory` | NPC memory block with header |
+| `.cz-npc-memory-header` | Memory block header with sigil |
+| `.cz-npc-identity` | NPC name and trust tier row |
+| `.cz-npc-name` | NPC display name text |
+| `.cz-trust-badge` | Trust tier badge (honored/trusted/neutral/cold/hostile) |
+| `.cz-npc-rep-row` | Reputation row with label and value |
+| `.cz-npc-rep-value` | Reputation number display |
+| `.cz-npc-memory-note` | Deterministic memory/lore text |
+| `.cz-npc-dialogue-state` | Dialogue state indicator row |
+| `.cz-npc-line` | NPC dialogue text |
+| `.cz-quest-tracker` | Quest tracker container |
+| `.cz-quest-objectives` | Quest objectives list |
+| `.cz-quest-objective` | Individual quest objective |
+| `.cz-action-btn` | Action buttons (accept/complete/talk) |
+
+## Trust Tiers
+
+Trust tier is determined by reputation value and maps to visual states:
+
+| Reputation | Tier | CSS Class | Visual |
+|------------|------|-----------|--------|
+| ≥ 5 | HONORED | `trust-tier--honored` | Violet glow, premium feel |
+| ≥ 3 | TRUSTED | `trust-tier--trusted` | Green emphasis |
+| ≥ 1 | NEUTRAL | `trust-tier--neutral` | Cyan standard |
+| ≤ -1 | COLD | `trust-tier--cold` | Muted grey-blue |
+| ≤ -3 | HOSTILE | `trust-tier--hostile` | Ruby/fire danger |
+
+## Memory Notes
+
+Memory notes are deterministic based on dialogue state:
+
+| Dialogue State | Memory Note |
+|----------------|-------------|
+| `quest_completed` | "VERIFIED TRUSTWORTHY // MEMORY LOCKED" |
+| `quest_ready_to_complete` | "AWAITING COMPLETION // SUPPLY READY" |
+| `quest_active_ready_to_sell` | "PROCESSING ACTIVE // PLANK PENDING" |
+| `quest_active_ready_to_process` | "GATHERING COMPLETE // PROCESSING NEEDED" |
+| `quest_active_missing_wood` | "ORDER PENDING // WOOD NEEDED" |
+| `quest_available` | "TRADE ACTIVE // OPEN TO BUSINESS" |
+
+## Test IDs
+
+| Test ID | Element |
+|---------|---------|
+| `npc-dialogue-village_trader_001` | Main NPC dialogue panel |
+| `npc-memory-village_trader_001` | NPC memory block |
+| `npc-trust-tier-village_trader_001` | Trust tier badge |
+| `npc-reputation-village_trader_001` | Reputation value display |
+| `npc-memory-note-village_trader_001` | Memory/lore text |
+| `npc-dialogue-memory-state-village_trader_001` | Dialogue state indicator |
+| `npc-dialogue-line-village_trader_001` | NPC dialogue text |
+| `npc-name-village_trader_001` | NPC name display |
+| `quest-tracker-village_supply_order_001` | Quest tracker |
+| `quest-objective-{objectiveId}` | Quest objective item |
+| `quest-reward-village_supply_order_001` | Reward preview |
+| `accept-quest-village_supply_order_001` | Accept quest button |
+| `complete-quest-village_supply_order_001` | Complete quest button |
+
+## Where the Panel Appears
+
+The NPC Dialogue Panel appears in the `/2d` path when:
+
+1. Player is near Mira the Quartermaster (`village_trader_001` at position 462, 503)
+2. Player interacts with the NPC (triggers `/api/npc/talk`)
+3. The panel is displayed in the `GameplayWindowsLayer` component
+
+The panel uses the same z-index and positioning as other gameplay windows (z-index 70, fixed top-right).
+
+## Data Source
+
+All NPC memory and reputation values come from `LiveGameplaySnapshot`:
+
+```typescript
+interface NpcReputationSnapshot {
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly reputation: number;
+  readonly completedQuestIds: readonly string[];
+}
+
+interface NpcDialogueSnapshot {
+  readonly npcId: string;
+  readonly displayName: string;
+  readonly dialogueState: string;
+  readonly line: string;
+  readonly availableQuestIds: readonly string[];
+  readonly activeQuestIds: readonly string[];
+  readonly completedQuestIds: readonly string[];
+}
+```
+
+## Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `apps/client-2d/src/ui/windows/NpcDialoguePanel.tsx` | React component with Cyber-Zen styling |
+| `apps/client-2d/src/theme.css` | Cyber-Zen CSS tokens and component styles |
+| `apps/client-2d/src/game/liveGameplaySnapshot.ts` | Client-side snapshot types |
+| `server/src/quests/NpcQuestService.ts` | Server-side NPC quest and reputation service |
+| `server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts` | Snapshot composition with NPC data |
+
+## Determinism Rules
+
+- **No** `Math.random()` for trust tier determination
+- **No** `Date.now()` for memory note generation
+- **No** random decorative text
+- **No** fake data
+- Memory notes derived deterministically from `dialogueState` and `completedQuestIds`
+- Trust tier derived deterministically from `reputation` value

--- a/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
+++ b/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
@@ -10,6 +10,7 @@ import type { WorldPoiSnapshot } from "../world/WorldPoiTypes.js";
 import { createDefaultStatBlock, statKeyToPropertyName, isEquipmentStatKey, capStatValue } from "../equipment/EquipmentStatTypes.js";
 import type { EquipmentStatBlock } from "../equipment/EquipmentStatTypes.js";
 import { getStarterProcessingStations } from "../crafting/ProcessingStations.js";
+import { npcQuestService } from "../quests/NpcQuestService.js";
 
 interface LegacyInventorySlot {
   readonly itemId?: string;
@@ -182,6 +183,51 @@ export async function composeLiveGameplaySnapshotFromLegacy(
         y: s.position.y,
         interactionRadius: s.interactionRadius,
       }));
+    },
+    // NPC Quest system integration
+    getActiveQuests: (playerId: string) => {
+      const activeQuests = npcQuestService.getActiveQuests(playerId);
+      return activeQuests.map((q) => ({
+        questId: q.questId,
+        state: q.state,
+        objectives: q.objectives.map((obj) => ({
+          objectiveId: obj.objectiveId,
+          title: obj.title,
+          current: obj.current,
+          required: obj.required,
+          completed: obj.completed,
+        })),
+      }));
+    },
+    getAvailableQuests: (playerId: string) => {
+      const availableQuests = npcQuestService.getAvailableQuests(playerId);
+      return availableQuests.map((q) => ({
+        questId: q.questId,
+        state: q.state,
+        objectives: q.objectives.map((obj) => ({
+          objectiveId: obj.objectiveId,
+          title: obj.title,
+          current: obj.current,
+          required: obj.required,
+          completed: obj.completed,
+        })),
+      }));
+    },
+    getCompletedQuestIds: (playerId: string) => {
+      // Get from active quests that are completed, or query the service
+      const playerState = (npcQuestService as any).playerQuestStates?.get(playerId);
+      if (playerState?.completedQuestIds) {
+        return [...playerState.completedQuestIds];
+      }
+      return [];
+    },
+    getNpcDialogues: (playerId: string) => {
+      // Return dialogues for all known NPCs (village_trader_001)
+      const npcIds = ["village_trader_001"];
+      return npcIds.map((npcId) => npcQuestService.getNpcDialogue(playerId, npcId));
+    },
+    getNpcReputations: (playerId: string) => {
+      return npcQuestService.getAllNpcReputations(playerId);
     },
   });
 


### PR DESCRIPTION
## Summary

Adds Mira's First Supply Order starter quest that connects NPC dialogue to resource economy progress.

### Changes

1. **Server-side integration** (`server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts`)
   - Integrated `npcQuestService` into `LiveGameplaySnapshotComposer`
   - Quest state now exposed in the live gameplay snapshot

2. **Cyber-Zen NPC Dialogue Panel** (`apps/client-2d/src/ui/windows/NpcDialoguePanel.tsx`)
   - Full Cyber-Zen styling using Arelorian Stitch design system
   - NPC Memory block with identity, trust tier badge, and reputation value
   - Deterministic memory notes based on dialogue state
   - Quest tracker with styled objectives and rewards

3. **Trust Tiers** (based on reputation value)
   - `HONORED` (≥5) - Violet glow
   - `TRUSTED` (≥3) - Green emphasis
   - `NEUTRAL` (≥1) - Cyan standard
   - `COLD` (≤-1) - Muted grey-blue
   - `HOSTILE` (≤-3) - Ruby/fire danger

4. **Quest: Mira's First Supply Order** (`village_supply_order_001`)
   - Objective: Gather 2x wood_log → Process 1x wood_plank → Sell to Mira → Return
   - Reward: 10 coins, 25 gathering XP, 25 crafting XP, +1 reputation

### Test IDs

| Test ID | Element |
|---------|---------|
| `npc-memory-village_trader_001` | NPC memory block |
| `npc-trust-tier-village_trader_001` | Trust tier badge |
| `npc-reputation-village_trader_001` | Reputation value |
| `npc-memory-note-village_trader_001` | Memory/lore text |
| `npc-dialogue-memory-state-village_trader_001` | Dialogue state indicator |
| `npc-dialogue-village_trader_001` | Main NPC dialogue panel |
| `quest-tracker-village_supply_order_001` | Quest tracker |
| `accept-quest-village_supply_order_001` | Accept quest button |
| `complete-quest-village_supply_order_001` | Complete quest button |

### Documentation

- `docs/NPC_MEMORY_REPUTATION.md` - Cyber-Zen design documentation
- `docs/CLIENT_2D_LIVE_RENDER_AUDIT.md` - Updated with NPC panel status

### Verification

```bash
pnpm --filter @wasd/shared build
pnpm --filter @wasd/server exec tsc --noEmit
pnpm run guard:all
pnpm -r --if-present test
pnpm run ci:verify
pnpm run test:e2e:ci
```

### Determinism

- **No** `Math.random()` for gameplay
- **No** `Date.now()` for gameplay state
- Client sends intent only
- Server validates and mutates
- Failed validation does not mutate state
- Rewards cannot be claimed twice
- Quest objective order is stable

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/06e1e0ac-d52c-4298-baa0-40d11d69e3ee)