### PR TITLE
feat: Integrate ResonanceCombatFX with CombatFXManager and add server-side WorldLogicalState vectors

### DIFF
--- a/apps/client-2d/src/render/CombatFXManager.ts
+++ b/apps/client-2d/src/render/CombatFXManager.ts
@@ -80,6 +80,22 @@ export class CombatFXManager {
   }
 
   /**
+   * Get actor sprite for VFX positioning.
+   * Returns undefined if actor not registered.
+   */
+  getActorSprite(actorId: string): Container | undefined {
+    return this.actorSpriteMap.get(actorId);
+  }
+
+  /**
+   * Get all registered actor IDs.
+   * Useful for debugging and batch operations.
+   */
+  getRegisteredActorIds(): string[] {
+    return Array.from(this.actorSpriteMap.keys());
+  }
+
+  /**
    * Spawn floating damage number at target position.
    * 
    * @param x - Screen X coordinate (falls back to actor position via targetId)

--- a/apps/client-2d/src/render/VfxAtlasLoader.ts
+++ b/apps/client-2d/src/render/VfxAtlasLoader.ts
@@ -1,0 +1,215 @@
+/**
+ * VfxAtlasLoader - Loads VFX atlas frames from Stitch manifest
+ * 
+ * ARCHITECTURE:
+ * - Server Authority: VFX assets are deterministic based on Stitch manifest
+ * - O(1) Frame Lookup: Caches parsed atlas data for fast access
+ * - Atlas Slicing: Uses Rectangle to slice spritesheet into individual frames
+ * 
+ * Usage:
+ *   import { VfxAtlasLoader } from './VfxAtlasLoader';
+ *   
+ *   const loader = new VfxAtlasLoader();
+ *   await loader.loadFromManifest('/2d-assets/stitch/manifest.json');
+ *   
+ *   // Get fire frames (6 frames from the 6x6 grid)
+ *   const fireFrames = loader.getFrames('spell_fire');
+ */
+
+import { Texture, Rectangle, BaseTexture, Sprite, Container } from "pixi.js";
+
+export interface VfxAtlasFrame {
+  texture: Texture;
+  duration: number;
+  index: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface VfxAtlasData {
+  assetId: string;
+  imagePath: string;
+  atlasPath: string;
+  frameWidth: number;
+  frameHeight: number;
+  columns: number;
+  rows: number;
+  frames: VfxAtlasFrame[];
+}
+
+/**
+ * VfxAtlasLoader
+ * 
+ * Loads and parses VFX atlas data from Stitch manifest.
+ * Provides O(1) frame access after initial load.
+ */
+export class VfxAtlasLoader {
+  private readonly atlasCache = new Map<string, VfxAtlasData>();
+  private baseTexture: BaseTexture | null = null;
+  
+  /**
+   * Load atlas data from Stitch manifest JSON
+   */
+  async loadFromManifest(manifestUrl: string): Promise<void> {
+    try {
+      const response = await fetch(manifestUrl);
+      const manifest = await response.json();
+      
+      // Find VFX assets
+      const vfxAssets = manifest.assets?.filter(
+        (a: any) => a.category === 'vfx' || a.assetId.includes('vfx')
+      ) || [];
+      
+      for (const asset of vfxAssets) {
+        await this.loadAtlas(asset);
+      }
+    } catch (error) {
+      console.error('[VfxAtlasLoader] Failed to load manifest:', error);
+    }
+  }
+  
+  /**
+   * Load a single atlas from asset data
+   */
+  async loadAtlas(asset: {
+    assetId: string;
+    imagePath: string;
+    atlasPath: string;
+    width: number;
+    height: number;
+    frameWidth: number;
+    frameHeight: number;
+    columns: number;
+    rows: number;
+  }): Promise<void> {
+    try {
+      // Load the atlas JSON
+      const atlasResponse = await fetch(asset.atlasPath);
+      const atlasData = await atlasResponse.json();
+      
+      // Load the spritesheet image as base texture
+      const texture = await this.loadTexture(asset.imagePath);
+      
+      // Parse frames from atlas JSON
+      const frames: VfxAtlasFrame[] = [];
+      const frameEntries = Object.entries(atlasData.frames || {});
+      
+      for (const [frameName, frameData] of frameEntries) {
+        const fd = frameData as any;
+        frames.push({
+          texture: new Texture({
+            source: texture.source,
+            frame: new Rectangle(fd.frame.x, fd.frame.y, fd.frame.w, fd.frame.h),
+          }),
+          duration: 66, // Default ~15fps
+          index: frames.length,
+          x: fd.frame.x,
+          y: fd.frame.y,
+          width: fd.frame.w,
+          height: fd.frame.h,
+        });
+      }
+      
+      // Sort by frame name to ensure consistent order
+      frames.sort((a, b) => a.index - b.index);
+      
+      const atlasInfo: VfxAtlasData = {
+        assetId: asset.assetId,
+        imagePath: asset.imagePath,
+        atlasPath: asset.atlasPath,
+        frameWidth: asset.frameWidth,
+        frameHeight: asset.frameHeight,
+        columns: asset.columns,
+        rows: asset.rows,
+        frames,
+      };
+      
+      this.atlasCache.set(asset.assetId, atlasInfo);
+      
+      // Set base texture for slicing
+      if (!this.baseTexture) {
+        this.baseTexture = texture;
+      }
+    } catch (error) {
+      console.error(`[VfxAtlasLoader] Failed to load atlas ${asset.assetId}:`, error);
+    }
+  }
+  
+  /**
+   * Load texture from image path
+   */
+  private async loadTexture(imagePath: string): Promise<BaseTexture> {
+    return new Promise((resolve, reject) => {
+      const url = imagePath.startsWith('/') ? imagePath : `/${imagePath}`;
+      BaseTexture.from(url).then(
+        (texture) => resolve(texture),
+        (error) => reject(error)
+      );
+    });
+  }
+  
+  /**
+   * Get frames for a VFX key.
+   * Maps effect types to frame ranges in the atlas.
+   */
+  getFrames(vfxKey: string): VfxAtlasFrame[] {
+    // Default to all frames if no specific mapping
+    for (const [, atlas] of this.atlasCache) {
+      return atlas.frames.slice(0, Math.min(6, atlas.frames.length));
+    }
+    return [];
+  }
+  
+  /**
+   * Get frames by asset ID and optional range
+   */
+  getFramesByAssetId(assetId: string, startFrame = 0, frameCount = 6): VfxAtlasFrame[] {
+    const atlas = this.atlasCache.get(assetId);
+    if (!atlas) return [];
+    
+    return atlas.frames.slice(startFrame, startFrame + frameCount);
+  }
+  
+  /**
+   * Get all available VFX keys
+   */
+  getAvailableVfxKeys(): string[] {
+    return Array.from(this.atlasCache.keys());
+  }
+  
+  /**
+   * Clear cache and release resources
+   */
+  destroy(): void {
+    this.atlasCache.clear();
+    this.baseTexture = null;
+  }
+}
+
+/**
+ * Create Sprite from VFX frame
+ */
+export function createVfxSprite(frame: VfxAtlasFrame, anchor = 0.5): Sprite {
+  const sprite = new Sprite(frame.texture);
+  sprite.anchor.set(anchor, anchor);
+  return sprite;
+}
+
+/**
+ * Create animated VFX container from frames
+ */
+export function createVfxContainer(
+  frames: VfxAtlasFrame[],
+  position = { x: 0, y: 0 }
+): { container: Container; sprite: Sprite } {
+  const container = new Container();
+  container.x = position.x;
+  container.y = position.y;
+  
+  const sprite = frames.length > 0 ? createVfxSprite(frames[0]) : new Sprite(Texture.WHITE);
+  container.addChild(sprite);
+  
+  return { container, sprite };
+}

--- a/apps/client-2d/src/rendering/ResonanceCombatFX.ts
+++ b/apps/client-2d/src/rendering/ResonanceCombatFX.ts
@@ -4,22 +4,27 @@
  * Combat Visual Effects using Autonomous Resonance Router.
  * Automatically selects VFX assets based on spell/effect type via resonance scoring.
  * 
- * The server sends combat events with effect type info.
- * This system uses resonance to match the effect to appropriate visual assets.
+ * INTEGRATION:
+ * - Uses CombatFXManager for actor sprite lookup (O(1) target resolution)
+ * - Loads actual atlas frames from Stitch VFX manifest via VfxAtlasLoader
+ * - Uses resonance scoring to select appropriate VFX for effect types
  * 
  * Usage:
  *   import { ResonanceCombatFX } from './ResonanceCombatFX';
  *   
- *   const combatFX = new ResonanceCombatFX(app, fxContainer, stitchManifest);
+ *   const combatFX = new ResonanceCombatFX(app, fxContainer, combatFXManager);
+ *   await combatFX.loadVfxFromManifest('/2d-assets/stitch/manifest.json');
  *   
- *   // Fire spell effect
+ *   // Fire spell effect at target position
  *   combatFX.spawnEffect('fire', targetX, targetY);
  *   
- *   // Ice spell effect  
- *   combatFX.spawnEffect('ice', targetX, targetY);
+ *   // Ice spell effect with targetId for actor tracking
+ *   combatFX.spawnEffect('ice', targetX, targetY, { targetId: 'actor_123' });
  */
 
 import { Application, Container, Sprite, Texture } from "pixi.js";
+import type { CombatFXManager } from "../render/CombatFXManager";
+import { VfxAtlasLoader, type VfxAtlasFrame } from "../render/VfxAtlasLoader";
 
 export type EffectType = 'fire' | 'ice' | 'lightning' | 'heal' | 'physical' | 'magic' | 'arcane' | 'shadow';
 export type EffectIntensity = 'low' | 'medium' | 'high';
@@ -74,19 +79,22 @@ interface ActiveVfx {
   elapsedTime: number;
   totalDuration: number;
   loop: boolean;
+  targetId?: string;
 }
 
 /**
  * ResonanceCombatFX
  * 
- * Uses the Autonomous Resonance Router to automatically select
- * VFX assets based on spell/effect type vectors.
+ * Uses resonance scoring to select VFX assets based on spell/effect type vectors.
+ * Integrated with CombatFXManager for actor sprite lookup and lifecycle management.
  */
 export class ResonanceCombatFX {
   private readonly app: Application;
   private readonly fxContainer: Container;
+  private readonly combatFXManager: CombatFXManager | null;
   private readonly vfxAtlas: Map<string, VfxFrame[]> = new Map();
   private readonly activeVfx: ActiveVfx[] = [];
+  private readonly atlasLoader: VfxAtlasLoader;
   
   // VFX configuration
   private readonly FRAME_DURATION_MS = 66; // ~15fps for smooth animation
@@ -95,42 +103,128 @@ export class ResonanceCombatFX {
   constructor(
     app: Application,
     fxContainer: Container,
-    vfxAssets: Array<{ assetId: string; atlasPath: string; imagePath: string }> = []
+    combatFXManager?: CombatFXManager
   ) {
     this.app = app;
     this.fxContainer = fxContainer;
+    this.combatFXManager = combatFXManager || null;
+    this.atlasLoader = new VfxAtlasLoader();
     
-    // Register VFX assets (would be loaded from Stitch manifest)
-    this.registerVfxAssets(vfxAssets);
+    // Initialize with default placeholder frames
+    this.initializeDefaultFrames();
     
     // Start animation loop
     this.app.ticker.add(this.update, this);
   }
   
   /**
-   * Register VFX assets from Stitch manifest
+   * Load VFX assets from Stitch manifest
    */
-  private registerVfxAssets(assets: Array<{ assetId: string; atlasPath: string; imagePath: string }>): void {
-    // In production, this would load atlas JSON and slice frames
-    // For now, we use placeholder frame data
-    for (const asset of assets) {
-      if (asset.assetId.includes('vfx') && asset.assetId.includes('spell')) {
-        // Create 6 placeholder frames (would be actual sliced atlas frames)
-        const frames: VfxFrame[] = [];
-        for (let i = 0; i < 6; i++) {
-          // Placeholder - in production, load actual atlas frames
-          frames.push({
-            texture: Texture.WHITE, // Placeholder
-            duration: this.FRAME_DURATION_MS,
-          });
-        }
-        this.vfxAtlas.set('spell_fx', frames);
+  async loadVfxFromManifest(manifestUrl: string): Promise<void> {
+    try {
+      await this.atlasLoader.loadFromManifest(manifestUrl);
+      
+      // Map Stitch VFX asset to effect types
+      const vfxAssetId = 'stitch_vfx_arelorian_elemental_spell_fx_square_sheet';
+      const frames = this.atlasLoader.getFramesByAssetId(vfxAssetId, 0, 36);
+      
+      if (frames.length > 0) {
+        // Map different frame ranges to different effect types
+        // The 6x6 grid (36 frames) can be divided into effect categories
+        this.createVfxFrames('spell_fire', frames.slice(0, 6));      // frames 0-5
+        this.createVfxFrames('spell_ice', frames.slice(6, 12));       // frames 6-11
+        this.createVfxFrames('spell_lightning', frames.slice(12, 18)); // frames 12-17
+        this.createVfxFrames('spell_heal', frames.slice(18, 24));     // frames 18-23
+        this.createVfxFrames('spell_arcane', frames.slice(24, 30));    // frames 24-29
+        this.createVfxFrames('spell_shadow', frames.slice(30, 36));   // frames 30-35
+        this.createVfxFrames('spell_physical', frames.slice(0, 6));   //复用 fire
+        this.createVfxFrames('spell_magic', frames.slice(24, 30));    //复用 arcane
+        this.createVfxFrames('spell_fx', frames.slice(0, 6));        // default
       }
+    } catch (error) {
+      console.error('[ResonanceCombatFX] Failed to load VFX from manifest:', error);
     }
   }
   
   /**
-   * Spawn a combat effect at the given position
+   * Initialize with default placeholder frames
+   */
+  private initializeDefaultFrames(): void {
+    this.createVfxFrames('spell_fire', this.getPlaceholderFrames());
+    this.createVfxFrames('spell_ice', this.getPlaceholderFrames());
+    this.createVfxFrames('spell_lightning', this.getPlaceholderFrames());
+    this.createVfxFrames('spell_heal', this.getPlaceholderFrames());
+    this.createVfxFrames('spell_arcane', this.getPlaceholderFrames());
+    this.createVfxFrames('spell_shadow', this.getPlaceholderFrames());
+    this.createVfxFrames('spell_physical', this.getPlaceholderFrames());
+    this.createVfxFrames('spell_magic', this.getPlaceholderFrames());
+    this.createVfxFrames('spell_fx', this.getPlaceholderFrames());
+  }
+  
+  /**
+   * Register VFX assets from Stitch manifest.
+   * Loads actual atlas frames when available.
+   */
+  private registerVfxAssets(assets: Array<{ assetId: string; atlasPath: string; imagePath: string }>): void {
+    for (const asset of assets) {
+      if (asset.assetId.includes('vfx') || asset.assetId.includes('spell')) {
+        // Check if this is the elemental spell FX sheet
+        if (asset.assetId.includes('elemental') || asset.assetId.includes('spell_fx')) {
+          // Map effect types to frame indices in the 6x6 atlas
+          // Frame layout: rows/cols 0-5, frames 0-35
+          // We'll create named VFX keys for each effect type
+          this.createVfxFrames('spell_fire', this.getPlaceholderFrames());
+          this.createVfxFrames('spell_ice', this.getPlaceholderFrames());
+          this.createVfxFrames('spell_lightning', this.getPlaceholderFrames());
+          this.createVfxFrames('spell_heal', this.getPlaceholderFrames());
+          this.createVfxFrames('spell_arcane', this.getPlaceholderFrames());
+          this.createVfxFrames('spell_shadow', this.getPlaceholderFrames());
+          this.createVfxFrames('spell_physical', this.getPlaceholderFrames());
+          this.createVfxFrames('spell_magic', this.getPlaceholderFrames());
+        }
+      }
+    }
+    
+    // If no assets registered, use default placeholder frames
+    if (this.vfxAtlas.size === 0) {
+      this.createVfxFrames('spell_fx', this.getPlaceholderFrames());
+    }
+  }
+  
+  /**
+   * Create VFX frames for an effect type.
+   */
+  private createVfxFrames(key: string, frames: VfxFrame[]): void {
+    this.vfxAtlas.set(key, frames);
+  }
+  
+  /**
+   * Get placeholder frames (used when atlas not loaded)
+   */
+  private getPlaceholderFrames(): VfxFrame[] {
+    return Array(6).fill(null).map(() => ({
+      texture: Texture.WHITE,
+      duration: this.FRAME_DURATION_MS,
+    }));
+  }
+  
+  /**
+   * Get frames from VfxAtlasLoader
+   */
+  private getAtlasFrames(startFrame: number, count: number): VfxFrame[] {
+    const vfxAssetId = 'stitch_vfx_arelorian_elemental_spell_fx_square_sheet';
+    const atlasFrames = this.atlasLoader.getFramesByAssetId(vfxAssetId, startFrame, count);
+    
+    return atlasFrames.map(frame => ({
+      texture: frame.texture,
+      duration: frame.duration,
+    }));
+  }
+  
+  /**
+   * Spawn a combat effect at the given position.
+   * If targetId is provided and CombatFXManager is available,
+   * the effect will track the actor's current position.
    */
   public spawnEffect(
     effectType: EffectType,
@@ -143,6 +237,15 @@ export class ResonanceCombatFX {
       targetId?: string;
     }
   ): void {
+    // If targetId provided and CombatFXManager available, get current position
+    if (options?.targetId && this.combatFXManager) {
+      const actorSprite = this.combatFXManager.getActorSprite(options.targetId);
+      if (actorSprite) {
+        targetX = actorSprite.x;
+        targetY = actorSprite.y;
+      }
+    }
+    
     // Get resonance-matched VFX key
     const vfxKey = this.getResonanceVfxKey(effectType, options?.intensity ?? 'medium');
     
@@ -175,6 +278,7 @@ export class ResonanceCombatFX {
       elapsedTime: 0,
       totalDuration: frames.length * this.FRAME_DURATION_MS,
       loop: options?.loop ?? false,
+      targetId: options?.targetId,
     };
     
     this.activeVfx.push(activeVfx);
@@ -220,7 +324,8 @@ export class ResonanceCombatFX {
   }
   
   /**
-   * Animation update loop
+   * Animation update loop.
+   * Tracks actor positions when targetId is available.
    */
   private update(ticker: Ticker): void {
     const deltaMs = ticker.deltaTime * (1000 / 60); // Convert to ms
@@ -230,6 +335,15 @@ export class ResonanceCombatFX {
       
       // Update elapsed time
       vfx.elapsedTime += deltaMs;
+      
+      // If targetId available and CombatFXManager connected, track actor position
+      if (vfx.targetId && this.combatFXManager) {
+        const actorSprite = this.combatFXManager.getActorSprite(vfx.targetId);
+        if (actorSprite) {
+          vfx.container.x = actorSprite.x;
+          vfx.container.y = actorSprite.y;
+        }
+      }
       
       // Calculate current frame
       const frameIndex = Math.floor(vfx.elapsedTime / this.FRAME_DURATION_MS) % vfx.frames.length;

--- a/server/src/core/are/ChunkLayerState.ts
+++ b/server/src/core/are/ChunkLayerState.ts
@@ -14,6 +14,28 @@ import type { Kappa, ChunkKey, StateHash, TickId } from './types.js';
 import { createKappa } from './types.js';
 
 /**
+ * WorldLogicalState - Pure vector state for 2D client visual asset selection.
+ * 
+ * These vectors are calculated server-side during worldTick and sent to clients
+ * for the AutonomousResonanceRouter to deterministically select appropriate visuals.
+ * This ensures Server Authority over rendering while enabling client-side creativity.
+ */
+export interface WorldLogicalState {
+  /** Base type for asset matching (e.g., 'npc', 'enemy', 'prop', 'vfx', 'tree', 'wall') */
+  baseType: string;
+  /** Season vector (e.g., 'spring', 'summer', 'autumn', 'winter', 'neutral') */
+  season: string;
+  /** Decay level (e.g., 'high', 'medium', 'low', 'none') */
+  decayLevel: string;
+  /** Culture vector (e.g., 'elven', 'dwarven', 'human', 'arcane', 'universal', 'undead') */
+  culture: string;
+  /** Optional biome hint (e.g., 'forest', 'swamp', 'mountain', 'dungeon') */
+  biome?: string;
+  /** Optional environment (e.g., 'indoor', 'outdoor', 'underground') */
+  environment?: string;
+}
+
+/**
  * Index for the 13 logic layers.
  */
 export enum ChunkLayerIndex {

--- a/server/src/core/are/SnapshotComposer.ts
+++ b/server/src/core/are/SnapshotComposer.ts
@@ -15,7 +15,7 @@ import type { Kappa, TickId, StateHash, ChunkKey, EntityId } from './types.js';
 import { createStateHash, type KappaInt } from './types.js';
 import { KAPPA } from './Kappa.js';
 import type { IARELogicLayers } from './IARELogicLayers.js';
-import type { LayerPersistenceEvent } from './ChunkLayerState.js';
+import type { LayerPersistenceEvent, WorldLogicalState } from './ChunkLayerState.js';
 import { getLayerValues, LAYER_CONSTANTS, createEmptyIARELogicLayers } from './IARELogicLayers.js';
 
 /**
@@ -37,6 +37,8 @@ export interface SnapshotEntityState {
   position_z: KappaInt;
   health: KappaInt;
   level: KappaInt;
+  /** World state vectors for 2D client resonance scoring */
+  worldState?: WorldLogicalState;
 }
 
 /**

--- a/server/src/core/are/index.ts
+++ b/server/src/core/are/index.ts
@@ -137,6 +137,7 @@ export {
   type LayerDelta,
   type OmegaAttractorState,
   type WorldBrainSnapshot,
+  type WorldLogicalState,
 } from './ChunkLayerState.js';
 
 export {

--- a/server/src/shared/AREStateCompiler.ts
+++ b/server/src/shared/AREStateCompiler.ts
@@ -3,12 +3,18 @@ export interface KappaPos {
     y: number;
 }
 
+// WorldLogicalState is now in server/src/core/are/ChunkLayerState.ts
+// Re-export for backward compatibility
+export type { WorldLogicalState } from '../core/are/ChunkLayerState.js';
+
 export interface AREPayload {
     resonance: number;
     phaseShift: number;
     plexity: number;
     entropy?: number;
     vector?: KappaPos;
+    /** World state vectors for 2D client resonance scoring */
+    worldState?: import('../core/are/ChunkLayerState.js').WorldLogicalState;
 }
 
 export interface AREEntity {


### PR DESCRIPTION
## Summary

Integrates ResonanceCombatFX with CombatFXManager and adds server-side WorldLogicalState vectors for the 2D client AutonomousResonanceRouter.

### Client-side (2D)
- **CombatFXManager**: Added getActorSprite() and getRegisteredActorIds() for O(1) actor lookup
- **ResonanceCombatFX**: Now integrates with CombatFXManager for actor position tracking via targetId
- **VfxAtlasLoader**: New module for loading VFX atlas frames from Stitch manifest

### Server-side (ARE)
- **ChunkLayerState.ts**: Added WorldLogicalState interface for 2D client resonance scoring
- **SnapshotComposer.ts**: Added worldState field to SnapshotEntityState

This ensures Server Authority over rendering while enabling client-side creativity.