### PR TITLE
feat(language): load Living Duden from game-data at startup

### DIFF
--- a/game-data/language/README.md
+++ b/game-data/language/README.md
@@ -1,8 +1,8 @@
-# Living Duden Game-Data Storage Contract
+# Living Duden Game-Data Runtime Store
 
 This folder is the shared content home for the Living Language / Living Duden system.
 
-The goal is to make words, phrase genomes, faction dialects, and learned speech logic available to every future gameplay module without forcing those modules to import private server-core state.
+The goal is to make words, phrase genomes, faction dialects, and reviewed learned speech logic available to every future gameplay module through real loaded data, not through private server-core maps or pretend wrappers.
 
 ## Storage Layers
 
@@ -33,14 +33,14 @@ This prevents the repository content pack from becoming a hidden mutable runtime
 
 ```text
 getContentDataRoot()
-→ game-data/language/*.seed.json
-→ game-data/language/*.promoted.json
-→ runtime learned delta store
-→ LivingDudenArchive / LanguageDataStore facade
-→ NPC, quest, economy, guild, politics, UI modules
+→ game-data/language/living-duden.seed.json
+→ game-data/language/living-duden.promoted.json
+→ LanguageGameDataStore.loadLivingDudenGameData()
+→ LivingDudenArchive.loadSeedData(...)
+→ NPC, quest, economy, guild, politics, UI modules read the same hydrated archive
 ```
 
-Modules should depend on a public language-data facade, not on private maps inside `server/src/core/language/LivingDudenArchive.ts`.
+This is an actual runtime load path. It must not be reduced to a naming layer that only hides private maps.
 
 ## Write Path
 
@@ -63,12 +63,15 @@ NPC speech decision
 - Learned state must be reproducible from deterministic events or explicitly published content-pack files.
 - Side-channel dashboards may read summaries, but they must not become the source of gameplay truth.
 
-## Suggested JSON Shape
+## Runtime Implementation
+
+`server/src/core/language/LanguageGameDataStore.ts` loads real JSON files through `resolveContentFile("language/...")`, validates that they contain lexeme objects, and hydrates `LivingDudenArchive` during `initializeLivingLanguageSystem()`.
+
+## JSON Shape
 
 ```json
 {
   "schemaVersion": 1,
-  "contentHash": "sha256:<canonical-json-hash>",
   "lexemes": [
     {
       "id": "arel_greeting_wacht",
@@ -79,11 +82,11 @@ NPC speech decision
       "concepts": ["greeting", "guard", "duty"],
       "grammar": {
         "partOfSpeech": "greeting",
-        "allowedPositions": ["address", "opening"]
+        "allowedPositions": ["address", "subject"]
       },
       "worldBindings": {
         "factionIds": ["forest_village"],
-        "questTypes": ["patrol", "warning"]
+        "questTypes": ["patrol"]
       },
       "baseWeight": 1
     }
@@ -93,4 +96,4 @@ NPC speech decision
 
 ## Next Implementation Step
 
-Add a `LanguageContentRepository` that loads from `resolveContentFile("language/...")`, validates canonical JSON, and hydrates `LivingDudenArchive` before NPC runtime speech begins.
+Persist runtime learned deltas as deterministic event records, then add a promotion command that writes reviewed lexemes into `living-duden.promoted.json` with a canonical content hash generated from the committed JSON.

--- a/game-data/language/README.md
+++ b/game-data/language/README.md
@@ -1,0 +1,96 @@
+# Living Duden Game-Data Storage Contract
+
+This folder is the shared content home for the Living Language / Living Duden system.
+
+The goal is to make words, phrase genomes, faction dialects, and learned speech logic available to every future gameplay module without forcing those modules to import private server-core state.
+
+## Storage Layers
+
+```text
+Layer 0: canonical seed content
+  game-data/language/living-duden.seed.json
+  game-data/language/phrase-genomes.seed.json
+  game-data/language/faction-dialects.seed.json
+
+Layer 1: promoted learned content
+  game-data/language/living-duden.promoted.json
+  game-data/language/phrase-genomes.promoted.json
+
+Layer 2: runtime learned deltas
+  persistence/runtime/language/duden-deltas.jsonl
+  or database table: language_learning_events
+```
+
+## Rule
+
+`game-data/` is not the per-tick mutable truth path.
+
+Runtime learning must first be recorded as deterministic speech-outcome events. A later promotion step may publish selected learned lexemes or phrase genomes back into `game-data/language/*.promoted.json`.
+
+This prevents the repository content pack from becoming a hidden mutable runtime database while still making approved language knowledge reusable by NPC, quest, economy, guild, politics, tutorial, and UI modules.
+
+## Read Path
+
+```text
+getContentDataRoot()
+→ game-data/language/*.seed.json
+→ game-data/language/*.promoted.json
+→ runtime learned delta store
+→ LivingDudenArchive / LanguageDataStore facade
+→ NPC, quest, economy, guild, politics, UI modules
+```
+
+Modules should depend on a public language-data facade, not on private maps inside `server/src/core/language/LivingDudenArchive.ts`.
+
+## Write Path
+
+```text
+NPC speech decision
+→ speechHash + selectedLexemeIds + phraseGenomeId
+→ player/world outcome
+→ deterministic learning event
+→ runtime delta store
+→ optional review/promotion
+→ game-data/language/*.promoted.json
+```
+
+## Green-State Constraints
+
+- No mock lexeme snapshots in the truth path.
+- No direct wall-clock ordering for learned words.
+- No random promotion.
+- No module-local duplicate dictionaries.
+- Learned state must be reproducible from deterministic events or explicitly published content-pack files.
+- Side-channel dashboards may read summaries, but they must not become the source of gameplay truth.
+
+## Suggested JSON Shape
+
+```json
+{
+  "schemaVersion": 1,
+  "contentHash": "sha256:<canonical-json-hash>",
+  "lexemes": [
+    {
+      "id": "arel_greeting_wacht",
+      "lemma": "Wacht",
+      "language": "arel",
+      "invented": false,
+      "morphemes": ["wacht"],
+      "concepts": ["greeting", "guard", "duty"],
+      "grammar": {
+        "partOfSpeech": "greeting",
+        "allowedPositions": ["address", "opening"]
+      },
+      "worldBindings": {
+        "factionIds": ["forest_village"],
+        "questTypes": ["patrol", "warning"]
+      },
+      "baseWeight": 1
+    }
+  ]
+}
+```
+
+## Next Implementation Step
+
+Add a `LanguageContentRepository` that loads from `resolveContentFile("language/...")`, validates canonical JSON, and hydrates `LivingDudenArchive` before NPC runtime speech begins.

--- a/game-data/language/living-duden.promoted.json
+++ b/game-data/language/living-duden.promoted.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "kind": "living-duden-promoted",
+  "description": "Reviewed learned lexemes promoted from deterministic runtime learning events into reusable content-pack data.",
+  "contentHash": "sha256:pending-generated-by-canonicalizer",
+  "lexemes": []
+}

--- a/game-data/language/living-duden.promoted.json
+++ b/game-data/language/living-duden.promoted.json
@@ -2,6 +2,5 @@
   "schemaVersion": 1,
   "kind": "living-duden-promoted",
   "description": "Reviewed learned lexemes promoted from deterministic runtime learning events into reusable content-pack data.",
-  "contentHash": "sha256:pending-generated-by-canonicalizer",
   "lexemes": []
 }

--- a/game-data/language/living-duden.seed.json
+++ b/game-data/language/living-duden.seed.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "kind": "living-duden-seed",
+  "description": "Canonical seed lexemes for the Living Language system. Runtime learning is stored as deterministic deltas and only promoted here after review.",
+  "contentHash": "sha256:pending-generated-by-canonicalizer",
+  "lexemes": []
+}

--- a/game-data/language/living-duden.seed.json
+++ b/game-data/language/living-duden.seed.json
@@ -1,7 +1,59 @@
 {
   "schemaVersion": 1,
   "kind": "living-duden-seed",
-  "description": "Canonical seed lexemes for the Living Language system. Runtime learning is stored as deterministic deltas and only promoted here after review.",
-  "contentHash": "sha256:pending-generated-by-canonicalizer",
-  "lexemes": []
+  "description": "Canonical seed lexemes loaded by the Living Language runtime through game-data/language.",
+  "lexemes": [
+    {
+      "id": "arel_greeting_wacht",
+      "lemma": "Wacht",
+      "language": "arel",
+      "invented": false,
+      "morphemes": ["wacht"],
+      "concepts": ["greeting", "guard", "duty"],
+      "emotion": { "duty": 0.8, "trust": 0.35 },
+      "social": { "register": "military" },
+      "worldBindings": { "factionIds": ["forest_village"], "questTypes": ["patrol"] },
+      "grammar": { "partOfSpeech": "greeting", "allowedPositions": ["address", "subject"] },
+      "baseWeight": 1
+    },
+    {
+      "id": "arel_trade_handel",
+      "lemma": "Handel",
+      "language": "arel",
+      "invented": false,
+      "morphemes": ["han", "del"],
+      "concepts": ["trade", "market", "offer"],
+      "emotion": { "trust": 0.45, "pride": 0.2 },
+      "social": { "register": "guild" },
+      "worldBindings": { "factionIds": ["forest_village"], "questTypes": ["trade", "delivery"] },
+      "grammar": { "partOfSpeech": "noun", "allowedPositions": ["object", "reason"] },
+      "baseWeight": 1
+    },
+    {
+      "id": "arel_help_bitt",
+      "lemma": "Bitt",
+      "language": "arel",
+      "invented": false,
+      "morphemes": ["bitt"],
+      "concepts": ["request", "help", "need"],
+      "emotion": { "trust": 0.35, "hunger": 0.2 },
+      "social": { "register": "peasant" },
+      "worldBindings": { "questTypes": ["help", "gather", "delivery"] },
+      "grammar": { "partOfSpeech": "verb", "allowedPositions": ["verb", "reason"] },
+      "baseWeight": 1
+    },
+    {
+      "id": "arel_quest_auftrag",
+      "lemma": "Auftrag",
+      "language": "arel",
+      "invented": false,
+      "morphemes": ["auf", "trag"],
+      "concepts": ["quest", "task", "reward"],
+      "emotion": { "duty": 0.55, "trust": 0.4, "pride": 0.25 },
+      "social": { "register": "formal" },
+      "worldBindings": { "questTypes": ["gather", "delivery", "craft"] },
+      "grammar": { "partOfSpeech": "noun", "allowedPositions": ["object", "reason"] },
+      "baseWeight": 1
+    }
+  ]
 }

--- a/server/src/core/language/LanguageGameDataStore.ts
+++ b/server/src/core/language/LanguageGameDataStore.ts
@@ -2,6 +2,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolveContentFile } from "../../modules/content/contentDataRoot.js";
 import { loadSeedData, type LexemeBlueprint } from "./LivingDudenArchive.js";
 
+type BlueprintSocial = NonNullable<LexemeBlueprint["social"]>;
+type BlueprintGrammar = NonNullable<LexemeBlueprint["grammar"]>;
+
 const TAG = "LANGUAGE_GAME_DATA_STORE_V1";
 const FILES = Object.freeze([
   "language/living-duden.seed.json",
@@ -60,15 +63,15 @@ function normalizeBlueprint(raw: unknown, source: string, index: number): Lexeme
   const emotion = numericRecord(raw.emotion) as LexemeBlueprint["emotion"] | undefined;
   const worldBindings = stringArrayRecord(raw.worldBindings) as LexemeBlueprint["worldBindings"] | undefined;
   const social = socialInput && text(socialInput.register) ? {
-    register: text(socialInput.register) as LexemeBlueprint["social"]["register"],
-    ...(numericRecord(socialInput.overrides) ? { overrides: numericRecord(socialInput.overrides) as LexemeBlueprint["social"]["overrides"] } : {}),
+    register: text(socialInput.register) as BlueprintSocial["register"],
+    ...(numericRecord(socialInput.overrides) ? { overrides: numericRecord(socialInput.overrides) as BlueprintSocial["overrides"] } : {}),
   } : undefined;
   const grammar = grammarInput && text(grammarInput.partOfSpeech) ? {
-    partOfSpeech: text(grammarInput.partOfSpeech) as LexemeBlueprint["grammar"]["partOfSpeech"],
-    ...(text(grammarInput.gender) ? { gender: text(grammarInput.gender) as LexemeBlueprint["grammar"]["gender"] } : {}),
+    partOfSpeech: text(grammarInput.partOfSpeech) as BlueprintGrammar["partOfSpeech"],
+    ...(text(grammarInput.gender) ? { gender: text(grammarInput.gender) as BlueprintGrammar["gender"] } : {}),
     ...(text(grammarInput.plural) ? { plural: text(grammarInput.plural) } : {}),
     ...(text(grammarInput.conjugationClass) ? { conjugationClass: text(grammarInput.conjugationClass) } : {}),
-    allowedPositions: textList(grammarInput.allowedPositions) as LexemeBlueprint["grammar"]["allowedPositions"],
+    allowedPositions: textList(grammarInput.allowedPositions) as BlueprintGrammar["allowedPositions"],
   } : undefined;
   const baseWeight = Number(raw.baseWeight);
 

--- a/server/src/core/language/LanguageGameDataStore.ts
+++ b/server/src/core/language/LanguageGameDataStore.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolveContentFile } from "../../modules/content/contentDataRoot.js";
+import { loadSeedData, type LexemeBlueprint } from "./LivingDudenArchive.js";
+
+const TAG = "LANGUAGE_GAME_DATA_STORE_V1";
+const FILES = Object.freeze([
+  "language/living-duden.seed.json",
+  "language/living-duden.promoted.json",
+]);
+
+export interface LanguageGameDataLoadReport {
+  readonly filesRead: number;
+  readonly filesMissing: readonly string[];
+  readonly lexemesLoaded: number;
+  readonly sourceFiles: readonly string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function textList(value: unknown, fallback: readonly string[] = []): readonly string[] {
+  if (!Array.isArray(value)) return Object.freeze([...fallback]);
+  return Object.freeze(value.map((entry) => text(entry)).filter(Boolean));
+}
+
+function normalizeBlueprint(raw: unknown, source: string, index: number): LexemeBlueprint {
+  if (!isRecord(raw)) throw new Error(`[${TAG}] ${source}.lexemes[${index}] must be an object`);
+  const id = text(raw.id);
+  const lemma = text(raw.lemma);
+  const language = text(raw.language);
+  if (!id || !lemma || !language) throw new Error(`[${TAG}] ${source}.lexemes[${index}] requires id, lemma, and language`);
+  const grammar = isRecord(raw.grammar) ? raw.grammar : undefined;
+  const social = isRecord(raw.social) ? raw.social : undefined;
+  return Object.freeze({
+    id,
+    lemma,
+    language,
+    invented: Boolean(raw.invented),
+    morphemes: textList(raw.morphemes, [lemma.toLowerCase()]),
+    concepts: textList(raw.concepts),
+    emotion: isRecord(raw.emotion) ? raw.emotion as any : undefined,
+    social: social && text(social.register) ? { register: text(social.register) as any, overrides: isRecord(social.overrides) ? social.overrides as any : undefined } : undefined,
+    worldBindings: isRecord(raw.worldBindings) ? raw.worldBindings as any : undefined,
+    grammar: grammar && text(grammar.partOfSpeech) ? {
+      partOfSpeech: text(grammar.partOfSpeech) as any,
+      gender: text(grammar.gender) ? text(grammar.gender) as any : undefined,
+      plural: text(grammar.plural) || undefined,
+      conjugationClass: text(grammar.conjugationClass) || undefined,
+      allowedPositions: textList(grammar.allowedPositions) as any,
+    } : undefined,
+    baseWeight: Number.isFinite(Number(raw.baseWeight)) ? Number(raw.baseWeight) : undefined,
+  });
+}
+
+function extractBlueprints(data: unknown, source: string): readonly LexemeBlueprint[] {
+  const root = Array.isArray(data) ? { lexemes: data } : data;
+  if (!isRecord(root) || !Array.isArray(root.lexemes)) throw new Error(`[${TAG}] ${source} must contain a lexemes array`);
+  return Object.freeze(root.lexemes.map((entry, index) => normalizeBlueprint(entry, source, index)));
+}
+
+export function loadLivingDudenGameData(): LanguageGameDataLoadReport {
+  const missing: string[] = [];
+  const sources: string[] = [];
+  let filesRead = 0;
+  let lexemesLoaded = 0;
+  for (const relative of FILES) {
+    const filePath = resolveContentFile(relative);
+    if (!existsSync(filePath)) {
+      missing.push(relative);
+      continue;
+    }
+    const lexemes = extractBlueprints(JSON.parse(readFileSync(filePath, "utf-8")), relative);
+    filesRead += 1;
+    sources.push(relative);
+    lexemesLoaded += loadSeedData(lexemes);
+  }
+  return Object.freeze({ filesRead, filesMissing: Object.freeze(missing), lexemesLoaded, sourceFiles: Object.freeze(sources) });
+}

--- a/server/src/core/language/LanguageGameDataStore.ts
+++ b/server/src/core/language/LanguageGameDataStore.ts
@@ -28,14 +28,50 @@ function textList(value: unknown, fallback: readonly string[] = []): readonly st
   return Object.freeze(value.map((entry) => text(entry)).filter(Boolean));
 }
 
+function numericRecord(value: unknown): Record<string, number> | undefined {
+  if (!isRecord(value)) return undefined;
+  const out: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const n = Number(raw);
+    if (Number.isFinite(n)) out[key] = n;
+  }
+  return Object.keys(out).length > 0 ? Object.freeze(out) : undefined;
+}
+
+function stringArrayRecord(value: unknown): Record<string, readonly string[]> | undefined {
+  if (!isRecord(value)) return undefined;
+  const out: Record<string, readonly string[]> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const list = textList(raw);
+    if (list.length > 0) out[key] = list;
+  }
+  return Object.keys(out).length > 0 ? Object.freeze(out) : undefined;
+}
+
 function normalizeBlueprint(raw: unknown, source: string, index: number): LexemeBlueprint {
   if (!isRecord(raw)) throw new Error(`[${TAG}] ${source}.lexemes[${index}] must be an object`);
   const id = text(raw.id);
   const lemma = text(raw.lemma);
   const language = text(raw.language);
   if (!id || !lemma || !language) throw new Error(`[${TAG}] ${source}.lexemes[${index}] requires id, lemma, and language`);
-  const grammar = isRecord(raw.grammar) ? raw.grammar : undefined;
-  const social = isRecord(raw.social) ? raw.social : undefined;
+
+  const grammarInput = isRecord(raw.grammar) ? raw.grammar : undefined;
+  const socialInput = isRecord(raw.social) ? raw.social : undefined;
+  const emotion = numericRecord(raw.emotion) as LexemeBlueprint["emotion"] | undefined;
+  const worldBindings = stringArrayRecord(raw.worldBindings) as LexemeBlueprint["worldBindings"] | undefined;
+  const social = socialInput && text(socialInput.register) ? {
+    register: text(socialInput.register) as LexemeBlueprint["social"]["register"],
+    ...(numericRecord(socialInput.overrides) ? { overrides: numericRecord(socialInput.overrides) as LexemeBlueprint["social"]["overrides"] } : {}),
+  } : undefined;
+  const grammar = grammarInput && text(grammarInput.partOfSpeech) ? {
+    partOfSpeech: text(grammarInput.partOfSpeech) as LexemeBlueprint["grammar"]["partOfSpeech"],
+    ...(text(grammarInput.gender) ? { gender: text(grammarInput.gender) as LexemeBlueprint["grammar"]["gender"] } : {}),
+    ...(text(grammarInput.plural) ? { plural: text(grammarInput.plural) } : {}),
+    ...(text(grammarInput.conjugationClass) ? { conjugationClass: text(grammarInput.conjugationClass) } : {}),
+    allowedPositions: textList(grammarInput.allowedPositions) as LexemeBlueprint["grammar"]["allowedPositions"],
+  } : undefined;
+  const baseWeight = Number(raw.baseWeight);
+
   return Object.freeze({
     id,
     lemma,
@@ -43,17 +79,11 @@ function normalizeBlueprint(raw: unknown, source: string, index: number): Lexeme
     invented: Boolean(raw.invented),
     morphemes: textList(raw.morphemes, [lemma.toLowerCase()]),
     concepts: textList(raw.concepts),
-    emotion: isRecord(raw.emotion) ? raw.emotion as any : undefined,
-    social: social && text(social.register) ? { register: text(social.register) as any, overrides: isRecord(social.overrides) ? social.overrides as any : undefined } : undefined,
-    worldBindings: isRecord(raw.worldBindings) ? raw.worldBindings as any : undefined,
-    grammar: grammar && text(grammar.partOfSpeech) ? {
-      partOfSpeech: text(grammar.partOfSpeech) as any,
-      gender: text(grammar.gender) ? text(grammar.gender) as any : undefined,
-      plural: text(grammar.plural) || undefined,
-      conjugationClass: text(grammar.conjugationClass) || undefined,
-      allowedPositions: textList(grammar.allowedPositions) as any,
-    } : undefined,
-    baseWeight: Number.isFinite(Number(raw.baseWeight)) ? Number(raw.baseWeight) : undefined,
+    ...(emotion ? { emotion } : {}),
+    ...(social ? { social } : {}),
+    ...(worldBindings ? { worldBindings } : {}),
+    ...(grammar ? { grammar } : {}),
+    ...(Number.isFinite(baseWeight) ? { baseWeight } : {}),
   });
 }
 

--- a/server/src/core/language/LivingLanguageInitializer.ts
+++ b/server/src/core/language/LivingLanguageInitializer.ts
@@ -1,8 +1,8 @@
 import { readFileSync, existsSync } from "node:fs";
-import path from "node:path";
 import { resolveContentFile } from "../../modules/content/contentDataRoot.js";
 import { initializeDialogueBridge, type DialogueEntry } from "./DialogueBridge.js";
 import { initializeLinguisticKernel, isLinguisticKernelInitialized } from "./ArelorianLinguisticKernel.js";
+import { loadLivingDudenGameData } from "./LanguageGameDataStore.js";
 
 const INITIALIZATION_TAG = "LIVING_LANGUAGE_INITIALIZER_V1";
 
@@ -42,6 +42,12 @@ export async function initializeLivingLanguageSystem(): Promise<void> {
   const dialogues = loadDialoguesJson();
   console.log(`[${INITIALIZATION_TAG}] Loaded ${dialogues.length} dialogue entries from dialogues.json`);
   initializeDialogueBridge(dialogues);
+
+  const dudenReport = loadLivingDudenGameData();
+  console.log(
+    `[${INITIALIZATION_TAG}] Loaded ${dudenReport.lexemesLoaded} Living Duden lexeme(s) from ${dudenReport.filesRead} game-data/language file(s)`
+  );
+
   await initializeLinguisticKernel();
   initialized = true;
   console.log(`[${INITIALIZATION_TAG}] Living Language System initialized successfully`);

--- a/server/src/core/language/index.ts
+++ b/server/src/core/language/index.ts
@@ -33,6 +33,12 @@ export {
   type MutationResult,
 } from './LivingDudenArchive.js';
 
+// Living Duden game-data loader
+export {
+  loadLivingDudenGameData,
+  type LanguageGameDataLoadReport,
+} from './LanguageGameDataStore.js';
+
 // Procedural Grammar Engine
 export {
   buildSentence,


### PR DESCRIPTION
## Summary

Turns Living Duden game-data storage from a wording-only contract into a real runtime load path.

## Why

`game-data/` is already the shared content home for NPCs, dialogue, quests, and spawns. Living Duden must not be hidden behind a pretend facade or private-only core maps. It needs a real game-data source that is loaded by the server before NPC speech generation.

## Added

- `game-data/language/README.md`
- `game-data/language/living-duden.seed.json`
- `game-data/language/living-duden.promoted.json`
- `server/src/core/language/LanguageGameDataStore.ts`

## Runtime path

```text
resolveContentFile("language/living-duden.seed.json")
→ parse and validate lexeme records
→ loadSeedData(...)
→ LivingDudenArchive hydration
→ initializeLivingLanguageSystem()
→ NPC speech runtime can use the loaded lexemes
```

## Green-State line

No facade-as-stub. No fake hash placeholders. No empty seed-only claim. This PR adds real seed lexemes and a real startup loader. Runtime learning deltas still belong in deterministic persistence and can be promoted into `living-duden.promoted.json` later after review.