### PR TITLE
fix(audit): mark world poi legacy seed fallback

### DIFF
--- a/server/src/world/WorldPoiGenerator.ts
+++ b/server/src/world/WorldPoiGenerator.ts
@@ -21,8 +21,8 @@ import { SeededARERng } from "@wasd/shared";
 import type { WorldPoiSnapshot, WorldPoiType } from "./WorldPoiTypes.js";
 import { getCampResourceBias } from "./WorldPoiTypes.js";
 
-/** World seed for the game world */
-const WORLD_SEED = "areloria:earth_1_1";
+/** Legacy fallback world seed. Runtime callers should pass worldSeed explicitly. */
+const WORLD_SEED = "areloria:earth_1_1"; // STATELESS_AUDIT_ALLOW
 
 /** Chunk size in tiles (kappa units / 1000) */
 const CHUNK_TILES = 16;
@@ -65,19 +65,16 @@ function getPoiTypeForBiome(biome: ChunkBiomeId, rng: SeededARERng): WorldPoiTyp
   switch (biome) {
     case "forest":
     case "forest_village": {
-      // Forests can have logging camps
       const roll = rng.intInclusive(0, 999);
-      return roll < 350 ? "logging_camp" : null; // 35% chance
+      return roll < 350 ? "logging_camp" : null;
     }
     case "mountain": {
-      // Mountains can have mining camps
       const roll = rng.intInclusive(0, 999);
-      return roll < 300 ? "mining_camp" : null; // 30% chance
+      return roll < 300 ? "mining_camp" : null;
     }
     case "plains": {
-      // Plains can have fishing camps (near water)
       const roll = rng.intInclusive(0, 999);
-      return roll < 250 ? "fishing_camp" : null; // 25% chance
+      return roll < 250 ? "fishing_camp" : null;
     }
     default:
       return null;


### PR DESCRIPTION
Marks the `WorldPoiGenerator` module-level world seed as an explicit legacy fallback using the stateless audit allow marker. This keeps the current POI generation behavior stable while preventing the audit from treating the known fallback as hidden runtime state. The full resolverized POI generator rewrite remains a follow-up target.