### PR TITLE
fix: repair workspace config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,5 +17,5 @@ allowBuilds:
   "esbuild": true
   "prisma": true
   "protobufjs": true
-  sharp: set this to true or false
+  "sharp": true
   "ssh2": true


### PR DESCRIPTION
Repairs the workspace allowBuilds configuration by replacing the invalid placeholder value for sharp with a boolean value. This prevents pnpm workspace parsing/install issues after the WorldThinShell merge.