### PR TITLE
fix: use public API instead of private property access

### DIFF
--- a/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
+++ b/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
@@ -214,12 +214,9 @@ export async function composeLiveGameplaySnapshotFromLegacy(
       }));
     },
     getCompletedQuestIds: (playerId: string) => {
-      // Get from active quests that are completed, or query the service
-      const playerState = (npcQuestService as any).playerQuestStates?.get(playerId);
-      if (playerState?.completedQuestIds) {
-        return [...playerState.completedQuestIds];
-      }
-      return [];
+      // Use public NPC dialogue method to get completed quest IDs
+      const dialogue = npcQuestService.getNpcDialogue(playerId, "village_trader_001");
+      return [...dialogue.completedQuestIds];
     },
     getNpcDialogues: (playerId: string) => {
       // Return dialogues for all known NPCs (village_trader_001)


### PR DESCRIPTION
## Summary

Fixes a potential code scanning issue where `npcQuestService.playerQuestStates` (a private property) was being accessed directly.

### Change

Instead of accessing the private `playerQuestStates` Map:
```typescript
const playerState = (npcQuestService as any).playerQuestStates?.get(playerId);
if (playerState?.completedQuestIds) {
  return [...playerState.completedQuestIds];
}
```

Now uses the public `getNpcDialogue()` method which already returns `completedQuestIds` as part of the dialogue snapshot:
```typescript
const dialogue = npcQuestService.getNpcDialogue(playerId, "village_trader_001");
return [...dialogue.completedQuestIds];
```

### Benefits

- Uses only public APIs
- No type casting to `any`
- Follows proper encapsulation
- Should resolve code scanning alerts about private property access

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/06e1e0ac-d52c-4298-baa0-40d11d69e3ee)