### PR TITLE
fix(world): resolve poi seed through runtime resolver

### DIFF
--- a/server/src/resources/ResourceWorldSeedResolver.ts
+++ b/server/src/resources/ResourceWorldSeedResolver.ts
@@ -1,6 +1,23 @@
-export const LEGACY_RESOURCE_WORLD_SEED = "areloria:legacy-resource-seed"; // STATELESS_AUDIT_ALLOW
+export class MissingResourceWorldSeedError extends Error {
+  constructor(context: string) {
+    super(`Missing worldSeed for ${context}`);
+    this.name = "MissingResourceWorldSeedError";
+  }
+}
 
-export function resolveResourceWorldSeed(worldSeed: string | null | undefined): string {
-  const trimmed = typeof worldSeed === "string" ? worldSeed.trim() : "";
-  return trimmed.length > 0 ? trimmed : LEGACY_RESOURCE_WORLD_SEED;
+function cleanSeed(value: unknown): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function resolveResourceWorldSeed(worldSeed: string | null | undefined, context = "resource generation"): string {
+  const explicitSeed = cleanSeed(worldSeed);
+  if (explicitSeed) return explicitSeed;
+
+  const runtimeSeed = cleanSeed(process.env.WASD_WORLD_SEED)
+    ?? cleanSeed(process.env.ARELORIA_WORLD_SEED)
+    ?? cleanSeed(process.env.WORLD_SEED);
+
+  if (runtimeSeed) return runtimeSeed;
+  throw new MissingResourceWorldSeedError(context);
 }

--- a/server/src/world/WorldPoiGenerator.ts
+++ b/server/src/world/WorldPoiGenerator.ts
@@ -20,9 +20,10 @@
 import { SeededARERng } from "@wasd/shared";
 import type { WorldPoiSnapshot, WorldPoiType } from "./WorldPoiTypes.js";
 import { getCampResourceBias } from "./WorldPoiTypes.js";
+import { resolveResourceWorldSeed } from "../resources/ResourceWorldSeedResolver.js";
 
-/** Legacy fallback world seed. Runtime callers should pass worldSeed explicitly. */
-const WORLD_SEED = "areloria:earth_1_1"; // STATELESS_AUDIT_ALLOW
+/** Runtime-resolved world seed. No hardcoded seed fallback. */
+const WORLD_SEED = resolveResourceWorldSeed(undefined, "world poi generator");
 
 /** Chunk size in tiles (kappa units / 1000) */
 const CHUNK_TILES = 16;


### PR DESCRIPTION
Updates world POI seed resolution to use the shared resolver path. The resolver now requires a supplied seed or configured runtime seed and no longer carries a literal legacy seed. The POI generator now uses that resolver path.