### PR TITLE
docs: encode ARE conversation rules and wiki standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,36 @@ The 3D client remains part of the repository, but it is not the active release g
 
 ---
 
+## Core truth
+
+Areloria is developed under this technical rule:
+
+```text
+Kein Snapshot, kein Spiel.
+Kein Tick, keine Wahrheit.
+Kein Guard, keine Architektur.
+Kein /2d Proof, keine Integration.
+```
+
+A feature is considered real only when it is visible or verifiable through the active runtime path, server state, generated manifest, replay/state hash, or CI/smoke test. Detached demos do not count as production integration.
+
+Canonical server flow:
+
+```text
+client intent
+→ server validation
+→ deterministic TickSystem
+→ canonical delta
+→ AREReplayBuffer / StateHash
+→ SnapshotComposer or runtime manifest
+→ /2d observer rendering
+→ guard/test/workflow protection
+```
+
+`server/src/core/WorldTick.ts` is legacy mass, not the new extension point. New systems must target `WorldTickScheduler`, `TickSystemRegistry`, ports, deltas, replay sinks and snapshot/runtime-manifest output.
+
+---
+
 ## Current project state
 
 Areloria is no longer only a shell or prototype. The repository now contains a playable deterministic browser-MMORPG foundation with these active layers:
@@ -24,6 +54,9 @@ Areloria is no longer only a shell or prototype. The repository now contains a p
 ```text
 /2d runtime path
 server-authoritative gameplay snapshots
+TickSystemRegistry and WorldTickScheduler foundation
+WorldBrainTickSystem as subsystem, not scheduler owner
+TickSystemContextProvider for deterministic HTTP route context
 resource gather/process/sell economy loop
 NPC resource quest loop
 Cyber-Zen NPC dialogue and reputation UI
@@ -37,15 +70,14 @@ Recent high-value systems:
 | Area | Current status |
 | --- | --- |
 | Runtime client | `/2d` is the primary proof path; 3D is not the current release blocker |
-| Server tick | 10Hz deterministic server-authoritative gameplay model |
+| Server tick | 10Hz deterministic server-authoritative gameplay model via scheduler/registry migration |
+| Route tick context | HTTP routes should use `TickSystemContextProvider`, not legacy tick internals |
 | Economy | resource gathering, processing/crafting, selling, wallet/XP progression |
 | NPC quests | Mira / village supply style NPC resource quest loop |
 | NPC social layer | reputation, memory, persisted memory state and rumor network |
 | UI style | Cyber-Zen / Arelorian Stitch dark-neon HUD language |
 | Assets | Stitch 2.5D sprite atlas intake, manifest generation and quarantine-first QA |
 | Deployment | VPS-oriented flow; production Docker file is `Dockerfile.vps` |
-
-A feature is considered real only when it is visible or verifiable through the active runtime path, server state, generated manifest, or CI/smoke test. Detached demos do not count as production integration.
 
 ---
 
@@ -101,18 +133,23 @@ randomUUID()
 process uptime as gameplay input
 host/container identity as gameplay input
 unordered iteration where order changes state
+external API timing as simulation input
 ```
 
 Use instead:
 
 ```text
-explicit logical tick / logicalIndex
+TickId / logicalIndex
+KappaInt / branded core types
+StateHash
+DeterministicPrng
 ARE clock/time adapters
 stable seeds from world facts
 content hashes for generated assets
 row-major frame order for atlases
 stable sorted traversal
 stable JSON formatting
+explicit replay input
 ```
 
 Good seed parts:
@@ -147,7 +184,12 @@ Only observed or relevant regions receive expensive simulation.
 Unobserved regions decay, summarize, or sleep.
 ```
 
-This keeps server load proportional to active player observation and relevant world pressure.
+Spatial truth must come from `UnifiedChunkContract`:
+
+```text
+simulationRadiusChunks = 2 → 5×5 simulation/interest envelope
+broadcastRadiusChunks  = 1 → 3×3 client broadcast envelope
+```
 
 ### 5. The 10Hz server tick is sacred
 
@@ -176,6 +218,64 @@ If uncertain, do not damage the structure.
 ```
 
 NPCs, swarms, bosses, decay systems, watchdogs, and world events must not damage or destroy player-built, paid, or protected structures unless an explicit reviewed policy allows it.
+
+---
+
+## New module implementation standard
+
+Every new server-side module follows:
+
+```text
+Types
+→ Ports
+→ TickSystem
+→ Delta
+→ Replay sink
+→ Snapshot or runtime manifest sink
+→ /2d proof where player-visible
+→ Unit/guard tests
+→ Docs
+```
+
+Examples: weather, settlement pressure, disease, faction pressure, dungeon pressure, trading pressure, NPC social systems.
+
+External APIs, LLMs, asset generators and telemetry collectors are adapters, not authoritative tick truth.
+
+Correct:
+
+```text
+external adapter outside tick
+→ sanitized deterministic input event
+→ TickSystem consumes event on tick boundary
+→ state delta
+→ replay/snapshot proof
+```
+
+Wrong:
+
+```text
+TickSystem.tick()
+→ fetch external API
+→ mutate canonical state from response timing/content
+```
+
+See `docs/ARE_MODULE_IMPLEMENTATION_STANDARD.md`.
+
+---
+
+## Kappa and chunk math
+
+Kappa is the integer coordinate contract:
+
+```text
+1 world unit = 1000 Kappa
+1 chunk side = 64 world units = 64,000 Kappa
+1 chunk plane = 64,000 × 64,000 = 4,096,000,000 Kappa cells
+```
+
+Do not confuse 4,096 logical tiles with Kappa-cell count.
+
+Boundary decimal adapters may round into Kappa for compatibility. Internal simulation state must already be integer Kappa.
 
 ---
 
@@ -227,18 +327,6 @@ Direct memory is stronger than rumor memory. Broad autonomous AI behavior should
 - Deterministic critical hits and damage calculations.
 - Replay-safe loot drop rolls.
 - Region threat and oracle pressure may affect outcomes through explicit state only.
-
-### Warfronts, Oracle and brain/watchdog systems
-
-These systems are planned or partially present as bounded deterministic layers:
-
-- deterministic cycle timing,
-- warning/prophecy output from explicit records,
-- bounded low-frequency brain interpretation,
-- fast-path watchdog checks,
-- telemetry as side-channel observability rather than gameplay truth.
-
-All simulation-affecting output must be deterministic, bounded, inspectable, and compatible with tick constraints.
 
 ---
 
@@ -402,6 +490,8 @@ node scripts/sync-wiki.mjs
 
 `sync-wiki.mjs` should use `.wiki-build` in CI when available and fall back to `docs/wiki` only for manual/simple syncs.
 
+Current workflow `.github/workflows/sync-wiki.yml` is expected to trigger on README, docs and wiki-builder changes.
+
 ---
 
 ## Deployment
@@ -465,6 +555,7 @@ Automated agents must follow:
 
 ```text
 docs/AGENT_FEATURE_PR_POLICY.md
+docs/AGENT_ARE_SKILL_PLAYBOOK.md
 ```
 
 Hard rules:
@@ -472,6 +563,7 @@ Hard rules:
 - small PRs only,
 - no unrelated lockfile churn,
 - no hidden nondeterminism,
+- no direct new logic in legacy `WorldTick.ts`,
 - no broad deploy changes inside gameplay PRs,
 - no protected structure damage without explicit policy,
 - every new simulation path must be covered by determinism guardrails,
@@ -498,6 +590,10 @@ Start with:
 
 ```text
 docs/START_HERE.md
+docs/ARELORIA_CODE_TRUTH_MANIFEST_2026_06.md
+docs/ARE_MODULE_IMPLEMENTATION_STANDARD.md
+docs/AGENT_ARE_SKILL_PLAYBOOK.md
+docs/CONVERSATION_ARCHIVE_SYNTHESIS_2026_06.md
 docs/PROJECT_STATUS_2026.md
 docs/ROADMAP_TO_RELEASE.md
 docs/ARELORIAN_PROJECT_KNOWLEDGE_BASE.md
@@ -506,6 +602,7 @@ docs/ARELORIAN_PROJECT_KNOWLEDGE_BASE.md
 Important focused docs include:
 
 ```text
+docs/CONVERSATION_DERIVED_PROJECT_RULES_2026_06.md
 docs/AGENT_FEATURE_PR_POLICY.md
 docs/ARE_DETERMINISM_CLASSIFICATION.md
 docs/ARE_TELEMETRY_SIDE_CHANNEL.md
@@ -518,7 +615,7 @@ docs/DEPLOY_PORT_MAP.md
 docs/NGINX_HOST_GATEWAY.md
 ```
 
-Prefer active code and current docs over older historical notes.
+Prefer active code and current docs over older historical notes. Conversation ZIPs are source material only and must not be committed raw.
 
 ---
 

--- a/docs/AGENT_ARE_SKILL_PLAYBOOK.md
+++ b/docs/AGENT_ARE_SKILL_PLAYBOOK.md
@@ -1,0 +1,158 @@
+# Agent ARE Skill Playbook
+
+This playbook tells agents how to work in Areloria/WASD without damaging the architecture. It is distilled from conversation archives, PR reviews, CI failures and merged refactor work.
+
+## First rule
+
+```text
+Read current code and current docs before writing new code.
+Do not trust old conversation snippets over active repository state.
+```
+
+## Required mental model
+
+```text
+No Snapshot, no game.
+No Tick, no truth.
+No Guard, no architecture.
+No /2d proof, no integration.
+```
+
+## What agents must avoid
+
+```text
+- direct expansion of server/src/core/WorldTick.ts
+- broad rewrites of unrelated modules
+- hidden Date.now()/Math.random() in simulation code
+- client-authoritative gameplay state
+- disconnected demo UI pretending to be integration
+- raw conversation dumps in docs
+- secrets, tokens, VPS credentials or env files in commits
+- Dockerfile.prod assumptions for VPS deploy
+- 3D build gates in 2D-only release work
+- silent CI soft-fails with `|| echo`
+```
+
+## Branch and PR practice
+
+```text
+1. Create a focused branch.
+2. Keep PRs small enough to review.
+3. Include docs when architecture changes.
+4. Include nearest tests/guards.
+5. Do not claim green until current head checks are green.
+6. Use squash merge for messy agent histories.
+7. Never push raw private logs or conversation ZIPs.
+```
+
+## Reading order for agents
+
+```text
+README.md
+docs/START_HERE.md
+docs/ARELORIA_CODE_TRUTH_MANIFEST_2026_06.md
+docs/ARE_MODULE_IMPLEMENTATION_STANDARD.md
+docs/CONVERSATION_DERIVED_PROJECT_RULES_2026_06.md
+docs/CONVERSATION_ARCHIVE_SYNTHESIS_2026_06.md
+docs/AGENT_FEATURE_PR_POLICY.md
+```
+
+## New module skill
+
+When asked to add a module, always shape it as:
+
+```text
+Types
+Ports
+TickSystem
+Delta
+Replay sink
+Snapshot/manifest sink
+Tests
+Docs
+```
+
+Then ask whether UI proof belongs in the same PR or a follow-up PR. Do not create a hidden service that never reaches `/2d`.
+
+## Legacy resolution skill
+
+When an old term appears, translate it before coding:
+
+| Old / risky term | Canonical target |
+| --- | --- |
+| `WorldTick.ts` as extension point | `WorldTickScheduler` + `TickSystemRegistry` |
+| `worldBrain.tick()` after registry | `WorldBrainTickSystem` registered in registry |
+| route reads `tick.tickCount` | `TickSystemContextProvider` or snapshot/read port |
+| `SpatialBroadcastGrid` local math | `UnifiedChunkContract` + `InterestGrid` |
+| direct DB write in tick | write-behind persistence queue |
+| client mutation | server intent route + authoritative snapshot |
+| real-time API in tick | external adapter + deterministic input event |
+
+## Review-comment skill
+
+Do not blindly apply review comments. Judge them against the manifest:
+
+```text
+Does it preserve determinism?
+Does it preserve server authority?
+Does it feed snapshot/replay/manifest?
+Does it reduce legacy WorldTick coupling?
+Does it avoid broad scope creep?
+```
+
+Apply comments that fix real correctness, compile, guard or proof-path issues. Push back on comments that reintroduce legacy architecture or speculative complexity.
+
+## CI triage skill
+
+When a workflow fails:
+
+```text
+1. Identify current PR head SHA.
+2. Ignore failures from older heads.
+3. Fetch the failed job log.
+4. Patch the smallest real cause.
+5. Re-check only current-head runs.
+6. Report success only when checks are complete.
+```
+
+Common failure classes from recent archives:
+
+```text
+- isolatedModules requires `export type`
+- branded ChunkKey/KappaInt tests using raw string/number
+- stale route signatures after TickSystemContextProvider migration
+- architecture lint catches Date.now/Math.random in core
+- guard:all accidentally hard-fails intended red baseline audit
+- wiki workflow syncs docs/wiki without building .wiki-build first
+```
+
+## Documentation skill
+
+When importing conversation knowledge:
+
+```text
+Summarize rules.
+Remove secrets.
+Remove temporary agent chatter.
+Normalize old names to canonical names.
+Point to active code/docs.
+Do not store raw exports.
+```
+
+## Done statement template
+
+A useful final report says:
+
+```text
+Changed:
+- files touched
+- rules encoded
+- wiki sync impact
+
+Verified:
+- commands/checks run or not run
+- current PR link
+- remaining risk
+```
+
+Never write “green” unless the current head actually has green required checks.

--- a/docs/ARELORIA_CODE_TRUTH_MANIFEST_2026_06.md
+++ b/docs/ARELORIA_CODE_TRUTH_MANIFEST_2026_06.md
@@ -1,0 +1,214 @@
+# ARELORIA Code Truth Manifest — June 2026
+
+This document is a technical constitution for Areloria/WASD. It is not a raw conversation log, not a spiritual text, and not a speculative theory dump. It is a repo-safe distillation of the architecture rules repeatedly proven by code, audits, PRs, CI failures, and conversation exports.
+
+Use it as the first filter for future implementation work. If this document conflicts with active code and current tests, update the code or this document explicitly; do not silently invent a third path.
+
+## Prime rule
+
+```text
+Kein Snapshot, kein Spiel.
+Kein Tick, keine Wahrheit.
+Kein Guard, keine Architektur.
+Kein /2d Proof, keine Integration.
+```
+
+## Core reality chain
+
+A gameplay or world-system feature is real only when it follows this chain:
+
+```text
+server-authoritative input
+→ deterministic 10Hz tick / TickSystem
+→ canonical state mutation as delta
+→ StateHash / replay evidence
+→ SnapshotComposer or runtime manifest
+→ /2d client renders as observer
+→ guard/test/workflow protects against regression
+```
+
+Detached previews, isolated services, local-only UI, unobserved mocks, and routes that do not feed snapshot or manifest are not production integration.
+
+## WorldTick is not the new truth
+
+`server/src/core/WorldTick.ts` is legacy mass. It may still exist as a compatibility shell until migration completes, but it is not the canonical extension point for new systems.
+
+Canonical direction:
+
+```text
+WorldTickScheduler
+→ TickSystemRegistry
+→ ordered TickSystem modules
+→ AREReplayBuffer
+→ SnapshotComposer
+→ WriteBehindPersistenceQueue
+```
+
+New modules must not import or expand `WorldTick.ts`. They must implement `TickSystem`, read through ports, emit deterministic deltas, and feed replay/snapshot sinks.
+
+## Current canonical scheduler order
+
+```text
+WorldTickScheduler 10Hz
+  → TickSystemRegistry
+    1. InputTickSystem
+    2. SpatialInterestTickSystem
+    3. ResourceEconomyTickSystem
+    4. NpcMemoryRumorTickSystem
+    5. WorldBrainTickSystem
+    6. SnapshotComposerTickSystem
+  → AREReplayBuffer
+  → WriteBehindPersistenceQueue
+```
+
+The World Brain is a subsystem, not a scheduler owner.
+
+## Kappa truth
+
+Kappa is not decorative terminology. It is the integer coordinate contract.
+
+```text
+1 world unit = 1000 Kappa
+1 chunk side = 64 world units = 64,000 Kappa
+1 chunk plane = 64,000 × 64,000 = 4,096,000,000 Kappa cells
+```
+
+Do not confuse `64 × 64 = 4,096 logical tiles` with `64,000 × 64,000 Kappa cells`.
+
+Decimal values may appear only at boundaries. Boundary adapters such as `createKappaFromDecimal` must round to nearest Kappa for compatibility. Internal simulation state must already be integer Kappa.
+
+## Determinism law
+
+Forbidden in gameplay causality:
+
+```text
+Math.random()
+Date.now()
+new Date()
+performance.now()
+randomUUID()
+external API timing
+process uptime as gameplay input
+host/container identity as gameplay input
+unordered iteration where order mutates state
+```
+
+Use instead:
+
+```text
+TickId
+logicalIndex
+StateHash
+DeterministicPrng
+content hash
+stable seed parts
+stable sorted traversal
+row-major atlas order
+explicit replay input
+```
+
+Telemetry may use wall-clock time only when it is a side channel and cannot feed gameplay, replay, snapshot truth, loot, economy, NPC state, or persistence semantics.
+
+## Spatial truth
+
+The old observer/broadcast split caused confusion. The correct interpretation is:
+
+```text
+simulationRadiusChunks = 2 → 5×5 interest/simulation envelope
+broadcastRadiusChunks  = 1 → 3×3 client broadcast envelope
+```
+
+Both values must come from `UnifiedChunkContract`, not from local constants or ad-hoc radius math.
+
+## Persistence truth
+
+Persistence is not reality. Tick state is reality.
+
+```text
+Tick produces truth
+Replay/EventLog proves transition
+Snapshot exposes truth
+Persistence writes asynchronously
+```
+
+Database, filesystem, API storage, analytics and logs are side effects. They must not block or define the 10Hz canonical simulation.
+
+## Route migration rule
+
+HTTP routes must not reach into `WorldTick.tickCount` or assume old loop internals. Routes that need tick context use `TickSystemContextProvider` or canonical snapshot/read ports.
+
+Good route output includes explicit deterministic tick context when needed:
+
+```json
+{
+  "ok": true,
+  "result": {},
+  "tickContext": {
+    "tickId": 123,
+    "worldTimeHours": 2.95,
+    "seedHash": "..."
+  }
+}
+```
+
+## External AI / LLM boundary
+
+External AI, free LLM endpoints, oracle adapters, and helper services may assist presentation, diagnostics, suggestions, or non-authoritative text. They must not inject hidden simulation impulses.
+
+Allowed shape:
+
+```text
+adapter outside tick
+→ explicit sanitized input event
+→ deterministic TickSystem handles state consequence
+→ snapshot exposes result
+```
+
+Forbidden shape:
+
+```text
+TickSystem calls external API
+external timing/response mutates state
+client receives non-replayable truth
+```
+
+## Asset truth
+
+Stitch/generated assets follow quarantine-first intake:
+
+```text
+raw input
+→ deterministic inspect/classify/validate
+→ accepted/manual_review/quarantine
+→ stable runtime manifest
+→ /2d preview/proof
+```
+
+Manifest entries must use stable source paths, sorted IDs, row-major frame order, and no `/tmp/...` runtime references.
+
+## Required eight-question check before code
+
+Before emitting or merging code, answer:
+
+```text
+1. Is it server-authoritative?
+2. Is it deterministic and reproducible?
+3. Does core state use integer/Kappa types?
+4. Is every mutation traceable by replay/event/state hash?
+5. Does it flow into SnapshotComposer or runtime manifest?
+6. Is it visible/provable in /2d where player-visible?
+7. Do guards/tests/workflows protect it?
+8. Did it avoid old WorldTick, dead 3D gates, wrong Docker paths and secrets?
+```
+
+## CI and guard truth
+
+`guard:all` must protect current architecture without blocking intentionally-red baseline audits unless the repo explicitly switches that audit to hard-fail mode.
+
+A red baseline is useful only when it is documented, tracked, and non-blocking until the remediation phase is ready.
+
+## Security hygiene
+
+Conversation ZIPs and agent logs are source material only. Never commit raw conversation exports. Never commit credentials, server passwords, API keys, tokens, private URLs, env files, or provider secrets.
+
+When imported history mentions secrets, rotate them outside this repo instead of documenting values.

--- a/docs/ARE_MODULE_IMPLEMENTATION_STANDARD.md
+++ b/docs/ARE_MODULE_IMPLEMENTATION_STANDARD.md
@@ -1,0 +1,169 @@
+# ARE Module Implementation Standard
+
+This is the default schema for new server-side Areloria modules such as weather, settlement pressure, disease, faction pressure, dungeon pressure, trading pressure, or NPC social systems.
+
+The goal is to prevent detached services and legacy `WorldTick.ts` growth. Every module must become part of the canonical tick/snapshot/replay chain or remain explicitly outside gameplay truth.
+
+## Module done-chain
+
+A module is not complete until this chain is closed:
+
+```text
+Types
+→ Ports
+→ TickSystem
+→ Delta
+→ Replay sink
+→ Snapshot or runtime manifest sink
+→ /2d proof where player-visible
+→ Unit/guard tests
+→ Docs
+```
+
+## File shape
+
+Recommended server layout:
+
+```text
+server/src/modules/<module>/
+  <Module>Types.ts
+  <Module>Ports.ts
+  <Module>TickSystem.ts
+  <Module>Snapshot.ts
+  __tests__/<Module>TickSystem.test.ts
+```
+
+Core-only modules may live in `server/src/core/are/` only when they are part of the scheduler, replay, snapshot, guard, or Kappa foundation.
+
+## Seven non-negotiable rules
+
+```text
+1. No direct import from server/src/core/WorldTick.ts.
+2. No Date.now(), Math.random(), performance.now(), randomUUID() in TickSystem logic.
+3. No I/O, DB, filesystem, network or external API call inside TickSystem.tick().
+4. Core values use integer/Kappa/brand types where state is authoritative.
+5. State changes are emitted as deltas, not hidden side effects.
+6. Deltas feed replay and SnapshotComposer/runtime manifest.
+7. Tests prove same input + same tick = same output.
+```
+
+## Port pattern
+
+Modules read and write only through ports. Ports make tests deterministic and prevent scheduler ownership leakage.
+
+```ts
+export interface WeatherStatePort {
+  listActiveChunkKeys(): readonly ChunkKey[];
+  readWeatherState(chunkKey: ChunkKey): WeatherState | null;
+  commitWeatherDelta(delta: WeatherDelta): void;
+}
+
+export interface WeatherReplaySink {
+  recordWeatherDelta(delta: WeatherDelta): void;
+}
+
+export interface WeatherSnapshotSink {
+  includeWeatherDelta(delta: WeatherDelta): void;
+}
+```
+
+## TickSystem pattern
+
+```ts
+export class WeatherTickSystem implements TickSystem {
+  readonly name = "weather";
+  readonly priority = TickSystemPriority.GAMEPLAY;
+  enabled = true;
+
+  constructor(
+    private readonly state: WeatherStatePort,
+    private readonly replay: WeatherReplaySink,
+    private readonly snapshot: WeatherSnapshotSink,
+  ) {}
+
+  tick(context: TickSystemContext): void {
+    const chunkKeys = [...this.state.listActiveChunkKeys()].sort(compareChunkKeys);
+
+    for (const chunkKey of chunkKeys) {
+      const previous = this.state.readWeatherState(chunkKey) ?? createDefaultWeather(chunkKey);
+      const next = evolveWeather(previous, context.tickCount);
+      const delta = createWeatherDelta(context.tickCount, chunkKey, previous, next);
+
+      this.state.commitWeatherDelta(delta);
+      this.replay.recordWeatherDelta(delta);
+      this.snapshot.includeWeatherDelta(delta);
+    }
+  }
+}
+```
+
+## External data rule
+
+Real-world APIs, LLMs, telemetry collectors, payment providers, asset generators and external AI services are adapters, not simulation truth.
+
+Correct shape:
+
+```text
+external adapter outside tick
+→ sanitized deterministic input event
+→ TickSystem consumes event on tick boundary
+→ state delta
+→ replay/snapshot proof
+```
+
+Wrong shape:
+
+```text
+TickSystem.tick()
+→ fetch external API
+→ mutate canonical state from response timing/content
+```
+
+## WeatherLogic example
+
+Weather in Areloria is gameplay weather unless explicitly stated otherwise. Gameplay weather should not call a real weather API inside the tick.
+
+Required state fields should be bounded integers such as:
+
+```text
+humidity: KappaInt 0..1000
+pressure: KappaInt 0..1000
+temperature: KappaInt 0..1000
+windX/windZ: KappaInt -1000..1000
+kind: enum clear/cloud/rain/storm/fog/ash/snow
+stateHash: StateHash
+```
+
+A real weather service may influence cosmetic UI or produce a sanitized input event, but the authoritative simulation must still be replayable from stored inputs.
+
+## Required tests
+
+Every new module PR should include tests for:
+
+```text
+- TickSystem name and priority
+- stable sorted chunk traversal
+- same input and tick produces same delta/hash
+- replay sink receives delta
+- snapshot or manifest sink receives output
+- no mutation on failed validation
+- no direct WorldTick import
+- no forbidden runtime APIs in tick logic
+```
+
+## PR checklist
+
+```text
+Summary
+Changed files
+Runtime proof path
+Determinism notes
+Replay/Snapshot notes
+Verification commands
+Known limitations
+Follow-up work
+```
+
+## Acceptance rule
+
+A module may be merged as a foundation PR before /2d UI only if the PR explicitly states it is foundation-only and the next PR is the snapshot/UI proof. For player-visible features, `/2d` proof is mandatory before calling the feature complete.

--- a/docs/CONVERSATION_ARCHIVE_SYNTHESIS_2026_06.md
+++ b/docs/CONVERSATION_ARCHIVE_SYNTHESIS_2026_06.md
@@ -1,0 +1,224 @@
+# Conversation Archive Synthesis — June 2026
+
+This document summarizes the useful technical information extracted from local `conversation_*.zip` archives reviewed on 2026-06-10. It intentionally excludes raw chat logs, secrets, credentials, private tokens and temporary agent chatter.
+
+The goal is to preserve project-relevant engineering knowledge in a form that future agents can actually use.
+
+## Reviewed archive shape
+
+The imported ZIPs contained thousands of event records from agent sessions, including user requests, terminal/file observations, PR summaries, CI failures and route/refactor notes.
+
+Recurring subject clusters:
+
+```text
+WorldTick migration
+TickSystemRegistry and WorldTickScheduler
+WorldBrainTickSystem
+TickSystemContextProvider for HTTP routes
+Kappa math correction
+UnifiedChunkContract and ObserverEngine conflict
+ChunkKey / KappaInt branded type errors
+Route migration to deterministic tick context
+ARE determinism and architecture lint gates
+README/wiki sync and documentation automation
+```
+
+## High-value extracted facts
+
+### 1. WorldTick migration is the dominant architecture pressure
+
+The archives repeatedly show the same correction: do not use `server/src/core/WorldTick.ts` as the new extension point.
+
+Observed old pattern:
+
+```text
+route or module reaches into WorldTick
+route reads tickCount directly
+WorldTick grows more domain imports
+WorldBrain runs as special case after registry
+```
+
+Correct pattern:
+
+```text
+WorldTickScheduler owns logical stepping only
+TickSystemRegistry orders systems
+WorldBrain is WorldBrainTickSystem
+routes use TickSystemContextProvider or snapshot/read ports
+SnapshotComposer exposes truth
+```
+
+### 2. Phase 11 route migration matters
+
+The archives document Phase 11 route integration through `TickSystemContextProvider`.
+
+Routes called out as migrated or requiring the same pattern:
+
+```text
+gameplaySnapshot.ts
+onboardingRoute.ts
+questEventRoute.ts
+lootRoutes.ts
+inventoryRoute.ts
+craftingRoute.ts
+equipmentRoute.ts
+resourceGatherRoute.ts
+skillEventRoute.ts
+selfHealWorkshopRoute.ts
+areHeartbeat.ts
+areReplayRoute.ts
+manifestResyncRoute.ts
+```
+
+Rule: HTTP routes must not depend on legacy `WorldTick.tickCount`. They should use deterministic tick context and server-resolved player identity.
+
+### 3. Kappa math was corrected
+
+Correct values:
+
+```text
+CHUNK_SIZE_TILES = 64 per side
+CHUNK_SIZE_KAPPA = 64,000 per side
+Kappa cells per chunk plane = 64,000 × 64,000 = 4,096,000,000
+```
+
+Do not regress to the old mistaken `4,096 Kappa cells` wording. `4,096` is logical tile count, not Kappa-cell count.
+
+### 4. Chunk radius conflict was resolved conceptually
+
+The archives identify the old mismatch:
+
+```text
+ObserverEngine.viewDistanceChunks = 2 → 5×5 simulation interest
+SpatialBroadcastGrid = 3×3 broadcast envelope
+```
+
+Correct resolution:
+
+```text
+UNIFIED_CHUNK_CONTRACT.simulationRadiusChunks = 2
+UNIFIED_CHUNK_CONTRACT.broadcastRadiusChunks = 1
+```
+
+Observer, broadcast and active-chunk logic must use this contract instead of local constants.
+
+### 5. Core audit baseline improved, but remaining debt is known
+
+Captured audit trajectory:
+
+```text
+Before: 2 PASS, 5 FAIL, 1 PARTIAL
+After:  4 PASS, 3 FAIL, 1 PARTIAL
+```
+
+Remaining themes:
+
+```text
+worldtick_domain_imports must shrink
+any_unknown_in_core must be reduced
+non_deterministic_apis must be eliminated from simulation-critical paths
+snapshot_fields_origin needs full proof
+```
+
+Do not hide these failures. Track them as phase work.
+
+### 6. Branded types are useful but require test discipline
+
+Repeated TypeScript failures involved branded values such as `ChunkKey`, `KappaInt`, `TickId` and `StateHash`.
+
+Tests should use local helper functions instead of `as any`:
+
+```ts
+function ck(value: `${number}:${number}`): ChunkKey {
+  return value as ChunkKey;
+}
+
+function k(value: number): KappaInt {
+  if (!Number.isSafeInteger(value)) throw new Error(`Invalid KappaInt: ${value}`);
+  return value as KappaInt;
+}
+```
+
+Strict branded types are part of the architecture, not an annoyance to bypass.
+
+### 7. `createKappaFromDecimal` must round to nearest Kappa
+
+Boundary adapter semantics are backward-compatible:
+
+```text
+3.14159 → 3142
+3.4999  → 3500
+```
+
+Therefore `createKappaFromDecimal` / boundary world-unit conversion must use nearest-Kappa rounding. After boundary conversion, core state must remain integer Kappa.
+
+### 8. External LLM/API services are adapters, not truth
+
+Archives mention possible free LLM/API providers for presentation or assistant layers. They may be useful only outside authoritative tick causality.
+
+Allowed:
+
+```text
+external adapter
+→ sanitized event
+→ deterministic TickSystem consumes event
+→ replay/snapshot proof
+```
+
+Forbidden:
+
+```text
+TickSystem.tick()
+→ external API call
+→ state mutation from response timing/content
+```
+
+### 9. Wiki sync is already the right kind of automation
+
+The correct wiki flow is:
+
+```text
+README.md / docs/** / docs/wiki/** / scripts/wiki/** changes
+→ build autonomous wiki into .wiki-build
+→ sync .wiki-build into GitHub wiki
+```
+
+A workflow that copies only `docs/wiki/**` is insufficient. The current workflow should keep build-before-sync behavior.
+
+## Practical migration map
+
+| Old pressure | New canonical response |
+| --- | --- |
+| More logic in `WorldTick.ts` | Add or register a `TickSystem` |
+| Route needs tick | Use `TickSystemContextProvider` |
+| Module needs randomness | Use deterministic seed/hash/PRNG |
+| Module needs persistence | Emit delta, queue write-behind side effect |
+| Client needs state | Read snapshot or runtime manifest |
+| New asset pack | Quarantine-first intake pipeline |
+| New gameplay system | Types → Ports → TickSystem → Delta → Replay/Snapshot → /2d proof |
+| CI fails | Current head only, fetch log, smallest patch |
+
+## Security notes
+
+The archives may contain operational context and references to credentials or tokens. This synthesis does not include those values. Treat historical secrets as potentially compromised and rotate them through the appropriate provider/VPS process.
+
+Never commit:
+
+```text
+raw conversation zips
+raw event json logs
+tokens
+API keys
+VPS passwords
+.env files
+private URLs
+private asset license material
+```
+
+## Final working rule
+
+```text
+Old conversations are useful as evidence.
+Active code and canonical docs are the source of truth.
+The correct output is deterministic code, replayable state, snapshot proof, /2d visibility and green guardrails.
+```

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -4,11 +4,22 @@ Begin with these current documents:
 
 - `README.md`
 - `AGENTS.md`
+- `docs/ARELORIA_CODE_TRUTH_MANIFEST_2026_06.md`
+- `docs/ARE_MODULE_IMPLEMENTATION_STANDARD.md`
+- `docs/AGENT_ARE_SKILL_PLAYBOOK.md`
+- `docs/CONVERSATION_ARCHIVE_SYNTHESIS_2026_06.md`
 - `docs/PROJECT_STATUS_2026.md`
 - `docs/ROADMAP_TO_RELEASE.md`
 - `docs/ARELORIAN_PROJECT_KNOWLEDGE_BASE.md`
 - `docs/CONVERSATION_DERIVED_PROJECT_RULES_2026_06.md`
 
-Then read the current project rule documents in `docs/`.
+Core rule before implementation:
 
-Prefer current docs and active code over older historical notes.
+```text
+Kein Snapshot, kein Spiel.
+Kein Tick, keine Wahrheit.
+Kein Guard, keine Architektur.
+Kein /2d Proof, keine Integration.
+```
+
+Prefer active code and current docs over older historical notes. Raw conversation exports are source material only and must not be committed.

--- a/docs/wiki/ARE-Core-Reality-Standard.md
+++ b/docs/wiki/ARE-Core-Reality-Standard.md
@@ -1,0 +1,98 @@
+# ARE Core Reality Standard
+
+Tags: `are`, `core-reality`, `determinism`, `tick-system`, `2d`
+Status: `canonical-standard`
+
+This page is the wiki form of the Areloria code truth manifest.
+
+```text
+Kein Snapshot, kein Spiel.
+Kein Tick, keine Wahrheit.
+Kein Guard, keine Architektur.
+Kein /2d Proof, keine Integration.
+```
+
+---
+
+## Canonical chain
+
+```text
+server-authoritative input
+→ deterministic tick
+→ canonical delta
+→ replay/state hash
+→ SnapshotComposer or runtime manifest
+→ /2d client observer
+→ guard/test/workflow
+```
+
+Anything outside this chain is either a prototype, an adapter, a diagnostic side-channel, or unfinished work.
+
+---
+
+## New module rule
+
+New modules follow:
+
+```text
+Types
+→ Ports
+→ TickSystem
+→ Delta
+→ Replay sink
+→ Snapshot/manifest sink
+→ /2d proof if player-visible
+→ Tests
+→ Docs
+```
+
+Never implement new gameplay as a direct `WorldTick.ts` patch.
+
+---
+
+## Forbidden in authoritative logic
+
+```text
+Math.random()
+Date.now()
+new Date()
+performance.now()
+randomUUID()
+external API timing
+client-authored gameplay mutation
+```
+
+Use TickId, KappaInt, StateHash, DeterministicPrng, stable sorted traversal and explicit replay input instead.
+
+---
+
+## Spatial truth
+
+```text
+simulationRadiusChunks = 2 → 5×5 interest/simulation
+broadcastRadiusChunks  = 1 → 3×3 client broadcast
+```
+
+Both come from `UnifiedChunkContract`.
+
+---
+
+## Kappa truth
+
+```text
+1 world unit = 1000 Kappa
+1 chunk side = 64,000 Kappa
+1 chunk plane = 4,096,000,000 Kappa cells
+```
+
+Boundary decimal adapters may round into Kappa. Internal state must already be integer.
+
+---
+
+## See also
+
+- [[Home]]
+- [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]]
+- [[Determinism]]
+- [[Systems Architecture|Systems_Architecture]]
+- [[Implementation Map|Implementation-Map]]

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,226 +1,116 @@
-# Areloria Codex Engine 🐉
+# Areloria Codex Engine
 
-> **The Living Knowledge Base of a Deterministic World**
+Tags: `home`, `are`, `determinism`, `2d`, `tick-system`, `wiki`
+Status: `living-index`
 
-```
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║     ███████╗██╗  ██╗██╗   ██╗████████╗██████╗  ██████╗ ██████╗ ███████╗   ║
-║     ██╔════╝██║ ██╔╝██║   ██║╚══██╔══╝██╔══██╗██╔═══██╗██╔══██╗██╔════╝   ║
-║     ███████╗█████╔╝ ██║   ██║   ██║   ██████╔╝██║   ██║██║  ██║███████╗   ║
-║     ╚════██║██╔═██╗ ██║   ██║   ██║   ██╔══██╗██║   ██║██║  ██║╚════██║   ║
-║     ███████║██║  ██╗╚██████╔╝   ██║   ██║  ██║╚██████╔╝██████╔╝███████║   ║
-║     ╚══════╝╚═╝  ╚═╝ ╚═════╝    ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝   ║
-║                                                                              ║
-║                        CODEX ENGINE — v1.0.0                                  ║
-╚══════════════════════════════════════════════════════════════════════════════╝
+> The living knowledge base of a deterministic browser MMORPG engine.
+
+```text
+Kein Snapshot, kein Spiel.
+Kein Tick, keine Wahrheit.
+Kein Guard, keine Architektur.
+Kein /2d Proof, keine Integration.
 ```
 
 ---
 
-## The Five Pillars of Knowledge
+## Current canonical truth
 
+Areloria uses a 2D-first, server-authoritative, deterministic runtime path.
+
+```text
+client intent
+→ server validation
+→ deterministic TickSystem
+→ canonical delta
+→ replay/state hash
+→ SnapshotComposer or runtime manifest
+→ /2d observer rendering
+→ guard/test/wiki proof
 ```
-                    ┌─────────────────────────────────────┐
-                    │      AUTHENTIC REALITY EMANCIPATION   │
-                    │            (ARE LOGIC CORE)          │
-                    └──────────────────┬──────────────────┘
-                                       │
-           ┌───────────────────────────┼───────────────────────────┐
-           │                           │                           │
-           ▼                           ▼                           ▼
-    ┌─────────────┐           ┌─────────────┐           ┌─────────────┐
-    │  ERDOS      │           │  WORLD TICK │           │   NPC CORE  │
-    │  ATTRACTOR  │           │   10Hz SIM  │           │  AUTONOMY   │
-    └─────────────┘           └─────────────┘           └─────────────┘
-           │                           │                           │
-           └───────────────────────────┼───────────────────────────┘
-                                       │
-                    ┌─────────────────┴─────────────────┐
-                    │      IMPLEMENTATION MAP          │
-                    │   (From Theory to Code)        │
-                    └─────────────────────────────────┘
+
+Old `WorldTick.ts` language in historical docs should be interpreted as legacy compatibility unless a current file explicitly says otherwise. New systems must target `WorldTickScheduler`, `TickSystemRegistry`, snapshot/replay sinks, and `/2d` proof.
+
+---
+
+## Core architecture map
+
+| Layer | Canonical anchor | Meaning |
+| --- | --- | --- |
+| Core types | `server/src/core/are/types.ts` | Kappa, TickId, StateHash, ChunkKey |
+| Kappa math | `server/src/core/are/Kappa.ts` | integer fixed-point truth |
+| Scheduler | `server/src/core/are/WorldTickScheduler.ts` | thin logical stepping |
+| Registry | `server/src/core/are/TickSystemRegistry.ts` | ordered deterministic systems |
+| Brain | `server/src/core/are/WorldBrainTickSystem.ts` | 13-layer brain as subsystem |
+| Route tick context | `server/src/core/are/TickSystemContextProvider.ts` | deterministic HTTP route tick context |
+| Spatial contract | `server/src/core/spatial/UnifiedChunkContract.ts` | simulation/broadcast radii and chunk truth |
+| Snapshot | `server/src/core/are/SnapshotComposer.ts` | server output truth |
+| Replay | `server/src/core/are/AREReplayBuffer.ts` | reconstructable mutation evidence |
+| Persistence | write-behind queue | side effect, not simulation truth |
+
+---
+
+## Must-read project rules
+
+| Page | Purpose |
+| --- | --- |
+| [[ARE Core Reality Standard|ARE-Core-Reality-Standard]] | Current technical constitution |
+| [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]] | New scheduler/registry interpretation |
+| [[Determinism]] | Determinism guardrails |
+| [[Systems Architecture|Systems_Architecture]] | System-level map |
+| [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]] | Stitch and asset pipeline |
+| [[ARE Logic Core|ARE-Logic-Core]] | ARE rule layer |
+
+Repository docs synced into the wiki also include:
+
+```text
+docs/ARELORIA_CODE_TRUTH_MANIFEST_2026_06.md
+docs/ARE_MODULE_IMPLEMENTATION_STANDARD.md
+docs/AGENT_ARE_SKILL_PLAYBOOK.md
+docs/CONVERSATION_ARCHIVE_SYNTHESIS_2026_06.md
+docs/CONVERSATION_DERIVED_PROJECT_RULES_2026_06.md
 ```
 
 ---
 
-## Core Systems Architecture
+## Runtime proof path
 
-### 🔮 Deterministic Engine
+A feature is not considered integrated until it is visible or verifiable through one of these channels:
 
-| System | File | Status | Purpose |
-|--------|------|--------|---------|
-| `WorldTick` | `server/src/core/WorldTick.ts` | 🟢 Live | 10Hz simulation heartbeat |
-| `AREClock` | `server/src/core/AREClock.ts` | 🟢 Live | Deterministic time |
-| `ARERng` | `server/src/core/ARERng.ts` | 🟢 Live | Seeded randomness |
-| `Manifest` | `server/src/core/manifest/` | 🟢 Live | State hash chain |
+```text
+/2d live client
+server-authoritative snapshot
+runtime asset manifest
+deterministic replay/state hash
+CI guard/test/smoke proof
+```
 
-### 🤖 Autonomous NPCs
-
-| System | File | Status | Purpose |
-|--------|------|--------|---------|
-| `NPCSystem` | `server/src/modules/npc/` | 🟢 Live | NPC runtime |
-| `MemoryCache` | `server/src/modules/npc/memory.ts` | 🟢 Live | Event persistence |
-| `Relationships` | `server/src/modules/npc/relations.ts` | 🟢 Live | NPC connections |
-
-### ⚔️ Combat & Loot
-
-| System | File | Status | Purpose |
-|--------|------|--------|---------|
-| `CombatDirector` | `server/src/modules/combat/` | 🟢 Live | Server-authoritative combat |
-| `AntiNinjaLoot` | `server/src/modules/loot/` | 🟢 Live | 60s kill lock |
-| `PlayerStatsSync` | `server/src/core/` | 🟢 Live | XP/level broadcast |
+Detached demos and one-off preview pages are useful only as prototypes. They are not production proof.
 
 ---
 
-## Design Language — Stitch Theme
+## Wiki automation
 
-### Color Palette
+This wiki is built from repository documentation.
 
-```css
-:root {
-  /* Primary — Deep Marine (void of space) */
-  --deep-marine: #0a0e14;
-  --void-black: #070711;
-  
-  /* Accent — Ethereal Energy */
-  --primary-blurple: #afc8f0;
-  --energy-amber: #ffb77d;
-  --mana-cyan: #00e5ff;
-  --malachite: #2ae500;
-  
-  /* Glassmorphism */
-  --glass-bg: rgba(16, 20, 25, 0.6);
-  --glass-border: rgba(175, 200, 240, 0.15);
-  --glass-glow: rgba(0, 229, 255, 0.1);
-}
+```text
+README.md / docs/*.md / docs/wiki/*.md / scripts/wiki/**
+→ scripts/wiki/build-autonomous-wiki.mjs
+→ .wiki-build
+→ scripts/sync-wiki.mjs
+→ GitHub wiki
 ```
 
-### Typography System
-
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│ DISPLAY — Epilogue (geometric, sharp)                                │
-│ ████████████████████████████████████████████████████████████████     │
-│ Areloria Codex Engine — The Living World Simulation                 │
-├──────────────────────────────────────────────────────────────────────┤
-│ BODY — Inter (readable, modern)                                     │
-│ ████████████████████████████████████████████████████████████████     │
-│ Deterministic simulation with 10Hz tick. Every state reproducible.    │
-├──────────────────────────────────────────────────────────────────────┤
-│ CODE — JetBrains Mono (precise, technical)                          │
-│ ████████████████████████████████████████████████████████████████     │
-│ WorldTick.ts:100 → const tick = await clock.tick()                 │
-└──────────────────────────────────────────────────────────────────────┘
-```
-
-### Visual Motifs
-
-```
-✦ Starfield particles in void background
-✦ Hexagonal grid overlay (subtle)
-✦ Glyph borders with corner accents
-✦ Pulsing energy lines between connected concepts
-✦ Depth layers with parallax scroll
-```
+The sync must build first and sync second. Copying only `docs/wiki/**` is not enough because the generated wiki depends on README, docs, module maps and package metadata.
 
 ---
 
-## Quick Navigation
+## See also
 
-### Start Here
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│  🚀 QUICK START                                                     │
-├─────────────────────────────────────────────────────────────────────┤
-│                                                                     │
-│  1. [README.md](../README.md)          → Project overview          │
-│  2. [Vision](Areloria-Vision)       → World design philosophy     │
-│  3. [ARE-Logic-Core](ARE-Logic-Core) → Core simulation model       │
-│  4. [NPC_Core](NPC_Core)            → Autonomous NPCs              │
-│  5. [Deployment](../DEPLOYMENT.md)  → VPS setup                   │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-### By Category
-
-| 🎯 Vision | ⚙️ Systems | 🤖 NPCs | 🛡️ Operations |
-|-----------|-------------|---------|-----------------|
-| [Areloria Vision](Areloria-Vision) | [ARE-Logic-Core](ARE-Logic-Core) | [NPC_Core](NPC_Core) | [Guard_and_Ops](Guard_and_Ops) |
-| [Research Publications](Research-Publications) | [WorldTick](WorldTick-and-10Hz-Simulation) | [Economy_and_Matrix](Economy_and_Matrix) | [Systems_Architecture](Systems_Architecture) |
-| [Determinism](Determinism) | [Asset Forge](Asset-Forge-and-2D-Pipeline) | — | — |
-
----
-
-## Status Indicators
-
-```
-🟢 LIVE     — Fully implemented and running
-🟡 BETA     — Implemented but may change
-🔵 PLANNED  — On the roadmap
-⚪ RESEARCH — Theoretical / under exploration
-```
-
----
-
-## Maintenance Rules
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│  📜 WIKI CONVENTIONS                                               │
-├─────────────────────────────────────────────────────────────────────┤
-│                                                                     │
-│  ✓ Use [[Page]] wiki links for internal navigation                │
-│  ✓ Start each page with Tags: and Status:                         │
-│  ✓ Link back to Home, Glossary, and at least one implementation   │
-│  ✓ Use Implementation anchors (file paths) for code references    │
-│  ✓ End with See also section                                      │
-│  ✗ Don't use theory without code anchor                           │
-│  ✗ Don't duplicate information across pages                        │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
----
-
-## Auto-Generated Content
-
-This wiki is automatically synced from project documentation. The **Codex Engine** pulls from:
-
-```
-Source                          → Generated Page
-─────────────────────────────────────────────────
-docs/wiki/*.md                  → (copied as-is)
-server/src/                     → Implementation-Map
-.git/commits                    → Changelog
-docs/ROADMAP_TO_RELEASE.md      → Roadmap
-docs/PROJECT_STATUS_2026.md     → Status
-```
-
----
-
-## External Resources
-
-| Resource | Link |
-|----------|------|
-| 🌐 Project Website | [Arelorian.de](https://www.Arelorian.de) |
-| 📂 GitHub Repository | [OuroborosCollective/Wasd](https://github.com/OuroborosCollective/Wasd) |
-| 🎨 Design System | [Stitch Integration](../STITCH_MCP_INTEGRATION.md) |
-| 📊 Open Science | [OSF Publications](Research-Publications) |
-
----
-
-```
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║   "The world must be allowed to become strange,                             ║
-║    but never nondeterministic by accident."                                  ║
-║                                                                              ║
-║                              — Areloria Design Principles                     ║
-║                                                                              ║
-╚══════════════════════════════════════════════════════════════════════════════╝
+- [[WorldTick and 10Hz Simulation|WorldTick-and-10Hz-Simulation]]
+- [[ARE Core Reality Standard|ARE-Core-Reality-Standard]]
+- [[Determinism]]
+- [[Implementation Map|Implementation-Map]]
+- [[Glossary]]
 
 Status: Living Wiki | Last Sync: Auto-generated
-Version: 1.0.0 | Build: Deterministic 🔮
-```

--- a/docs/wiki/WorldTick-and-10Hz-Simulation.md
+++ b/docs/wiki/WorldTick-and-10Hz-Simulation.md
@@ -1,24 +1,66 @@
 # WorldTick and 10Hz Simulation
 
-Tags: `worldtick`, `10hz`, `server`, `simulation`, `determinism`
-Status: `implementation-anchor`
+Tags: `10hz`, `tick-system`, `scheduler`, `determinism`, `server`
+Status: `migration-anchor`
 
-`WorldTick` is the authoritative heartbeat of the Areloria server simulation.
+This page records the current 10Hz simulation rule. Historical references to `WorldTick` must be interpreted through the current refactor:
 
-The design target is a stable **10Hz loop**, meaning one authoritative simulation step every `100ms`. Rendering can be smooth and interpolated, but authoritative decisions should happen at tick boundaries.
+```text
+WorldTickScheduler
+→ TickSystemRegistry
+→ ordered TickSystem modules
+→ AREReplayBuffer
+→ SnapshotComposer
+→ WriteBehindPersistenceQueue
+```
+
+`server/src/core/WorldTick.ts` may still exist as a legacy compatibility surface, but it is not the canonical extension point for new logic.
+
+---
+
+## Prime rule
+
+```text
+Kein Snapshot, kein Spiel.
+Kein Tick, keine Wahrheit.
+Kein Guard, keine Architektur.
+Kein /2d Proof, keine Integration.
+```
 
 ---
 
 ## Why 10Hz matters
 
-A fixed tick rate keeps core logic reproducible:
+A fixed 10Hz tick keeps authoritative gameplay reproducible:
 
 - combat timing,
 - NPC decisions,
 - resource updates,
-- collision / interaction windows,
-- event replay,
-- future [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]] propagation.
+- economy and quest events,
+- world-brain pressure,
+- replay verification,
+- snapshot production.
+
+Rendering may interpolate. Server truth changes only through deterministic tick boundaries.
+
+---
+
+## Canonical scheduler order
+
+```text
+WorldTickScheduler 10Hz
+  → TickSystemRegistry
+    1. InputTickSystem
+    2. SpatialInterestTickSystem
+    3. ResourceEconomyTickSystem
+    4. NpcMemoryRumorTickSystem
+    5. WorldBrainTickSystem
+    6. SnapshotComposerTickSystem
+  → AREReplayBuffer
+  → WriteBehindPersistenceQueue
+```
+
+The World Brain is a TickSystem. It must not control the scheduler directly.
 
 ---
 
@@ -26,34 +68,74 @@ A fixed tick rate keeps core logic reproducible:
 
 Core simulation should prefer:
 
-```txt
-currentTick
-entityId
-logical position
-seed / deterministic input
+```text
+TickId
+logicalIndex
+KappaInt
+ChunkKey
+StateHash
+explicit seed
+stable sorted traversal
 ```
 
 and avoid hidden dependencies on:
 
-```txt
+```text
 Date.now()
+new Date()
 Math.random()
-floating delta time
-iteration order of unordered maps
+performance.now()
 external API timing
+unordered map/object iteration where order changes state
 ```
 
 ---
 
-## Rendering boundary
+## HTTP route tick context
 
-Client rendering may interpolate between server snapshots. That does not change the authoritative tick.
+HTTP routes that need tick awareness should use `TickSystemContextProvider` or sanctioned read ports, not `WorldTick.tickCount`.
 
-Related pages:
+Canonical route response shape:
 
-- [[Determinism]]
-- [[Systems Architecture|Systems_Architecture]]
-- [[Asset Forge and 2D Pipeline|Asset-Forge-and-2D-Pipeline]]
+```json
+{
+  "ok": true,
+  "result": {},
+  "tickContext": {
+    "tickId": 123,
+    "tickIndex": 123,
+    "worldTimeHours": 2.95,
+    "tickTimestamp": 12300,
+    "seedHash": "..."
+  }
+}
+```
+
+---
+
+## Kappa / chunk math note
+
+Do not confuse logical tiles with Kappa cells.
+
+```text
+chunk side = 64 logical tiles
+Kappa scale = 1000
+chunk side = 64,000 Kappa
+chunk Kappa plane = 64,000 × 64,000 = 4,096,000,000 Kappa cells
+```
+
+---
+
+## Spatial radius contract
+
+The old conflict is resolved by naming two different envelopes:
+
+```text
+simulationRadiusChunks = 2 → 5×5 simulation/interest envelope
+broadcastRadiusChunks  = 1 → 3×3 client broadcast envelope
+```
+
+Both must come from `UnifiedChunkContract`.
 
 ---
 
@@ -61,43 +143,14 @@ Related pages:
 
 | Path | Meaning |
 | --- | --- |
-| `server/src/core/WorldTick.ts` | Authoritative simulation loop |
-| `server/src/networking/WebSocketServer.ts` | Player message delivery |
-| `client/src/engine/renderer.ts` | Client interpolation / rendering layer |
-| `apps/client-2d/src/stackedProps.ts` | 2D prop rendering path |
-| `server/src/modules/world/ChunkModificationDirector.ts` | Depletion persistence for resources |
-| `server/src/modules/world/ResourcePopulator.ts` | Deterministic resource entity generation |
-
-## Resources Entity System
-
-As of 2026-05-31, WorldTick supports `type: 'RESOURCE'` entities in `world_snapshot`:
-
-```typescript
-// Resources broadcast to clients
-this.ws.sendToPlayer(socketId, {
-  type: "world_snapshot",
-  tick: this.tickCount,
-  self: selfId,
-  other_players: [...],
-  npcs: [...],
-  loot: [...],
-  resources: [  // NEW
-    {
-      id: 'res_wood_0_5_0',
-      type: 'RESOURCE',
-      resourceType: 'wood',
-      x, z,            // World space
-      kappaX, kappaZ,   // KAPPA space (1 unit = 1000 KAPPA)
-      yield: 5,
-      maxYield: 5,
-      depleted: false,
-      regrowRate: 600, // Ticks
-    }
-  ]
-});
-```
-
-Resource entity IDs format: `res_{type}_{chunkX}_{chunkZ}_{index}`
+| `server/src/core/are/WorldTickScheduler.ts` | thin logical scheduler |
+| `server/src/core/are/TickSystemRegistry.ts` | deterministic system ordering |
+| `server/src/core/are/TickSystem.ts` | subsystem contract |
+| `server/src/core/are/TickSystemContextProvider.ts` | deterministic route tick context |
+| `server/src/core/are/WorldBrainTickSystem.ts` | 13-layer brain as TickSystem |
+| `server/src/core/are/SnapshotComposer.ts` | snapshot truth output |
+| `server/src/core/are/AREReplayBuffer.ts` | replay/delta evidence |
+| `server/src/core/spatial/UnifiedChunkContract.ts` | canonical spatial constants |
 
 ---
 
@@ -105,18 +158,21 @@ Resource entity IDs format: `res_{type}_{chunkX}_{chunkZ}_{index}`
 
 When editing tick logic:
 
-1. keep changes small,
-2. add deterministic tests when possible,
-3. avoid broad bot-generated rewrites,
-4. do not mix NPC, economy, combat and CI changes in one PR,
-5. document new tick rules in [[Implementation Map|Implementation-Map]].
+1. do not add new domain logic to `server/src/core/WorldTick.ts`,
+2. add or modify a `TickSystem`,
+3. read and write through ports,
+4. emit replayable deltas,
+5. feed snapshot/manifest output,
+6. prove through tests or `/2d` where player-visible,
+7. document new rules in current docs/wiki.
 
 ---
 
 ## See also
 
 - [[Home]]
-- [[Glossary]]
-- [[ARE Logic Core|ARE-Logic-Core]]
-- [[ARE-Erdos Attractor Model|ARE-Erdos-Attractor-Model]]
+- [[ARE Core Reality Standard|ARE-Core-Reality-Standard]]
+- [[Determinism]]
+- [[Systems Architecture|Systems_Architecture]]
 - [[Implementation Map|Implementation-Map]]
+- [[Glossary]]


### PR DESCRIPTION
## Summary

- Synthesizes the uploaded conversation ZIP archives into repo-safe ARE architecture docs.
- Adds the ARE code truth manifest, module implementation standard, agent skill playbook, and conversation archive synthesis.
- Updates README to make the current canonical architecture explicit: no new logic in legacy `WorldTick.ts`; use `WorldTickScheduler`, `TickSystemRegistry`, replay/state hash, snapshot/manifest, and `/2d` proof.
- Updates wiki source pages so generated wiki content no longer presents `WorldTick.ts` as the new extension truth.

## Files

- `README.md`
- `docs/START_HERE.md`
- `docs/ARELORIA_CODE_TRUTH_MANIFEST_2026_06.md`
- `docs/ARE_MODULE_IMPLEMENTATION_STANDARD.md`
- `docs/AGENT_ARE_SKILL_PLAYBOOK.md`
- `docs/CONVERSATION_ARCHIVE_SYNTHESIS_2026_06.md`
- `docs/wiki/Home.md`
- `docs/wiki/WorldTick-and-10Hz-Simulation.md`
- `docs/wiki/ARE-Core-Reality-Standard.md`

## Wiki sync

The existing `.github/workflows/sync-wiki.yml` already triggers on README/docs/wiki-builder changes, builds `.wiki-build`, verifies `Home.md`, and syncs via `scripts/sync-wiki.mjs` using `WIKI_SOURCE_DIR=.wiki-build`. This PR updates the source docs that feed that flow.

## Safety

- No raw conversation JSON or ZIP content committed.
- No credentials, tokens, server passwords, or secrets copied.
- Documentation-only; no runtime code changes.

## Verification

- Documentation-only review.
- Wiki sync should run after merge because docs and README paths are covered by the workflow.