### PR TITLE
fix(deploy): require stateless world seed at runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       HOST: "0.0.0.0"
       CLIENT_2D_MARKER: "${CLIENT_2D_MARKER:-REAL_PIXI_CLIENT}"
       CLIENT_2D_BUILD_SHA: "${CLIENT_2D_BUILD_SHA:-}"
+      WASD_WORLD_SEED: "${WASD_WORLD_SEED:?WASD_WORLD_SEED is required for stateless deterministic world generation}"
 
       API_KEY: "${API_KEY:-}"
       API_KEYS: "${API_KEYS:-}"

--- a/docs/STATELESS_WORLD_SEED_RUNTIME.md
+++ b/docs/STATELESS_WORLD_SEED_RUNTIME.md
@@ -1,0 +1,37 @@
+# Stateless World Seed Runtime
+
+`WASD_WORLD_SEED` is required runtime configuration for stateless deterministic world generation.
+
+## Required locations
+
+### GitHub Actions
+
+Set a repository secret or variable named exactly:
+
+```txt
+WASD_WORLD_SEED
+```
+
+Recommended value for current production world:
+
+```txt
+areloria:earth_1_1
+```
+
+### VPS Runtime
+
+Set the same key in the VPS deploy environment file used by Docker Compose, usually:
+
+```txt
+/opt/areloria/.env.docker
+```
+
+Required entry:
+
+```env
+WASD_WORLD_SEED=areloria:earth_1_1
+```
+
+## Why this is required
+
+World generation must not contain hidden module-level seed literals. The seed may be stable, but it must come from explicit runtime configuration. If `WASD_WORLD_SEED` is missing, the server should fail fast instead of silently generating a different world.


### PR DESCRIPTION
Adds WASD_WORLD_SEED to the Docker runtime environment for the Arelorian engine and documents the required GitHub/VPS runtime configuration. Compose now fails fast when the world seed is missing instead of allowing hidden fallback world generation.