### PR TITLE
revert: back to Node.js 22 - workflows failing on main

### DIFF
--- a/.github/workflows/architecture-lint.yml
+++ b/.github/workflows/architecture-lint.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
 
       - run: pnpm --version

--- a/.github/workflows/are-determinism-gate.yml
+++ b/.github/workflows/are-determinism-gate.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Run Core Reality Alignment Audit
         run: |

--- a/.github/workflows/asset-inbox-stitch-import.yml
+++ b/.github/workflows/asset-inbox-stitch-import.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Enable pnpm
         run: corepack enable

--- a/.github/workflows/ast-self-healing.yml
+++ b/.github/workflows/ast-self-healing.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
       
       - name: Install Dependencies
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
       
       - name: Install Dependencies

--- a/.github/workflows/biome-atlas-assets.yml
+++ b/.github/workflows/biome-atlas-assets.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Extract biome atlas
         run: |

--- a/.github/workflows/client-2d-itch-export.yml
+++ b/.github/workflows/client-2d-itch-export.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/client-2d-smoke.yml
+++ b/.github/workflows/client-2d-smoke.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/client2d-tile-render-patch.yml
+++ b/.github/workflows/client2d-tile-render-patch.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Patch biome tile rendering
         run: |

--- a/.github/workflows/dependabot-checker.yml
+++ b/.github/workflows/dependabot-checker.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/import-forest-biome-pack.yml
+++ b/.github/workflows/import-forest-biome-pack.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Verify importer exists
         run: test -f scripts/import-forest-biome-pack.mjs

--- a/.github/workflows/import-kenney-ui-pack.yml
+++ b/.github/workflows/import-kenney-ui-pack.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Enable pnpm via Corepack
         run: |

--- a/.github/workflows/import-stitch-atlases.yml
+++ b/.github/workflows/import-stitch-atlases.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/import-stitch-release-assets.yml
+++ b/.github/workflows/import-stitch-release-assets.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Install tools
         run: |

--- a/.github/workflows/jules_deterministic_audit.yml
+++ b/.github/workflows/jules_deterministic_audit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/monorepo-guard.yml
+++ b/.github/workflows/monorepo-guard.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
       - run: pnpm install --ignore-scripts
       - run: pnpm guard:monorepo

--- a/.github/workflows/pixi-asset-plan.yml
+++ b/.github/workflows/pixi-asset-plan.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Enable pnpm via Corepack
         run: |

--- a/.github/workflows/portal-smoke.yml
+++ b/.github/workflows/portal-smoke.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/runtime-version-lock.yml
+++ b/.github/workflows/runtime-version-lock.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Check runtime version locks
         run: node scripts/check-runtime-version-lock.mjs

--- a/.github/workflows/safe-test-lab.yml
+++ b/.github/workflows/safe-test-lab.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
       
       - name: Install pnpm

--- a/.github/workflows/stateless-hardcode-audit.yml
+++ b/.github/workflows/stateless-hardcode-audit.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Print toolchain
         run: |

--- a/.github/workflows/stitch-atlas-intake.yml
+++ b/.github/workflows/stitch-atlas-intake.yml
@@ -367,7 +367,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -457,7 +457,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Build autonomous wiki
         env:

--- a/.github/workflows/vps-docker-deploy-on-merge.yml
+++ b/.github/workflows/vps-docker-deploy-on-merge.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Set up pnpm
         run: |

--- a/.github/workflows/vps-docker-deploy.yml
+++ b/.github/workflows/vps-docker-deploy.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Set up pnpm
         run: |

--- a/.github/workflows/weapon-assets.yml
+++ b/.github/workflows/weapon-assets.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Extract
         run: |


### PR DESCRIPTION
## Revert Summary

Reverting Node.js 24 → 22 because workflows are failing with pnpm lockfile policy errors.

**Why:**
- Multiple workflows failing after Node 24 upgrade
- pnpm install fails with lockfile policy checks
- Root cause is not the Node version itself but pnpm/lockfile issues that need separate investigation

**Note:** The deprecation warning says Node 20 will be forced to 24 on September 16, 2026. We should investigate and re-apply the Node 24 upgrade properly after fixing the lockfile issues.

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5dd34f09-e67b-425a-9daa-9134b3b7a062)