### PR TITLE
fix(are): add registerEntity method to SnapshotComposer

### DIFF
--- a/server/src/core/are/SnapshotComposer.ts
+++ b/server/src/core/are/SnapshotComposer.ts
@@ -101,7 +101,36 @@ export class SnapshotComposer {
     
     this.chunkSnapshots.set(chunkId, chunkSnapshot);
   }
-  
+
+  /**
+   * Register a single entity state for snapshot composition.
+   * Used by AutoModuleKatalysator to feed entity states to the snapshot system.
+   */
+  registerEntity(entityId: EntityId, state: {
+    position_x: KappaInt;
+    position_z: KappaInt;
+    health: KappaInt;
+    level: KappaInt;
+  }): void {
+    const entityState: SnapshotEntityState = {
+      id: entityId,
+      position_x: state.position_x,
+      position_z: state.position_z,
+      health: state.health,
+      level: state.level
+    };
+
+    const defaultChunkId = 'default' as ChunkKey;
+
+    if (this.chunkSnapshots.has(defaultChunkId)) {
+      const existing = this.chunkSnapshots.get(defaultChunkId)!;
+      existing.entityStates.push(entityState);
+    } else {
+      const emptyLayers = createEmptyIARELogicLayers();
+      this.addChunk(defaultChunkId, 0 as TickId, [entityState], emptyLayers);
+    }
+  }
+
   /**
    * Validate layer integrity: ∑ Are = const
    * Throws DeterminismViolation if check fails.


### PR DESCRIPTION
## Description

Fixes a TypeScript compilation error in the audit_logic workflow where `AutoModuleKatalysator` calls `snapshotComposer.registerEntity()` but the method didn't exist on the `SnapshotComposer` class.

## Changes

- Added `registerEntity()` method to `SnapshotComposer` class in `server/src/core/are/SnapshotComposer.ts`
- The method registers entity states for snapshot composition, used by the AutoModuleKatalysator to feed entity states to the PixiJS client snapshot system

## TypeScript Errors Fixed

```
Property 'registerEntity' does not exist on type 'SnapshotComposer'.
```

## Testing

- [x] TypeScript compiles without errors (`tsc --noEmit`)
- [x] No breaking changes to existing SnapshotComposer functionality

## Related

Fixes the failing `audit_logic` job in GitHub Actions workflow run `27283951997`

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/22149088-5a63-4953-8082-7a0ec5142e8f)