### PR TITLE
fix(world): add stateless hardcode resolver seam

### DIFF
--- a/apps/client-2d/src/world/StatelessWorldRuntimeResolver.test.ts
+++ b/apps/client-2d/src/world/StatelessWorldRuntimeResolver.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveBiomeId,
+  resolvePlayerId,
+  resolveSpawnCell,
+  resolveStatelessWorldRuntime,
+  resolveVisibleChunkKeys,
+  stableWorldHash32,
+} from "./StatelessWorldRuntimeResolver";
+
+describe("StatelessWorldRuntimeResolver", () => {
+  it("derives the same state for the same explicit inputs", () => {
+    const a = resolveStatelessWorldRuntime({
+      identity: "are-player-1",
+      worldSeed: "areloria:test-world",
+    });
+    const b = resolveStatelessWorldRuntime({
+      identity: "are-player-1",
+      worldSeed: "areloria:test-world",
+    });
+
+    expect(a).toEqual(b);
+    expect(a.chunkKey).toMatch(/^-?\d+_-?\d+$/);
+    expect(a.visibleChunkKeys).toHaveLength(9);
+  });
+
+  it("does not collapse missing identity to guest", () => {
+    const playerId = resolvePlayerId(null, "areloria:test-world");
+    expect(playerId).toMatch(/^anon_[0-9a-f]{8}$/);
+    expect(playerId).not.toBe("guest");
+  });
+
+  it("uses current position before stored spawn or generated spawn", () => {
+    const state = resolveStatelessWorldRuntime({
+      identity: "player-current",
+      worldSeed: "areloria:test-world",
+      storedSpawn: { x: 9000, z: 9000 },
+      currentPosition: { x: 34, z: -17 },
+    });
+
+    expect(state.position).toEqual({ x: 34, z: -17 });
+    expect(state.chunkX).toBe(2);
+    expect(state.chunkZ).toBe(-2);
+  });
+
+  it("uses stored spawn before generated spawn", () => {
+    const state = resolveStatelessWorldRuntime({
+      identity: "player-stored",
+      worldSeed: "areloria:test-world",
+      storedSpawn: { x: -49, z: 81 },
+    });
+
+    expect(state.spawnCell).toEqual({ x: -49, z: 81 });
+    expect(state.position).toEqual({ x: -49, z: 81 });
+  });
+
+  it("generates different deterministic spawns for different players", () => {
+    const a = resolveSpawnCell({
+      playerId: "player-a",
+      worldSeed: "areloria:test-world",
+      chunkSizeTiles: 16,
+    });
+    const b = resolveSpawnCell({
+      playerId: "player-b",
+      worldSeed: "areloria:test-world",
+      chunkSizeTiles: 16,
+    });
+
+    expect(a).not.toEqual(b);
+  });
+
+  it("derives biome from seed and chunk coordinates", () => {
+    const a = resolveBiomeId({ worldSeed: "areloria:a", chunkX: 2, chunkZ: 3 });
+    const b = resolveBiomeId({ worldSeed: "areloria:a", chunkX: 2, chunkZ: 3 });
+    const c = resolveBiomeId({ worldSeed: "areloria:b", chunkX: 2, chunkZ: 3 });
+
+    expect(a).toBe(b);
+    expect(typeof c).toBe("string");
+  });
+
+  it("creates square visible chunk windows", () => {
+    expect(resolveVisibleChunkKeys({ chunkX: 10, chunkZ: -4, viewRadiusChunks: 1 })).toEqual([
+      "9_-5",
+      "10_-5",
+      "11_-5",
+      "9_-4",
+      "10_-4",
+      "11_-4",
+      "9_-3",
+      "10_-3",
+      "11_-3",
+    ]);
+  });
+
+  it("stable hash is deterministic unsigned 32-bit", () => {
+    const hash = stableWorldHash32("areloria:test");
+    expect(hash).toBe(stableWorldHash32("areloria:test"));
+    expect(hash).toBeGreaterThanOrEqual(0);
+    expect(hash).toBeLessThanOrEqual(0xffffffff);
+  });
+});

--- a/apps/client-2d/src/world/StatelessWorldRuntimeResolver.ts
+++ b/apps/client-2d/src/world/StatelessWorldRuntimeResolver.ts
@@ -1,0 +1,246 @@
+/**
+ * ARELORIA Stateless World Runtime Resolver
+ *
+ * Converts explicit deterministic inputs into runtime world state.
+ *
+ * Axioms are allowed constants. Runtime state is not allowed to live as
+ * hardcoded literals inside React components or render boot paths.
+ */
+
+export const STATELESS_WORLD_AXIOMS = Object.freeze({
+  KAPPA_INVARIANT: 1000,
+  CHUNK_SIZE_TILES: 16,
+  VIEW_RADIUS_CHUNKS: 1,
+});
+
+export interface WorldPositionInput {
+  readonly x: number;
+  readonly z: number;
+}
+
+export interface StoredSpawnInput {
+  readonly x: number;
+  readonly z: number;
+}
+
+export interface StatelessWorldRuntimeInputs {
+  readonly identity: string | null | undefined;
+  readonly worldSeed: string | null | undefined;
+  readonly kappaInvariant?: number | null;
+  readonly chunkSizeTiles?: number | null;
+  readonly viewRadiusChunks?: number | null;
+  readonly currentPosition?: WorldPositionInput | null;
+  readonly storedSpawn?: StoredSpawnInput | null;
+}
+
+export interface InitialChunkPlanInput {
+  readonly worldSeed: string;
+  readonly chunkX: number;
+  readonly chunkZ: number;
+  readonly biomeId: string;
+  readonly kappa: number;
+  readonly chunkTiles: number;
+}
+
+export interface StatelessWorldRuntimeState {
+  readonly playerId: string;
+  readonly worldSeed: string;
+  readonly kappaInvariant: number;
+  readonly chunkSizeTiles: number;
+  readonly viewRadiusChunks: number;
+  readonly position: WorldPositionInput;
+  readonly chunkX: number;
+  readonly chunkZ: number;
+  readonly chunkKey: string;
+  readonly biomeId: string;
+  readonly visibleChunkKeys: readonly string[];
+  readonly spawnCell: WorldPositionInput;
+  readonly initialChunkPlanInput: InitialChunkPlanInput;
+}
+
+const BIOME_LADDER = [
+  { ceiling: 7, id: "cyber_zen_glass" },
+  { ceiling: 28, id: "deep_forest" },
+  { ceiling: 58, id: "plains" },
+  { ceiling: 82, id: "temperate_swamp" },
+  { ceiling: 100, id: "forest_village" },
+] as const;
+
+function sanitizeNonEmpty(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function positiveInteger(value: number | null | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || !Number.isInteger(value) || Number(value) <= 0) return fallback;
+  return Number(value);
+}
+
+function finitePosition(value: WorldPositionInput | StoredSpawnInput | null | undefined): WorldPositionInput | null {
+  if (!value) return null;
+  const x = Number(value.x);
+  const z = Number(value.z);
+  if (!Number.isFinite(x) || !Number.isFinite(z)) return null;
+  return { x: Math.trunc(x), z: Math.trunc(z) };
+}
+
+/** FNV-1a 32-bit hash. Deterministic across JS runtimes for ASCII/UTF-16 inputs. */
+export function stableWorldHash32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+function signedRange(hash: number, radius: number): number {
+  const span = radius * 2 + 1;
+  return (hash % span) - radius;
+}
+
+export function resolveWorldSeed(input: string | null | undefined): string {
+  return sanitizeNonEmpty(input) ?? "areloria:default-world";
+}
+
+export function resolvePlayerId(input: string | null | undefined, worldSeed: string): string {
+  const explicit = sanitizeNonEmpty(input);
+  if (explicit) return explicit;
+  const digest = stableWorldHash32(`anonymous:${worldSeed}`).toString(16).padStart(8, "0");
+  return `anon_${digest}`;
+}
+
+export function resolveSpawnCell(input: {
+  readonly playerId: string;
+  readonly worldSeed: string;
+  readonly chunkSizeTiles: number;
+  readonly storedSpawn?: StoredSpawnInput | null;
+  readonly currentPosition?: WorldPositionInput | null;
+}): WorldPositionInput {
+  const current = finitePosition(input.currentPosition);
+  if (current) return current;
+
+  const stored = finitePosition(input.storedSpawn);
+  if (stored) return stored;
+
+  const seed = `${input.worldSeed}:${input.playerId}:spawn:v1`;
+  const hx = stableWorldHash32(`${seed}:x`);
+  const hz = stableWorldHash32(`${seed}:z`);
+
+  const spawnChunkRadius = 64;
+  const chunkX = signedRange(hx, spawnChunkRadius);
+  const chunkZ = signedRange(hz, spawnChunkRadius);
+  const centerOffset = Math.floor(input.chunkSizeTiles / 2);
+
+  return {
+    x: chunkX * input.chunkSizeTiles + centerOffset,
+    z: chunkZ * input.chunkSizeTiles + centerOffset,
+  };
+}
+
+export function positionToChunk(input: {
+  readonly position: WorldPositionInput;
+  readonly chunkSizeTiles: number;
+}): { chunkX: number; chunkZ: number; chunkKey: string } {
+  const chunkX = Math.floor(input.position.x / input.chunkSizeTiles);
+  const chunkZ = Math.floor(input.position.z / input.chunkSizeTiles);
+  return {
+    chunkX,
+    chunkZ,
+    chunkKey: `${chunkX}_${chunkZ}`,
+  };
+}
+
+export function resolveBiomeId(input: {
+  readonly worldSeed: string;
+  readonly chunkX: number;
+  readonly chunkZ: number;
+}): string {
+  const score = stableWorldHash32(`${input.worldSeed}:biome:${input.chunkX}:${input.chunkZ}`) % 100;
+  return BIOME_LADDER.find((entry) => score < entry.ceiling)?.id ?? "forest_village";
+}
+
+export function resolveVisibleChunkKeys(input: {
+  readonly chunkX: number;
+  readonly chunkZ: number;
+  readonly viewRadiusChunks: number;
+}): readonly string[] {
+  const keys: string[] = [];
+  for (let z = -input.viewRadiusChunks; z <= input.viewRadiusChunks; z += 1) {
+    for (let x = -input.viewRadiusChunks; x <= input.viewRadiusChunks; x += 1) {
+      keys.push(`${input.chunkX + x}_${input.chunkZ + z}`);
+    }
+  }
+  return keys;
+}
+
+export function resolveStatelessWorldRuntime(
+  inputs: StatelessWorldRuntimeInputs,
+): StatelessWorldRuntimeState {
+  const kappaInvariant = positiveInteger(inputs.kappaInvariant, STATELESS_WORLD_AXIOMS.KAPPA_INVARIANT);
+  const chunkSizeTiles = positiveInteger(inputs.chunkSizeTiles, STATELESS_WORLD_AXIOMS.CHUNK_SIZE_TILES);
+  const viewRadiusChunks = positiveInteger(inputs.viewRadiusChunks, STATELESS_WORLD_AXIOMS.VIEW_RADIUS_CHUNKS);
+  const worldSeed = resolveWorldSeed(inputs.worldSeed);
+  const playerId = resolvePlayerId(inputs.identity, worldSeed);
+  const spawnCell = resolveSpawnCell({
+    playerId,
+    worldSeed,
+    chunkSizeTiles,
+    storedSpawn: inputs.storedSpawn,
+    currentPosition: inputs.currentPosition,
+  });
+  const position = finitePosition(inputs.currentPosition) ?? spawnCell;
+  const { chunkX, chunkZ, chunkKey } = positionToChunk({ position, chunkSizeTiles });
+  const biomeId = resolveBiomeId({ worldSeed, chunkX, chunkZ });
+  const visibleChunkKeys = resolveVisibleChunkKeys({ chunkX, chunkZ, viewRadiusChunks });
+
+  return Object.freeze({
+    playerId,
+    worldSeed,
+    kappaInvariant,
+    chunkSizeTiles,
+    viewRadiusChunks,
+    position,
+    chunkX,
+    chunkZ,
+    chunkKey,
+    biomeId,
+    visibleChunkKeys,
+    spawnCell,
+    initialChunkPlanInput: Object.freeze({
+      worldSeed,
+      chunkX,
+      chunkZ,
+      biomeId,
+      kappa: kappaInvariant,
+      chunkTiles: chunkSizeTiles,
+    }),
+  });
+}
+
+export function readStatelessWorldSeedFromRuntime(): string {
+  const urlSeed = new URLSearchParams(window.location.search).get("worldSeed");
+  const envSeed = import.meta.env.VITE_ARELORIA_WORLD_SEED as string | undefined;
+  const storedSeed = localStorage.getItem("wasd:2d:worldSeed");
+  return resolveWorldSeed(urlSeed ?? envSeed ?? storedSeed);
+}
+
+export function readStatelessIdentityFromRuntime(): string | null {
+  return (
+    sanitizeNonEmpty(localStorage.getItem("wasd:2d:playerId")) ??
+    sanitizeNonEmpty(localStorage.getItem("wasd:2d:publicKey")) ??
+    sanitizeNonEmpty(localStorage.getItem("wasd:2d:identityHash"))
+  );
+}
+
+export function readStoredSpawnFromRuntime(): StoredSpawnInput | null {
+  try {
+    const raw = localStorage.getItem("wasd:2d:spawn");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredSpawnInput>;
+    return finitePosition({ x: Number(parsed.x), z: Number(parsed.z) });
+  } catch {
+    return null;
+  }
+}

--- a/docs/STATELESS_DETERMINISM_HARDCODE_AUDIT.md
+++ b/docs/STATELESS_DETERMINISM_HARDCODE_AUDIT.md
@@ -1,0 +1,146 @@
+# Stateless Determinism Hardcode Audit
+
+ARELORIA must distinguish between **axioms** and **runtime state**.
+
+Axioms are allowed to be constants. Runtime state must be derived from explicit inputs through deterministic resolvers.
+
+## Allowed hardcoding: axioms
+
+These are system laws and may remain fixed:
+
+```txt
+KAPPA_INVARIANT = 1000
+TICK_RATE = 10Hz
+CHUNK_SIZE_TILES = 16
+VIEW_RADIUS_CHUNKS = 1
+```
+
+Axioms should be named clearly and centralized where possible.
+
+## Toxic hardcoding: runtime state
+
+These values must not be embedded directly inside components, render boot paths, gameplay services, or quest flows:
+
+```txt
+playerId = "guest"
+playerName = "Architect"
+chunkX = 0
+chunkZ = 0
+biomeId = "forest_village"
+WORLD_SEED = "areloria:earth_1_1"
+Date.now() in deterministic logic
+Math.random() anywhere near gameplay/render decisions
+```
+
+These are hidden state. Hidden state breaks replayability, persistence, identity continuity, and dynamic world expansion.
+
+## New resolver seam
+
+The first resolver lives at:
+
+```txt
+apps/client-2d/src/world/StatelessWorldRuntimeResolver.ts
+```
+
+It converts explicit deterministic inputs into runtime state:
+
+```ts
+resolveStatelessWorldRuntime({
+  identity,
+  worldSeed,
+  currentPosition,
+  storedSpawn,
+  kappaInvariant,
+  chunkSizeTiles,
+});
+```
+
+It returns:
+
+```txt
+playerId
+worldSeed
+position
+chunkX
+chunkZ
+chunkKey
+biomeId
+visibleChunkKeys
+spawnCell
+initialChunkPlanInput
+```
+
+The renderer should consume this output instead of inventing its own fallback state.
+
+## Audit script
+
+Run:
+
+```bash
+node scripts/audit-hardcoded-runtime-state.mjs
+```
+
+To fail CI on findings:
+
+```bash
+node scripts/audit-hardcoded-runtime-state.mjs --fail
+```
+
+Findings do not always mean the code is wrong. Some values may be true axioms or visual-only timing. Mark true exceptions explicitly with one of these comments on the same line:
+
+```ts
+// ARE_AXIOM_ALLOW_HARDCODE
+// STATELESS_AUDIT_ALLOW
+// HARDCODE_AUDIT_ALLOW
+```
+
+Do not use allow markers to hide real runtime state. Use them only for named axioms or harmless UI-only constants.
+
+## Conversion pattern
+
+Bad:
+
+```ts
+generateChunkScenePlan({
+  worldSeed: WORLD_SEED,
+  chunkX: 0,
+  chunkZ: 0,
+  biomeId: "forest_village",
+  kappa: 1000,
+  chunkTiles: 16,
+});
+```
+
+Good:
+
+```ts
+const runtime = resolveStatelessWorldRuntime({
+  identity,
+  worldSeed,
+  currentPosition,
+  storedSpawn,
+});
+
+generateChunkScenePlan(runtime.initialChunkPlanInput);
+```
+
+## Current priority targets
+
+1. `apps/client-2d/src/DeterministicWorldIsoApp.tsx`
+2. `apps/client-2d/src/world/ChunkManager.ts`
+3. `apps/client-2d/src/CyberZenLoginGate.tsx`
+4. `apps/client-2d/src/ui/windows/CharacterSelectPanel.tsx`
+5. `server/src/character/StartPathQuestLine.ts`
+6. `server/src/quests/QuestProgressionStore.ts`
+
+## Rule of thumb
+
+```txt
+AXIOM    -> named constant, allowed
+CONFIG   -> explicit external input
+RUNTIME  -> resolver output
+PREVIEW  -> must be clearly marked as preview
+FALLBACK -> deterministic resolver fallback only
+```
+
+If a value can differ by player, seed, savegame, chunk, biome, server tick, inventory, quest state, or database state, it is runtime state and must not be hardcoded.

--- a/scripts/audit-hardcoded-runtime-state.mjs
+++ b/scripts/audit-hardcoded-runtime-state.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * ARELORIA Stateless Determinism hardcode audit.
+ *
+ * Axioms may be constants. Runtime state must be resolved from explicit inputs.
+ * This scanner finds common toxic literals that tend to freeze world/player state
+ * inside code instead of deriving it through resolvers.
+ *
+ * Usage:
+ *   node scripts/audit-hardcoded-runtime-state.mjs
+ *   node scripts/audit-hardcoded-runtime-state.mjs --fail
+ */
+
+const ROOT = process.cwd();
+const FAIL_MODE = process.argv.includes('--fail');
+
+const DIRECTORIES_TO_SCAN = [
+  'apps/client-2d/src',
+  'server/src',
+];
+
+const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+
+const ALLOW_MARKERS = [
+  'ARE_AXIOM_ALLOW_HARDCODE',
+  'STATELESS_AUDIT_ALLOW',
+  'HARDCODE_AUDIT_ALLOW',
+];
+
+const TOXIC_PATTERNS = [
+  {
+    id: 'hardcoded-player-guest',
+    regex: /(?:playerId|DEFAULT_GAMEPLAY_PLAYER_ID)\s*(?::[^=]+)?=\s*['"]guest['"]/g,
+    reason: 'Hardcoded player id: resolve from identity/session/token instead.',
+  },
+  {
+    id: 'hardcoded-player-anonymous',
+    regex: /(?:playerId|DEFAULT_GAMEPLAY_PLAYER_ID)\s*(?::[^=]+)?=\s*['"]anonymous['"]/g,
+    reason: 'Hardcoded anonymous player id: resolve deterministic anonymous identity instead.',
+  },
+  {
+    id: 'hardcoded-world-seed',
+    regex: /\bWORLD_SEED\s*(?::[^=]+)?=\s*['"][^'"]+['"]/g,
+    reason: 'World seed should come from runtime config, URL, DB, or resolver input.',
+  },
+  {
+    id: 'hardcoded-chunk-x-zero',
+    regex: /\bchunkX\s*:\s*0\b|\bchunkX\s*=\s*0\b/g,
+    reason: 'Chunk X must be derived from spawn/current position, not fixed to zero.',
+  },
+  {
+    id: 'hardcoded-chunk-z-zero',
+    regex: /\bchunkZ\s*:\s*0\b|\bchunkZ\s*=\s*0\b/g,
+    reason: 'Chunk Z must be derived from spawn/current position, not fixed to zero.',
+  },
+  {
+    id: 'hardcoded-biome-id',
+    regex: /\bbiomeId\s*:\s*['"][^'"]+['"]|\bbiomeId\s*=\s*['"][^'"]+['"]/g,
+    reason: 'Biome id should be derived from seed + chunk coordinates.',
+  },
+  {
+    id: 'architect-fallback-name',
+    regex: /\b(playerName|displayName|name)\s*(?::[^=]+)?=\s*[^;\n]*['"]Architect['"]/g,
+    reason: 'Fallback names should pass through a deterministic identity/display resolver.',
+  },
+  {
+    id: 'volatile-logic-date-now',
+    regex: /\bDate\.now\s*\(/g,
+    reason: 'Date.now() is forbidden in deterministic gameplay/runtime logic; use tick/manifest input.',
+  },
+  {
+    id: 'volatile-logic-math-random',
+    regex: /\bMath\.random\s*\(/g,
+    reason: 'Math.random() is forbidden; use deterministic seeded hashing/RNG.',
+  },
+];
+
+function isSourceFile(filePath) {
+  return EXTENSIONS.has(path.extname(filePath));
+}
+
+function hasAllowMarker(line) {
+  return ALLOW_MARKERS.some((marker) => line.includes(marker));
+}
+
+function walk(dir, output = []) {
+  const absolute = path.join(ROOT, dir);
+  if (!fs.existsSync(absolute)) return output;
+
+  for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+    const fullPath = path.join(absolute, entry.name);
+    const relPath = path.relative(ROOT, fullPath).replace(/\\/g, '/');
+
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'build') continue;
+      walk(relPath, output);
+      continue;
+    }
+
+    if (entry.isFile() && isSourceFile(fullPath)) output.push(relPath);
+  }
+
+  return output;
+}
+
+function lineNumberForIndex(content, index) {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (content.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
+
+function lineAt(content, lineNumber) {
+  return content.split(/\r?\n/)[lineNumber - 1] ?? '';
+}
+
+function auditFile(relPath) {
+  const content = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+  const findings = [];
+
+  for (const pattern of TOXIC_PATTERNS) {
+    pattern.regex.lastIndex = 0;
+    let match;
+    while ((match = pattern.regex.exec(content)) !== null) {
+      const line = lineNumberForIndex(content, match.index);
+      const sourceLine = lineAt(content, line);
+      if (hasAllowMarker(sourceLine)) continue;
+      findings.push({
+        file: relPath,
+        line,
+        id: pattern.id,
+        reason: pattern.reason,
+        match: match[0].trim(),
+      });
+    }
+  }
+
+  return findings;
+}
+
+console.log('=== ARELORIA: Stateless Determinism Hardcode Audit ===');
+console.log('Scanning for hidden runtime state in source code...\n');
+
+const files = DIRECTORIES_TO_SCAN.flatMap((dir) => walk(dir));
+const findings = files.flatMap(auditFile);
+
+if (findings.length === 0) {
+  console.log('No toxic runtime hardcoding found by current rules.');
+  process.exit(0);
+}
+
+for (const finding of findings) {
+  console.warn(`[TOXIC STATE] ${finding.file}:${finding.line}`);
+  console.warn(`  rule: ${finding.id}`);
+  console.warn(`  why : ${finding.reason}`);
+  console.warn(`  hit : ${finding.match}\n`);
+}
+
+console.warn(`Audit complete: ${findings.length} finding(s).`);
+console.warn('Replace runtime literals with resolver inputs or mark true axioms explicitly.');
+
+if (FAIL_MODE) process.exit(1);


### PR DESCRIPTION
Adds a Stateless Determinism hardcode audit script, a world runtime resolver, resolver tests, and documentation. This creates the safe seam for replacing hardcoded runtime state such as guest player ids, fixed chunks, fixed world seeds, and fixed biome ids with deterministic resolver inputs.