### PR TITLE
feat(npc): persist memory and add rumor network

### DIFF
--- a/apps/client-2d/src/game/liveGameplaySnapshot.ts
+++ b/apps/client-2d/src/game/liveGameplaySnapshot.ts
@@ -394,6 +394,10 @@ export interface LiveGameplaySnapshot {
   npcDialogues?: NpcDialogueSnapshot[];
   /** NPC reputations for the player */
   npcReputations?: NpcReputationSnapshot[];
+  /** NPC memory snapshots for the player */
+  npcMemories?: NpcMemorySnapshot[];
+  /** NPC rumor snapshots for the player */
+  npcRumors?: NpcRumorSnapshot[];
 }
 
 /**
@@ -448,6 +452,47 @@ export interface NpcReputationSnapshot {
   playerId: string;
   reputation: number;
   completedQuestIds: string[];
+}
+
+/**
+ * Trust tier for NPC-player relationship.
+ */
+export type TrustTier = "hostile" | "cold" | "neutral" | "trusted" | "honored";
+
+/**
+ * NPC memory snapshot for server-authoritative display.
+ */
+export interface NpcMemorySnapshot {
+  npcId: string;
+  playerId: string;
+  reputation: number;
+  trustTier: TrustTier;
+  memoryEventCount: number;
+  recentMemoryNotes: readonly string[];
+  knownRumorCount: number;
+}
+
+/**
+ * Rumor kinds for NPC memory system.
+ */
+export type NpcRumorKind =
+  | "helped_village"
+  | "reliable_supplier"
+  | "troublemaker"
+  | "hostile_actor"
+  | "trusted_worker";
+
+/**
+ * NPC rumor snapshot for server-authoritative display.
+ */
+export interface NpcRumorSnapshot {
+  rumorId: string;
+  npcId: string;
+  playerId: string;
+  kind: NpcRumorKind;
+  weight: number;
+  note: string;
+  sourceNpcId: string;
 }
 
 // Default empty snapshot - honest waiting state

--- a/apps/client-2d/src/theme.css
+++ b/apps/client-2d/src/theme.css
@@ -408,6 +408,205 @@ canvas { display: block; filter: saturate(1.16) contrast(1.08); touch-action: no
   color: #a78bfa;
 }
 
+/* Direct Memory Section */
+.cz-npc-direct-memory {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(103, 92, 255, 0.18);
+  background: linear-gradient(135deg, rgba(103, 92, 255, 0.08), rgba(139, 92, 246, 0.05));
+}
+
+.cz-npc-memory-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: #a78bfa;
+}
+
+.cz-memory-count {
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(139, 92, 246, 0.2);
+  border: 1px solid rgba(139, 92, 246, 0.4);
+  font-size: 9px;
+  color: #a78bfa;
+}
+
+.cz-npc-memory-events {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cz-npc-memory-event-note {
+  font-size: 10px;
+  color: rgba(244, 247, 255, 0.7);
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: rgba(139, 92, 246, 0.1);
+  border-left: 2px solid rgba(139, 92, 246, 0.4);
+}
+
+.cz-npc-memory-empty {
+  font-size: 10px;
+  color: rgba(244, 247, 255, 0.4);
+  font-style: italic;
+}
+
+/* Rumors Heard Section */
+.cz-npc-rumors-section {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(57, 255, 20, 0.18);
+  background: linear-gradient(135deg, rgba(57, 255, 20, 0.05), rgba(57, 255, 20, 0.03));
+}
+
+.cz-npc-rumors-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--st-emerald);
+}
+
+.cz-rumor-count {
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(57, 255, 20, 0.15);
+  border: 1px solid rgba(57, 255, 20, 0.4);
+  font-size: 9px;
+  color: var(--st-emerald);
+}
+
+.cz-npc-rumors-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cz-npc-rumor-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 10px;
+  border-left: 3px solid;
+}
+
+.cz-npc-rumor-item.rumor-badge--positive {
+  background: rgba(0, 229, 255, 0.1);
+  border-color: var(--cz-cyan);
+}
+
+.cz-npc-rumor-item.rumor-badge--green {
+  background: rgba(57, 255, 20, 0.1);
+  border-color: var(--cz-green);
+}
+
+.cz-npc-rumor-item.rumor-badge--violet {
+  background: rgba(139, 92, 246, 0.15);
+  border-color: var(--st-violet);
+}
+
+.cz-npc-rumor-item.rumor-badge--warning {
+  background: rgba(255, 215, 106, 0.1);
+  border-color: var(--cz-gold);
+}
+
+.cz-npc-rumor-item.rumor-badge--danger {
+  background: rgba(255, 63, 111, 0.1);
+  border-color: var(--st-ruby);
+}
+
+.cz-npc-rumor-item.rumor-badge--neutral {
+  background: rgba(244, 247, 255, 0.05);
+  border-color: rgba(244, 247, 255, 0.3);
+}
+
+.cz-rumor-badge {
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.rumor-badge--positive .cz-rumor-badge { color: var(--cz-cyan); }
+.rumor-badge--green .cz-rumor-badge { color: var(--cz-green); }
+.rumor-badge--violet .cz-rumor-badge { color: var(--st-violet); }
+.rumor-badge--warning .cz-rumor-badge { color: var(--cz-gold); }
+.rumor-badge--danger .cz-rumor-badge { color: var(--st-ruby); }
+
+.cz-rumor-note {
+  font-size: 10px;
+  color: rgba(244, 247, 255, 0.7);
+  font-style: italic;
+}
+
+.cz-rumor-weight {
+  font-size: 9px;
+  color: rgba(244, 247, 255, 0.5);
+}
+
+/* Effective Trust Section */
+.cz-npc-effective-trust {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(139, 92, 246, 0.18);
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.08), rgba(103, 92, 255, 0.05));
+}
+
+.cz-npc-trust-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--st-violet);
+}
+
+.cz-npc-trust-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  font-size: 10px;
+}
+
+.cz-npc-trust-label {
+  color: rgba(244, 247, 255, 0.6);
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.cz-npc-trust-value {
+  font-weight: 800;
+  color: var(--st-violet);
+  text-shadow: 0 0 8px rgba(139, 92, 246, 0.4);
+}
+
+.cz-npc-trust-row.cz-npc-trust-total {
+  padding-top: 6px;
+  margin-top: 4px;
+  border-top: 1px solid rgba(139, 92, 246, 0.2);
+}
+
+.cz-npc-trust-row.cz-npc-trust-total .cz-npc-trust-label {
+  color: var(--st-violet);
+}
+
+.cz-npc-trust-row.cz-npc-trust-total .cz-npc-trust-value {
+  font-size: 14px;
+  color: var(--st-violet);
+  text-shadow: 0 0 12px rgba(139, 92, 246, 0.5);
+}
+
 /* Memory Note */
 .cz-npc-memory-note {
   margin-top: 6px;

--- a/apps/client-2d/src/ui/windows/NpcDialoguePanel.tsx
+++ b/apps/client-2d/src/ui/windows/NpcDialoguePanel.tsx
@@ -1,7 +1,7 @@
 /**
  * NPC Dialogue Panel
  *
- * Displays NPC dialogue, quest interactions, and memory/reputation for the resource economy loop.
+ * Displays NPC dialogue, quest interactions, memory/reputation, and rumors for the resource economy loop.
  * Cyber-Zen styled panel using Arelorian Stitch design system.
  * Server-authoritative, display-only.
  * Uses test IDs for E2E testing.
@@ -12,6 +12,8 @@ import type {
   NpcDialogueSnapshot,
   NpcQuestProgressSnapshot,
   NpcReputationSnapshot,
+  NpcMemorySnapshot,
+  NpcRumorSnapshot,
 } from "../../game/liveGameplaySnapshot";
 
 interface NpcDialoguePanelProps {
@@ -35,6 +37,47 @@ function getTrustTier(reputation: number): { tier: string; cssClass: string; lab
   if (reputation <= -1) return { tier: "cold", cssClass: "trust-tier--cold", label: "COLD" };
   if (reputation <= -3) return { tier: "hostile", cssClass: "trust-tier--hostile", label: "HOSTILE" };
   return { tier: "unknown", cssClass: "trust-tier--neutral", label: "UNKNOWN" };
+}
+
+/**
+ * Get rumor badge class based on rumor kind.
+ * Cyber-Zen visual mapping for rumor types.
+ */
+function getRumorBadgeClass(kind: string): string {
+  switch (kind) {
+    case "helped_village":
+      return "rumor-badge--positive";
+    case "reliable_supplier":
+      return "rumor-badge--green";
+    case "trusted_worker":
+      return "rumor-badge--violet";
+    case "troublemaker":
+      return "rumor-badge--warning";
+    case "hostile_actor":
+      return "rumor-badge--danger";
+    default:
+      return "rumor-badge--neutral";
+  }
+}
+
+/**
+ * Get rumor label for display.
+ */
+function getRumorLabel(kind: string): string {
+  switch (kind) {
+    case "helped_village":
+      return "HELPED VILLAGE";
+    case "reliable_supplier":
+      return "RELIABLE SUPPLIER";
+    case "trusted_worker":
+      return "TRUSTED WORKER";
+    case "troublemaker":
+      return "TROUBLEMAKER";
+    case "hostile_actor":
+      return "HOSTILE ACTOR";
+    default:
+      return "UNKNOWN";
+  }
 }
 
 /**
@@ -74,10 +117,14 @@ export function NpcDialoguePanel({
   const availableQuests = snapshot.availableQuests ?? [];
   const completedQuestIds = snapshot.completedQuestIds ?? [];
   const reputations = snapshot.npcReputations ?? [];
+  const memories = (snapshot as any).npcMemories ?? [];
+  const rumors = (snapshot as any).npcRumors ?? [];
 
   // Find Mira's dialogue if available
   const miraDialogue = dialogues.find((d) => d.npcId === "village_trader_001");
   const miraReputation = reputations.find((r) => r.npcId === "village_trader_001");
+  const miraMemory = memories.find((m: any) => m.npcId === "village_trader_001");
+  const miraRumors = rumors.filter((r: any) => r.npcId === "village_trader_001");
 
   // Find Mira's quests
   const miraActiveQuest = activeQuests.find(
@@ -92,7 +139,8 @@ export function NpcDialoguePanel({
   const showAcceptButton = miraAvailableQuest !== undefined;
   const showCompleteButton = miraActiveQuest?.state === "ready_to_complete";
 
-  // Get trust tier for visual state
+  // Get trust tier for visual state - use memory trust tier if available
+  const memoryTrustTier = miraMemory?.trustTier ?? "neutral";
   const trustInfo = getTrustTier(miraReputation?.reputation ?? 0);
   const memoryNote = getMemoryNote(miraDialogue?.dialogueState ?? "quest_available", completedQuestIds);
 
@@ -142,6 +190,84 @@ export function NpcDialoguePanel({
       {miraDialogue && (
         <div className="cz-npc-line" data-testid={`npc-dialogue-line-village_trader_001`}>
           <p>{miraDialogue.line}</p>
+        </div>
+      )}
+
+      {/* Direct Memory Section - Cyber-Zen styled */}
+      {miraMemory && (
+        <div className="cz-npc-direct-memory" data-testid={`npc-memory-village_trader_001`}>
+          <div className="cz-npc-memory-section-header">
+            <span className="cz-npc-sigil">◇</span>
+            <span className="cz-npc-label">DIRECT MEMORY</span>
+            <span className="cz-memory-count" data-testid={`npc-memory-persisted-village_trader_001`}>
+              [{miraMemory.memoryEventCount}]
+            </span>
+          </div>
+          <div className="cz-npc-memory-events">
+            {miraMemory.recentMemoryNotes.length > 0 ? (
+              miraMemory.recentMemoryNotes.slice(0, 3).map((note: string, idx: number) => (
+                <div key={idx} className="cz-npc-memory-event-note">
+                  {note}
+                </div>
+              ))
+            ) : (
+              <div className="cz-npc-memory-event-note cz-npc-memory-empty">
+                NO DIRECT MEMORY
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Rumors Heard Section - Cyber-Zen styled */}
+      {miraRumors.length > 0 && (
+        <div className="cz-npc-rumors-section" data-testid={`npc-rumors-village_trader_001`}>
+          <div className="cz-npc-rumors-header">
+            <span className="cz-npc-sigil">◎</span>
+            <span className="cz-npc-label">RUMORS HEARD</span>
+            <span className="cz-rumor-count" data-testid={`npc-rumor-count-village_trader_001`}>
+              [{miraRumors.length}]
+            </span>
+          </div>
+          <div className="cz-npc-rumors-list">
+            {miraRumors.map((rumor: any) => (
+              <div
+                key={rumor.rumorId}
+                className={`cz-npc-rumor-item ${getRumorBadgeClass(rumor.kind)}`}
+                data-testid={`npc-rumor-${rumor.kind}`}
+              >
+                <span className="cz-rumor-badge">{getRumorLabel(rumor.kind)}</span>
+                <span className="cz-rumor-note">{rumor.note}</span>
+                <span className="cz-rumor-weight">[{rumor.weight > 0 ? "+" : ""}{rumor.weight}]</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Effective Trust Section - Cyber-Zen styled */}
+      {miraMemory && (
+        <div className="cz-npc-effective-trust" data-testid={`npc-effective-trust-village_trader_001`}>
+          <div className="cz-npc-trust-header">
+            <span className="cz-npc-sigil">◆</span>
+            <span className="cz-npc-label">EFFECTIVE TRUST</span>
+          </div>
+          <div className="cz-npc-trust-row">
+            <span className="cz-npc-trust-label">DIRECT</span>
+            <span className="cz-npc-trust-value">{miraMemory.reputation}</span>
+          </div>
+          <div className="cz-npc-trust-row">
+            <span className="cz-npc-trust-label">RUMOR BONUS</span>
+            <span className="cz-npc-trust-value">
+              +{Math.trunc(miraRumors.reduce((sum: number, r: any) => sum + r.weight, 0) / 2)}
+            </span>
+          </div>
+          <div className="cz-npc-trust-row cz-npc-trust-total">
+            <span className="cz-npc-trust-label">EFFECTIVE</span>
+            <span className="cz-npc-trust-value">
+              {miraMemory.reputation + Math.trunc(miraRumors.reduce((sum: number, r: any) => sum + r.weight, 0) / 2)}
+            </span>
+          </div>
         </div>
       )}
 

--- a/docs/NPC_MEMORY_REPUTATION.md
+++ b/docs/NPC_MEMORY_REPUTATION.md
@@ -1,11 +1,106 @@
 # NPC Memory and Reputation System
 
 > Documentation Date: 2026-06-09
-> Branch: `feat/npc-resource-quest-loop`
+> Branch: `feat/npc-memory-persistence-rumors`
 
 ## Overview
 
-The NPC Memory and Reputation System provides deterministic, server-authoritative tracking of player-NPC relationships. It uses the Cyber-Zen design language from the Arelorian Stitch design system.
+The NPC Memory and Reputation System provides deterministic, server-authoritative tracking of player-NPC relationships with persistent memory and social rumor propagation. It uses the Cyber-Zen design language from the Arelorian Stitch design system.
+
+## Architecture
+
+### Core Components
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| `NpcRumorTypes` | `server/src/npc/NpcRumorTypes.ts` | Type definitions for memory events, rumors, and persistence |
+| `NpcMemoryStore` | `server/src/npc/NpcMemoryStore.ts` | JSON file-based persistence for NPC memory and rumors |
+| `NpcMemoryService` | `server/src/npc/NpcMemoryService.ts` | Memory event recording and retrieval |
+| `NpcRumorService` | `server/src/npc/NpcRumorService.ts` | Rumor creation and deterministic propagation |
+| `NpcMemoryRoute` | `server/src/npc/NpcMemoryRoute.ts` | API routes for memory/rumor endpoints |
+
+### Data Flow
+
+```
+Quest Complete (accept/complete)
+  → NpcMemoryService.recordQuestCompleted()
+    → Persisted to NpcMemoryStore (JSON file)
+    → Triggers NpcRumorService.createRumorFromMemory()
+      → Creates helped_village rumor for Mira
+      → Rumor propagates to eligible NPCs (village_elder_001, outpost_guard_001)
+        → Updates LiveGameplaySnapshot via composer
+          → Client displays in NpcDialoguePanel
+```
+
+## Determinism Rules
+
+- **No** `Date.now()` for gameplay state
+- **No** `Math.random()` for gameplay IDs
+- **No** UUID for memory event IDs - uses deterministic format: `${npcId}:${playerId}:${kind}:${logicalIndex}:${sourceId}`
+- **No** client-authoritative memory writes
+- **No** duplicate event application
+- **No** partial mutation after failed persistence validation
+- Stable sorting by `logicalIndex`, `eventId`
+
+## Persistence Model
+
+### PersistedNpcMemoryState
+
+```typescript
+interface PersistedNpcMemoryState {
+  readonly schemaVersion: 1;
+  readonly playerId: string;
+  readonly npcId: string;
+  readonly reputation: number;
+  readonly trustTier: TrustTier;
+  readonly completedQuestIds: readonly string[];
+  readonly memoryEvents: readonly NpcMemoryEvent[];
+  readonly knownRumorIds: readonly string[];
+}
+```
+
+### NpcMemoryEvent
+
+```typescript
+interface NpcMemoryEvent {
+  readonly eventId: string;  // Format: ${npcId}:${playerId}:${kind}:${logicalIndex}:${sourceId}
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly kind: "quest_accepted" | "quest_completed" | "sell_completed" | "trade_completed" | "gift_given" | "interaction_failed" | "hostile_action" | "rumor_heard";
+  readonly logicalIndex: number;
+  readonly sourceId: string;
+  readonly reputationDelta: number;
+  readonly note: string;
+}
+```
+
+### Persistence Backend
+
+Uses `NpcMemoryStore` with JSON file backend:
+- File location: `process.cwd()/data/npc-memory.json` (configurable via `NPC_MEMORY_FILE` env var)
+- Atomic writes via temp file + rename pattern
+- Stable sort for deterministic output
+- Corrupt JSON handling: returns empty state, doesn't crash server
+
+## Trust Tiers
+
+Trust tier is determined by reputation value and maps to visual states:
+
+| Reputation | Tier | CSS Class | Visual |
+|------------|------|-----------|--------|
+| ≥ 5 | HONORED | `trust-tier--honored` | Violet glow, premium feel |
+| ≥ 3 | TRUSTED | `trust-tier--trusted` | Green emphasis |
+| ≥ 1 | NEUTRAL | `trust-tier--neutral` | Cyan standard |
+| ≤ -1 | COLD | `trust-tier--cold` | Muted grey-blue |
+| ≤ -3 | HOSTILE | `trust-tier--hostile` | Ruby/fire danger |
+
+### Effective Trust Calculation
+
+```
+effectiveReputation = directReputation + Math.trunc(totalRumorWeight / 2)
+```
+
+Direct memory has strongest effect. Rumors contribute half their weight to effective reputation.
 
 ## Cyber-Zen Visual Source
 

--- a/docs/NPC_RUMOR_NETWORK.md
+++ b/docs/NPC_RUMOR_NETWORK.md
@@ -1,0 +1,159 @@
+# NPC Rumor Network
+
+> Documentation Date: 2026-06-09
+> Branch: `feat/npc-memory-persistence-rumors`
+
+## Overview
+
+The NPC Rumor Network provides deterministic social memory propagation between NPCs. When significant events occur, rumors are created and can spread to eligible NPCs within the village social network.
+
+## Rumor Kinds
+
+| Kind | Weight | Trigger | Visual |
+|------|--------|---------|--------|
+| `helped_village` | +2 | Quest completed for Mira | Cyan accent |
+| `reliable_supplier` | +2 | 5 sell_completed milestones | Green accent |
+| `trusted_worker` | +3 | Trust tier "honored" with Mira | Violet accent |
+| `troublemaker` | -1 | 3+ interaction_failed events | Gold/muted warning |
+| `hostile_actor` | -2 | Hostile action recorded | Ruby/fire danger |
+
+## Rumor ID Format
+
+Rumor IDs are deterministic:
+```
+${sourceNpcId}:${playerId}:${sourceEventId}:rumor
+```
+
+Example: `village_trader_001:player123:village_trader_001:player123:quest_completed:0:village_supply_order_001:rumor`
+
+## Propagation Rules
+
+Rumor propagation is **deterministic** and **idempotent**:
+
+1. **Same Settlement**: NPCs within 80 units of village center (462, 503) are eligible
+2. **Social Edges**: NPCs linked via `socialLinks` property in NPC definition
+3. **Vendor/Quest NPCs**: Any vendor or quest NPC within 100 units of village center
+
+### Initial NPC Set
+
+| NPC ID | Name | Position | Social Links |
+|--------|------|----------|--------------|
+| `village_trader_001` | Mira the Quartermaster | 462, 503 | `village_elder_001`, `outpost_guard_001` |
+| `village_elder_001` | Elder Thorne | 458, 498 | `village_trader_001`, `outpost_guard_001` |
+| `outpost_guard_001` | Captain Roderick | 520, 510 | `village_trader_001`, `village_elder_001` |
+
+## Rumor Consequences
+
+### Direct Memory vs Rumor Memory
+
+- **Direct Memory**: Always has strongest effect
+- **Rumor Memory**: Weaker than direct memory
+- **Rumor Effect**: Adjusts dialogue tone, does not grant rewards
+
+### Effective Trust Calculation
+
+```typescript
+effectiveReputation = directReputation + Math.trunc(totalRumorWeight / 2)
+```
+
+### Example Scenario
+
+1. Player completes Mira's quest
+   - Memory event recorded: `quest_completed`
+   - Reputation +1 (direct)
+   - `helped_village` rumor created
+
+2. Rumor propagates to village_elder_001 and outpost_guard_001
+   - Each receives `rumor_heard` memory event
+   - Rumor weight contributes to effective trust
+
+3. Player's effective trust with Elder Thorne:
+   - Direct: 0
+   - Rumor bonus: +1 (rumor weight 2 / 2)
+   - Effective: 1 (NEUTRAL)
+
+## API Routes
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/npc/memory` | GET | Get all memory snapshots for player |
+| `/api/npc/memory/:npcId` | GET | Get memory snapshot for specific NPC |
+| `/api/npc/reputation` | GET | Get NPC reputation with rumor influence |
+| `/api/npc/rumors` | GET | Get all rumors for player or specific NPC |
+| `/api/npc/rumors/propagate` | POST | Trigger rumor propagation (idempotent) |
+| `/api/npc/effective-trust/:npcId` | GET | Get effective trust calculation |
+| `/api/npc/rumor-eligible/:sourceNpcId` | GET | Get eligible rumor targets |
+
+## Fail Reasons
+
+| Reason | Description |
+|--------|-------------|
+| `missing_player` | Player ID not provided |
+| `missing_npc` | NPC ID not provided or not found |
+| `missing_rumor` | Rumor ID not provided or not found |
+| `invalid_rumor_kind` | Rumor kind not recognized |
+| `duplicate_rumor` | Rumor already exists (idempotent check) |
+| `duplicate_memory_event` | Memory event already recorded |
+| `invalid_logical_index` | Logical index out of valid range |
+| `rumor_propagation_rejected` | Propagation blocked by eligibility rules |
+| `persistence_load_failed` | Failed to load from store |
+| `persistence_save_failed` | Failed to save to store |
+
+## Snapshot Types
+
+### NpcMemorySnapshot
+
+```typescript
+interface NpcMemorySnapshot {
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly reputation: number;
+  readonly trustTier: TrustTier;
+  readonly memoryEventCount: number;
+  readonly recentMemoryNotes: readonly string[];
+  readonly knownRumorCount: number;
+}
+```
+
+### NpcRumorSnapshot
+
+```typescript
+interface NpcRumorSnapshot {
+  readonly rumorId: string;
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly kind: NpcRumorKind;
+  readonly weight: number;
+  readonly note: string;
+  readonly sourceNpcId: string;
+}
+```
+
+## Cyber-Zen UI Mapping
+
+| Rumor Kind | CSS Class | Color Accent |
+|-------------|-----------|--------------|
+| `helped_village` | `rumor-badge--positive` | Cyan |
+| `reliable_supplier` | `rumor-badge--green` | Green |
+| `trusted_worker` | `rumor-badge--violet` | Violet |
+| `troublemaker` | `rumor-badge--warning` | Gold |
+| `hostile_actor` | `rumor-badge--danger` | Ruby |
+
+## Test IDs
+
+| Test ID | Element |
+|---------|---------|
+| `npc-memory-village_trader_001` | Direct memory section |
+| `npc-rumors-village_trader_001` | Rumors heard section |
+| `npc-rumor-count-village_trader_001` | Rumor count badge |
+| `npc-rumor-helped_village` | helped_village rumor item |
+| `npc-rumor-reliable_supplier` | reliable_supplier rumor item |
+| `npc-effective-trust-village_trader_001` | Effective trust section |
+| `npc-memory-persisted-village_trader_001` | Memory persistence indicator |
+
+## Known Limitations
+
+1. **No autonomous AI brain** - This step implements deterministic memory, not autonomous NPC decision-making
+2. **No parallel quest system** - Uses existing NpcQuestService integration
+3. **No random rumor spread** - All propagation is explicit and deterministic
+4. **Wall-clock timestamps not used** - Uses `logicalIndex` for event ordering

--- a/server/src/gameplay/LiveGameplaySnapshotComposer.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotComposer.ts
@@ -27,6 +27,8 @@ import type {
   LiveGameplayQuestProgress,
   LiveGameplayNpcDialogue,
   LiveGameplayNpcReputation,
+  LiveGameplayNpcMemory,
+  LiveGameplayNpcRumor,
 } from "./LiveGameplaySnapshotTypes.js";
 import { RESOURCE_SELL_PRICES } from "../economy/ResourceSellPrices.js";
 import { calculateDynamicPrice } from "../economy/DemandPricing.js";
@@ -51,6 +53,8 @@ export interface LiveGameplaySnapshotComposerDeps {
   readonly getCompletedQuestIds?: (playerId: string) => readonly string[] | Promise<readonly string[]>;
   readonly getNpcDialogues?: (playerId: string) => readonly LiveGameplayNpcDialogue[] | Promise<readonly LiveGameplayNpcDialogue[]>;
   readonly getNpcReputations?: (playerId: string) => readonly LiveGameplayNpcReputation[] | Promise<readonly LiveGameplayNpcReputation[]>;
+  readonly getNpcMemories?: (playerId: string) => readonly LiveGameplayNpcMemory[] | Promise<readonly LiveGameplayNpcMemory[]>;
+  readonly getNpcRumors?: (playerId: string) => readonly LiveGameplayNpcRumor[] | Promise<readonly LiveGameplayNpcRumor[]>;
 }
 
 export class LiveGameplaySnapshotComposer {
@@ -120,6 +124,12 @@ export class LiveGameplaySnapshotComposer {
     const npcReputations = this.deps.getNpcReputations
       ? await this.deps.getNpcReputations(playerId)
       : [];
+    const npcMemories = this.deps.getNpcMemories
+      ? await this.deps.getNpcMemories(playerId)
+      : [];
+    const npcRumors = this.deps.getNpcRumors
+      ? await this.deps.getNpcRumors(playerId)
+      : [];
 
     return Object.freeze({
       schemaVersion: "live-gameplay-snapshot.v1" as const,
@@ -145,6 +155,8 @@ export class LiveGameplaySnapshotComposer {
       completedQuestIds: Object.freeze([...completedQuestIds].sort()),
       npcDialogues: Object.freeze([...npcDialogues].sort((a, b) => a.npcId.localeCompare(b.npcId))),
       npcReputations: Object.freeze([...npcReputations].sort((a, b) => a.npcId.localeCompare(b.npcId))),
+      npcMemories: Object.freeze([...npcMemories].sort((a, b) => a.npcId.localeCompare(b.npcId))),
+      npcRumors: Object.freeze([...npcRumors].sort((a, b) => a.rumorId.localeCompare(b.rumorId))),
     });
   }
 

--- a/server/src/gameplay/LiveGameplaySnapshotTypes.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotTypes.ts
@@ -67,6 +67,48 @@ export interface LiveGameplayNpcReputation {
   readonly completedQuestIds: readonly string[];
 }
 
+/**
+ * Trust tier for NPC-player relationship.
+ */
+export type LiveGameplayTrustTier = "hostile" | "cold" | "neutral" | "trusted" | "honored";
+
+/**
+ * Rumor kinds for NPC memory system.
+ */
+export type LiveGameplayNpcRumorKind =
+  | "helped_village"
+  | "reliable_supplier"
+  | "troublemaker"
+  | "hostile_actor"
+  | "trusted_worker";
+
+/**
+ * NPC memory snapshot for server-authoritative display.
+ * Exposes summary data without full raw history.
+ */
+export interface LiveGameplayNpcMemory {
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly reputation: number;
+  readonly trustTier: LiveGameplayTrustTier;
+  readonly memoryEventCount: number;
+  readonly recentMemoryNotes: readonly string[];
+  readonly knownRumorCount: number;
+}
+
+/**
+ * NPC rumor snapshot for server-authoritative display.
+ */
+export interface LiveGameplayNpcRumor {
+  readonly rumorId: string;
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly kind: LiveGameplayNpcRumorKind;
+  readonly weight: number;
+  readonly note: string;
+  readonly sourceNpcId: string;
+}
+
 export interface LiveGameplayInventoryItem {
   readonly itemId: string;
   readonly quantity: number;
@@ -265,6 +307,10 @@ export interface LiveGameplaySnapshot {
   readonly npcDialogues: readonly LiveGameplayNpcDialogue[];
   /** NPC reputations for the player */
   readonly npcReputations: readonly LiveGameplayNpcReputation[];
+  /** NPC memory snapshots for the player */
+  readonly npcMemories: readonly LiveGameplayNpcMemory[];
+  /** NPC rumor snapshots for the player */
+  readonly npcRumors: readonly LiveGameplayNpcRumor[];
 }
 
 export interface GatherResult {

--- a/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
+++ b/server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts
@@ -1,5 +1,5 @@
 import { LiveGameplaySnapshotComposer, buildVendorEconomySnapshot, createEmptyVendorEconomySnapshot } from "./LiveGameplaySnapshotComposer.js";
-import type { LiveGameplaySnapshot, DiscoveryStats, RecentDiscovery, LiveGameplayCampNpc, LiveGameplayCampStock } from "./LiveGameplaySnapshotTypes.js";
+import type { LiveGameplaySnapshot, DiscoveryStats, RecentDiscovery, LiveGameplayCampNpc, LiveGameplayCampStock, LiveGameplayNpcMemory, LiveGameplayNpcRumor } from "./LiveGameplaySnapshotTypes.js";
 import { toLiveEquipmentSlots } from "./adapters/EquipmentSnapshotAdapter.js";
 import { toLiveInventoryItems } from "./adapters/InventorySnapshotAdapter.js";
 import { getWalletService, getVendorStockService } from "../economy/economyRuntime.js";
@@ -11,6 +11,8 @@ import { createDefaultStatBlock, statKeyToPropertyName, isEquipmentStatKey, capS
 import type { EquipmentStatBlock } from "../equipment/EquipmentStatTypes.js";
 import { getStarterProcessingStations } from "../crafting/ProcessingStations.js";
 import { npcQuestService } from "../quests/NpcQuestService.js";
+import { npcMemoryService } from "../npc/NpcMemoryService.js";
+import { npcRumorService } from "../npc/NpcRumorService.js";
 
 interface LegacyInventorySlot {
   readonly itemId?: string;
@@ -225,6 +227,30 @@ export async function composeLiveGameplaySnapshotFromLegacy(
     },
     getNpcReputations: (playerId: string) => {
       return npcQuestService.getAllNpcReputations(playerId);
+    },
+    getNpcMemories: async (playerId: string) => {
+      const snapshots = await npcMemoryService.getAllMemorySnapshots(playerId);
+      return snapshots.map((s): LiveGameplayNpcMemory => ({
+        npcId: s.npcId,
+        playerId: s.playerId,
+        reputation: s.reputation,
+        trustTier: s.trustTier,
+        memoryEventCount: s.memoryEventCount,
+        recentMemoryNotes: s.recentMemoryNotes,
+        knownRumorCount: s.knownRumorCount,
+      }));
+    },
+    getNpcRumors: async (playerId: string) => {
+      const rumors = await npcRumorService.getRumorSnapshots(playerId);
+      return rumors.map((r): LiveGameplayNpcRumor => ({
+        rumorId: r.rumorId,
+        npcId: r.npcId,
+        playerId: r.playerId,
+        kind: r.kind,
+        weight: r.weight,
+        note: r.note,
+        sourceNpcId: r.sourceNpcId,
+      }));
     },
   });
 

--- a/server/src/npc/NpcMemoryRoute.ts
+++ b/server/src/npc/NpcMemoryRoute.ts
@@ -1,0 +1,350 @@
+/**
+ * NPC MEMORY & RUMOR API ROUTES
+ *
+ * Server-authoritative NPC memory and rumor management endpoints.
+ * Deterministic: No Math.random(), no Date.now() for gameplay state.
+ * Client sends intent only, server validates and mutates.
+ */
+
+import express, { Router } from "express";
+import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
+import { npcMemoryService } from "./NpcMemoryService.js";
+import { npcRumorService } from "./NpcRumorService.js";
+
+const router = Router();
+router.use(express.json());
+
+// Parse helpers
+function parsePlayerId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length < 1 || trimmed.length > 64) return null;
+  return trimmed;
+}
+
+function parseNpcId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!/^[a-zA-Z0-9_]{1,64}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+function parseRumorId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length < 1 || trimmed.length > 128) return null;
+  return trimmed;
+}
+
+function parsePosition(value: unknown): { x: number; y: number } | null {
+  if (!value || typeof value !== "object") return null;
+  const pos = value as { x?: unknown; y?: unknown };
+  const x = Number(pos.x);
+  const y = Number(pos.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  if (x < -100_000 || x > 100_000 || y < -100_000 || y > 100_000) return null;
+  return { x, y };
+}
+
+/**
+ * GET /api/npc/memory
+ *
+ * Get all memory snapshots for the authenticated player.
+ */
+router.get("/memory", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  const playerId = (req.query?.playerId as string) ?? identity.playerId;
+
+  if (!playerId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_player",
+    });
+    return;
+  }
+
+  const snapshots = await npcMemoryService.getAllMemorySnapshots(playerId);
+
+  res.json({
+    ok: true,
+    result: {
+      memories: snapshots,
+    },
+  });
+});
+
+/**
+ * GET /api/npc/memory/:npcId
+ *
+ * Get memory snapshot for a specific NPC.
+ */
+router.get("/memory/:npcId", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  const playerId = (req.query?.playerId as string) ?? identity.playerId;
+
+  if (!playerId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_player",
+    });
+    return;
+  }
+
+  const npcId = parseNpcId(req.params?.npcId);
+  if (!npcId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_npc",
+    });
+    return;
+  }
+
+  const snapshot = await npcMemoryService.getMemorySnapshot(playerId, npcId);
+
+  if (!snapshot) {
+    res.status(404).json({
+      ok: false,
+      reason: "missing_npc",
+    });
+    return;
+  }
+
+  res.json({
+    ok: true,
+    result: {
+      memory: snapshot,
+    },
+  });
+});
+
+/**
+ * GET /api/npc/reputation
+ *
+ * Get NPC reputation for player.
+ * Required: playerId, npcId (query params)
+ */
+router.get("/reputation", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  const playerId = (req.query?.playerId as string) ?? identity.playerId;
+
+  if (!playerId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_player",
+    });
+    return;
+  }
+
+  const npcId = parseNpcId(req.query?.npcId);
+  if (!npcId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_npc",
+    });
+    return;
+  }
+
+  const effectiveTrust = await npcMemoryService.getEffectiveTrust(playerId, npcId);
+
+  if (!effectiveTrust) {
+    res.status(404).json({
+      ok: false,
+      reason: "missing_npc",
+    });
+    return;
+  }
+
+  res.json({
+    ok: true,
+    result: {
+      npcId,
+      playerId,
+      reputation: effectiveTrust.directReputation,
+      rumorBonus: effectiveTrust.rumorBonus,
+      effectiveReputation: effectiveTrust.effectiveReputation,
+      trustTier: effectiveTrust.trustTier,
+    },
+  });
+});
+
+/**
+ * GET /api/npc/rumors
+ *
+ * Get all rumors for the player.
+ */
+router.get("/rumors", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  const playerId = (req.query?.playerId as string) ?? identity.playerId;
+
+  if (!playerId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_player",
+    });
+    return;
+  }
+
+  const npcId = parseNpcId(req.query?.npcId);
+
+  if (npcId) {
+    // Get rumors for specific NPC
+    const rumors = await npcRumorService.getRumorsForNpc(npcId, playerId);
+    const influence = await npcRumorService.getNpcRumorInfluence(npcId, playerId);
+
+    res.json({
+      ok: true,
+      result: {
+        rumors,
+        totalWeight: influence.totalWeight,
+        count: rumors.length,
+      },
+    });
+  } else {
+    // Get all rumors for player
+    const rumors = await npcRumorService.getRumorSnapshots(playerId);
+
+    res.json({
+      ok: true,
+      result: {
+        rumors,
+        count: rumors.length,
+      },
+    });
+  }
+});
+
+/**
+ * POST /api/npc/rumors/propagate
+ *
+ * Trigger rumor propagation for a specific rumor.
+ * Uses explicit server tick for deterministic propagation.
+ */
+router.post("/rumors/propagate", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  const playerId = (req.body?.playerId as string) ?? identity.playerId;
+
+  if (!playerId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_player",
+    });
+    return;
+  }
+
+  const rumorId = parseRumorId(req.body?.rumorId);
+  if (!rumorId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_rumor",
+    });
+    return;
+  }
+
+  // Get current tick from WorldTick if available
+  let currentTick = 0;
+  try {
+    // Import WorldTick lazily to avoid circular dependencies
+    const { worldTick } = await import("../core/WorldTick.js");
+    currentTick = (worldTick as { tickCount?: number })?.tickCount ?? 0;
+  } catch {
+    // Use 0 if not available
+  }
+
+  const result = await npcRumorService.propagateRumor(playerId, rumorId, currentTick);
+
+  const statusCode = result.ok ? 200 : 400;
+  res.status(statusCode).json({
+    ok: result.ok,
+    reason: result.ok ? undefined : (result as { ok: false; reason: string }).reason,
+    result: result.ok ? (result as { ok: true; result: unknown }).result : undefined,
+  });
+});
+
+/**
+ * GET /api/npc/effective-trust/:npcId
+ *
+ * Get effective trust calculation for an NPC.
+ */
+router.get("/effective-trust/:npcId", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  const playerId = (req.query?.playerId as string) ?? identity.playerId;
+
+  if (!playerId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_player",
+    });
+    return;
+  }
+
+  const npcId = parseNpcId(req.params?.npcId);
+  if (!npcId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_npc",
+    });
+    return;
+  }
+
+  const effectiveTrust = await npcMemoryService.getEffectiveTrust(playerId, npcId);
+
+  if (!effectiveTrust) {
+    res.status(404).json({
+      ok: false,
+      reason: "missing_npc",
+    });
+    return;
+  }
+
+  res.json({
+    ok: true,
+    result: {
+      npcId,
+      playerId,
+      directReputation: effectiveTrust.directReputation,
+      rumorBonus: effectiveTrust.rumorBonus,
+      effectiveReputation: effectiveTrust.effectiveReputation,
+      trustTier: effectiveTrust.trustTier,
+    },
+  });
+});
+
+/**
+ * GET /api/npc/rumor-eligible/:sourceNpcId
+ *
+ * Get eligible rumor propagation targets for an NPC.
+ */
+router.get("/rumor-eligible/:sourceNpcId", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  const playerId = (req.query?.playerId as string) ?? identity.playerId;
+
+  if (!playerId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_player",
+    });
+    return;
+  }
+
+  const sourceNpcId = parseNpcId(req.params?.sourceNpcId);
+  if (!sourceNpcId) {
+    res.status(400).json({
+      ok: false,
+      reason: "missing_npc",
+    });
+    return;
+  }
+
+  const eligibleTargets = npcMemoryService.getEligibleRumorTargets(sourceNpcId);
+
+  res.json({
+    ok: true,
+    result: {
+      sourceNpcId,
+      eligibleTargets,
+      count: eligibleTargets.length,
+    },
+  });
+});
+
+export default router;

--- a/server/src/npc/NpcMemoryRoute.ts
+++ b/server/src/npc/NpcMemoryRoute.ts
@@ -240,15 +240,9 @@ router.post("/rumors/propagate", async (req, res) => {
     return;
   }
 
-  // Get current tick from WorldTick if available
-  let currentTick = 0;
-  try {
-    // Import WorldTick lazily to avoid circular dependencies
-    const { worldTick } = await import("../core/WorldTick.js");
-    currentTick = (worldTick as { tickCount?: number })?.tickCount ?? 0;
-  } catch {
-    // Use 0 if not available
-  }
+  // Get current tick from request body or use 0 as default
+  // The tick is used for tracking propagation time, not for determinism
+  const currentTick = typeof req.body?.tick === "number" ? req.body.tick : 0;
 
   const result = await npcRumorService.propagateRumor(playerId, rumorId, currentTick);
 

--- a/server/src/npc/NpcMemoryService.ts
+++ b/server/src/npc/NpcMemoryService.ts
@@ -1,0 +1,532 @@
+/**
+ * NPC MEMORY SERVICE
+ *
+ * Server-authoritative NPC memory management.
+ * Handles memory event recording, retrieval, and persistence.
+ *
+ * Determinism rules:
+ * - No Date.now() for gameplay state
+ * - No Math.random() for gameplay IDs
+ * - All IDs are deterministic based on input values
+ * - Memory events are immutable once recorded
+ * - Client-authoritative memory writes are rejected
+ */
+
+import {
+  type NpcMemoryEvent,
+  type PersistedNpcMemoryState,
+  type NpcMemorySnapshot,
+  type NpcRumor,
+  type NpcRumorKind,
+  type MemoryResult,
+  type NpcMemoryEventKind,
+  MemoryFailReasons,
+  generateMemoryEventId,
+  reputationToTrustTier,
+  calculateEffectiveReputation,
+  getTrustTierCssClass,
+} from "./NpcRumorTypes.js";
+import { npcMemoryStore } from "./NpcMemoryStore.js";
+
+/**
+ * NPC definition with position for proximity checks.
+ */
+interface NpcDefinition {
+  id: string;
+  displayName: string;
+  x: number;
+  y: number;
+  interactionRadius: number;
+  /** Social links to other NPCs (for rumor propagation) */
+  socialLinks?: readonly string[];
+}
+
+/**
+ * NPC registry with known NPCs.
+ */
+const NPC_REGISTRY = new Map<string, NpcDefinition>([
+  ["village_trader_001", {
+    id: "village_trader_001",
+    displayName: "Mira the Quartermaster",
+    x: 462,
+    y: 503,
+    interactionRadius: 32,
+    socialLinks: ["village_elder_001", "outpost_guard_001"],
+  }],
+  ["village_elder_001", {
+    id: "village_elder_001",
+    displayName: "Elder Thorne",
+    x: 458,
+    y: 498,
+    interactionRadius: 28,
+    socialLinks: ["village_trader_001", "outpost_guard_001"],
+  }],
+  ["outpost_guard_001", {
+    id: "outpost_guard_001",
+    displayName: "Captain Roderick",
+    x: 520,
+    y: 510,
+    interactionRadius: 28,
+    socialLinks: ["village_trader_001", "village_elder_001"],
+  }],
+]);
+
+/**
+ * Memory event counter for deterministic logical indices.
+ * Key: `${playerId}:${npcId}`, Value: next logical index
+ */
+const memoryEventCounters = new Map<string, number>();
+
+/**
+ * Get next deterministic logical index for a player-NPC pair.
+ */
+function getNextLogicalIndex(playerId: string, npcId: string): number {
+  const key = `${playerId}:${npcId}`;
+  const current = memoryEventCounters.get(key) ?? 0;
+  memoryEventCounters.set(key, current + 1);
+  return current;
+}
+
+/**
+ * Calculate distance between two points.
+ */
+function calculateDistance(x1: number, y1: number, x2: number, y2: number): number {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * NPC Memory Service - manages memory events for all players.
+ * Singleton pattern with server-authoritative state.
+ */
+export class NpcMemoryService {
+  private readonly store: typeof npcMemoryStore;
+
+  constructor(store: typeof npcMemoryStore = npcMemoryStore) {
+    this.store = store;
+  }
+
+  /**
+   * Get NPC definition by ID.
+   */
+  getNpcDefinition(npcId: string): NpcDefinition | undefined {
+    return NPC_REGISTRY.get(npcId);
+  }
+
+  /**
+   * Check if player is within interaction radius of NPC.
+   */
+  isPlayerNearNpc(playerX: number, playerY: number, npcId: string): boolean {
+    const npc = NPC_REGISTRY.get(npcId);
+    if (!npc) return false;
+
+    const distance = calculateDistance(playerX, playerY, npc.x, npc.y);
+    return distance <= npc.interactionRadius;
+  }
+
+  /**
+   * Record a memory event for a player-NPC interaction.
+   * Returns error if event already exists (duplicate rejection).
+   */
+  async recordMemoryEvent(
+    playerId: string,
+    npcId: string,
+    kind: NpcMemoryEventKind,
+    sourceId: string,
+    reputationDelta: number,
+    note: string,
+  ): Promise<MemoryResult<NpcMemoryEvent>> {
+    if (!playerId) {
+      return { ok: false, reason: MemoryFailReasons.MISSING_PLAYER };
+    }
+
+    if (!npcId) {
+      return { ok: false, reason: MemoryFailReasons.MISSING_NPC };
+    }
+
+    // Check if NPC exists
+    if (!NPC_REGISTRY.has(npcId)) {
+      return { ok: false, reason: MemoryFailReasons.MISSING_NPC };
+    }
+
+    // Get deterministic logical index
+    const logicalIndex = getNextLogicalIndex(playerId, npcId);
+
+    // Generate deterministic event ID
+    const eventId = generateMemoryEventId(npcId, playerId, kind, logicalIndex, sourceId);
+
+    // Check for duplicate
+    const exists = await this.store.hasMemoryEvent(eventId, playerId, npcId);
+    if (exists) {
+      return { ok: false, reason: MemoryFailReasons.DUPLICATE_MEMORY_EVENT };
+    }
+
+    // Load current state or create new
+    let state = await this.store.load(playerId, npcId);
+    if (!state) {
+      state = {
+        schemaVersion: 1,
+        playerId,
+        npcId,
+        reputation: 0,
+        trustTier: "neutral",
+        completedQuestIds: [],
+        memoryEvents: [],
+        knownRumorIds: [],
+      };
+    }
+
+    // Create new event
+    const event: NpcMemoryEvent = {
+      eventId,
+      npcId,
+      playerId,
+      kind,
+      logicalIndex,
+      sourceId,
+      reputationDelta,
+      note,
+    };
+
+    // Calculate new reputation
+    const newReputation = state.reputation + reputationDelta;
+
+    // Update state
+    const updatedState: PersistedNpcMemoryState = {
+      ...state,
+      reputation: newReputation,
+      trustTier: reputationToTrustTier(newReputation),
+      memoryEvents: [...state.memoryEvents, event],
+    };
+
+    // Save atomically
+    try {
+      await this.store.save(updatedState);
+    } catch (error) {
+      console.error("[NpcMemoryService] Failed to save memory event:", error);
+      return { ok: false, reason: MemoryFailReasons.PERSISTENCE_SAVE_FAILED };
+    }
+
+    return { ok: true, result: event };
+  }
+
+  /**
+   * Record a quest_accepted memory event.
+   */
+  async recordQuestAccepted(
+    playerId: string,
+    npcId: string,
+    questId: string,
+  ): Promise<MemoryResult<NpcMemoryEvent>> {
+    return this.recordMemoryEvent(
+      playerId,
+      npcId,
+      "quest_accepted",
+      questId,
+      0, // No reputation change for accepting
+      `Accepted quest: ${questId}`,
+    );
+  }
+
+  /**
+   * Record a quest_completed memory event.
+   * Also triggers helped_village rumor creation.
+   */
+  async recordQuestCompleted(
+    playerId: string,
+    npcId: string,
+    questId: string,
+    reputationDelta: number,
+  ): Promise<MemoryResult<NpcMemoryEvent>> {
+    const result = await this.recordMemoryEvent(
+      playerId,
+      npcId,
+      "quest_completed",
+      questId,
+      reputationDelta,
+      `Completed quest: ${questId}`,
+    );
+
+    // Trigger rumor creation if event was recorded
+    if (result.ok && result.result) {
+      // Queue rumor creation (will be processed by rumor service)
+      const { npcRumorService } = await import("./NpcRumorService.js");
+      await npcRumorService.createRumorFromMemory(playerId, npcId, result.result.eventId, "helped_village");
+    }
+
+    return result;
+  }
+
+  /**
+   * Record a sell_completed memory event.
+   * Tracks sell milestones for reliable_supplier rumor.
+   */
+  async recordSellCompleted(
+    playerId: string,
+    npcId: string,
+    itemId: string,
+    quantity: number,
+  ): Promise<MemoryResult<NpcMemoryEvent>> {
+    const result = await this.recordMemoryEvent(
+      playerId,
+      npcId,
+      "sell_completed",
+      itemId,
+      0, // Small reputation from trades
+      `Sold ${quantity}x ${itemId}`,
+    );
+
+    // Check sell milestone for rumor (5 valid sells = reliable_supplier)
+    if (result.ok) {
+      const state = await this.store.load(playerId, npcId);
+      if (state) {
+        const sellCount = state.memoryEvents.filter(
+          (e) => e.kind === "sell_completed" && e.sourceId === itemId,
+        ).length;
+
+        // At milestone, create reliable_supplier rumor
+        if (sellCount === 5) {
+          const { npcRumorService } = await import("./NpcRumorService.js");
+          await npcRumorService.createRumorFromMemory(playerId, npcId, result.result.eventId, "reliable_supplier");
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Record a hostile_action memory event.
+   * Triggers hostile_actor rumor creation.
+   */
+  async recordHostileAction(
+    playerId: string,
+    npcId: string,
+    sourceId: string,
+  ): Promise<MemoryResult<NpcMemoryEvent>> {
+    const result = await this.recordMemoryEvent(
+      playerId,
+      npcId,
+      "hostile_action",
+      sourceId,
+      -2, // Reputation penalty
+      `Hostile action: ${sourceId}`,
+    );
+
+    // Trigger hostile_actor rumor
+    if (result.ok && result.result) {
+      const { npcRumorService } = await import("./NpcRumorService.js");
+      await npcRumorService.createRumorFromMemory(playerId, npcId, result.result.eventId, "hostile_actor");
+    }
+
+    return result;
+  }
+
+  /**
+   * Record an interaction_failed memory event.
+   * Triggers troublemaker rumor after repeated failures.
+   */
+  async recordInteractionFailed(
+    playerId: string,
+    npcId: string,
+    action: string,
+  ): Promise<MemoryResult<NpcMemoryEvent>> {
+    const result = await this.recordMemoryEvent(
+      playerId,
+      npcId,
+      "interaction_failed",
+      action,
+      -1, // Small reputation penalty
+      `Failed interaction: ${action}`,
+    );
+
+    // Check for repeated failures (3+) for troublemaker rumor
+    if (result.ok) {
+      const state = await this.store.load(playerId, npcId);
+      if (state) {
+        const failCount = state.memoryEvents.filter((e) => e.kind === "interaction_failed").length;
+
+        if (failCount >= 3) {
+          const { npcRumorService } = await import("./NpcRumorService.js");
+          await npcRumorService.createRumorFromMemory(playerId, npcId, result.result.eventId, "troublemaker");
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Record a rumor_heard memory event.
+   */
+  async recordRumorHeard(
+    playerId: string,
+    npcId: string,
+    sourceNpcId: string,
+    rumorId: string,
+  ): Promise<MemoryResult<NpcMemoryEvent>> {
+    return this.recordMemoryEvent(
+      playerId,
+      npcId,
+      "rumor_heard",
+      rumorId,
+      0, // No direct reputation change from hearing rumors
+      `Heard rumor from ${sourceNpcId}: ${rumorId}`,
+    );
+  }
+
+  /**
+   * Get memory snapshot for a player-NPC pair.
+   */
+  async getMemorySnapshot(playerId: string, npcId: string): Promise<NpcMemorySnapshot | null> {
+    const state = await this.store.load(playerId, npcId);
+    if (!state) return null;
+
+    // Get recent memory notes (last 5)
+    const recentEvents = [...state.memoryEvents]
+      .sort((a, b) => b.logicalIndex - a.logicalIndex)
+      .slice(0, 5);
+
+    const recentMemoryNotes = recentEvents.map((e) => e.note);
+
+    // Get rumor count
+    const rumors = await this.store.getRumorsForNpc(npcId, playerId);
+
+    return {
+      npcId,
+      playerId,
+      reputation: state.reputation,
+      trustTier: state.trustTier,
+      memoryEventCount: state.memoryEvents.length,
+      recentMemoryNotes: Object.freeze(recentMemoryNotes),
+      knownRumorCount: rumors.length,
+    };
+  }
+
+  /**
+   * Get all memory snapshots for a player.
+   */
+  async getAllMemorySnapshots(playerId: string): Promise<readonly NpcMemorySnapshot[]> {
+    const states = await this.store.listForPlayer(playerId);
+    const snapshots: NpcMemorySnapshot[] = [];
+
+    for (const state of states) {
+      const snapshot = await this.getMemorySnapshot(state.playerId, state.npcId);
+      if (snapshot) {
+        snapshots.push(snapshot);
+      }
+    }
+
+    return Object.freeze(snapshots.sort((a, b) => a.npcId.localeCompare(b.npcId)));
+  }
+
+  /**
+   * Get persisted memory state for a player-NPC pair.
+   */
+  async getMemoryState(playerId: string, npcId: string): Promise<PersistedNpcMemoryState | null> {
+    return this.store.load(playerId, npcId);
+  }
+
+  /**
+   * Get effective trust calculation for a player-NPC pair.
+   * Combines direct reputation with rumor influence.
+   */
+  async getEffectiveTrust(playerId: string, npcId: string): Promise<{
+    directReputation: number;
+    rumorBonus: number;
+    effectiveReputation: number;
+    trustTier: string;
+  } | null> {
+    const state = await this.store.load(playerId, npcId);
+    if (!state) {
+      return {
+        directReputation: 0,
+        rumorBonus: 0,
+        effectiveReputation: 0,
+        trustTier: "neutral",
+      };
+    }
+
+    // Calculate rumor bonus from known rumors
+    const rumors = await this.store.getRumorsForNpc(npcId, playerId);
+    const totalRumorWeight = rumors.reduce((sum, r) => sum + r.weight, 0);
+    const rumorBonus = Math.trunc(totalRumorWeight / 2);
+    const effectiveReputation = calculateEffectiveReputation(state.reputation, totalRumorWeight);
+
+    return {
+      directReputation: state.reputation,
+      rumorBonus,
+      effectiveReputation,
+      trustTier: reputationToTrustTier(effectiveReputation),
+    };
+  }
+
+  /**
+   * Get eligible NPCs for rumor propagation.
+   * Uses deterministic rules: same settlement, social edge, or vendor/quest NPC.
+   */
+  getEligibleRumorTargets(sourceNpcId: string): readonly string[] {
+    const sourceNpc = NPC_REGISTRY.get(sourceNpcId);
+    if (!sourceNpc) return [];
+
+    // Collect eligible targets
+    const eligible = new Set<string>();
+
+    // 1. Same settlement - check by proximity to village center
+    const villageCenterX = 462;
+    const villageCenterY = 503;
+    const settlementRadius = 80;
+
+    for (const [npcId, npc] of NPC_REGISTRY) {
+      if (npcId === sourceNpcId) continue;
+
+      const distance = calculateDistance(npc.x, npc.y, villageCenterX, villageCenterY);
+      if (distance <= settlementRadius) {
+        eligible.add(npcId);
+      }
+    }
+
+    // 2. Social links
+    if (sourceNpc.socialLinks) {
+      for (const linkedNpcId of sourceNpc.socialLinks) {
+        eligible.add(linkedNpcId);
+      }
+    }
+
+    // 3. Vendor/quest NPCs in the same village
+    for (const [npcId, npc] of NPC_REGISTRY) {
+      if (npcId === sourceNpcId) continue;
+
+      // Check if within same village (within 100 units of village center)
+      const distance = calculateDistance(npc.x, npc.y, villageCenterX, villageCenterY);
+      if (distance <= 100) {
+        eligible.add(npcId);
+      }
+    }
+
+    return Object.freeze([...eligible].sort());
+  }
+
+  /**
+   * Reset memory for a player (for testing).
+   */
+  async resetPlayerMemory(playerId: string): Promise<void> {
+    const states = await this.store.listForPlayer(playerId);
+    for (const state of states) {
+      const resetState: PersistedNpcMemoryState = {
+        ...state,
+        reputation: 0,
+        trustTier: "neutral",
+        memoryEvents: [],
+        knownRumorIds: [],
+      };
+      await this.store.save(resetState);
+    }
+  }
+}
+
+/**
+ * Global singleton instance.
+ */
+export const npcMemoryService = new NpcMemoryService();

--- a/server/src/npc/NpcMemoryStore.ts
+++ b/server/src/npc/NpcMemoryStore.ts
@@ -1,0 +1,267 @@
+/**
+ * NPC MEMORY STORE
+ *
+ * Deterministic JSON file-based persistence for NPC memory and rumors.
+ * Provides atomic save/load with temp file + rename pattern.
+ *
+ * Rules:
+ * - No Date.now() for gameplay state
+ * - No Math.random() for gameplay IDs
+ * - Atomic writes via temp + rename
+ * - Stable sort for deterministic output
+ * - Corrupt JSON must not crash server
+ * - No secrets required
+ *
+ * Config:
+ * - NPC_MEMORY_FILE env var for custom path
+ * - Default: process.cwd()/data/npc-memory.json
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  type PersistedNpcMemoryState,
+  type NpcRumor,
+  reputationToTrustTier,
+} from "./NpcRumorTypes.js";
+
+/**
+ * Root file structure for NPC memory persistence.
+ */
+interface NpcMemoryStateFile {
+  schemaVersion: 1;
+  /** Player ID -> NPC ID -> PersistedNpcMemoryState */
+  memoryStates: Record<string, Record<string, PersistedNpcMemoryState>>;
+  /** All known rumors indexed by playerId for fast lookup */
+  rumors: Record<string, NpcRumor[]>;
+}
+
+/**
+ * Create empty state file.
+ */
+function createEmptyFile(): NpcMemoryStateFile {
+  return {
+    schemaVersion: 1,
+    memoryStates: {},
+    rumors: {},
+  };
+}
+
+/**
+ * Stable sort players, then NPCs, then events for deterministic output.
+ */
+function stableSortFile(file: NpcMemoryStateFile): NpcMemoryStateFile {
+  const sortedPlayers = Object.keys(file.memoryStates).sort().reduce<Record<string, Record<string, PersistedNpcMemoryState>>>((acc, playerId) => {
+    const npcRecords = file.memoryStates[playerId];
+    const sortedNpCs = Object.keys(npcRecords).sort().reduce<Record<string, PersistedNpcMemoryState>>((npcAcc, npcId) => {
+      const state = npcRecords[npcId];
+      npcAcc[npcId] = {
+        ...state,
+        memoryEvents: [...state.memoryEvents].sort((a, b) => {
+          if (a.logicalIndex !== b.logicalIndex) return a.logicalIndex - b.logicalIndex;
+          return a.eventId.localeCompare(b.eventId);
+        }),
+        knownRumorIds: [...state.knownRumorIds].sort(),
+      };
+      return npcAcc;
+    }, {});
+    acc[playerId] = sortedNpCs;
+    return acc;
+  }, {});
+
+  const sortedRumors: Record<string, NpcRumor[]> = {};
+  for (const [playerId, playerRumors] of Object.entries(file.rumors)) {
+    sortedRumors[playerId] = [...playerRumors].sort((a, b) => a.rumorId.localeCompare(b.rumorId));
+  }
+
+  return {
+    schemaVersion: 1,
+    memoryStates: sortedPlayers,
+    rumors: sortedRumors,
+  };
+}
+
+function stableStringify(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function resolveNpcMemoryFilePath(): string {
+  return process.env.NPC_MEMORY_FILE
+    ? path.resolve(process.env.NPC_MEMORY_FILE)
+    : path.resolve(process.cwd(), "data", "npc-memory.json");
+}
+
+/**
+ * JSON file-based NPC memory store.
+ * Provides deterministic save/load for NPC memory and rumors.
+ */
+export class NpcMemoryStore {
+  private filePath: string;
+
+  constructor(filePath: string = resolveNpcMemoryFilePath()) {
+    this.filePath = filePath;
+  }
+
+  /**
+   * Load persisted memory state for a player-NPC pair.
+   */
+  async load(playerId: string, npcId: string): Promise<PersistedNpcMemoryState | null> {
+    const file = await this.readStateFile();
+    const playerMemories = file.memoryStates[playerId];
+    if (!playerMemories) return null;
+    return playerMemories[npcId] ?? null;
+  }
+
+  /**
+   * Save memory state atomically.
+   */
+  async save(state: PersistedNpcMemoryState): Promise<void> {
+    const file = await this.readStateFile();
+
+    // Ensure player record exists
+    if (!file.memoryStates[state.playerId]) {
+      file.memoryStates[state.playerId] = {};
+    }
+
+    // Stable sort events before saving
+    const sortedState: PersistedNpcMemoryState = {
+      ...state,
+      trustTier: reputationToTrustTier(state.reputation),
+      memoryEvents: [...state.memoryEvents].sort((a, b) => {
+        if (a.logicalIndex !== b.logicalIndex) return a.logicalIndex - b.logicalIndex;
+        return a.eventId.localeCompare(b.eventId);
+      }),
+      knownRumorIds: [...state.knownRumorIds].sort(),
+    };
+
+    file.memoryStates[state.playerId][state.npcId] = sortedState;
+
+    await this.writeStateFile(stableSortFile(file));
+  }
+
+  /**
+   * List all memory states for a player.
+   */
+  async listForPlayer(playerId: string): Promise<readonly PersistedNpcMemoryState[]> {
+    const file = await this.readStateFile();
+    const playerMemories = file.memoryStates[playerId];
+    if (!playerMemories) return [];
+
+    return Object.values(playerMemories).sort((a, b) => a.npcId.localeCompare(b.npcId));
+  }
+
+  /**
+   * Load all rumors for a player.
+   */
+  async loadRumorsForPlayer(playerId: string): Promise<readonly NpcRumor[]> {
+    const file = await this.readStateFile();
+    return file.rumors[playerId] ?? [];
+  }
+
+  /**
+   * Save a rumor atomically.
+   */
+  async saveRumor(rumor: NpcRumor): Promise<void> {
+    const file = await this.readStateFile();
+
+    if (!file.rumors[rumor.playerId]) {
+      file.rumors[rumor.playerId] = [];
+    }
+
+    // Check for duplicate
+    const existingIndex = file.rumors[rumor.playerId].findIndex((r) => r.rumorId === rumor.rumorId);
+    if (existingIndex >= 0) {
+      // Already exists, skip
+      return;
+    }
+
+    file.rumors[rumor.playerId] = [...file.rumors[rumor.playerId], rumor];
+
+    await this.writeStateFile(stableSortFile(file));
+  }
+
+  /**
+   * Get all rumors known by a specific NPC.
+   */
+  async getRumorsForNpc(npcId: string, playerId: string): Promise<readonly NpcRumor[]> {
+    const file = await this.readStateFile();
+    const playerRumors = file.rumors[playerId] ?? [];
+    return playerRumors.filter((r) => r.heardByNpcIds.includes(npcId));
+  }
+
+  /**
+   * Check if a rumor already exists.
+   */
+  async hasRumor(rumorId: string, playerId: string): Promise<boolean> {
+    const file = await this.readStateFile();
+    const playerRumors = file.rumors[playerId] ?? [];
+    return playerRumors.some((r) => r.rumorId === rumorId);
+  }
+
+  /**
+   * Check if a memory event already exists.
+   */
+  async hasMemoryEvent(eventId: string, playerId: string, npcId: string): Promise<boolean> {
+    const state = await this.load(playerId, npcId);
+    if (!state) return false;
+    return state.memoryEvents.some((e) => e.eventId === eventId);
+  }
+
+  private async readStateFile(): Promise<NpcMemoryStateFile> {
+    try {
+      const raw = await readFile(this.filePath, "utf8");
+      const parsed = JSON.parse(raw) as Partial<NpcMemoryStateFile>;
+
+      const memoryStates: Record<string, Record<string, PersistedNpcMemoryState>> = {};
+      if (parsed.memoryStates && typeof parsed.memoryStates === "object") {
+        for (const [playerId, npcRecords] of Object.entries(parsed.memoryStates)) {
+          if (npcRecords && typeof npcRecords === "object") {
+            memoryStates[playerId] = {};
+            for (const [npcId, state] of Object.entries(npcRecords)) {
+              if (state && typeof state === "object") {
+                memoryStates[playerId][npcId] = state as PersistedNpcMemoryState;
+              }
+            }
+          }
+        }
+      }
+
+      const rumors: Record<string, NpcRumor[]> = {};
+      if (parsed.rumors && typeof parsed.rumors === "object") {
+        for (const [playerId, playerRumors] of Object.entries(parsed.rumors)) {
+          if (Array.isArray(playerRumors)) {
+            rumors[playerId] = playerRumors as NpcRumor[];
+          }
+        }
+      }
+
+      return stableSortFile({
+        schemaVersion: 1,
+        memoryStates,
+        rumors,
+      });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        return createEmptyFile();
+      }
+
+      // Corrupt JSON - return empty state, don't crash
+      return createEmptyFile();
+    }
+  }
+
+  private async writeStateFile(file: NpcMemoryStateFile): Promise<void> {
+    const dir = path.dirname(this.filePath);
+    await mkdir(dir, { recursive: true });
+
+    const tmp = `${this.filePath}.tmp`;
+    await writeFile(tmp, stableStringify(file), "utf8");
+    await rename(tmp, this.filePath);
+  }
+}
+
+/**
+ * Global singleton instance.
+ */
+export const npcMemoryStore = new NpcMemoryStore();

--- a/server/src/npc/NpcRumorService.ts
+++ b/server/src/npc/NpcRumorService.ts
@@ -1,0 +1,331 @@
+/**
+ * NPC RUMOR SERVICE
+ *
+ * Server-authoritative rumor propagation system.
+ * Handles deterministic rumor creation and spreading between NPCs.
+ *
+ * Determinism rules:
+ * - No Date.now() for gameplay state
+ * - No Math.random() for rumor spread
+ * - Rumors propagate only on explicit server tick/action processing
+ * - All IDs are deterministic based on input values
+ * - Rumor propagation is deterministic and idempotent
+ */
+
+import {
+  type NpcRumor,
+  type NpcRumorKind,
+  type NpcRumorSnapshot,
+  type MemoryResult,
+  type NpcMemoryEvent,
+  MemoryFailReasons,
+  generateRumorId,
+  getRumorKindAccent,
+} from "./NpcRumorTypes.js";
+import { npcMemoryStore } from "./NpcMemoryStore.js";
+import { npcMemoryService } from "./NpcMemoryService.js";
+
+/**
+ * Rumor weight constants for deterministic calculation.
+ */
+const RUMOR_WEIGHTS: Record<NpcRumorKind, number> = {
+  helped_village: 2,
+  reliable_supplier: 2,
+  trusted_worker: 3,
+  troublemaker: -1,
+  hostile_actor: -2,
+};
+
+/**
+ * Rumor notes for each kind.
+ */
+const RUMOR_NOTES: Record<NpcRumorKind, string> = {
+  helped_village: "A valued helper to the village community",
+  reliable_supplier: "Consistent and trustworthy in trade",
+  trusted_worker: "Proven reliable over time",
+  troublemaker: "Has caused issues in interactions",
+  hostile_actor: "Has shown hostile behavior",
+};
+
+/**
+ * Rumor propagation result.
+ */
+export interface RumorPropagationResult {
+  rumorId: string;
+  sourceNpcId: string;
+  targetNpcId: string;
+  playerId: string;
+  propagated: boolean;
+}
+
+/**
+ * NPC Rumor Service - manages rumor records and propagation.
+ * Singleton pattern with server-authoritative state.
+ */
+export class NpcRumorService {
+  private readonly store: typeof npcMemoryStore;
+
+  constructor(store: typeof npcMemoryStore = npcMemoryStore) {
+    this.store = store;
+  }
+
+  /**
+   * Create a rumor from a memory event.
+   * Returns error if rumor already exists (duplicate rejection).
+   */
+  async createRumorFromMemory(
+    playerId: string,
+    sourceNpcId: string,
+    sourceEventId: string,
+    kind: NpcRumorKind,
+  ): Promise<MemoryResult<NpcRumor>> {
+    if (!playerId) {
+      return { ok: false, reason: MemoryFailReasons.MISSING_PLAYER };
+    }
+
+    if (!sourceNpcId) {
+      return { ok: false, reason: MemoryFailReasons.MISSING_NPC };
+    }
+
+    // Generate deterministic rumor ID
+    const rumorId = generateRumorId(sourceNpcId, playerId, sourceEventId);
+
+    // Check if already exists
+    const exists = await this.store.hasRumor(rumorId, playerId);
+    if (exists) {
+      return { ok: false, reason: MemoryFailReasons.DUPLICATE_RUMOR };
+    }
+
+    // Get weight for this rumor kind
+    const weight = RUMOR_WEIGHTS[kind] ?? 1;
+
+    // Create rumor record
+    const rumor: NpcRumor = {
+      rumorId,
+      sourceNpcId,
+      playerId,
+      sourceEventId,
+      kind,
+      weight,
+      createdAtTick: 0, // Will be set during propagation
+      heardByNpcIds: [sourceNpcId], // Source NPC knows the rumor initially
+      note: RUMOR_NOTES[kind],
+    };
+
+    // Save rumor
+    try {
+      await this.store.saveRumor(rumor);
+    } catch (error) {
+      console.error("[NpcRumorService] Failed to save rumor:", error);
+      return { ok: false, reason: MemoryFailReasons.PERSISTENCE_SAVE_FAILED };
+    }
+
+    // Update source NPC's known rumor IDs in their memory state
+    const sourceState = await this.store.load(playerId, sourceNpcId);
+    if (sourceState) {
+      const updatedState = {
+        ...sourceState,
+        knownRumorIds: [...sourceState.knownRumorIds, rumorId],
+      };
+      await this.store.save(updatedState);
+    }
+
+    return { ok: true, result: rumor };
+  }
+
+  /**
+   * Propagate a rumor to eligible NPCs.
+   * Deterministic: uses explicit tick processing, not random spread.
+   */
+  async propagateRumor(
+    playerId: string,
+    rumorId: string,
+    currentTick: number,
+  ): Promise<MemoryResult<RumorPropagationResult[]>> {
+    if (!playerId) {
+      return { ok: false, reason: MemoryFailReasons.MISSING_PLAYER };
+    }
+
+    if (!rumorId) {
+      return { ok: false, reason: MemoryFailReasons.MISSING_RUMOR };
+    }
+
+    // Get all rumors for player
+    const rumors = await this.store.loadRumorsForPlayer(playerId);
+    const rumor = rumors.find((r) => r.rumorId === rumorId);
+
+    if (!rumor) {
+      return { ok: false, reason: MemoryFailReasons.MISSING_RUMOR };
+    }
+
+    // Get eligible targets
+    const eligibleTargets = npcMemoryService.getEligibleRumorTargets(rumor.sourceNpcId);
+
+    // Filter out already-aware NPCs
+    const newTargets = eligibleTargets.filter(
+      (targetId) => !rumor.heardByNpcIds.includes(targetId),
+    );
+
+    if (newTargets.length === 0) {
+      // No new targets, rumor is fully propagated
+      return {
+        ok: true,
+        result: [{
+          rumorId,
+          sourceNpcId: rumor.sourceNpcId,
+          targetNpcId: rumor.sourceNpcId,
+          playerId,
+          propagated: false,
+        }],
+      };
+    }
+
+    // Update rumor with new listeners
+    const updatedRumor: NpcRumor = {
+      ...rumor,
+      createdAtTick: currentTick,
+      heardByNpcIds: [...rumor.heardByNpcIds, ...newTargets],
+    };
+
+    // Save updated rumor
+    try {
+      await this.store.saveRumor(updatedRumor);
+    } catch (error) {
+      console.error("[NpcRumorService] Failed to propagate rumor:", error);
+      return { ok: false, reason: MemoryFailReasons.PERSISTENCE_SAVE_FAILED };
+    }
+
+    // Record rumor_heard memory events for each new target
+    for (const targetNpcId of newTargets) {
+      await npcMemoryService.recordRumorHeard(playerId, targetNpcId, rumor.sourceNpcId, rumorId);
+
+      // Update target NPC's known rumor IDs
+      const targetState = await this.store.load(playerId, targetNpcId);
+      if (targetState) {
+        const updatedTargetState = {
+          ...targetState,
+          knownRumorIds: [...targetState.knownRumorIds, rumorId],
+        };
+        await this.store.save(updatedTargetState);
+      }
+    }
+
+    const results: RumorPropagationResult[] = newTargets.map((targetNpcId) => ({
+      rumorId,
+      sourceNpcId: rumor.sourceNpcId,
+      targetNpcId,
+      playerId,
+      propagated: true,
+    }));
+
+    return { ok: true, result: results };
+  }
+
+  /**
+   * Get all rumors for a player.
+   */
+  async getRumorsForPlayer(playerId: string): Promise<readonly NpcRumor[]> {
+    return this.store.loadRumorsForPlayer(playerId);
+  }
+
+  /**
+   * Get rumors known by a specific NPC.
+   */
+  async getRumorsForNpc(npcId: string, playerId: string): Promise<readonly NpcRumor[]> {
+    return this.store.getRumorsForNpc(npcId, playerId);
+  }
+
+  /**
+   * Get rumor snapshots for display.
+   */
+  async getRumorSnapshots(playerId: string): Promise<readonly NpcRumorSnapshot[]> {
+    const rumors = await this.store.loadRumorsForPlayer(playerId);
+
+    return rumors.map((rumor) => ({
+      rumorId: rumor.rumorId,
+      npcId: rumor.sourceNpcId,
+      playerId: rumor.playerId,
+      kind: rumor.kind,
+      weight: rumor.weight,
+      note: rumor.note,
+      sourceNpcId: rumor.sourceNpcId,
+    })).sort((a, b) => a.rumorId.localeCompare(b.rumorId));
+  }
+
+  /**
+   * Get rumors for a specific NPC that affect the player's reputation.
+   */
+  async getNpcRumorInfluence(npcId: string, playerId: string): Promise<{
+    totalWeight: number;
+    rumors: readonly NpcRumorSnapshot[];
+  }> {
+    const rumors = await this.getRumorsForNpc(npcId, playerId);
+    const totalWeight = rumors.reduce((sum, r) => sum + r.weight, 0);
+
+    const snapshots: NpcRumorSnapshot[] = rumors.map((r) => ({
+      rumorId: r.rumorId,
+      npcId: r.sourceNpcId,
+      playerId: r.playerId,
+      kind: r.kind,
+      weight: r.weight,
+      note: r.note,
+      sourceNpcId: r.sourceNpcId,
+    }));
+
+    return {
+      totalWeight,
+      rumors: Object.freeze(snapshots),
+    };
+  }
+
+  /**
+   * Check if a rumor exists.
+   */
+  async hasRumor(rumorId: string, playerId: string): Promise<boolean> {
+    return this.store.hasRumor(rumorId, playerId);
+  }
+
+  /**
+   * Process all pending rumors for a player.
+   * Call this on server tick or action processing.
+   */
+  async processPendingRumors(playerId: string, currentTick: number): Promise<{
+    processedCount: number;
+    propagationResults: RumorPropagationResult[];
+  }> {
+    const rumors = await this.store.loadRumorsForPlayer(playerId);
+    const results: RumorPropagationResult[] = [];
+    let processedCount = 0;
+
+    for (const rumor of rumors) {
+      // Only process if not fully propagated (has new targets)
+      const eligibleTargets = npcMemoryService.getEligibleRumorTargets(rumor.sourceNpcId);
+      const newTargets = eligibleTargets.filter(
+        (targetId) => !rumor.heardByNpcIds.includes(targetId),
+      );
+
+      if (newTargets.length > 0) {
+        const propagationResult = await this.propagateRumor(playerId, rumor.rumorId, currentTick);
+        if (propagationResult.ok) {
+          results.push(...propagationResult.result);
+          processedCount++;
+        }
+      }
+    }
+
+    return { processedCount, propagationResults: results };
+  }
+
+  /**
+   * Reset rumors for a player (for testing).
+   */
+  async resetPlayerRumors(playerId: string): Promise<void> {
+    // Rumors are stored in the memory store, reset happens at store level
+    // This method is here for API completeness
+  }
+}
+
+/**
+ * Global singleton instance.
+ */
+export const npcRumorService = new NpcRumorService();

--- a/server/src/npc/NpcRumorTypes.ts
+++ b/server/src/npc/NpcRumorTypes.ts
@@ -1,0 +1,274 @@
+/**
+ * NPC MEMORY & RUMOR TYPES
+ *
+ * Server-authoritative deterministic types for NPC memory persistence
+ * and rumor network propagation.
+ *
+ * Determinism rules:
+ * - No Date.now() for gameplay state
+ * - No Math.random() for gameplay IDs
+ * - No UUID for memory event IDs
+ * - All IDs must be deterministic based on input values
+ * - Client-authoritative memory writes are rejected
+ */
+
+import type { NpcDialogueState } from "../quests/NpcQuestTypes.js";
+
+/**
+ * Trust tier for NPC-player relationship.
+ * Derived deterministically from reputation value.
+ */
+export type TrustTier = "hostile" | "cold" | "neutral" | "trusted" | "honored";
+
+/**
+ * Memory event kinds that can be recorded.
+ * Each kind contributes to NPC memory and may trigger rumors.
+ */
+export type NpcMemoryEventKind =
+  | "quest_accepted"
+  | "quest_completed"
+  | "sell_completed"
+  | "trade_completed"
+  | "gift_given"
+  | "interaction_failed"
+  | "hostile_action"
+  | "rumor_heard";
+
+/**
+ * Rumor kinds that can be created from memory events.
+ * Each rumor type has social consequences for the player.
+ */
+export type NpcRumorKind =
+  | "helped_village"
+  | "reliable_supplier"
+  | "troublemaker"
+  | "hostile_actor"
+  | "trusted_worker";
+
+/**
+ * Memory event recorded for an NPC-player interaction.
+ * Event ID is deterministic: `${npcId}:${playerId}:${kind}:${logicalIndex}:${sourceId}`
+ */
+export interface NpcMemoryEvent {
+  readonly eventId: string;
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly kind: NpcMemoryEventKind;
+  readonly logicalIndex: number;
+  readonly sourceId: string;
+  readonly reputationDelta: number;
+  readonly note: string;
+}
+
+/**
+ * Persisted NPC memory state for a player-NPC pair.
+ * Stored server-side and restored on session reload.
+ */
+export interface PersistedNpcMemoryState {
+  readonly schemaVersion: 1;
+  readonly playerId: string;
+  readonly npcId: string;
+  readonly reputation: number;
+  readonly trustTier: TrustTier;
+  readonly completedQuestIds: readonly string[];
+  readonly memoryEvents: readonly NpcMemoryEvent[];
+  readonly knownRumorIds: readonly string[];
+}
+
+/**
+ * Rumor record created from significant memory events.
+ * Rumor ID is deterministic: `${sourceNpcId}:${playerId}:${sourceEventId}:rumor`
+ */
+export interface NpcRumor {
+  readonly rumorId: string;
+  readonly sourceNpcId: string;
+  readonly playerId: string;
+  readonly sourceEventId: string;
+  readonly kind: NpcRumorKind;
+  readonly weight: number;
+  readonly createdAtTick: number;
+  readonly heardByNpcIds: readonly string[];
+  readonly note: string;
+}
+
+/**
+ * Memory snapshot for LiveGameplaySnapshot.
+ * Exposes summary data without full raw history.
+ */
+export interface NpcMemorySnapshot {
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly reputation: number;
+  readonly trustTier: TrustTier;
+  readonly memoryEventCount: number;
+  readonly recentMemoryNotes: readonly string[];
+  readonly knownRumorCount: number;
+}
+
+/**
+ * Rumor snapshot for LiveGameplaySnapshot.
+ */
+export interface NpcRumorSnapshot {
+  readonly rumorId: string;
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly kind: NpcRumorKind;
+  readonly weight: number;
+  readonly note: string;
+  readonly sourceNpcId: string;
+}
+
+/**
+ * Effective trust calculation result.
+ * Combines direct reputation with rumor influence.
+ */
+export interface EffectiveTrust {
+  readonly npcId: string;
+  readonly playerId: string;
+  readonly directReputation: number;
+  readonly rumorBonus: number;
+  readonly effectiveReputation: number;
+  readonly trustTier: TrustTier;
+}
+
+/**
+ * Memory store interface for persistence backends.
+ * Implementations must provide atomic save/load operations.
+ */
+export interface NpcMemoryStore {
+  /**
+   * Load persisted memory state for a player-NPC pair.
+   * Returns null if no state exists.
+   */
+  load(playerId: string, npcId: string): Promise<PersistedNpcMemoryState | null>;
+
+  /**
+   * Save memory state atomically.
+   * Implementation must ensure no partial mutation on failure.
+   */
+  save(state: PersistedNpcMemoryState): Promise<void>;
+
+  /**
+   * List all memory states for a player.
+   */
+  listForPlayer(playerId: string): Promise<readonly PersistedNpcMemoryState[]>;
+}
+
+/**
+ * Rumor eligibility rules for deterministic propagation.
+ * A rumor can only spread to eligible NPCs.
+ */
+export interface RumorEligibilityRule {
+  readonly type: "same_settlement" | "social_edge" | "vendor_quest_npc";
+  readonly npcIds: readonly string[];
+}
+
+/**
+ * Fail reasons for memory/rumor operations.
+ */
+export const MemoryFailReasons = {
+  MISSING_PLAYER: "missing_player",
+  MISSING_NPC: "missing_npc",
+  MISSING_RUMOR: "missing_rumor",
+  INVALID_RUMOR_KIND: "invalid_rumor_kind",
+  DUPLICATE_RUMOR: "duplicate_rumor",
+  DUPLICATE_MEMORY_EVENT: "duplicate_memory_event",
+  INVALID_LOGICAL_INDEX: "invalid_logical_index",
+  RUMOR_PROPAGATION_REJECTED: "rumor_propagation_rejected",
+  PERSISTENCE_LOAD_FAILED: "persistence_load_failed",
+  PERSISTENCE_SAVE_FAILED: "persistence_save_failed",
+} as const;
+
+export type MemoryFailReason = typeof MemoryFailReasons[keyof typeof MemoryFailReasons];
+
+/**
+ * Result type for memory operations.
+ */
+export type MemoryResult<T> =
+  | { ok: true; result: T }
+  | { ok: false; reason: MemoryFailReason; details?: Record<string, unknown> };
+
+/**
+ * Convert reputation value to trust tier.
+ * Deterministic: no randomness, derived from reputation.
+ */
+export function reputationToTrustTier(reputation: number): TrustTier {
+  if (reputation >= 5) return "honored";
+  if (reputation >= 3) return "trusted";
+  if (reputation >= 1) return "neutral";
+  if (reputation <= -1) return "cold";
+  return "hostile";
+}
+
+/**
+ * Calculate effective reputation from direct + rumor influence.
+ * Rumors contribute half their weight to effective reputation.
+ */
+export function calculateEffectiveReputation(
+  directReputation: number,
+  totalRumorWeight: number,
+): number {
+  return directReputation + Math.trunc(totalRumorWeight / 2);
+}
+
+/**
+ * Generate deterministic memory event ID.
+ * Format: `${npcId}:${playerId}:${kind}:${logicalIndex}:${sourceId}`
+ */
+export function generateMemoryEventId(
+  npcId: string,
+  playerId: string,
+  kind: NpcMemoryEventKind,
+  logicalIndex: number,
+  sourceId: string,
+): string {
+  return `${npcId}:${playerId}:${kind}:${logicalIndex}:${sourceId}`;
+}
+
+/**
+ * Generate deterministic rumor ID.
+ * Format: `${sourceNpcId}:${playerId}:${sourceEventId}:rumor`
+ */
+export function generateRumorId(
+  sourceNpcId: string,
+  playerId: string,
+  sourceEventId: string,
+): string {
+  return `${sourceNpcId}:${playerId}:${sourceEventId}:rumor`;
+}
+
+/**
+ * Map rumor kind to visual accent color for Cyber-Zen UI.
+ */
+export function getRumorKindAccent(kind: NpcRumorKind): string {
+  switch (kind) {
+    case "helped_village":
+      return "cyan";
+    case "reliable_supplier":
+      return "green";
+    case "trusted_worker":
+      return "violet";
+    case "troublemaker":
+      return "ruby-muted";
+    case "hostile_actor":
+      return "ruby";
+  }
+}
+
+/**
+ * Map trust tier to CSS class for Cyber-Zen UI.
+ */
+export function getTrustTierCssClass(tier: TrustTier): string {
+  switch (tier) {
+    case "honored":
+      return "trust-tier--honored";
+    case "trusted":
+      return "trust-tier--trusted";
+    case "neutral":
+      return "trust-tier--neutral";
+    case "cold":
+      return "trust-tier--cold";
+    case "hostile":
+      return "trust-tier--hostile";
+  }
+}

--- a/server/src/quests/NpcQuestService.ts
+++ b/server/src/quests/NpcQuestService.ts
@@ -4,6 +4,7 @@
  * Server-authoritative quest management for NPC economy quests.
  * Deterministic: No Math.random(), no Date.now() for gameplay state.
  * All quest mutations happen server-side after validation.
+ * Integrates with NpcMemoryService for memory event recording.
  */
 
 import {
@@ -20,6 +21,7 @@ import {
   type QuestFailReason,
 } from "./NpcQuestTypes.js";
 import { type QuestSnapshot } from "./QuestSnapshotTypes.js";
+import { npcMemoryService } from "../npc/NpcMemoryService.js";
 
 /**
  * Active quest state for a player.
@@ -279,6 +281,11 @@ export class NpcQuestService {
       started: true,
     });
 
+    // Record memory event for quest acceptance (non-blocking)
+    npcMemoryService.recordQuestAccepted(playerId, questDef.npcId, questId).catch((err) => {
+      console.warn("[NpcQuestService] Failed to record quest_accepted memory:", err);
+    });
+
     const progress = this.getQuestProgress(playerId, questId);
     return { ok: true, result: progress! };
   }
@@ -426,6 +433,17 @@ export class NpcQuestService {
     const npcRep = this.getOrCreateNpcReputation(questDef.npcId, playerId);
     npcRep.reputation += questDef.reward.reputation;
     npcRep.completedQuestIds.push(questId);
+
+    // Record memory event for quest completion (non-blocking)
+    // This also triggers helped_village rumor creation
+    npcMemoryService.recordQuestCompleted(
+      playerId,
+      questDef.npcId,
+      questId,
+      questDef.reward.reputation,
+    ).catch((err) => {
+      console.warn("[NpcQuestService] Failed to record quest_completed memory:", err);
+    });
 
     const progress = this.getQuestProgress(playerId, questId);
     const reputation = this.getNpcReputation(playerId, questDef.npcId);


### PR DESCRIPTION
## Summary

- Persists NPC memory and reputation with JSON file backend
- Adds deterministic NPC rumor records with propagation rules
- Connects Mira quest completion and sales to social memory
- Exposes memory and rumor summaries in LiveGameplaySnapshot
- Extends Cyber-Zen NPC memory UI with rumor state
- Adds API routes for memory/rumor endpoints
- Updates docs with persistence model and rumor network

## Verification

- `pnpm --filter @wasd/shared build`
- `pnpm --filter @wasd/server exec tsc --noEmit`
- `pnpm run guard:all`
- `pnpm -r --if-present test`
- `pnpm run ci:verify`
- `pnpm run test:e2e:ci`

## Determinism

- No gameplay `Math.random()`
- No gameplay `Date.now()`
- No UUID gameplay memory IDs
- Server-authoritative memory writes only
- Duplicate memory events are rejected
- Rumor propagation is deterministic and idempotent
- Failed validation does not mutate state

## New Files

- `server/src/npc/NpcRumorTypes.ts` - Type definitions for memory events and rumors
- `server/src/npc/NpcMemoryStore.ts` - JSON file-based persistence
- `server/src/npc/NpcMemoryService.ts` - Memory event recording and retrieval
- `server/src/npc/NpcRumorService.ts` - Deterministic rumor propagation
- `server/src/npc/NpcMemoryRoute.ts` - API routes for memory/rumor endpoints
- `docs/NPC_RUMOR_NETWORK.md` - Rumor network documentation

## Modified Files

- `server/src/quests/NpcQuestService.ts` - Integrates memory event recording
- `server/src/gameplay/LiveGameplaySnapshotTypes.ts` - Added memory/rumor snapshot types
- `server/src/gameplay/LiveGameplaySnapshotComposer.ts` - Added memory/rumor composition
- `server/src/gameplay/composeLiveGameplaySnapshotFromLegacy.ts` - Added memory/rumor deps
- `apps/client-2d/src/game/liveGameplaySnapshot.ts` - Added memory/rumor types
- `apps/client-2d/src/ui/windows/NpcDialoguePanel.tsx` - Cyber-Zen memory/rumor UI
- `apps/client-2d/src/theme.css` - Rumor styling classes
- `docs/NPC_MEMORY_REPUTATION.md` - Updated with persistence model