### PR TITLE
fix(docker): install @wasd/portal dependencies in Dockerfile.vps

### DIFF
--- a/Dockerfile.vps
+++ b/Dockerfile.vps
@@ -57,8 +57,8 @@ RUN --mount=type=cache,id=wasd-vps-pnpm-store,target=/pnpm/store \
       > pnpm-workspace.yaml && \
     python3 scripts/sync-pnpm-lockfile-for-docker.py && \
     # Exclude client-2d - it's prebuilt on GitHub Actions
-    pnpm --filter @wasd/server... --filter @wasd/engine... --filter @wasd/core-logic... --filter @wasd/shared... install --lockfile-only --no-frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only && \
-    pnpm --filter @wasd/server... --filter @wasd/engine... --filter @wasd/core-logic... --filter @wasd/shared... install --frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
+    pnpm --filter @wasd/server... --filter @wasd/engine... --filter @wasd/core-logic... --filter @wasd/shared... --filter @wasd/portal... install --lockfile-only --no-frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only && \
+    pnpm --filter @wasd/server... --filter @wasd/engine... --filter @wasd/core-logic... --filter @wasd/shared... --filter @wasd/portal... install --frozen-lockfile --prefer-offline --ignore-scripts --network-concurrency=1 --child-concurrency=1 --reporter=append-only
 
 COPY . .
 RUN rm -rf packages/sdk-examples || true && \


### PR DESCRIPTION
## Description

Fixes Docker build failure where `@wasd/portal` dependencies were not installed, causing `tsc && vite build` to fail with "node_modules missing" error.

## Changes

- Added `--filter @wasd/portal...` to both pnpm install commands in `Dockerfile.vps`

## Error Fixed

```
#34 4.184 [ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @wasd/portal@1.0.0 build: `tsc && vite build`
#34 4.184 Exit status 2
#34 4.187 [WARN]  Local package.json exists, but node_modules missing, did you mean to install?
```

## Also Includes

Previous commit on this branch:
- `631cf884` fix(are): add registerEntity method to SnapshotComposer

## Testing

- [x] Docker build should complete without missing node_modules errors

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/22149088-5a63-4953-8082-7a0ec5142e8f)