### PR TITLE
Remove wall-clock time from world layout runtime

### DIFF
--- a/server/src/world/layout/WorldLayoutReportLog.ts
+++ b/server/src/world/layout/WorldLayoutReportLog.ts
@@ -15,6 +15,7 @@ function ensureDir(dirPath: string): void {
 export class WorldLayoutReportLog {
   private readonly logPath: string;
   private readonly maxEntries: number;
+  private sequence = 0;
 
   constructor(logPath: string, maxEntries = 5000) {
     this.logPath = logPath;
@@ -22,8 +23,12 @@ export class WorldLayoutReportLog {
     ensureDir(path.dirname(logPath));
   }
 
-  record(entry: Omit<LayoutReportEntry, "timestamp">): LayoutReportEntry {
-    const full: LayoutReportEntry = { ...entry, timestamp: Date.now() };
+  record(entry: Omit<LayoutReportEntry, "timestamp"> & { timestamp?: number }): LayoutReportEntry {
+    const full: LayoutReportEntry = {
+      ...entry,
+      timestamp: normalizeDeterministicTimestamp(entry.timestamp, () => this.nextSequence()),
+    };
+
     try {
       fs.appendFileSync(this.logPath, JSON.stringify(full) + "\n", "utf-8");
     } catch {
@@ -63,4 +68,15 @@ export class WorldLayoutReportLog {
       return fs.readFileSync(this.logPath, "utf-8").split("\n").filter((l) => l.trim().length > 0).length;
     } catch { return 0; }
   }
+
+  private nextSequence(): number {
+    this.sequence += 1;
+    return this.sequence;
+  }
+}
+
+function normalizeDeterministicTimestamp(value: unknown, fallback: () => number): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : fallback();
 }

--- a/server/src/world/layout/WorldLayoutRoadConnectivityValidator.ts
+++ b/server/src/world/layout/WorldLayoutRoadConnectivityValidator.ts
@@ -12,7 +12,7 @@ import type { LayoutConstraintRule, LayoutIssue, LayoutRuleContext, SpatialEntit
 import { pointDistance } from "./WorldLayoutSpatialIndex.js";
 
 let issueCounter = 0;
-function makeId(): string { return `RD-${Date.now()}-${(++issueCounter).toString(36)}`; }
+function makeId(): string { return `RD-${(++issueCounter).toString(36).padStart(4, "0")}`; }
 
 /**
  * Build an adjacency graph from road entities based on proximity.

--- a/server/src/world/layout/WorldLayoutValidator.ts
+++ b/server/src/world/layout/WorldLayoutValidator.ts
@@ -7,9 +7,7 @@
 
 import type {
   LayoutValidationResult,
-  LayoutIssue,
   SpatialEntity,
-  LayoutRuleContext,
   WorldLayoutConfig,
 } from "./WorldLayoutTypes.js";
 import { WorldLayoutSpatialIndex } from "./WorldLayoutSpatialIndex.js";
@@ -27,6 +25,7 @@ export class WorldLayoutValidator {
   private readonly registry = new WorldLayoutConstraintRegistry();
   private readonly spatialIndex: WorldLayoutSpatialIndex;
   private readonly config: WorldLayoutConfig;
+  private validationSequence = 0;
 
   constructor(config: WorldLayoutConfig, spatialIndex?: WorldLayoutSpatialIndex) {
     this.config = config;
@@ -58,9 +57,9 @@ export class WorldLayoutValidator {
   /**
    * Run all validation rules against the current spatial index.
    */
-  validate(entities?: SpatialEntity[]): LayoutValidationResult {
+  validate(entities?: SpatialEntity[], deterministicTimestamp?: number): LayoutValidationResult {
     const allEntities = entities ?? this.spatialIndex.getAll();
-    const context: LayoutRuleContext = {
+    const context = {
       allEntities,
       chunkSize: this.config.chunkSize,
     };
@@ -82,7 +81,10 @@ export class WorldLayoutValidator {
       ok: issues.length === 0,
       issues,
       score,
-      timestamp: Date.now(),
+      timestamp: normalizeDeterministicTimestamp(
+        deterministicTimestamp,
+        () => ++this.validationSequence,
+      ),
     };
   }
 
@@ -99,4 +101,10 @@ export class WorldLayoutValidator {
   getRules(): Array<{ id: string; name: string }> {
     return this.registry.getAll().map((r) => ({ id: r.id, name: r.name }));
   }
+}
+
+function normalizeDeterministicTimestamp(value: unknown, fallback: () => number): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : fallback();
 }

--- a/server/src/world/layout/WorldLayoutWallConnectivityValidator.ts
+++ b/server/src/world/layout/WorldLayoutWallConnectivityValidator.ts
@@ -12,7 +12,7 @@ import type { LayoutConstraintRule, LayoutIssue, LayoutRuleContext, SpatialEntit
 import { pointDistance } from "./WorldLayoutSpatialIndex.js";
 
 let issueCounter = 0;
-function makeId(): string { return `WL-${Date.now()}-${(++issueCounter).toString(36)}`; }
+function makeId(): string { return `WL-${(++issueCounter).toString(36).padStart(4, "0")}`; }
 
 function buildWallGraph(walls: SpatialEntity[], maxDist: number): Map<string, Set<string>> {
   const graph = new Map<string, Set<string>>();

--- a/server/src/world/services/GLBAssetIngestionPipeline.ts
+++ b/server/src/world/services/GLBAssetIngestionPipeline.ts
@@ -5,7 +5,7 @@
  * Runs automatically on asset import. Feeds into WorldPlacementRuleEngine.
  */
 
-import type { AssetProfile, ColliderType, NavImpact, InstancingStrategy } from "../rules/assetProfiles.js";
+import type { AssetProfile, InstancingStrategy } from "../rules/assetProfiles.js";
 import { getAssetProfile, resolveProfileFromPath, resolveProfileFromMetadata } from "../rules/assetProfiles.js";
 
 export type IngestionState = "pending" | "analyzing" | "profiled" | "validated" | "ready" | "failed";
@@ -30,6 +30,7 @@ export interface AssetIngestionResult {
 export class GLBAssetIngestionPipeline {
   private cache = new Map<string, AssetIngestionResult>();
   private listeners: Array<(result: AssetIngestionResult) => void> = [];
+  private ingestSequence = 0;
 
   /**
    * Ingest a GLB asset. Analyzes meshes, materials, bounding box, and resolves profile.
@@ -45,7 +46,7 @@ export class GLBAssetIngestionPipeline {
     },
     categoryHint?: string
   ): Promise<AssetIngestionResult> {
-    const start = Date.now();
+    const startOrdinal = this.ingestSequence;
     const cached = this.cache.get(assetId);
     if (cached && cached.state === "ready") return cached;
 
@@ -132,12 +133,13 @@ export class GLBAssetIngestionPipeline {
       }
 
       result.state = "ready";
-    } catch (err: any) {
+    } catch (err: unknown) {
       result.state = "failed";
-      result.errors.push(err.message ?? String(err));
+      result.errors.push(err instanceof Error ? err.message : String(err));
     }
 
-    result.ingestTimeMs = Date.now() - start;
+    this.ingestSequence += 1;
+    result.ingestTimeMs = this.ingestSequence - startOrdinal;
     this.cache.set(assetId, result);
 
     for (const listener of this.listeners) {
@@ -197,5 +199,6 @@ export class GLBAssetIngestionPipeline {
 
   clear(): void {
     this.cache.clear();
+    this.ingestSequence = 0;
   }
 }

--- a/server/src/world/services/WorldPlacementRuleEngine.ts
+++ b/server/src/world/services/WorldPlacementRuleEngine.ts
@@ -11,7 +11,7 @@
  * - Placement state tracking
  */
 
-import type { SpatialEntity, LayoutIssue, GLBFootprintDescriptor } from "../layout/WorldLayoutTypes.js";
+import type { SpatialEntity, LayoutIssue } from "../layout/WorldLayoutTypes.js";
 import { WorldLayoutRuleEngine } from "../layout/WorldLayoutRuleEngine.js";
 import type { AssetProfile } from "../rules/assetProfiles.js";
 import { getAssetProfile, resolveProfileFromPath, resolveProfileFromMetadata } from "../rules/assetProfiles.js";
@@ -56,6 +56,7 @@ export class WorldPlacementRuleEngine {
   private terrainAdapter: TerrainQueryAdapter | null = null;
   private vegetationAdapter: VegetationExclusionAdapter | null = null;
   private navAdapter: NavDirtyAdapter | null = null;
+  private placementSequence = 0;
 
   constructor(
     layoutEngine: WorldLayoutRuleEngine,
@@ -230,7 +231,7 @@ export class WorldPlacementRuleEngine {
       terrainChanged,
       vegetationExclusionApplied: vegExclusionApplied,
       navDirty,
-      timestamp: Date.now(),
+      timestamp: this.nextPlacementTimestamp(request),
     };
 
     if (state === "validated") {
@@ -384,6 +385,17 @@ export class WorldPlacementRuleEngine {
     // Fixed TS2554: Pass [entity] to validate()
     const result = this.layoutEngine.getValidator().validate([entity]);
     return result.issues;
+  }
+
+  private nextPlacementTimestamp(request: PlacementRequest): number {
+    const metadata = request.metadata ?? {};
+    const provided = metadata.tick ?? metadata.timestamp ?? metadata.simulationMs;
+    if (typeof provided === "number" && Number.isSafeInteger(provided) && provided >= 0) {
+      return provided;
+    }
+
+    this.placementSequence += 1;
+    return this.placementSequence;
   }
 }
 


### PR DESCRIPTION
## Ziel

Entfernt die vom Determinism-Audit gemeldeten `Date.now()`-Treffer aus World/Layout/GLB-Runtime-Pfaden.

## Änderungen

- `WorldLayoutReportLog.ts`
  - ersetzt Wallclock-Timestamp durch deterministischen Sequenz-/Input-Timestamp

- `WorldLayoutRoadConnectivityValidator.ts`
  - ersetzt `RD-${Date.now()}-*` durch deterministische Issue-Sequenz

- `WorldLayoutWallConnectivityValidator.ts`
  - ersetzt `WL-${Date.now()}-*` durch deterministische Issue-Sequenz

- `WorldLayoutValidator.ts`
  - `validate()` akzeptiert optionalen deterministischen Timestamp
  - fallback ist eine lokale deterministische Validierungssequenz

- `GLBAssetIngestionPipeline.ts`
  - ersetzt Ingestion-Dauer auf Basis von `Date.now()` durch deterministischen Ingestion-Ordinal
  - entfernt `any` im catch-Pfad

- `WorldPlacementRuleEngine.ts`
  - PlacementResult-Timestamp kommt aus `request.metadata.tick/timestamp/simulationMs` oder deterministischer Placement-Sequenz

## Warum

Der Audit verbietet `Date.now()` in deterministischer Gameplay-/Runtime-Logik. Diese Änderung hält die Felder numerisch kompatibel, aber entfernt Wallclock-Abhängigkeit aus dem Wahrheitspfad.