### PR TITLE
fix(are): update spatial broadcast test chunk keys

### DIFF
--- a/server/src/core/are/__tests__/SpatialBroadcastTickSystem.test.ts
+++ b/server/src/core/are/__tests__/SpatialBroadcastTickSystem.test.ts
@@ -107,12 +107,12 @@ describe('SpatialBroadcastGrid', () => {
       grid.upsert('npc1', 110, 210, 'npc', {});
       grid.upsert('player2', 5000, 5000, 'player', {}); // Different chunk
       
-      const entities = grid.getEntitiesInChunk(createChunkKey('1:3'));
+      const entities = grid.getEntitiesInChunk(createChunkKey(1, 3));
       expect(entities.length).toBe(2);
     });
 
     it('should return empty array for empty chunk', () => {
-      const entities = grid.getEntitiesInChunk(createChunkKey('999:999'));
+      const entities = grid.getEntitiesInChunk(createChunkKey(999, 999));
       expect(entities.length).toBe(0);
     });
   });


### PR DESCRIPTION
Updates SpatialBroadcastTickSystem tests to call createChunkKey with chunk coordinates instead of legacy string input. This preserves the stricter branded ChunkKey API and fixes the related TypeScript test errors.