### PR TITLE
feat(npc): load game-data NPCs into WorldTick runtime

### DIFF
--- a/server/src/core/are/WorldTickThinShellAdapter.ts
+++ b/server/src/core/are/WorldTickThinShellAdapter.ts
@@ -7,6 +7,7 @@ import { ChatChannelRouter, type ChatRecipient } from '../../modules/chat/ChatCh
 import { getActiveGameWebSocketServer } from '../../networking/WebSocketServer.js';
 import type { NPCSystem } from '../../modules/npc/NPCSystem.js';
 import { NPCSystem as RealNPCSystem } from '../../modules/npc/NPCSystem.js';
+import { loadGameDataNpcsIntoSystem, type NpcGameDataLoadReport } from '../../modules/npc/NPCGameDataStore.js';
 import type { LootEntity } from '../../modules/world/LootDirector.js';
 import { lootDirector as deterministicLootDirector } from '../../modules/world/LootDirector.js';
 
@@ -58,6 +59,16 @@ function createManifestManager(adapter: WorldTickAdapter) {
   };
 }
 
+function emptyNpcLoadReport(): NpcGameDataLoadReport {
+  return Object.freeze({
+    npcDefinitionsRead: 0,
+    spawnRowsRead: 0,
+    npcsLoaded: 0,
+    missingSpawnDefinitions: Object.freeze([]),
+    duplicateSpawnNpcIds: Object.freeze([]),
+  });
+}
+
 export class WorldTickAdapter {
   readonly thinShell: WorldTickThinShell = worldTickThinShell;
   get tickCount(): number { return this.thinShell.getTickCount(); }
@@ -75,6 +86,7 @@ export class WorldTickAdapter {
   /** Backward-compatible public surface used by combat/persistence/skill integrations. */
   readonly npcSystem: NPCSystem;
   readonly deterministicLootDirector: { getAllLoot(): LootEntity[] };
+  private npcGameDataReport: NpcGameDataLoadReport = emptyNpcLoadReport();
 
   readonly chunkSystem = new StubChunkSystem();
   readonly observerEngine = new StubObserverEngine();
@@ -116,7 +128,7 @@ export class WorldTickAdapter {
   };
 
   readonly liveHeal = {
-    getStatus: () => ({ tickCount: this.tickCount, autoRepair: autoRepairService.getStatus(), usage: { prompt_tokens: 0, completion_tokens: 0 }, areShadow: { replayBufferSize: 0, lastSnapshot: null }, electroweakPruning: { ttlTicks: 1200, stats: {} }, emergence: { events: [] } }),
+    getStatus: () => ({ tickCount: this.tickCount, autoRepair: autoRepairService.getStatus(), usage: { prompt_tokens: 0, completion_tokens: 0 }, areShadow: { replayBufferSize: 0, lastSnapshot: null }, electroweakPruning: { ttlTicks: 1200, stats: {} }, emergence: { events: [] }, npcGameData: this.npcGameDataReport }),
     flush: () => {},
   };
   readonly assetHealthService = { getStatus: () => ({}), getStats: () => null, flush: () => {} };
@@ -125,6 +137,7 @@ export class WorldTickAdapter {
     // Create real NPC system for ARE truth path and preserve legacy adapter alias.
     this.realNPCSystem = new RealNPCSystem();
     this.npcSystem = this.realNPCSystem;
+    this.npcGameDataReport = loadGameDataNpcsIntoSystem(this.npcSystem);
 
     // Wire deterministic LootDirector for ARE truth path
     // This is the ARE-style loot system from modules/world/LootDirector
@@ -143,7 +156,7 @@ export class WorldTickAdapter {
       }),
     });
 
-    console.log('[WorldTickAdapter] Initialized with RealNPCSystem and deterministicLootDirector');
+    console.log(`[WorldTickAdapter] Initialized with RealNPCSystem, game-data NPCs=${this.npcGameDataReport.npcsLoaded}, and deterministicLootDirector`);
   }
 
   attachNetworkBridge(networkBridge: NetworkBridge): void {
@@ -171,6 +184,10 @@ export class WorldTickAdapter {
     return this.realNPCSystem;
   }
 
+  getNpcGameDataLoadReport(): NpcGameDataLoadReport {
+    return this.npcGameDataReport;
+  }
+
   async init(): Promise<void> {
     this.warfrontDomain.initialize(this.tickCount * 100);
   }
@@ -186,7 +203,7 @@ export class WorldTickAdapter {
   getVoteAdminDiagnostics(): any { return {}; }
   getPersistenceStats(): any { return this.thinShell.getPersistenceStats(); }
   debouncedSave(): void {}
-  createNPC(_id: string, _name: string, _x: number, _y: number): void {}
+  createNPC(id: string, name: string, x: number, y: number): void { this.npcSystem.createNPC(id, name, x, y); }
   updateLootCache(): void {}
   getPlaytesterDebugLogPath(): string { return ''; }
   buildPlaytesterMonitorPayload(_options?: any): any { return {}; }
@@ -194,14 +211,14 @@ export class WorldTickAdapter {
 
   getSpatialBroadcastStats(): { chunkCount: number; entityCount: number } {
     const snapshot = this.thinShell.getWorldBrainSnapshot();
-    return { chunkCount: snapshot?.active_chunks?.length ?? 0, entityCount: 0 };
+    return { chunkCount: snapshot?.active_chunks?.length ?? 0, entityCount: this.npcSystem.getAllNPCs().length + this.deterministicLootDirector.getAllLoot().length };
   }
 
   getAREGuardStatus(): AREInvariantGuardStatus | null { return validationState.getSnapshot().guard; }
   getWorldHashSnapshot(): WorldHashSnapshot | null {
     const snapshot = this.thinShell.getWorldBrainSnapshot();
     if (!snapshot) return null;
-    return { tick: this.tickCount, worldHash: snapshot.world_hash ?? '0'.repeat(64), chunkCount: snapshot.active_chunks?.length ?? 0, entityCount: 0, timestamp: this.tickCount };
+    return { tick: this.tickCount, worldHash: snapshot.world_hash ?? '0'.repeat(64), chunkCount: snapshot.active_chunks?.length ?? 0, entityCount: this.npcSystem.getAllNPCs().length + this.deterministicLootDirector.getAllLoot().length, timestamp: this.tickCount };
   }
   getReplayRecorderStats(): DeterministicRecorderStats { return tickRecorder.stats(); }
   getReplaySnapshot(tick: number): DeterministicReplaySnapshot | null { return tickRecorder.replay(tick); }

--- a/server/src/modules/npc/NPCGameDataStore.ts
+++ b/server/src/modules/npc/NPCGameDataStore.ts
@@ -1,0 +1,171 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolveContentFile } from "../content/contentDataRoot.js";
+import type { NPC, NPCSystem } from "./NPCSystem.js";
+
+const TAG = "NPC_GAME_DATA_STORE_V1";
+
+export interface NpcGameDataLoadReport {
+  readonly npcDefinitionsRead: number;
+  readonly spawnRowsRead: number;
+  readonly npcsLoaded: number;
+  readonly missingSpawnDefinitions: readonly string[];
+  readonly duplicateSpawnNpcIds: readonly string[];
+}
+
+type NpcDefinition = {
+  readonly id: string;
+  readonly name: string;
+  readonly role: string;
+  readonly dialogueId?: string;
+  readonly questHooks?: readonly string[];
+  readonly faction?: string;
+  readonly stats?: Record<string, unknown>;
+  readonly dropTable?: readonly unknown[];
+  readonly tags?: readonly string[];
+  readonly shopId?: string;
+};
+
+type NpcSpawn = {
+  readonly npcId: string;
+  readonly regionId: string;
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function finiteNumber(value: unknown, fallback = 0): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function stringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return Object.freeze([]);
+  return Object.freeze(value.map((entry) => text(entry)).filter(Boolean));
+}
+
+function readJson(relative: string): unknown {
+  const filePath = resolveContentFile(relative);
+  if (!existsSync(filePath)) throw new Error(`[${TAG}] Missing content file: ${relative}`);
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+function readNpcDefinitions(): readonly NpcDefinition[] {
+  const raw = readJson("npc/npcs.json");
+  if (!Array.isArray(raw)) throw new Error(`[${TAG}] npc/npcs.json must be an array`);
+  return Object.freeze(raw.map((entry, index) => {
+    if (!isRecord(entry)) throw new Error(`[${TAG}] npc/npcs.json[${index}] must be an object`);
+    const id = text(entry.id);
+    const name = text(entry.name);
+    const role = text(entry.role);
+    if (!id || !name || !role) throw new Error(`[${TAG}] npc/npcs.json[${index}] requires id, name, and role`);
+    return Object.freeze({
+      id,
+      name,
+      role,
+      ...(text(entry.dialogueId) ? { dialogueId: text(entry.dialogueId) } : {}),
+      ...(stringList(entry.questHooks).length > 0 ? { questHooks: stringList(entry.questHooks) } : {}),
+      ...(text(entry.faction) ? { faction: text(entry.faction) } : {}),
+      ...(isRecord(entry.stats) ? { stats: Object.freeze({ ...entry.stats }) } : {}),
+      ...(Array.isArray(entry.dropTable) ? { dropTable: Object.freeze([...entry.dropTable]) } : {}),
+      ...(stringList(entry.tags).length > 0 ? { tags: stringList(entry.tags) } : {}),
+      ...(text(entry.shopId) ? { shopId: text(entry.shopId) } : {}),
+    });
+  }));
+}
+
+function readNpcSpawns(): readonly NpcSpawn[] {
+  const raw = readJson("spawns/npc-spawns.json");
+  if (!Array.isArray(raw)) throw new Error(`[${TAG}] spawns/npc-spawns.json must be an array`);
+  const spawns: NpcSpawn[] = [];
+  raw.forEach((region, regionIndex) => {
+    if (!isRecord(region)) throw new Error(`[${TAG}] spawns/npc-spawns.json[${regionIndex}] must be an object`);
+    const regionId = text(region.regionId) || `region_${regionIndex}`;
+    if (!Array.isArray(region.spawns)) return;
+    region.spawns.forEach((spawn, spawnIndex) => {
+      if (!isRecord(spawn)) throw new Error(`[${TAG}] ${regionId}.spawns[${spawnIndex}] must be an object`);
+      const npcId = text(spawn.npcId);
+      if (!npcId) throw new Error(`[${TAG}] ${regionId}.spawns[${spawnIndex}] requires npcId`);
+      spawns.push(Object.freeze({
+        npcId,
+        regionId,
+        x: finiteNumber(spawn.x),
+        y: finiteNumber(spawn.y),
+        z: finiteNumber(spawn.z),
+      }));
+    });
+  });
+  return Object.freeze(spawns);
+}
+
+function npcFromGameData(def: NpcDefinition, spawn: NpcSpawn): NPC {
+  const health = finiteNumber(def.stats?.health, 90);
+  const maxHealth = finiteNumber(def.stats?.maxHealth, health);
+  const combatLevel = Math.max(1, Math.trunc(finiteNumber(def.stats?.combatLevel, 1)));
+  const npc: NPC = {
+    id: def.id,
+    name: def.name,
+    position: { x: spawn.x, y: spawn.y, z: spawn.z },
+    rotation: 0,
+    visionRange: 10,
+    visionAngle: 90,
+    targetId: null,
+    isProcessingAI: false,
+    role: def.role,
+    faction: def.faction ?? "Neutral",
+    tags: Object.freeze([def.role.toLowerCase().replace(/\s+/g, "_"), spawn.regionId, ...(def.tags ?? [])]),
+    health,
+    maxHealth,
+    skills: { combat: { level: combatLevel } },
+    state: "idle",
+    memory: Object.freeze({
+      dialogueId: def.dialogueId ?? null,
+      questHooks: Object.freeze([...(def.questHooks ?? [])]),
+      regionId: spawn.regionId,
+      source: "game-data/npc",
+    }),
+  };
+  if (def.dropTable && def.dropTable.length > 0) npc.dropTable = Object.freeze([...def.dropTable]);
+  if (def.shopId) npc.shopId = def.shopId;
+  return npc;
+}
+
+export function loadGameDataNpcsIntoSystem(npcSystem: NPCSystem): NpcGameDataLoadReport {
+  const definitions = readNpcDefinitions();
+  const spawns = readNpcSpawns();
+  const definitionsById = new Map(definitions.map((definition) => [definition.id, definition]));
+  const spawnedNpcIds = new Set<string>();
+  const missingSpawnDefinitions: string[] = [];
+  const duplicateSpawnNpcIds: string[] = [];
+  let loaded = 0;
+
+  for (const spawn of spawns) {
+    const definition = definitionsById.get(spawn.npcId);
+    if (!definition) {
+      missingSpawnDefinitions.push(spawn.npcId);
+      continue;
+    }
+    if (spawnedNpcIds.has(spawn.npcId)) {
+      duplicateSpawnNpcIds.push(spawn.npcId);
+      continue;
+    }
+    npcSystem.addNPC(npcFromGameData(definition, spawn));
+    spawnedNpcIds.add(spawn.npcId);
+    loaded += 1;
+  }
+
+  return Object.freeze({
+    npcDefinitionsRead: definitions.length,
+    spawnRowsRead: spawns.length,
+    npcsLoaded: loaded,
+    missingSpawnDefinitions: Object.freeze(missingSpawnDefinitions),
+    duplicateSpawnNpcIds: Object.freeze(duplicateSpawnNpcIds),
+  });
+}


### PR DESCRIPTION
## Summary

Loads `game-data/npc/npcs.json` and `game-data/spawns/npc-spawns.json` into the real `NPCSystem` used by `WorldTickThinShellAdapter`.

## Why

The content authoring guide already says NPCs and spawns belong in `game-data/`, and `validateContentRoot` already validates references. But the runtime adapter did not automatically hydrate those NPCs into the ARE world-state provider.

## Runtime path

```text
resolveContentFile("npc/npcs.json")
→ resolveContentFile("spawns/npc-spawns.json")
→ validate/load records
→ NPCSystem.addNPC(...)
→ WorldTickAdapter.npcSystem
→ WorldTickThinShell WorldStateProvider
→ NPCs become part of tick/world hash/runtime source
```

## Changes

- Adds `server/src/modules/npc/NPCGameDataStore.ts`.
- Loads definitions and spawn rows from game-data.
- Converts them into real `NPC` objects with position, role, faction, stats, drops, dialogue memory and quest hook memory.
- Hydrates the same `NPCSystem` used by `WorldTickThinShellAdapter`.
- Exposes a load report through `liveHeal` and `getNpcGameDataLoadReport()`.
- Fixes adapter `createNPC(...)` to create a real NPC instead of doing nothing.
- Makes spatial/world-hash entity counts include loaded NPCs and deterministic loot.

## Green-State line

No shadow-only content. No facade wording. No fake snapshots.

`game-data/npc` now becomes a real startup source for the WorldTick NPC truth path. CI still has to prove TypeScript/tests.

## Rebased after #1979

This PR was reopened after #1979 landed so its checks run against the current main.