### PR TITLE
fix(are): repair ouroboros type-only imports

### DIFF
--- a/server/src/core/are/OuroborosTickSystem.ts
+++ b/server/src/core/are/OuroborosTickSystem.ts
@@ -41,10 +41,10 @@ import { NPCMemoryCache } from "../../modules/npc/NPCMemoryCache.js";
 import type { NPCRelationshipSystem } from "../../modules/npc/NPCRelationshipSystem.js";
 import type {
   ChatChannelRouter,
-  type ChatRecipient,
-  type SendToPlayerFn,
-  type BroadcastFn,
-  type ResolveSocketIdFn,
+  ChatRecipient,
+  SendToPlayerFn,
+  BroadcastFn,
+  ResolveSocketIdFn,
 } from "../../modules/chat/ChatChannelRouter.js";
 import type { StatusEmitter } from "../../modules/chat/StatusEmitter.js";
 


### PR DESCRIPTION
Fixes the invalid nested type modifiers inside a type-only import in OuroborosTickSystem. This removes the TS2206 compiler error without changing runtime behavior.