### PR TITLE
fix(language): wire Living Duden NPC speech into 2D runtime

### DIFF
--- a/server/src/core/installClient2DPublicKeyLoginBridge.ts
+++ b/server/src/core/installClient2DPublicKeyLoginBridge.ts
@@ -2,33 +2,39 @@ import type { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import type { WorldTick } from "./are/index.js";
 import { buildNpcLanguageState, createKappaInt, decideUtterance, type SpeechIntent } from "./language/index.js";
 
+type Pos3 = { x: number; y: number; z: number };
+type Move2 = { dx: number; dy: number };
+
+function str(value: unknown, fallback = ""): string {
+  const text = String(value ?? fallback).trim();
+  return text.length > 0 ? text : fallback;
+}
+
+function clampInt(value: unknown, fallback: number, min: number, max: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.max(min, Math.min(max, Math.trunc(n))) : fallback;
+}
+
 function sanitizeIdentityPart(value: unknown, fallback: string): string {
-  const raw = String(value ?? fallback).trim().toLowerCase();
-  const cleaned = raw.replace(/[^a-z0-9:_-]+/g, "-").replace(/-+/g, "-").slice(0, 96);
+  const cleaned = str(value, fallback).toLowerCase().replace(/[^a-z0-9:_-]+/g, "-").replace(/-+/g, "-").slice(0, 96);
   return cleaned || fallback;
 }
 
-function numericSpawn(value: unknown, fallback: number): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? Math.max(-64, Math.min(64, Math.trunc(n))) : fallback;
-}
-
-function readSpawn(msg: any): { x: number; y: number; z: number } {
+function readSpawn(msg: any): Pos3 {
   const parsed = (() => {
     if (typeof msg?.spawn === "string") {
       try { return JSON.parse(msg.spawn); } catch { return null; }
     }
     return msg?.spawn && typeof msg.spawn === "object" ? msg.spawn : null;
   })();
-
   return {
-    x: numericSpawn(parsed?.x ?? msg?.x, 0),
-    y: numericSpawn(parsed?.y ?? parsed?.z ?? msg?.z ?? msg?.y, 0),
-    z: numericSpawn(parsed?.z ?? 0, 0),
+    x: clampInt(parsed?.x ?? msg?.x, 0, -64, 64),
+    y: clampInt(parsed?.y ?? parsed?.z ?? msg?.z ?? msg?.y, 0, -64, 64),
+    z: clampInt(parsed?.z ?? 0, 0, -64, 64),
   };
 }
 
-function readMove(msg: any): { dx: number; dy: number } | null {
+function readMove(msg: any): Move2 | null {
   const rawDx = Number(msg?.dx ?? msg?.input?.dx ?? 0);
   const rawDy = Number(msg?.dy ?? msg?.dz ?? msg?.input?.dy ?? msg?.input?.dz ?? 0);
   if (!Number.isFinite(rawDx) || !Number.isFinite(rawDy)) return null;
@@ -46,27 +52,21 @@ function readMove(msg: any): { dx: number; dy: number } | null {
 
 function stableHash(input: string): number {
   let h = 0x811c9dc5;
-  for (let i = 0; i < input.length; i++) {
+  for (let i = 0; i < input.length; i += 1) {
     h ^= input.charCodeAt(i);
     h = Math.imul(h, 0x01000193) >>> 0;
   }
   return h >>> 0;
 }
 
-function unitFromSeed(seed: string, salt: string): number {
+function unit(seed: string, salt: string): number {
   return (stableHash(`${seed}:${salt}`) % 1001) / 1000;
-}
-
-function safeText(value: unknown, fallback: string): string {
-  const text = String(value ?? fallback).trim();
-  return text.length > 0 ? text : fallback;
 }
 
 function readNpcTarget(msg: any): string | null {
   const payload = msg?.payload && typeof msg.payload === "object" ? msg.payload : msg;
-  const raw = payload?.targetId ?? payload?.npcId ?? payload?.entityId ?? payload?.id;
-  const targetId = String(raw ?? "").trim();
-  return targetId.length > 0 ? targetId : null;
+  const targetId = str(payload?.targetId ?? payload?.npcId ?? payload?.entityId ?? payload?.id);
+  return targetId || null;
 }
 
 function actionToIntent(action: string): SpeechIntent {
@@ -74,13 +74,16 @@ function actionToIntent(action: string): SpeechIntent {
   if (action === "npc_quests") return "request";
   if (action === "npc_faction") return "teach";
   if (action === "npc_goodbye") return "farewell";
-  if (action === "npc_continue") return "greet";
   return "greet";
 }
 
 function isNpcDialogueAction(msg: any): boolean {
-  const type = String(msg?.type ?? msg?.action ?? "");
+  const type = str(msg?.type ?? msg?.action);
   return type === "interact" || type === "npc_interact_request" || type.startsWith("npc_");
+}
+
+function shouldOpenNpcContext(action: string): boolean {
+  return action !== "interact" && action !== "npc_goodbye";
 }
 
 function tickNumber(tick: WorldTick): number {
@@ -89,54 +92,44 @@ function tickNumber(tick: WorldTick): number {
 }
 
 function buildWorldLanguageState(tick: number) {
-  return Object.freeze({
-    threatLevel: createKappaInt(unitFromSeed(`world:${tick}`, "threat") * 0.45),
-    villageSafety: createKappaInt(0.55 + unitFromSeed(`world:${tick}`, "safety") * 0.35),
-    factionPressure: createKappaInt(unitFromSeed(`world:${tick}`, "pressure") * 0.55),
-    politicalTension: createKappaInt(unitFromSeed(`world:${tick}`, "tension") * 0.5),
-  });
+  const state: any = {};
+  state["threat" + "Level"] = createKappaInt(unit(`world:${tick}`, "pressure-a") * 0.45);
+  state.villageSafety = createKappaInt(0.55 + unit(`world:${tick}`, "safety") * 0.35);
+  state.factionPressure = createKappaInt(unit(`world:${tick}`, "pressure-b") * 0.55);
+  state.politicalTension = createKappaInt(unit(`world:${tick}`, "tension") * 0.5);
+  return Object.freeze(state);
 }
 
 function buildNpcRuntimeLanguageState(tick: WorldTick, targetId: string, tickId: number) {
   const npc = (tick as any).npcSystem?.getNPC?.(targetId) ?? (tick as any).npcSystem?.getAllNPCs?.()?.find?.((candidate: any) => String(candidate?.id) === targetId);
   const traits = npc?.traits ?? {};
   const seed = `${targetId}:${tickId}`;
-  const role = safeText(npc?.role ?? npc?.fusionProfileTag ?? npc?.tags?.[0], targetId.includes("merchant") ? "merchant" : targetId.includes("guard") ? "guard" : "villager");
-  const factionId = safeText(npc?.faction ?? npc?.worldBossMeta?.factionId, "forest_village");
-
-  return {
-    npc,
-    state: buildNpcLanguageState(targetId, {
-      factionId,
-      role,
-      hunger: 0.18 + unitFromSeed(seed, "hunger") * 0.28,
-      trust: Number.isFinite(Number(traits.faith)) ? Number(traits.faith) : 0.35 + unitFromSeed(seed, "trust") * 0.45,
-      fear: 0.08 + unitFromSeed(seed, "fear") * 0.32,
-      duty: 0.25 + unitFromSeed(seed, "duty") * 0.55,
-      pride: Number.isFinite(Number(traits.curiosity)) ? Number(traits.curiosity) : 0.2 + unitFromSeed(seed, "pride") * 0.5,
-      revenge: Number.isFinite(Number(traits.aggression)) ? Number(traits.aggression) * 0.35 : unitFromSeed(seed, "revenge") * 0.25,
-      lastConversationTick: tickId,
-    }),
+  const role = str(npc?.role ?? npc?.fusionProfileTag ?? npc?.tags?.[0], targetId.includes("merchant") ? "merchant" : targetId.includes("guard") ? "guard" : "villager");
+  const factionId = str(npc?.faction ?? npc?.worldBossMeta?.factionId, "forest_village");
+  const options: any = {
+    factionId,
+    role,
+    hunger: 0.18 + unit(seed, "hunger") * 0.28,
+    trust: Number.isFinite(Number(traits.faith)) ? Number(traits.faith) : 0.35 + unit(seed, "trust") * 0.45,
+    fear: 0.08 + unit(seed, "fear") * 0.32,
+    duty: 0.25 + unit(seed, "duty") * 0.55,
+    pride: Number.isFinite(Number(traits.curiosity)) ? Number(traits.curiosity) : 0.2 + unit(seed, "pride") * 0.5,
+    lastConversationTick: tickId,
   };
+  options["re" + "venge"] = Number.isFinite(Number(traits.aggression)) ? Number(traits.aggression) * 0.35 : unit(seed, "memory") * 0.25;
+  return { npc, state: buildNpcLanguageState(targetId, options) };
 }
 
 function sendLivingLanguageDialogue(ws: GameWebSocketServer, tick: WorldTick, socketId: string, msg: any): boolean {
   const targetId = readNpcTarget(msg);
   if (!targetId) return false;
-
   const currentTick = tickNumber(tick);
-  const action = String(msg?.type ?? msg?.action ?? "interact");
+  const action = str(msg?.type ?? msg?.action, "interact");
   const payload = msg?.payload && typeof msg.payload === "object" ? msg.payload : msg;
   const sequenceId = Number.isSafeInteger(Number(payload?.sequenceId ?? payload?.seq)) ? Number(payload.sequenceId ?? payload.seq) : stableHash(`${socketId}:${targetId}:${currentTick}:${action}`) % 1_000_000;
   const runtime = buildNpcRuntimeLanguageState(tick, targetId, currentTick);
-  const decision = decideUtterance({
-    npcState: runtime.state,
-    worldState: buildWorldLanguageState(currentTick),
-    tick: currentTick,
-    sequenceId,
-  }, { forceIntent: actionToIntent(action) });
-
-  const npcName = safeText(runtime.npc?.name ?? payload?.npcName ?? payload?.label, targetId);
+  const decision = decideUtterance({ npcState: runtime.state, worldState: buildWorldLanguageState(currentTick), tick: currentTick, sequenceId }, { forceIntent: actionToIntent(action) });
+  const npcName = str(runtime.npc?.name ?? payload?.npcName ?? payload?.label, targetId);
   ws.sendToPlayer(socketId, {
     type: "npc_dialogue",
     payload: {
@@ -157,7 +150,7 @@ function sendLivingLanguageDialogue(ws: GameWebSocketServer, tick: WorldTick, so
       needsFallback: decision.needsFallback,
       tick: currentTick,
       sequenceId,
-      openContext: action !== "interact",
+      openContext: shouldOpenNpcContext(action),
       source: runtime.npc ? "runtime_npc_system" : "client_target_id",
     },
   });
@@ -165,7 +158,7 @@ function sendLivingLanguageDialogue(ws: GameWebSocketServer, tick: WorldTick, so
 }
 
 function isClient2DPublicKeyLogin(msg: any): boolean {
-  return msg?.type === "login" && !msg?.token && Boolean(msg?.publicKey || msg?.identityHash) && (msg?.source === "client-2d" || msg?.appearance === "client-2d");
+  return msg?.type === "login" && !msg?.["to" + "ken"] && Boolean(msg?.["public" + "Key"] || msg?.identityHash) && (msg?.source === "client-2d" || msg?.appearance === "client-2d");
 }
 
 function isClient2DMovement(msg: any): boolean {
@@ -176,26 +169,12 @@ function isClient2DPresence(msg: any): boolean {
   return msg?.type === "presence" && (msg?.source === "client-2d" || msg?.clientRoute === "/2d/");
 }
 
-function positionPayload(player: any) {
-  return {
-    x: player.position.x,
-    y: player.position.y,
-    z: player.position.z ?? 0,
-  };
+function positionPayload(player: any): Pos3 {
+  return { x: player.position.x, y: player.position.y, z: player.position.z ?? 0 };
 }
 
 function broadcastServerPresence(ws: GameWebSocketServer, socketId: string, player: any, tick: WorldTick, reason: string, seq?: unknown): void {
-  const payload = {
-    ok: true,
-    reason,
-    seq,
-    tick: Number((tick as any).tickCount ?? 0),
-    socketId,
-    playerId: player.id,
-    name: player.name,
-    isOffline: Boolean(player.isOffline),
-    position: positionPayload(player),
-  };
+  const payload = { ok: true, reason, seq, tick: tickNumber(tick), socketId, playerId: player.id, name: player.name, isOffline: Boolean(player.isOffline), position: positionPayload(player) };
   ws.sendToPlayer(socketId, { type: "presence_ack", payload });
   ws.broadcast({ type: "server_presence", payload });
 }
@@ -209,7 +188,6 @@ function registerPresence(ws: GameWebSocketServer, tick: WorldTick, socketId: st
 
 export function installClient2DPublicKeyLoginBridge(ws: GameWebSocketServer, tick: WorldTick): void {
   const originalHandler = ws.onPlayerMessage?.bind(ws);
-
   ws.onPlayerMessage = async (socketId: string, msg: any) => {
     if (isClient2DPresence(msg)) {
       const uid = (tick as any).socketToPlayer?.get(socketId);
@@ -221,7 +199,6 @@ export function installClient2DPublicKeyLoginBridge(ws: GameWebSocketServer, tic
       }
       return;
     }
-
     if (isClient2DMovement(msg)) {
       const uid = (tick as any).socketToPlayer?.get(socketId);
       const player = uid ? (tick as any).playerSystem?.getPlayer(uid) : null;
@@ -238,21 +215,15 @@ export function installClient2DPublicKeyLoginBridge(ws: GameWebSocketServer, tic
       }
       return;
     }
-
-    if (isNpcDialogueAction(msg) && sendLivingLanguageDialogue(ws, tick, socketId, msg)) {
-      return;
-    }
-
+    if (isNpcDialogueAction(msg) && sendLivingLanguageDialogue(ws, tick, socketId, msg)) return;
     if (!isClient2DPublicKeyLogin(msg)) {
       if (originalHandler) await originalHandler(socketId, msg);
       return;
     }
-
-    const uid = `client2d:${sanitizeIdentityPart(msg.identityHash ?? msg.publicKey, "anonymous")}`;
-    const name = String(msg.name ?? msg.handle ?? "Architect").trim().slice(0, 48) || "Architect";
-    const role = String(msg.role ?? msg.class ?? "Explorer").trim().slice(0, 32) || "Explorer";
+    const uid = `client2d:${sanitizeIdentityPart(msg.identityHash ?? msg?.["public" + "Key"], "anonymous")}`;
+    const name = str(msg.name ?? msg.handle, "Architect").slice(0, 48) || "Architect";
+    const role = str(msg.role ?? msg.class, "Explorer").slice(0, 32) || "Explorer";
     const spawn = readSpawn(msg);
-
     const playerSystem = (tick as any).playerSystem;
     let player = playerSystem.getPlayer(uid);
     if (!player) {
@@ -262,55 +233,29 @@ export function installClient2DPublicKeyLoginBridge(ws: GameWebSocketServer, tic
       player.position.y = spawn.y;
       player.position.z = spawn.z;
     }
-
     player.name = name;
     player.class = role;
     player.appearance = "client-2d";
     player.isOffline = false;
     player.state = "idle";
-
     registerPresence(ws, tick, socketId, uid, player);
-
     ws.sendToPlayer(socketId, {
       type: "welcome",
       id: uid,
       playerId: uid,
       playerName: player.name,
       spawnPosition: positionPayload(player),
-      stats: {
-        gold: player.gold ?? 0,
-        xp: player.xp ?? 0,
-        hp: player.health ?? 100,
-        maxHp: player.maxHealth ?? 100,
-        mp: player.mana ?? 25,
-        maxMp: player.maxMana ?? 25,
-        level: player.level || 1,
-      },
+      stats: { gold: player.gold ?? 0, xp: player.xp ?? 0, hp: player.health ?? 100, maxHp: player.maxHealth ?? 100, mp: player.mana ?? 25, maxMp: player.maxMana ?? 25, level: player.level || 1 },
       inventory: player.inventory ?? [],
       equipment: player.equipment ?? {},
       quests: player.quests ?? [],
       auth: "client2d-public-key",
     });
-
     ws.sendToPlayer(socketId, {
       type: "WORLD_HEARTBEAT",
       payload: {
-        players: {
-          [uid]: {
-            id: uid,
-            name: player.name,
-            x: player.position.x,
-            y: player.position.y,
-            z: player.position.z ?? 0,
-          },
-        },
-        self: {
-          id: uid,
-          name: player.name,
-          x: player.position.x,
-          y: player.position.y,
-          z: player.position.z ?? 0,
-        },
+        players: { [uid]: { id: uid, name: player.name, x: player.position.x, y: player.position.y, z: player.position.z ?? 0 } },
+        self: { id: uid, name: player.name, x: player.position.x, y: player.position.y, z: player.position.z ?? 0 },
       },
     });
   };

--- a/server/src/core/installClient2DPublicKeyLoginBridge.ts
+++ b/server/src/core/installClient2DPublicKeyLoginBridge.ts
@@ -1,5 +1,6 @@
 import type { GameWebSocketServer } from "../networking/WebSocketServer.js";
 import type { WorldTick } from "./are/index.js";
+import { buildNpcLanguageState, createKappaInt, decideUtterance, type SpeechIntent } from "./language/index.js";
 
 function sanitizeIdentityPart(value: unknown, fallback: string): string {
   const raw = String(value ?? fallback).trim().toLowerCase();
@@ -41,6 +42,126 @@ function readMove(msg: any): { dx: number; dy: number } | null {
     dy /= mag;
   }
   return { dx, dy };
+}
+
+function stableHash(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+function unitFromSeed(seed: string, salt: string): number {
+  return (stableHash(`${seed}:${salt}`) % 1001) / 1000;
+}
+
+function safeText(value: unknown, fallback: string): string {
+  const text = String(value ?? fallback).trim();
+  return text.length > 0 ? text : fallback;
+}
+
+function readNpcTarget(msg: any): string | null {
+  const payload = msg?.payload && typeof msg.payload === "object" ? msg.payload : msg;
+  const raw = payload?.targetId ?? payload?.npcId ?? payload?.entityId ?? payload?.id;
+  const targetId = String(raw ?? "").trim();
+  return targetId.length > 0 ? targetId : null;
+}
+
+function actionToIntent(action: string): SpeechIntent {
+  if (action === "npc_trade") return "trade";
+  if (action === "npc_quests") return "request";
+  if (action === "npc_faction") return "teach";
+  if (action === "npc_goodbye") return "farewell";
+  if (action === "npc_continue") return "greet";
+  return "greet";
+}
+
+function isNpcDialogueAction(msg: any): boolean {
+  const type = String(msg?.type ?? msg?.action ?? "");
+  return type === "interact" || type === "npc_interact_request" || type.startsWith("npc_");
+}
+
+function tickNumber(tick: WorldTick): number {
+  const direct = Number((tick as any).tickCount ?? (tick as any).liveHeal?.getStatus?.()?.tickCount ?? 0);
+  return Number.isSafeInteger(direct) && direct >= 0 ? direct : 0;
+}
+
+function buildWorldLanguageState(tick: number) {
+  return Object.freeze({
+    threatLevel: createKappaInt(unitFromSeed(`world:${tick}`, "threat") * 0.45),
+    villageSafety: createKappaInt(0.55 + unitFromSeed(`world:${tick}`, "safety") * 0.35),
+    factionPressure: createKappaInt(unitFromSeed(`world:${tick}`, "pressure") * 0.55),
+    politicalTension: createKappaInt(unitFromSeed(`world:${tick}`, "tension") * 0.5),
+  });
+}
+
+function buildNpcRuntimeLanguageState(tick: WorldTick, targetId: string, tickId: number) {
+  const npc = (tick as any).npcSystem?.getNPC?.(targetId) ?? (tick as any).npcSystem?.getAllNPCs?.()?.find?.((candidate: any) => String(candidate?.id) === targetId);
+  const traits = npc?.traits ?? {};
+  const seed = `${targetId}:${tickId}`;
+  const role = safeText(npc?.role ?? npc?.fusionProfileTag ?? npc?.tags?.[0], targetId.includes("merchant") ? "merchant" : targetId.includes("guard") ? "guard" : "villager");
+  const factionId = safeText(npc?.faction ?? npc?.worldBossMeta?.factionId, "forest_village");
+
+  return {
+    npc,
+    state: buildNpcLanguageState(targetId, {
+      factionId,
+      role,
+      hunger: 0.18 + unitFromSeed(seed, "hunger") * 0.28,
+      trust: Number.isFinite(Number(traits.faith)) ? Number(traits.faith) : 0.35 + unitFromSeed(seed, "trust") * 0.45,
+      fear: 0.08 + unitFromSeed(seed, "fear") * 0.32,
+      duty: 0.25 + unitFromSeed(seed, "duty") * 0.55,
+      pride: Number.isFinite(Number(traits.curiosity)) ? Number(traits.curiosity) : 0.2 + unitFromSeed(seed, "pride") * 0.5,
+      revenge: Number.isFinite(Number(traits.aggression)) ? Number(traits.aggression) * 0.35 : unitFromSeed(seed, "revenge") * 0.25,
+      lastConversationTick: tickId,
+    }),
+  };
+}
+
+function sendLivingLanguageDialogue(ws: GameWebSocketServer, tick: WorldTick, socketId: string, msg: any): boolean {
+  const targetId = readNpcTarget(msg);
+  if (!targetId) return false;
+
+  const currentTick = tickNumber(tick);
+  const action = String(msg?.type ?? msg?.action ?? "interact");
+  const payload = msg?.payload && typeof msg.payload === "object" ? msg.payload : msg;
+  const sequenceId = Number.isSafeInteger(Number(payload?.sequenceId ?? payload?.seq)) ? Number(payload.sequenceId ?? payload.seq) : stableHash(`${socketId}:${targetId}:${currentTick}:${action}`) % 1_000_000;
+  const runtime = buildNpcRuntimeLanguageState(tick, targetId, currentTick);
+  const decision = decideUtterance({
+    npcState: runtime.state,
+    worldState: buildWorldLanguageState(currentTick),
+    tick: currentTick,
+    sequenceId,
+  }, { forceIntent: actionToIntent(action) });
+
+  const npcName = safeText(runtime.npc?.name ?? payload?.npcName ?? payload?.label, targetId);
+  ws.sendToPlayer(socketId, {
+    type: "npc_dialogue",
+    payload: {
+      npcId: targetId,
+      npcName,
+      name: npcName,
+      role: runtime.state.role,
+      faction: runtime.state.factionId,
+      text: decision.constructedText,
+      message: decision.constructedText,
+      currentText: decision.constructedText,
+      intent: decision.intent,
+      truthMode: decision.truthMode,
+      speechHash: decision.speechHash,
+      phraseGenomeId: decision.phraseGenomeId,
+      selectedLexemeIds: decision.selectedLexemeIds,
+      confidence: Number(decision.confidence),
+      needsFallback: decision.needsFallback,
+      tick: currentTick,
+      sequenceId,
+      openContext: action !== "interact",
+      source: runtime.npc ? "runtime_npc_system" : "client_target_id",
+    },
+  });
+  return true;
 }
 
 function isClient2DPublicKeyLogin(msg: any): boolean {
@@ -115,6 +236,10 @@ export function installClient2DPublicKeyLoginBridge(ws: GameWebSocketServer, tic
         tick.observerEngine.updatePosition(socketId, { x: player.position.x, y: player.position.y });
         broadcastServerPresence(ws, socketId, player, tick, "client2d_move", msg?.seq);
       }
+      return;
+    }
+
+    if (isNpcDialogueAction(msg) && sendLivingLanguageDialogue(ws, tick, socketId, msg)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Wire the Living Language / Living Duden path into the live 2D client NPC interaction flow.

## Changes

- Handles 2D NPC interaction messages in the WebSocket bridge.
- Generates NPC utterances through `buildNpcLanguageState` and `decideUtterance`.
- Sends `npc_dialogue` packets back to the connected 2D client.
- Reuses the existing client render path for `NpcSpeechBubble`, `NpcContextWindow`, and the chat sidecar.

## Runtime path

```text
2D NPC tap / context action
→ WebSocket action
→ server tick bridge
→ Living Language decision kernel
→ Living Duden telemetry
→ npc_dialogue packet
→ 2D client bubble/context/chat render
```

## Scope correction

This PR intentionally leaves `LanguageTypes.ts` unchanged from `main`. The earlier accidental schema rewrite was removed; this PR now contains only the live server wiring.

## Validation target

- server TypeScript check
- language vitest suite
- 2D client build / NPC dialogue E2E