### PR TITLE
fix(server): harden WorldTick compatibility declaration

### DIFF
--- a/server/src/core/are/shell-compat.d.ts
+++ b/server/src/core/are/shell-compat.d.ts
@@ -1,1 +1,7 @@
-declare type WorldTick = import("./WorldTickThinShellAdapter.js").WorldTick;
+import type { WorldTick as ThinShellWorldTick } from "./WorldTickThinShellAdapter.js";
+
+declare global {
+  type WorldTick = ThinShellWorldTick;
+}
+
+export {};


### PR DESCRIPTION
Converts the WorldTick compatibility declaration into an explicit global augmentation. This keeps ServerBootstrap and other legacy type references working after the WorldThinShell migration without restoring WorldTick.ts.