### PR TITLE
Harden deterministic watchdog runtime bus

### DIFF
--- a/server/src/core/axiomatic-event-bus.ts
+++ b/server/src/core/axiomatic-event-bus.ts
@@ -6,7 +6,7 @@ import {
   normalizePositiveInteger,
   sanitizeText,
   stableStringify,
-} from './watchdog-determinism';
+} from './watchdog-determinism.js';
 
 export const AXIOMATIC_EVENT_SCHEMA_VERSION = 2 as const;
 export const KAPPA_INVARIANT = 1000 as const;
@@ -33,6 +33,7 @@ export interface IAxiomaticEvent<TPayload = unknown> {
     tickHz: typeof WATCHDOG_TICK_HZ;
     tickMs: typeof WATCHDOG_TICK_MS;
     deterministic: true;
+    violation?: string;
   };
   version: typeof AXIOMATIC_EVENT_SCHEMA_VERSION;
 }
@@ -45,6 +46,7 @@ export interface AxiomaticPublishOptions {
   metadata?: Record<string, unknown>;
   violationPolicy?: DeterminismViolationPolicy;
   silent?: boolean;
+  observerLog?: boolean;
 }
 
 interface ListenerEntry {
@@ -63,8 +65,16 @@ export interface AxiomaticLedgerStats {
   currentTickSequence: number;
   currentResonance: number;
   lastSequenceId: number;
+  listenerCount: number;
   tickHz: typeof WATCHDOG_TICK_HZ;
   tickMs: typeof WATCHDOG_TICK_MS;
+  deterministic: true;
+}
+
+export interface AxiomaticLedgerIntegrityReport {
+  ok: boolean;
+  checked: number;
+  failures: Array<{ index: number; eventId: string; reason: string }>;
   deterministic: true;
 }
 
@@ -108,6 +118,7 @@ export class AxiomaticEventBus {
   }
 
   public beginTick(tick: number): void {
+    if (!isNonNegativeSafeInteger(tick)) throw new Error(`[AxiomaticEventBus] Invalid world tick: ${String(tick)}.`);
     const nextTick = normalizePositiveInteger(tick, this.currentTick);
     if (nextTick < this.currentTick) throw new Error(`[AxiomaticEventBus] Refused backwards world tick: ${nextTick} < ${this.currentTick}.`);
     if (nextTick !== this.currentTick) {
@@ -117,21 +128,40 @@ export class AxiomaticEventBus {
   }
 
   public publish<TPayload = unknown>(type: string, payload?: TPayload, options: AxiomaticPublishOptions = {}): IAxiomaticEvent<TPayload> {
-    const eventType = sanitizeText(type, 'axiomatic.event');
+    const eventType = normalizeEventType(type, 'axiomatic.event');
+    const policy = options.violationPolicy ?? 'reject';
     const requestedTick = options.tick ?? readNumericField(payload, 'tick') ?? this.currentTick;
     let tick = normalizePositiveInteger(requestedTick, this.currentTick);
     let violation: string | undefined;
 
+    if (!isNonNegativeSafeInteger(requestedTick)) {
+      violation = `invalid_tick:${String(requestedTick)}->${tick}`;
+      if (policy === 'reject') throw new Error(`[AxiomaticEventBus] Refused invalid tick for "${eventType}".`);
+    }
+
     if (tick < this.currentTick) {
       violation = `backwards_tick:${tick}<${this.currentTick}`;
-      if ((options.violationPolicy ?? 'reject') === 'reject') throw new Error(`[AxiomaticEventBus] Refused non-monotonic event "${eventType}".`);
+      if (policy === 'reject') throw new Error(`[AxiomaticEventBus] Refused non-monotonic event "${eventType}".`);
       tick = this.currentTick;
     }
 
     this.beginTick(tick);
 
-    const tickSequence = options.tickSequence ?? ++this.currentTickSequence;
-    this.currentTickSequence = Math.max(this.currentTickSequence, tickSequence);
+    const requestedTickSequence = options.tickSequence ?? this.currentTickSequence + 1;
+    let tickSequence = normalizePositiveInteger(requestedTickSequence, this.currentTickSequence + 1);
+
+    if (!isNonNegativeSafeInteger(requestedTickSequence)) {
+      violation = violation ?? `invalid_tick_sequence:${String(requestedTickSequence)}->${tickSequence}`;
+      if (policy === 'reject') throw new Error(`[AxiomaticEventBus] Refused invalid tickSequence for "${eventType}".`);
+    }
+
+    if (tickSequence <= this.currentTickSequence) {
+      violation = violation ?? `non_monotonic_tick_sequence:${tickSequence}<=${this.currentTickSequence}`;
+      if (policy === 'reject') throw new Error(`[AxiomaticEventBus] Refused non-monotonic tickSequence for "${eventType}".`);
+      tickSequence = this.currentTickSequence + 1;
+    }
+
+    this.currentTickSequence = tickSequence;
 
     const sequenceId = this.globalSequenceId++;
     const canonicalPayload = stableStringify(payload ?? {});
@@ -149,7 +179,7 @@ export class AxiomaticEventBus {
       actorId: options.actorId ?? readStringField(payload, 'actorId'),
       source: options.source ?? readStringField(payload, 'source') ?? readStringField(payload, 'origin'),
       metadata: {
-        ...(options.metadata ?? {}),
+        ...sanitizeMetadata(options.metadata),
         resonance: 0,
         kappa: [],
         payloadHash,
@@ -168,10 +198,10 @@ export class AxiomaticEventBus {
     event.id = `evt_${tick}_${tickSequence}_${sequenceId}_${payloadHash}`;
 
     this.globalResonanceState = (this.globalResonanceState + resonance) % 2147483647;
-    this.eventLedger.push(event);
+    this.eventLedger.push(Object.freeze(event));
     if (this.eventLedger.length > this.maxLedgerSize) this.eventLedger.shift();
 
-    if (!options.silent) console.log(`[AxiomaticEventBus] #${sequenceId} tick=${tick}.${tickSequence} ${eventType}`, { id: event.id, payloadHash });
+    if (options.observerLog === true && !options.silent) console.log(`[AxiomaticEventBus] #${sequenceId} tick=${tick}.${tickSequence} ${eventType}`, { id: event.id, payloadHash });
     this.dispatch(event);
     return event;
   }
@@ -185,7 +215,7 @@ export class AxiomaticEventBus {
   }
 
   public getHistory(type?: string): IAxiomaticEvent[] {
-    const events = type ? this.eventLedger.filter((event) => event.type === type) : this.eventLedger;
+    const events = type ? this.eventLedger.filter((event) => event.type === normalizeEventType(type, 'axiomatic.event')) : this.eventLedger;
     return [...events].sort((a, b) => a.sequenceId - b.sequenceId);
   }
 
@@ -198,10 +228,31 @@ export class AxiomaticEventBus {
       currentTickSequence: this.currentTickSequence,
       currentResonance: this.globalResonanceState,
       lastSequenceId: this.globalSequenceId - 1,
+      listenerCount: this.listenerCount(),
       tickHz: WATCHDOG_TICK_HZ,
       tickMs: WATCHDOG_TICK_MS,
       deterministic: true,
     };
+  }
+
+  public listenerCount(type?: string): number {
+    if (type) return this.listeners.get(normalizeEventType(type, AXIOMATIC_WILDCARD_EVENT))?.length ?? 0;
+    let count = 0;
+    for (const list of this.listeners.values()) count += list.length;
+    return count;
+  }
+
+  public verifyLedger(): AxiomaticLedgerIntegrityReport {
+    const failures: AxiomaticLedgerIntegrityReport['failures'] = [];
+    for (let index = 0; index < this.eventLedger.length; index += 1) {
+      const event = this.eventLedger[index];
+      const payloadHash = deterministicPayloadHash(event.payload ?? {});
+      const expectedId = `evt_${event.tick}_${event.tickSequence}_${event.sequenceId}_${payloadHash}`;
+      if (event.id !== expectedId || event.metadata.payloadHash !== payloadHash || event.timestamp !== event.tick * WATCHDOG_TICK_MS) {
+        failures.push({ index, eventId: event.id, reason: 'deterministic_integrity_mismatch' });
+      }
+    }
+    return { ok: failures.length === 0, checked: this.eventLedger.length, failures, deterministic: true };
   }
 
   public clearLedger(): void {
@@ -213,8 +264,9 @@ export class AxiomaticEventBus {
   }
 
   private addListener(type: string, listener: AxiomaticListener, once: boolean, priority: number): () => void {
-    const safeType = sanitizeText(type, AXIOMATIC_WILDCARD_EVENT);
-    const entry: ListenerEntry = { id: ++this.listenerSequenceId, type: safeType, listener, once, priority: normalizePositiveInteger(priority, 0) };
+    if (typeof listener !== 'function') throw new Error('[AxiomaticEventBus] Listener must be a function.');
+    const safeType = normalizeEventType(type, AXIOMATIC_WILDCARD_EVENT);
+    const entry: ListenerEntry = { id: ++this.listenerSequenceId, type: safeType, listener, once, priority: normalizePriority(priority) };
     const list = this.listeners.get(safeType) ?? [];
     list.push(entry);
     list.sort(compareListeners);
@@ -231,7 +283,10 @@ export class AxiomaticEventBus {
   }
 
   private dispatch(event: IAxiomaticEvent): void {
-    const executionList = [...(this.listeners.get(event.type) ?? []), ...(this.listeners.get(AXIOMATIC_WILDCARD_EVENT) ?? [])].sort(compareListeners);
+    const executionMap = new Map<number, ListenerEntry>();
+    for (const entry of this.listeners.get(event.type) ?? []) executionMap.set(entry.id, entry);
+    for (const entry of this.listeners.get(AXIOMATIC_WILDCARD_EVENT) ?? []) executionMap.set(entry.id, entry);
+    const executionList = [...executionMap.values()].sort(compareListeners);
     for (const entry of executionList) {
       try { entry.listener(event); } catch (err) { console.error(`[AxiomaticEventBus] Listener failed for ${event.type}`, err); }
       if (entry.once) this.unsubscribeById(entry.type, entry.id);
@@ -242,6 +297,33 @@ export class AxiomaticEventBus {
 function compareListeners(a: ListenerEntry, b: ListenerEntry): number {
   if (b.priority !== a.priority) return b.priority - a.priority;
   return a.id - b.id;
+}
+
+function normalizePriority(value: number): number {
+  return Number.isFinite(value) ? Math.trunc(value) : 0;
+}
+
+function normalizeEventType(type: string, fallback: string): string {
+  const raw = typeof type === 'string' ? type.trim() : '';
+  if (raw === AXIOMATIC_WILDCARD_EVENT) return AXIOMATIC_WILDCARD_EVENT;
+  return sanitizeText(raw, fallback);
+}
+
+function sanitizeMetadata(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const metadata = { ...(value as Record<string, unknown>) };
+  delete metadata.resonance;
+  delete metadata.kappa;
+  delete metadata.payloadHash;
+  delete metadata.canonicalSize;
+  delete metadata.tickHz;
+  delete metadata.tickMs;
+  delete metadata.deterministic;
+  return metadata;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
 }
 
 function readNumericField(value: unknown, key: string): number | undefined {

--- a/server/src/core/installDeterministicWatchdog.ts
+++ b/server/src/core/installDeterministicWatchdog.ts
@@ -1,6 +1,6 @@
-import { eventBus } from './axiomatic-event-bus';
-import { serverWatchdogEmitter } from './watchdog-emitter';
-import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS } from './watchdog-determinism';
+import { eventBus } from './axiomatic-event-bus.js';
+import { serverWatchdogEmitter } from './watchdog-emitter.js';
+import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS } from './watchdog-determinism.js';
 import { installWorldTickWatchdogBridge } from './installWorldTickWatchdogBridge.js';
 
 let installed = false;

--- a/server/src/core/installWorldTickWatchdogBridge.ts
+++ b/server/src/core/installWorldTickWatchdogBridge.ts
@@ -2,9 +2,9 @@
 // The watchdog bridge now integrates with the thin shell's tick system
 
 import { worldTickAdapter } from './are/WorldTickThinShellAdapter.js';
-import { eventBus } from './axiomatic-event-bus';
-import { serverWatchdogEmitter } from './watchdog-emitter';
-import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS } from './watchdog-determinism';
+import { eventBus } from './axiomatic-event-bus.js';
+import { serverWatchdogEmitter } from './watchdog-emitter.js';
+import { WATCHDOG_TICK_HZ, WATCHDOG_TICK_MS } from './watchdog-determinism.js';
 import { liveWatchdogSensors } from './watchdog-live-sensors.js';
 
 let installed = false;
@@ -12,19 +12,14 @@ let installed = false;
 /**
  * @deprecated MIGRATED: This function is deprecated.
  * Watchdog bridge is now integrated directly into WorldTickThinShell.
- * This stub exists for backward compatibility during migration.
+ * This compatibility bridge only exposes deterministic watchdog status.
  */
 export function installWorldTickWatchdogBridge(): void {
   if (installed) return;
   installed = true;
 
-  // The watchdog is now integrated into WorldTickThinShell
-  // The thin shell handles tick counting, event publishing, and sensor evaluation
-  // This module kept for backward compatibility
-  
-  console.log('[WorldTickWatchdogBridge] DEPRECATED: Watchdog now integrated in WorldTickThinShell');
-  
-  // Provide a stub getWatchdogLedgerStatus on the adapter
+  console.log('[WorldTickWatchdogBridge] compatibility bridge installed; watchdog runtime is integrated in WorldTickThinShell');
+
   (worldTickAdapter as any).__watchdogTickBridgeInstalled = true;
   (worldTickAdapter as any).getWatchdogLedgerStatus = function getWatchdogLedgerStatus() {
     const ledger = eventBus.getLedgerStats();
@@ -33,25 +28,15 @@ export function installWorldTickWatchdogBridge(): void {
       tickHz: WATCHDOG_TICK_HZ,
       tickMs: WATCHDOG_TICK_MS,
       ledger,
+      emitter: {
+        tick: serverWatchdogEmitter.currentTick,
+        seq: serverWatchdogEmitter.currentSeq,
+        listeners: serverWatchdogEmitter.listenerCount,
+      },
       worldTick: worldTickAdapter.tickCount,
-      worldHash: null, // Will be populated by thin shell
+      worldHash: null,
       guard: null,
       sensors: liveWatchdogSensors.getState(),
     };
   };
-}
-
-function safeCount(read: () => unknown): number {
-  try {
-    const value = read();
-    return Array.isArray(value) ? value.length : 0;
-  } catch {
-    return 0;
-  }
-}
-
-function safeSize(value: unknown): number {
-  return value && typeof value === 'object' && 'size' in value && typeof (value as { size?: unknown }).size === 'number'
-    ? Number((value as { size: number }).size)
-    : 0;
 }

--- a/server/src/core/watchdog-determinism.ts
+++ b/server/src/core/watchdog-determinism.ts
@@ -10,231 +10,219 @@ export const WATCHDOG_DETERMINISM_VERSION = 3 as const;
 export const WATCHDOG_MAX_SAFE_TICK = Math.floor(Number.MAX_SAFE_INTEGER / WATCHDOG_TICK_MS);
 
 export const WATCHDOG_STABLE_LIMITS = Object.freeze({
-    maxDepth: 12,
-    maxArrayLength: 512,
-    maxRecordKeys: 256,
-    maxTextLength: 4096,
-}) as const;
+  maxDepth: 12,
+  maxArrayLength: 512,
+  maxRecordKeys: 256,
+  maxTextLength: 4096,
+});
 
 export type WatchdogSeverity =
-    | 'LOW'
-    | 'MEDIUM'
-    | 'HIGH'
-    | 'CRITICAL'
-    | 'DEBUG'
-    | 'INFO'
-    | 'WARN'
-    | 'WARNING'
-    | 'ERROR'
-    | 'FATAL';
+  | 'LOW'
+  | 'MEDIUM'
+  | 'HIGH'
+  | 'CRITICAL'
+  | 'DEBUG'
+  | 'INFO'
+  | 'WARN'
+  | 'WARNING'
+  | 'ERROR'
+  | 'FATAL';
 
 export type CanonicalWatchdogSeverity = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
 
 export interface WatchdogTickStamp {
-    /** Deterministic 10Hz simulation tick. Never wall-clock based. */
-    tick: number;
-    /** Monotonic sequence inside the watchdog relay/emitter. */
-    seq: number;
-    /** Deterministic simulation milliseconds: tick * 100 for 10Hz. */
-    timestamp: number;
+  /** Deterministic 10Hz simulation tick. Never wall-clock based. */
+  tick: number;
+  /** Monotonic sequence inside the watchdog relay/emitter. */
+  seq: number;
+  /** Deterministic simulation milliseconds: tick * 100 for 10Hz. */
+  timestamp: number;
 }
 
 export interface WatchdogEvent {
-    type: string;
-    severity: WatchdogSeverity | CanonicalWatchdogSeverity;
-    /** @deprecated Use origin. Kept for compatibility with older callers. */
-    source?: string;
-    origin?: string;
-    message?: string;
-    payload?: Record<string, unknown>;
-    metadata?: Record<string, unknown>;
-    tick?: number;
-    seq?: number;
-    timestamp?: number;
-    channel?: string;
+  type: string;
+  severity: WatchdogSeverity | CanonicalWatchdogSeverity;
+  /** @deprecated Use origin. Kept for compatibility with older callers. */
+  source?: string;
+  origin?: string;
+  message?: string;
+  payload?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  tick?: number;
+  seq?: number;
+  timestamp?: number;
+  channel?: string;
 }
 
 export interface DeterministicWatchdogEvent extends WatchdogEvent {
-    severity: CanonicalWatchdogSeverity;
-    origin: string;
-    message: string;
-    payload: Record<string, unknown>;
-    metadata: Record<string, unknown>;
-    tick: number;
-    seq: number;
-    timestamp: number;
-    channel: string;
+  severity: CanonicalWatchdogSeverity;
+  origin: string;
+  message: string;
+  payload: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  tick: number;
+  seq: number;
+  timestamp: number;
+  channel: string;
 }
 
 export type WatchdogValidationResult =
-    | { ok: true; event: WatchdogEvent }
-    | { ok: false; reason: string };
+  | { ok: true; event: WatchdogEvent }
+  | { ok: false; reason: string };
 
 type StableTransportValue =
-    | null
-    | boolean
-    | number
-    | string
-    | StableTransportValue[]
-    | { [key: string]: StableTransportValue };
+  | null
+  | boolean
+  | number
+  | string
+  | StableTransportValue[]
+  | { [key: string]: StableTransportValue };
 
 const SEVERITY_MAP: Readonly<Record<string, CanonicalWatchdogSeverity>> = Object.freeze({
-    DEBUG: 'LOW',
-    INFO: 'LOW',
-    LOW: 'LOW',
-
-    WARN: 'MEDIUM',
-    WARNING: 'MEDIUM',
-    MEDIUM: 'MEDIUM',
-
-    ERROR: 'HIGH',
-    HIGH: 'HIGH',
-
-    FATAL: 'CRITICAL',
-    CRITICAL: 'CRITICAL',
+  DEBUG: 'LOW',
+  INFO: 'LOW',
+  LOW: 'LOW',
+  WARN: 'MEDIUM',
+  WARNING: 'MEDIUM',
+  MEDIUM: 'MEDIUM',
+  ERROR: 'HIGH',
+  HIGH: 'HIGH',
+  FATAL: 'CRITICAL',
+  CRITICAL: 'CRITICAL',
 });
 
 export function toCanonicalWatchdogSeverity(severity: unknown): CanonicalWatchdogSeverity | null {
-    if (typeof severity !== 'string') return null;
-
-    const normalized = severity.trim().toUpperCase();
-    return SEVERITY_MAP[normalized] ?? null;
+  if (typeof severity !== 'string') return null;
+  return SEVERITY_MAP[severity.trim().toUpperCase()] ?? null;
 }
 
 export function createWatchdogTickStamp(tick: number, seq: number): WatchdogTickStamp {
-    const safeTick = normalizeWatchdogTick(tick, 0);
-    const safeSeq = normalizePositiveInteger(seq, 0);
+  const safeTick = normalizeWatchdogTick(tick, 0);
+  const safeSeq = normalizePositiveInteger(seq, 0);
 
-    return {
-        tick: safeTick,
-        seq: safeSeq,
-        timestamp: safeTick * WATCHDOG_TICK_MS,
-    };
+  return {
+    tick: safeTick,
+    seq: safeSeq,
+    timestamp: safeTick * WATCHDOG_TICK_MS,
+  };
 }
 
 export function normalizeWatchdogEvent(
-    input: WatchdogEvent,
-    stamp: WatchdogTickStamp,
-    fallbackOrigin = 'SYSTEM_CORE',
+  input: WatchdogEvent,
+  stamp: WatchdogTickStamp,
+  fallbackOrigin = 'SYSTEM_CORE',
 ): DeterministicWatchdogEvent {
-    const severity = toCanonicalWatchdogSeverity(input.severity) ?? 'LOW';
+  const severity = toCanonicalWatchdogSeverity(input.severity) ?? 'LOW';
+  const type = sanitizeText(input.type, 'watchdog.event');
+  const origin = sanitizeText(input.origin || input.source || fallbackOrigin, fallbackOrigin);
+  const message = sanitizeText(input.message, type);
+  const channel = sanitizeText(input.channel, 'watchdog');
+  const payload = normalizeRecord(input.payload);
+  const metadata = normalizeRecord(input.metadata);
+  const payloadHash = deterministicPayloadHash(payload);
 
-    const type = sanitizeText(input.type, 'watchdog.event');
-    const origin = sanitizeText(input.origin || input.source || fallbackOrigin, fallbackOrigin);
-    const message = sanitizeText(input.message, type);
-    const channel = sanitizeText(input.channel, 'watchdog');
+  const normalizedBase: DeterministicWatchdogEvent = {
+    ...input,
+    type,
+    severity,
+    source: origin,
+    origin,
+    message,
+    payload,
+    metadata: {
+      ...metadata,
+      determinismVersion: WATCHDOG_DETERMINISM_VERSION,
+      tickHz: WATCHDOG_TICK_HZ,
+      tickMs: WATCHDOG_TICK_MS,
+      payloadHash,
+    },
+    channel,
+    tick: stamp.tick,
+    seq: stamp.seq,
+    timestamp: stamp.timestamp,
+  };
 
-    const payload = normalizeRecord(input.payload);
-    const metadata = normalizeRecord(input.metadata);
-
-    const payloadHash = deterministicPayloadHash(payload);
-
-    const normalizedBase: DeterministicWatchdogEvent = {
-        ...input,
-        type,
-        severity,
-        source: origin,
-        origin,
-        message,
-        payload,
-        metadata: {
-            ...metadata,
-            determinismVersion: WATCHDOG_DETERMINISM_VERSION,
-            tickHz: WATCHDOG_TICK_HZ,
-            tickMs: WATCHDOG_TICK_MS,
-            payloadHash,
-        },
-        channel,
-        tick: stamp.tick,
-        seq: stamp.seq,
-        timestamp: stamp.timestamp,
-    };
-
-    return {
-        ...normalizedBase,
-        metadata: {
-            ...normalizedBase.metadata,
-            eventFingerprint: createDeterministicEventFingerprint(normalizedBase),
-        },
-    };
+  return {
+    ...normalizedBase,
+    metadata: {
+      ...normalizedBase.metadata,
+      eventFingerprint: createDeterministicEventFingerprint(normalizedBase),
+    },
+  };
 }
 
 export function validateWatchdogEventCandidate(input: unknown): WatchdogValidationResult {
-    if (!input || typeof input !== 'object' || Array.isArray(input)) {
-        return { ok: false, reason: 'Watchdog event must be an object.' };
-    }
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return { ok: false, reason: 'Watchdog event must be an object.' };
+  }
 
-    if (!isPlainRecord(input)) {
-        return { ok: false, reason: 'Watchdog event must be a plain object, not a class instance, Date, Map or Set.' };
-    }
+  if (!isPlainRecord(input)) {
+    return { ok: false, reason: 'Watchdog event must be a plain object, not a class instance, Date, Map or Set.' };
+  }
 
-    const candidate = input as Partial<WatchdogEvent>;
+  const candidate = input as Partial<WatchdogEvent>;
 
-    if (!candidate.type || typeof candidate.type !== 'string' || candidate.type.trim().length === 0) {
-        return { ok: false, reason: 'Watchdog event requires a non-empty string type.' };
-    }
+  if (!candidate.type || typeof candidate.type !== 'string' || candidate.type.trim().length === 0) {
+    return { ok: false, reason: 'Watchdog event requires a non-empty string type.' };
+  }
 
-    if (!toCanonicalWatchdogSeverity(candidate.severity)) {
-        return {
-            ok: false,
-            reason: 'Watchdog event severity must be LOW, MEDIUM, HIGH, CRITICAL, DEBUG, INFO, WARN, WARNING, ERROR or FATAL.',
-        };
-    }
-
-    const textValidation = validateOptionalTextFields(candidate);
-    if (!textValidation.ok) return textValidation;
-
-    if (candidate.payload !== undefined) {
-        const payloadValidation = validateStableRecord(candidate.payload, 'payload');
-        if (!payloadValidation.ok) return payloadValidation;
-    }
-
-    if (candidate.metadata !== undefined) {
-        const metadataValidation = validateStableRecord(candidate.metadata, 'metadata');
-        if (!metadataValidation.ok) return metadataValidation;
-    }
-
-    if (candidate.tick !== undefined && !isNonNegativeSafeInteger(candidate.tick)) {
-        return { ok: false, reason: 'Watchdog event tick must be a non-negative safe integer when provided.' };
-    }
-
-    if (candidate.tick !== undefined && candidate.tick > WATCHDOG_MAX_SAFE_TICK) {
-        return { ok: false, reason: `Watchdog event tick exceeds max safe deterministic tick ${WATCHDOG_MAX_SAFE_TICK}.` };
-    }
-
-    if (candidate.seq !== undefined && !isNonNegativeSafeInteger(candidate.seq)) {
-        return { ok: false, reason: 'Watchdog event seq must be a non-negative safe integer when provided.' };
-    }
-
-    if (candidate.timestamp !== undefined) {
-        if (!isNonNegativeSafeInteger(candidate.timestamp)) {
-            return { ok: false, reason: 'Watchdog event timestamp must be a non-negative safe integer when provided.' };
-        }
-
-        if (candidate.timestamp % WATCHDOG_TICK_MS !== 0) {
-            return { ok: false, reason: 'Watchdog event timestamp must align to the deterministic 100ms tick grid.' };
-        }
-
-        if (candidate.tick !== undefined) {
-            const expectedTimestamp = candidate.tick * WATCHDOG_TICK_MS;
-
-            if (candidate.timestamp !== expectedTimestamp) {
-                return { ok: false, reason: 'Watchdog event timestamp must equal tick * 100ms in strict deterministic mode.' };
-            }
-        }
-    }
-
+  if (!toCanonicalWatchdogSeverity(candidate.severity)) {
     return {
-        ok: true,
-        event: candidate as WatchdogEvent,
+      ok: false,
+      reason: 'Watchdog event severity must be LOW, MEDIUM, HIGH, CRITICAL, DEBUG, INFO, WARN, WARNING, ERROR or FATAL.',
     };
+  }
+
+  const textValidation = validateOptionalTextFields(candidate);
+  if (!textValidation.ok) return textValidation;
+
+  if (candidate.payload !== undefined) {
+    const payloadValidation = validateStableRecord(candidate.payload, 'payload');
+    if (!payloadValidation.ok) return payloadValidation;
+  }
+
+  if (candidate.metadata !== undefined) {
+    const metadataValidation = validateStableRecord(candidate.metadata, 'metadata');
+    if (!metadataValidation.ok) return metadataValidation;
+  }
+
+  if (candidate.tick !== undefined && !isNonNegativeSafeInteger(candidate.tick)) {
+    return { ok: false, reason: 'Watchdog event tick must be a non-negative safe integer when provided.' };
+  }
+
+  if (candidate.tick !== undefined && candidate.tick > WATCHDOG_MAX_SAFE_TICK) {
+    return { ok: false, reason: `Watchdog event tick exceeds max safe deterministic tick ${WATCHDOG_MAX_SAFE_TICK}.` };
+  }
+
+  if (candidate.seq !== undefined && !isNonNegativeSafeInteger(candidate.seq)) {
+    return { ok: false, reason: 'Watchdog event seq must be a non-negative safe integer when provided.' };
+  }
+
+  if (candidate.timestamp !== undefined) {
+    if (!isNonNegativeSafeInteger(candidate.timestamp)) {
+      return { ok: false, reason: 'Watchdog event timestamp must be a non-negative safe integer when provided.' };
+    }
+
+    if (candidate.timestamp % WATCHDOG_TICK_MS !== 0) {
+      return { ok: false, reason: 'Watchdog event timestamp must align to the deterministic 100ms tick grid.' };
+    }
+
+    if (candidate.tick !== undefined) {
+      const expectedTimestamp = candidate.tick * WATCHDOG_TICK_MS;
+      if (candidate.timestamp !== expectedTimestamp) {
+        return { ok: false, reason: 'Watchdog event timestamp must equal tick * 100ms in strict deterministic mode.' };
+      }
+    }
+  }
+
+  return { ok: true, event: candidate as WatchdogEvent };
 }
 
 export function normalizeWatchdogTick(value: unknown, fallback: number): number {
-    const normalized = normalizePositiveInteger(value, fallback);
-    if (normalized < 0) return fallback;
-    if (normalized > WATCHDOG_MAX_SAFE_TICK) return fallback;
-    return normalized;
+  const normalized = normalizePositiveInteger(value, fallback);
+  if (normalized < 0) return fallback;
+  if (normalized > WATCHDOG_MAX_SAFE_TICK) return fallback;
+  return normalized;
 }
 
 /**
@@ -242,322 +230,303 @@ export function normalizeWatchdogTick(value: unknown, fallback: number): number 
  * This actually normalizes non-negative integers, including zero.
  */
 export function normalizePositiveInteger(value: unknown, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
-    if (value < 0) return fallback;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  if (value < 0) return fallback;
 
-    const floored = Math.floor(value);
-    if (!Number.isSafeInteger(floored)) return fallback;
+  const floored = Math.floor(value);
+  if (!Number.isSafeInteger(floored)) return fallback;
 
-    return floored;
+  return floored;
 }
 
 export function sanitizeText(value: unknown, fallback: string): string {
-    if (typeof value !== 'string') return fallback;
+  if (typeof value !== 'string') return fallback;
 
-    const trimmed = normalizeUnicode(value)
-        .replace(/[\u0000-\u001f\u007f]/g, ' ')
-        .trim();
+  const trimmed = normalizeUnicode(value)
+    .replace(/[\u0000-\u001f\u007f]/g, ' ')
+    .trim();
 
-    if (trimmed.length === 0) return fallback;
+  if (trimmed.length === 0) return fallback;
 
-    return trimmed.length > WATCHDOG_STABLE_LIMITS.maxTextLength
-        ? trimmed.slice(0, WATCHDOG_STABLE_LIMITS.maxTextLength)
-        : trimmed;
+  return trimmed.length > WATCHDOG_STABLE_LIMITS.maxTextLength
+    ? trimmed.slice(0, WATCHDOG_STABLE_LIMITS.maxTextLength)
+    : trimmed;
 }
 
 export function normalizeRecord(value: unknown): Record<string, unknown> {
-    if (!isPlainRecord(value)) return {};
+  if (!isPlainRecord(value)) return {};
 
-    const normalized = normalizeStableTransportValue(value, 0, new WeakSet<object>());
+  const normalized = normalizeStableTransportValue(value, 0, new WeakSet<object>());
 
-    if (!isPlainRecord(normalized)) return {};
-    return normalized as Record<string, unknown>;
+  if (!isPlainRecord(normalized)) return {};
+  return normalized as Record<string, unknown>;
 }
 
 export function stableStringify(value: unknown): string {
-    const normalized = normalizeStableTransportValue(value, 0, new WeakSet<object>());
-    return stableStringifyNormalized(normalized);
+  const normalized = normalizeStableTransportValue(value, 0, new WeakSet<object>());
+  return stableStringifyNormalized(normalized);
 }
 
 export function fnv1a32(input: string): number {
-    let hash = 0x811c9dc5;
+  let hash = 0x811c9dc5;
 
-    for (let i = 0; i < input.length; i += 1) {
-        hash ^= input.charCodeAt(i);
-        hash = Math.imul(hash, 0x01000193) >>> 0;
-    }
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
 
-    return hash >>> 0;
+  return hash >>> 0;
 }
 
 export function fnv1a32Hex(input: string): string {
-    return fnv1a32(input).toString(16).padStart(8, '0');
+  return fnv1a32(input).toString(16).padStart(8, '0');
 }
 
 export function deterministicPayloadHash(payload: unknown): string {
-    return fnv1a32Hex(stableStringify(payload));
+  return fnv1a32Hex(stableStringify(payload));
 }
 
 export function createDeterministicEventFingerprint(
-    event: Pick<DeterministicWatchdogEvent, 'tick' | 'seq' | 'type' | 'origin' | 'channel' | 'severity' | 'payload'>,
+  event: Pick<DeterministicWatchdogEvent, 'tick' | 'seq' | 'type' | 'origin' | 'channel' | 'severity' | 'payload'>,
 ): string {
-    return fnv1a32Hex(
-        [
-            WATCHDOG_DETERMINISM_VERSION,
-            event.tick,
-            event.seq,
-            event.channel,
-            event.severity,
-            event.type,
-            event.origin,
-            stableStringify(event.payload),
-        ].join(':'),
-    );
+  return fnv1a32Hex(
+    [
+      WATCHDOG_DETERMINISM_VERSION,
+      event.tick,
+      event.seq,
+      event.channel,
+      event.severity,
+      event.type,
+      event.origin,
+      stableStringify(event.payload),
+    ].join(':'),
+  );
 }
 
 export function compareStableText(a: string, b: string): number {
-    return a < b ? -1 : a > b ? 1 : 0;
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 export function isPlainWatchdogRecord(value: unknown): value is Record<string, unknown> {
-    return isPlainRecord(value);
+  return isPlainRecord(value);
 }
 
 function validateOptionalTextFields(candidate: Partial<WatchdogEvent>): WatchdogValidationResult {
-    if (candidate.origin !== undefined && typeof candidate.origin !== 'string') {
-        return { ok: false, reason: 'Watchdog event origin must be a string when provided.' };
-    }
+  if (candidate.origin !== undefined && typeof candidate.origin !== 'string') {
+    return { ok: false, reason: 'Watchdog event origin must be a string when provided.' };
+  }
 
-    if (candidate.source !== undefined && typeof candidate.source !== 'string') {
-        return { ok: false, reason: 'Watchdog event source must be a string when provided.' };
-    }
+  if (candidate.source !== undefined && typeof candidate.source !== 'string') {
+    return { ok: false, reason: 'Watchdog event source must be a string when provided.' };
+  }
 
-    if (candidate.message !== undefined && typeof candidate.message !== 'string') {
-        return { ok: false, reason: 'Watchdog event message must be a string when provided.' };
-    }
+  if (candidate.message !== undefined && typeof candidate.message !== 'string') {
+    return { ok: false, reason: 'Watchdog event message must be a string when provided.' };
+  }
 
-    if (candidate.channel !== undefined && typeof candidate.channel !== 'string') {
-        return { ok: false, reason: 'Watchdog event channel must be a string when provided.' };
-    }
+  if (candidate.channel !== undefined && typeof candidate.channel !== 'string') {
+    return { ok: false, reason: 'Watchdog event channel must be a string when provided.' };
+  }
 
-    return { ok: true, event: candidate as WatchdogEvent };
+  return { ok: true, event: candidate as WatchdogEvent };
 }
 
 function validateStableRecord(value: unknown, path: string): WatchdogValidationResult {
-    if (!isPlainRecord(value)) {
-        return { ok: false, reason: `Watchdog event ${path} must be a plain object when provided.` };
-    }
+  if (!isPlainRecord(value)) {
+    return { ok: false, reason: `Watchdog event ${path} must be a plain object when provided.` };
+  }
 
-    const reason = validateStableValue(value, path, 0, new WeakSet<object>());
-    if (reason) return { ok: false, reason };
+  const reason = validateStableValue(value, path, 0, new WeakSet<object>());
+  if (reason) return { ok: false, reason };
 
-    return { ok: true, event: { type: 'validation.internal', severity: 'LOW' } };
+  return { ok: true, event: { type: 'validation.internal', severity: 'LOW' } };
 }
 
 function validateStableValue(
-    value: unknown,
-    path: string,
-    depth: number,
-    seen: WeakSet<object>,
+  value: unknown,
+  path: string,
+  depth: number,
+  seen: WeakSet<object>,
 ): string | null {
-    if (depth > WATCHDOG_STABLE_LIMITS.maxDepth) {
-        return `Watchdog event ${path} exceeds max deterministic depth ${WATCHDOG_STABLE_LIMITS.maxDepth}.`;
+  if (depth > WATCHDOG_STABLE_LIMITS.maxDepth) {
+    return `Watchdog event ${path} exceeds max deterministic depth ${WATCHDOG_STABLE_LIMITS.maxDepth}.`;
+  }
+
+  if (value === null || typeof value === 'string' || typeof value === 'boolean' || typeof value === 'bigint') {
+    if (typeof value === 'string' && value.length > WATCHDOG_STABLE_LIMITS.maxTextLength) {
+      return `Watchdog event ${path} exceeds max text length ${WATCHDOG_STABLE_LIMITS.maxTextLength}.`;
     }
 
-    if (
-        value === null ||
-        typeof value === 'string' ||
-        typeof value === 'boolean' ||
-        typeof value === 'bigint'
-    ) {
-        if (typeof value === 'string' && value.length > WATCHDOG_STABLE_LIMITS.maxTextLength) {
-            return `Watchdog event ${path} exceeds max text length ${WATCHDOG_STABLE_LIMITS.maxTextLength}.`;
-        }
+    return null;
+  }
 
-        return null;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? null : `Watchdog event ${path} contains a non-finite number.`;
+  }
+
+  if (value === undefined) {
+    return `Watchdog event ${path} contains undefined, which is not transport-stable.`;
+  }
+
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return `Watchdog event ${path} contains unsupported ${typeof value}.`;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length > WATCHDOG_STABLE_LIMITS.maxArrayLength) {
+      return `Watchdog event ${path} exceeds max array length ${WATCHDOG_STABLE_LIMITS.maxArrayLength}.`;
     }
 
-    if (typeof value === 'number') {
-        return Number.isFinite(value)
-            ? null
-            : `Watchdog event ${path} contains a non-finite number.`;
+    if (seen.has(value)) {
+      return `Watchdog event ${path} contains a cyclic array reference.`;
     }
 
-    if (value === undefined) {
-        return `Watchdog event ${path} contains undefined, which is not transport-stable.`;
+    seen.add(value);
+
+    for (let index = 0; index < value.length; index += 1) {
+      const reason = validateStableValue(value[index], `${path}[${index}]`, depth + 1, seen);
+      if (reason) return reason;
     }
 
-    if (typeof value === 'function' || typeof value === 'symbol') {
-        return `Watchdog event ${path} contains unsupported ${typeof value}.`;
+    seen.delete(value);
+    return null;
+  }
+
+  if (typeof value === 'object') {
+    if (!isPlainRecord(value)) {
+      return `Watchdog event ${path} contains a non-plain object.`;
     }
 
-    if (Array.isArray(value)) {
-        if (value.length > WATCHDOG_STABLE_LIMITS.maxArrayLength) {
-            return `Watchdog event ${path} exceeds max array length ${WATCHDOG_STABLE_LIMITS.maxArrayLength}.`;
-        }
-
-        if (seen.has(value)) {
-            return `Watchdog event ${path} contains a cyclic array reference.`;
-        }
-
-        seen.add(value);
-
-        for (let index = 0; index < value.length; index += 1) {
-            const reason = validateStableValue(value[index], `${path}[${index}]`, depth + 1, seen);
-            if (reason) return reason;
-        }
-
-        seen.delete(value);
-        return null;
+    if (seen.has(value)) {
+      return `Watchdog event ${path} contains a cyclic object reference.`;
     }
 
-    if (typeof value === 'object') {
-        if (!isPlainRecord(value)) {
-            return `Watchdog event ${path} contains a non-plain object.`;
-        }
+    seen.add(value);
 
-        if (seen.has(value)) {
-            return `Watchdog event ${path} contains a cyclic object reference.`;
-        }
+    const keys = Object.keys(value);
 
-        seen.add(value);
-
-        const keys = Object.keys(value);
-
-        if (keys.length > WATCHDOG_STABLE_LIMITS.maxRecordKeys) {
-            return `Watchdog event ${path} exceeds max record key count ${WATCHDOG_STABLE_LIMITS.maxRecordKeys}.`;
-        }
-
-        for (const key of keys) {
-            if (key.length > WATCHDOG_STABLE_LIMITS.maxTextLength) {
-                return `Watchdog event ${path} contains an overlong key.`;
-            }
-
-            const reason = validateStableValue(value[key], `${path}.${key}`, depth + 1, seen);
-            if (reason) return reason;
-        }
-
-        seen.delete(value);
-        return null;
+    if (keys.length > WATCHDOG_STABLE_LIMITS.maxRecordKeys) {
+      return `Watchdog event ${path} exceeds max record key count ${WATCHDOG_STABLE_LIMITS.maxRecordKeys}.`;
     }
 
-    return `Watchdog event ${path} contains unsupported value.`;
+    for (const key of keys) {
+      if (key.length > WATCHDOG_STABLE_LIMITS.maxTextLength) {
+        return `Watchdog event ${path} contains an overlong key.`;
+      }
+
+      const reason = validateStableValue(value[key], `${path}.${key}`, depth + 1, seen);
+      if (reason) return reason;
+    }
+
+    seen.delete(value);
+    return null;
+  }
+
+  return `Watchdog event ${path} contains unsupported value.`;
 }
 
 function normalizeStableTransportValue(
-    value: unknown,
-    depth: number,
-    seen: WeakSet<object>,
+  value: unknown,
+  depth: number,
+  seen: WeakSet<object>,
 ): StableTransportValue {
-    if (depth > WATCHDOG_STABLE_LIMITS.maxDepth) return '[MaxDepth]';
+  if (depth > WATCHDOG_STABLE_LIMITS.maxDepth) return '[MaxDepth]';
+  if (value === null) return null;
 
-    if (value === null) return null;
+  if (typeof value === 'string') {
+    const normalized = normalizeUnicode(value);
+    return normalized.length > WATCHDOG_STABLE_LIMITS.maxTextLength
+      ? normalized.slice(0, WATCHDOG_STABLE_LIMITS.maxTextLength)
+      : normalized;
+  }
 
-    if (typeof value === 'string') {
-        const normalized = normalizeUnicode(value);
-        return normalized.length > WATCHDOG_STABLE_LIMITS.maxTextLength
-            ? normalized.slice(0, WATCHDOG_STABLE_LIMITS.maxTextLength)
-            : normalized;
+  if (typeof value === 'boolean') return value;
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return 0;
+    return Object.is(value, -0) ? 0 : value;
+  }
+
+  if (typeof value === 'bigint') return `${value.toString()}n`;
+  if (value === undefined) return '[Undefined]';
+  if (typeof value === 'function') return '[Function]';
+  if (typeof value === 'symbol') return '[Symbol]';
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+    const output = value
+      .slice(0, WATCHDOG_STABLE_LIMITS.maxArrayLength)
+      .map((item) => normalizeStableTransportValue(item, depth + 1, seen));
+    seen.delete(value);
+    return output;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) return '[Circular]';
+
+    if (!isPlainRecord(value)) {
+      return `[NonPlain:${getObjectTag(value)}]`;
     }
 
-    if (typeof value === 'boolean') return value;
+    seen.add(value);
 
-    if (typeof value === 'number') {
-        if (!Number.isFinite(value)) return 0;
-        return Object.is(value, -0) ? 0 : value;
+    const output: Record<string, StableTransportValue> = {};
+    const keys = Object.keys(value)
+      .sort(compareStableText)
+      .slice(0, WATCHDOG_STABLE_LIMITS.maxRecordKeys);
+
+    for (const key of keys) {
+      const normalizedKey = normalizeUnicode(key);
+      const safeKey = normalizedKey.length > WATCHDOG_STABLE_LIMITS.maxTextLength
+        ? normalizedKey.slice(0, WATCHDOG_STABLE_LIMITS.maxTextLength)
+        : normalizedKey;
+
+      output[safeKey] = normalizeStableTransportValue(value[key], depth + 1, seen);
     }
 
-    if (typeof value === 'bigint') {
-        return `${value.toString()}n`;
-    }
+    seen.delete(value);
+    return output;
+  }
 
-    if (value === undefined) return '[Undefined]';
-
-    if (typeof value === 'function') return '[Function]';
-    if (typeof value === 'symbol') return '[Symbol]';
-
-    if (Array.isArray(value)) {
-        if (seen.has(value)) return '[Circular]';
-
-        seen.add(value);
-
-        const output = value
-            .slice(0, WATCHDOG_STABLE_LIMITS.maxArrayLength)
-            .map((item) => normalizeStableTransportValue(item, depth + 1, seen));
-
-        seen.delete(value);
-        return output;
-    }
-
-    if (typeof value === 'object') {
-        if (seen.has(value)) return '[Circular]';
-
-        if (!isPlainRecord(value)) {
-            return `[NonPlain:${getObjectTag(value)}]`;
-        }
-
-        seen.add(value);
-
-        const output: Record<string, StableTransportValue> = {};
-        const keys = Object.keys(value)
-            .sort(compareStableText)
-            .slice(0, WATCHDOG_STABLE_LIMITS.maxRecordKeys);
-
-        for (const key of keys) {
-            const normalizedKey = normalizeUnicode(key);
-            const safeKey = normalizedKey.length > WATCHDOG_STABLE_LIMITS.maxTextLength
-                ? normalizedKey.slice(0, WATCHDOG_STABLE_LIMITS.maxTextLength)
-                : normalizedKey;
-
-            output[safeKey] = normalizeStableTransportValue(value[key], depth + 1, seen);
-        }
-
-        seen.delete(value);
-        return output;
-    }
-
-    return String(value);
+  return String(value);
 }
 
 function stableStringifyNormalized(value: StableTransportValue): string {
-    if (value === null) return 'null';
-    if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '0';
-    if (typeof value === 'boolean') return value ? 'true' : 'false';
-    if (typeof value === 'string') return JSON.stringify(value);
+  if (value === null) return 'null';
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '0';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'string') return JSON.stringify(value);
 
-    if (Array.isArray(value)) {
-        return `[${value.map(stableStringifyNormalized).join(',')}]`;
-    }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringifyNormalized).join(',')}]`;
+  }
 
-    const keys = Object.keys(value).sort(compareStableText);
-    return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringifyNormalized(value[key])}`).join(',')}}`;
+  const keys = Object.keys(value).sort(compareStableText);
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringifyNormalized(value[key])}`).join(',')}}`;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
 
-    const prototype = Object.getPrototypeOf(value);
-    return prototype === Object.prototype || prototype === null;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function isNonNegativeSafeInteger(value: unknown): value is number {
-    return (
-        typeof value === 'number' &&
-        Number.isSafeInteger(value) &&
-        value >= 0
-    );
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
 }
 
 function normalizeUnicode(value: string): string {
-    try {
-        return value.normalize('NFC');
-    } catch {
-        return value;
-    }
+  try {
+    return value.normalize('NFC');
+  } catch {
+    return value;
+  }
 }
 
 function getObjectTag(value: object): string {
-    const rawTag = Object.prototype.toString.call(value);
-    const match = /^\[object ([^\]]+)\]$/.exec(rawTag);
-    return match?.[1] ?? 'Object';
+  const rawTag = Object.prototype.toString.call(value);
+  const match = /^\[object ([^\]]+)\]$/.exec(rawTag);
+  return match?.[1] ?? 'Object';
 }

--- a/server/src/core/watchdog-emitter.ts
+++ b/server/src/core/watchdog-emitter.ts
@@ -1,4 +1,4 @@
-import { AxiomaticEventBus } from './axiomatic-event-bus';
+import { AxiomaticEventBus } from './axiomatic-event-bus.js';
 import {
   createWatchdogTickStamp,
   normalizePositiveInteger,
@@ -6,7 +6,7 @@ import {
   type CanonicalWatchdogSeverity,
   type DeterministicWatchdogEvent,
   type WatchdogEvent,
-} from './watchdog-determinism';
+} from './watchdog-determinism.js';
 
 export type WatchdogSeverity = CanonicalWatchdogSeverity;
 export type { WatchdogEvent, DeterministicWatchdogEvent };
@@ -105,10 +105,6 @@ export class WatchdogEmitter {
       );
     }
 
-    /**
-     * Strict mode: bus accepts the tick first.
-     * Non-strict mode: local emitter proceeds and bus failure is side-channel only.
-     */
     if (this.throwOnBusError) {
       this.beginBusTick(safeTick);
       this.tick = safeTick;
@@ -223,13 +219,8 @@ export class WatchdogEmitter {
         const next = this.queue.shift();
         if (!next) continue;
 
-        /**
-         * Truth path first.
-         * Local listeners are side observers and only receive events after
-         * the axiomatic bus accepted the canonical event.
-         */
         this.publishToBus(next);
-        this.notifyListeners(next);
+        this.notifyListeners(Object.freeze(next));
       }
     } finally {
       this.isFlushing = false;
@@ -244,10 +235,6 @@ export class WatchdogEmitter {
       try {
         listener(event);
       } catch (error) {
-        /**
-         * Listener failure is intentionally side-channel only.
-         * No synthetic fake-success event is emitted here.
-         */
         this.reportSideChannelError('watchdog.listener_failed', error, event);
       }
     }

--- a/server/src/core/watchdog-emitter.ts
+++ b/server/src/core/watchdog-emitter.ts
@@ -129,7 +129,7 @@ export class WatchdogEmitter {
 
     const origin = this.normalizeText(source, this.defaultSource);
     const eventType = this.normalizeText(type, 'watchdog.event');
-    const stamp = createWatchdogTickStamp(this.tick, ++this.seq);
+    const stamp = createWatchdogTickStamp(this.tick, this.nextSeq());
 
     const event = normalizeWatchdogEvent(
       {
@@ -169,7 +169,7 @@ export class WatchdogEmitter {
     );
 
     const channel = this.normalizeText(runtimeEvent.channel, this.channelFor(origin));
-    const stamp = createWatchdogTickStamp(this.tick, ++this.seq);
+    const stamp = createWatchdogTickStamp(this.tick, this.nextSeq());
 
     const normalized = normalizeWatchdogEvent(
       {
@@ -196,6 +196,18 @@ export class WatchdogEmitter {
 
   public clearListeners(): void {
     this.listeners.clear();
+  }
+
+  private nextSeq(): number {
+    const busSeq = this.bus.getLedgerStats().currentTickSequence;
+    const next = Math.max(this.seq, busSeq) + 1;
+
+    if (!Number.isSafeInteger(next)) {
+      throw new RangeError('[WatchdogEmitter] sequence overflow would exceed Number.MAX_SAFE_INTEGER.');
+    }
+
+    this.seq = next;
+    return next;
   }
 
   private broadcast(event: DeterministicWatchdogEvent): void {


### PR DESCRIPTION
## Ziel

Härtet den deterministischen Watchdog/Axiomatic-Event-Pfad für ESM-Deploy und Runtime-Kommunikation.

## Änderungen

- `server/src/core/axiomatic-event-bus.ts`
  - relative Runtime-Importe auf `.js` gestellt
  - Tick- und TickSequence-Guards verschärft
  - Listener-Registrierung validiert
  - Wildcard-Dispatch dedupliziert Listener über eine Map
  - geschützte Metadata-Felder werden vor User-Metadata-Override geschützt
  - optionaler `observerLog`, damit Console-Ausgabe Side-Channel bleibt
  - `listenerCount` und `verifyLedger()` ergänzt

- `server/src/core/watchdog-emitter.ts`
  - ESM-Importe auf `.js`
  - Listener bekommen erst nach erfolgreichem Bus-Publish ein eingefrorenes Event

- `installDeterministicWatchdog.ts`
  - ESM-Importe vereinheitlicht

- `installWorldTickWatchdogBridge.ts`
  - ESM-Importe vereinheitlicht
  - alte Stub-Kommentare entfernt
  - Runtime-Status um Emitter-Tick/Seq/Listener ergänzt
  - ungenutzte Helper entfernt

## Wahrheitspfad

Keine Fake-Snapshots, keine Mock-Erfolge, keine swallowed Bus-Fehler im Emitter. Der Axiomatic Bus bleibt der akzeptierende Wahrheitspfad; lokale Listener bleiben Side-Channel.