### PR TITLE
fix(equipment): bind paperdoll slots to game-data truth

### DIFF
--- a/apps/client-2d/src/ui/windows/PaperdollPanel.tsx
+++ b/apps/client-2d/src/ui/windows/PaperdollPanel.tsx
@@ -1,7 +1,7 @@
 /**
  * Paperdoll Panel — Character Equipment View
  *
- * Shows character profile and equipped tool slots.
+ * Shows character profile and equipped slots from the server-backed gameplay snapshot.
  * Follows the Panzerschrank brutalist design aesthetic.
  *
  * Determinism rule:
@@ -36,7 +36,12 @@ export function PaperdollPanel({ paperdoll }: Props) {
 
       <div className="paperdoll-slots">
         {(paperdoll.slots ?? []).map((slot) => (
-          <article key={slot.slotId} className="paperdoll-slot">
+          <article
+            key={slot.slotId}
+            className="paperdoll-slot"
+            data-slot-id={slot.slotId}
+            data-item-id={slot.itemId ?? "empty"}
+          >
             <span className="paperdoll-slot-label">{formatSlotLabel(slot.slotId)}</span>
             <strong className="paperdoll-slot-title">{slot.title}</strong>
           </article>
@@ -48,6 +53,12 @@ export function PaperdollPanel({ paperdoll }: Props) {
 
 function formatSlotLabel(slotId: string): string {
   const labels: Record<string, string> = {
+    weapon: "Weapon",
+    helmet: "Helmet",
+    armor: "Armor",
+    boots: "Boots",
+    ring: "Ring",
+    amulet: "Amulet",
     woodcutting_tool: "Woodcutting",
     mining_tool: "Mining",
     fishing_tool: "Fishing",

--- a/game-data/AUTHORING_GUIDE.md
+++ b/game-data/AUTHORING_GUIDE.md
@@ -18,6 +18,13 @@ This guide describes how to add new content to Areloria.
 2. Define `id`, `title`, `objective`, `giverNpcId`.
 3. Add prerequisites or rewards if needed.
 
+## Adding Equipment / Paperdoll Slots
+1. Add canonical equipment slots to `game-data/equipment/equipment-slots.json`.
+2. Define `slotId`, `title`, `emptyTitle`, `kind`, and deterministic `order`.
+3. Add authored equippable item metadata to `game-data/equipment/equipment-items.json`.
+4. Every authored equipment `itemId` must already exist in server inventory definitions.
+5. Paperdoll and gameplay snapshots load this metadata from `game-data`; do not create UI-only slots or fake paperdoll data.
+
 ## Placing Spawns
 1. Add an entry to `game-data/spawns/npc-spawns.json`.
 2. Define `npcId`, `position` (x, y).
@@ -26,4 +33,6 @@ This guide describes how to add new content to Areloria.
 - **Broken References**: Ensure `dialogueId` in `npcs.json` matches an `id` in `dialogues.json`.
 - **Missing Nodes**: Ensure `nextNodeId` in `dialogues.json` exists in the `nodes` object of that dialogue.
 - **Invalid Quest IDs**: Ensure `prerequisiteQuestIds` in `quests.json` matches an `id` in `quests.json`.
+- **Invalid Equipment Item IDs**: Ensure every `game-data/equipment/equipment-items.json` `itemId` exists in inventory definitions.
+- **Invalid Equipment Slot IDs**: Ensure equipment item `slotId` values exist in `game-data/equipment/equipment-slots.json`.
 - **Validation**: Run `npx ts-node server/src/tools/validateContent.ts` to check for errors.

--- a/game-data/equipment/equipment-items.json
+++ b/game-data/equipment/equipment-items.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": 1,
+  "items": [
+    {
+      "itemId": "wooden_axe",
+      "slotId": "woodcutting_tool",
+      "title": "Wooden Axe",
+      "displayId": "equipment.wooden_axe",
+      "iconId": "item.wooden_axe",
+      "tier": 1,
+      "skillBonus": {
+        "skillId": "woodcutting",
+        "xpMultiplierPermille": 1100,
+        "gatherRespawnReductionTicks": 2
+      },
+      "stats": [
+        { "key": "woodcutting_xp_permille", "value": 1100 },
+        { "key": "gather_respawn_reduction_ticks", "value": 2 }
+      ],
+      "requirements": []
+    },
+    {
+      "itemId": "copper_pickaxe",
+      "slotId": "mining_tool",
+      "title": "Copper Pickaxe",
+      "displayId": "equipment.copper_pickaxe",
+      "iconId": "item.copper_pickaxe",
+      "tier": 1,
+      "skillBonus": {
+        "skillId": "mining",
+        "xpMultiplierPermille": 1100,
+        "gatherRespawnReductionTicks": 2
+      },
+      "stats": [
+        { "key": "mining_xp_permille", "value": 1100 },
+        { "key": "gather_respawn_reduction_ticks", "value": 2 }
+      ],
+      "requirements": []
+    },
+    {
+      "itemId": "simple_fishing_rod",
+      "slotId": "fishing_tool",
+      "title": "Simple Fishing Rod",
+      "displayId": "equipment.simple_fishing_rod",
+      "iconId": "item.simple_fishing_rod",
+      "tier": 1,
+      "skillBonus": {
+        "skillId": "fishing",
+        "xpMultiplierPermille": 1100,
+        "gatherRespawnReductionTicks": 2
+      },
+      "stats": [
+        { "key": "fishing_xp_permille", "value": 1100 },
+        { "key": "gather_respawn_reduction_ticks", "value": 2 }
+      ],
+      "requirements": []
+    },
+    {
+      "itemId": "copper_axe",
+      "slotId": "woodcutting_tool",
+      "title": "Copper Axe",
+      "displayId": "equipment.copper_axe",
+      "iconId": "item.copper_axe",
+      "tier": 2,
+      "skillBonus": {
+        "skillId": "woodcutting",
+        "xpMultiplierPermille": 1200,
+        "gatherRespawnReductionTicks": 3
+      },
+      "stats": [
+        { "key": "woodcutting_xp_permille", "value": 1200 },
+        { "key": "gather_respawn_reduction_ticks", "value": 3 }
+      ],
+      "requirements": [
+        { "key": "woodcutting_level", "value": 2 }
+      ]
+    },
+    {
+      "itemId": "reinforced_pickaxe",
+      "slotId": "mining_tool",
+      "title": "Reinforced Pickaxe",
+      "displayId": "equipment.reinforced_pickaxe",
+      "iconId": "item.reinforced_pickaxe",
+      "tier": 2,
+      "skillBonus": {
+        "skillId": "mining",
+        "xpMultiplierPermille": 1200,
+        "gatherRespawnReductionTicks": 3
+      },
+      "stats": [
+        { "key": "mining_xp_permille", "value": 1200 },
+        { "key": "gather_respawn_reduction_ticks", "value": 3 }
+      ],
+      "requirements": [
+        { "key": "mining_level", "value": 2 }
+      ]
+    },
+    {
+      "itemId": "reinforced_fishing_rod",
+      "slotId": "fishing_tool",
+      "title": "Reinforced Fishing Rod",
+      "displayId": "equipment.reinforced_fishing_rod",
+      "iconId": "item.reinforced_fishing_rod",
+      "tier": 2,
+      "skillBonus": {
+        "skillId": "fishing",
+        "xpMultiplierPermille": 1200,
+        "gatherRespawnReductionTicks": 3
+      },
+      "stats": [
+        { "key": "fishing_xp_permille", "value": 1200 },
+        { "key": "gather_respawn_reduction_ticks", "value": 3 }
+      ],
+      "requirements": [
+        { "key": "fishing_level", "value": 2 }
+      ]
+    }
+  ]
+}

--- a/game-data/equipment/equipment-slots.json
+++ b/game-data/equipment/equipment-slots.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "slots": [
+    {
+      "slotId": "weapon",
+      "title": "Weapon",
+      "emptyTitle": "Empty Weapon Slot",
+      "kind": "combat",
+      "order": 10
+    },
+    {
+      "slotId": "helmet",
+      "title": "Helmet",
+      "emptyTitle": "Empty Helmet Slot",
+      "kind": "armor",
+      "order": 20
+    },
+    {
+      "slotId": "armor",
+      "title": "Armor",
+      "emptyTitle": "Empty Armor Slot",
+      "kind": "armor",
+      "order": 30
+    },
+    {
+      "slotId": "boots",
+      "title": "Boots",
+      "emptyTitle": "Empty Boots Slot",
+      "kind": "armor",
+      "order": 40
+    },
+    {
+      "slotId": "ring",
+      "title": "Ring",
+      "emptyTitle": "Empty Ring Slot",
+      "kind": "accessory",
+      "order": 50
+    },
+    {
+      "slotId": "amulet",
+      "title": "Amulet",
+      "emptyTitle": "Empty Amulet Slot",
+      "kind": "accessory",
+      "order": 60
+    },
+    {
+      "slotId": "woodcutting_tool",
+      "title": "Woodcutting Tool",
+      "emptyTitle": "Empty Woodcutting Tool Slot",
+      "kind": "gathering_tool",
+      "order": 70
+    },
+    {
+      "slotId": "mining_tool",
+      "title": "Mining Tool",
+      "emptyTitle": "Empty Mining Tool Slot",
+      "kind": "gathering_tool",
+      "order": 80
+    },
+    {
+      "slotId": "fishing_tool",
+      "title": "Fishing Tool",
+      "emptyTitle": "Empty Fishing Tool Slot",
+      "kind": "gathering_tool",
+      "order": 90
+    }
+  ]
+}

--- a/server/src/character/PaperdollTypes.ts
+++ b/server/src/character/PaperdollTypes.ts
@@ -6,12 +6,23 @@
  */
 
 import type { CharacterProfileSnapshot } from "./CharacterTypes.js";
-import type { PlayerEquipmentState } from "../equipment/EquipmentTypes.js";
+import {
+  EQUIPMENT_DEFINITIONS,
+  EQUIPMENT_SLOT_DEFINITIONS,
+  compareEquipmentSlotIds,
+  type EquipmentNumberEntry,
+  type EquipmentSlotId,
+  type PlayerEquipmentState,
+} from "../equipment/EquipmentTypes.js";
 
 export interface PaperdollSlotSnapshot {
-  slotId: string;
+  slotId: EquipmentSlotId;
   itemId: string | null;
   title: string;
+  displayId?: string;
+  iconId?: string;
+  stats?: readonly EquipmentNumberEntry[];
+  requirements?: readonly EquipmentNumberEntry[];
 }
 
 export interface PaperdollSnapshot {
@@ -25,22 +36,37 @@ export function createPaperdollSnapshot(input: {
 }): PaperdollSnapshot {
   const equipped = input.equipment?.slots ?? [];
 
-  const slotIds = [
-    "woodcutting_tool",
-    "mining_tool",
-    "fishing_tool",
-  ];
-
   return {
     character: input.character,
-    slots: slotIds.map((slotId) => {
-      const found = equipped.find((slot) => slot.slotId === slotId);
+    slots: EQUIPMENT_SLOT_DEFINITIONS.map((slotDefinition) => {
+      const found = equipped.find((slot) => slot.slotId === slotDefinition.slotId);
+      const itemDefinition = found ? EQUIPMENT_DEFINITIONS[found.itemId] : undefined;
+
+      if (!found) {
+        return {
+          slotId: slotDefinition.slotId,
+          itemId: null,
+          title: slotDefinition.emptyTitle,
+        };
+      }
 
       return {
-        slotId,
-        itemId: found?.itemId ?? null,
-        title: found?.title ?? "Empty",
+        slotId: slotDefinition.slotId,
+        itemId: found.itemId,
+        title: itemDefinition?.title ?? found.title,
+        ...(itemDefinition?.displayId || found.displayId
+          ? { displayId: itemDefinition?.displayId ?? found.displayId }
+          : {}),
+        ...(itemDefinition?.iconId || found.iconId
+          ? { iconId: itemDefinition?.iconId ?? found.iconId }
+          : {}),
+        ...(itemDefinition?.stats || found.stats
+          ? { stats: [...(itemDefinition?.stats ?? found.stats ?? [])] }
+          : {}),
+        ...(itemDefinition?.requirements || found.requirements
+          ? { requirements: [...(itemDefinition?.requirements ?? found.requirements ?? [])] }
+          : {}),
       };
-    }).sort((a, b) => a.slotId.localeCompare(b.slotId)),
+    }).sort((a, b) => compareEquipmentSlotIds(a.slotId, b.slotId)),
   };
 }

--- a/server/src/equipment/EquipmentBonus.ts
+++ b/server/src/equipment/EquipmentBonus.ts
@@ -27,15 +27,15 @@ export function getGatheringToolBonus(input: {
 }): GatheringToolBonus {
   const equippedDefinitions = input.equipment.slots
     .map((slot) => EQUIPMENT_DEFINITIONS[slot.itemId])
-    .filter(Boolean);
+    .filter((definition) => Boolean(definition?.skillBonus));
 
   const matching = equippedDefinitions.find(
-    (definition) => definition.skillBonus.skillId === input.skillId,
+    (definition) => definition.skillBonus?.skillId === input.skillId,
   );
 
   return {
-    xpMultiplierPermille: matching?.skillBonus.xpMultiplierPermille ?? 1000,
-    gatherRespawnReductionTicks: matching?.skillBonus.gatherRespawnReductionTicks ?? 0,
+    xpMultiplierPermille: matching?.skillBonus?.xpMultiplierPermille ?? 1000,
+    gatherRespawnReductionTicks: matching?.skillBonus?.gatherRespawnReductionTicks ?? 0,
     tier: matching?.tier ?? 1,
     equipmentGatheringYield: 0,
     equipmentGatheringXp: 0,

--- a/server/src/equipment/EquipmentStore.ts
+++ b/server/src/equipment/EquipmentStore.ts
@@ -7,7 +7,9 @@
 
 import {
   EQUIPMENT_DEFINITIONS,
+  compareEquipmentSlotIds,
   createDefaultEquipmentState,
+  createEquippedSlotFromDefinition,
   isEquipmentItemId,
   normalizeEquipmentState,
   type EquipItemResult,
@@ -67,13 +69,8 @@ export class EquipmentStore {
         ...state,
         slots: [
           ...state.slots.filter((slot) => slot.slotId !== definition.slotId),
-          {
-            slotId: definition.slotId,
-            itemId: definition.itemId,
-            title: definition.title,
-            tier: definition.tier,
-          },
-        ],
+          createEquippedSlotFromDefinition(definition),
+        ].sort((a, b) => compareEquipmentSlotIds(a.slotId, b.slotId)),
       },
       input.playerId,
     );
@@ -114,7 +111,6 @@ export class EquipmentStore {
       };
     }
 
-    // Remove the slot
     const nextState = normalizeEquipmentState(
       {
         ...state,

--- a/server/src/equipment/EquipmentTypes.ts
+++ b/server/src/equipment/EquipmentTypes.ts
@@ -1,34 +1,63 @@
 /**
  * EQUIPMENT TYPES
  *
- * Deterministic equipment types for gathering tools and combat loot.
+ * Deterministic equipment types for gathering tools, combat slots and paperdoll truth.
+ * Canonical slot/item metadata is loaded from game-data/equipment at module init.
  * No Date.now(), no Math.random(), stable slot IDs and ordering.
  */
 
-import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+import fs from "node:fs";
+import { isInventoryItemId, type InventoryItemId } from "../inventory/InventoryTypes.js";
+import { resolveContentFile } from "../modules/content/contentDataRoot.js";
 
-export type EquipmentSlotId =
-  | "woodcutting_tool"
-  | "mining_tool"
-  | "fishing_tool"
-  | "weapon"
-  | "armor"
-  | "helmet"
-  | "boots"
-  | "ring"
-  | "amulet";
+const KNOWN_EQUIPMENT_SLOT_IDS = [
+  "amulet",
+  "armor",
+  "boots",
+  "fishing_tool",
+  "helmet",
+  "mining_tool",
+  "ring",
+  "weapon",
+  "woodcutting_tool",
+] as const;
+
+export type EquipmentSlotId = (typeof KNOWN_EQUIPMENT_SLOT_IDS)[number];
+export type EquipmentSlotKind = "combat" | "armor" | "accessory" | "gathering_tool";
+export type GatheringSkillId = "woodcutting" | "mining" | "fishing";
+
+export interface EquipmentNumberEntry {
+  key: string;
+  value: number;
+}
+
+export interface EquipmentSlotDefinition {
+  slotId: EquipmentSlotId;
+  title: string;
+  emptyTitle: string;
+  kind: EquipmentSlotKind;
+  order: number;
+}
+
+export interface EquipmentSkillBonus {
+  skillId: GatheringSkillId;
+  xpMultiplierPermille: number;
+  gatherRespawnReductionTicks: number;
+}
 
 export interface EquipmentItemDefinition {
   itemId: InventoryItemId;
   slotId: EquipmentSlotId;
   title: string;
-  /** Tool tier for gathering bonus calculations. Tier 1 = starter, Tier 2 = upgrade. */
+  /** Stable display identifier used by clients/atlases. */
+  displayId?: string;
+  /** Stable icon identifier used by clients/atlases. */
+  iconId?: string;
+  /** Tool/equipment tier. Tier 1 = starter, Tier 2 = upgrade. */
   tier: number;
-  skillBonus: {
-    skillId: "woodcutting" | "mining" | "fishing";
-    xpMultiplierPermille: number;
-    gatherRespawnReductionTicks: number;
-  };
+  skillBonus?: EquipmentSkillBonus;
+  stats?: readonly EquipmentNumberEntry[];
+  requirements?: readonly EquipmentNumberEntry[];
 }
 
 export interface EquippedSlot {
@@ -36,8 +65,11 @@ export interface EquippedSlot {
   itemId: InventoryItemId;
   title: string;
   tier: number;
-  /** Optional stats for procedural loot items */
-  stats?: ReadonlyArray<{ key: string; value: number }>;
+  displayId?: string;
+  iconId?: string;
+  /** Optional stats for procedural loot or authored game-data items. */
+  stats?: ReadonlyArray<EquipmentNumberEntry>;
+  requirements?: ReadonlyArray<EquipmentNumberEntry>;
 }
 
 export interface PlayerEquipmentState {
@@ -67,78 +99,206 @@ export interface UnequipItemResult {
   equipment?: PlayerEquipmentState;
 }
 
-export const EQUIPMENT_DEFINITIONS: Record<string, EquipmentItemDefinition> = {
-  wooden_axe: {
-    itemId: "wooden_axe",
-    slotId: "woodcutting_tool",
-    title: "Wooden Axe",
-    tier: 1,
-    skillBonus: {
-      skillId: "woodcutting",
-      xpMultiplierPermille: 1100,
-      gatherRespawnReductionTicks: 2,
-    },
-  },
-  copper_pickaxe: {
-    itemId: "copper_pickaxe",
-    slotId: "mining_tool",
-    title: "Copper Pickaxe",
-    tier: 1,
-    skillBonus: {
-      skillId: "mining",
-      xpMultiplierPermille: 1100,
-      gatherRespawnReductionTicks: 2,
-    },
-  },
-  simple_fishing_rod: {
-    itemId: "simple_fishing_rod",
-    slotId: "fishing_tool",
-    title: "Simple Fishing Rod",
-    tier: 1,
-    skillBonus: {
-      skillId: "fishing",
-      xpMultiplierPermille: 1100,
-      gatherRespawnReductionTicks: 2,
-    },
-  },
-  // Upgrade tools (Tier 2) - crafted from starter tools
-  copper_axe: {
-    itemId: "copper_axe",
-    slotId: "woodcutting_tool",
-    title: "Copper Axe",
-    tier: 2,
-    skillBonus: {
-      skillId: "woodcutting",
-      xpMultiplierPermille: 1200,
-      gatherRespawnReductionTicks: 3,
-    },
-  },
-  reinforced_pickaxe: {
-    itemId: "reinforced_pickaxe",
-    slotId: "mining_tool",
-    title: "Reinforced Pickaxe",
-    tier: 2,
-    skillBonus: {
-      skillId: "mining",
-      xpMultiplierPermille: 1200,
-      gatherRespawnReductionTicks: 3,
-    },
-  },
-  reinforced_fishing_rod: {
-    itemId: "reinforced_fishing_rod",
-    slotId: "fishing_tool",
-    title: "Reinforced Fishing Rod",
-    tier: 2,
-    skillBonus: {
-      skillId: "fishing",
-      xpMultiplierPermille: 1200,
-      gatherRespawnReductionTicks: 3,
-    },
-  },
-};
+const KNOWN_SLOT_ID_SET = new Set<string>(KNOWN_EQUIPMENT_SLOT_IDS);
+const VALID_SLOT_KINDS = new Set<string>(["combat", "armor", "accessory", "gathering_tool"]);
+const VALID_GATHERING_SKILLS = new Set<string>(["woodcutting", "mining", "fishing"]);
 
-export function isEquipmentItemId(itemId: string): itemId is keyof typeof EQUIPMENT_DEFINITIONS {
-  return itemId in EQUIPMENT_DEFINITIONS;
+function compareStableString(a: string, b: string): number {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+function readGameDataJson(relativePath: string): unknown {
+  const filename = resolveContentFile(relativePath);
+  try {
+    return JSON.parse(fs.readFileSync(filename, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[EquipmentGameData] Failed to load ${relativePath}: ${message}`);
+  }
+}
+
+export function isEquipmentSlotId(value: unknown): value is EquipmentSlotId {
+  return typeof value === "string" && KNOWN_SLOT_ID_SET.has(value);
+}
+
+function assertObject(value: unknown, context: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`[EquipmentGameData] ${context} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertString(value: unknown, context: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`[EquipmentGameData] ${context} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function assertInteger(value: unknown, context: string, min = 0): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < min) {
+    throw new Error(`[EquipmentGameData] ${context} must be an integer >= ${min}`);
+  }
+  return n;
+}
+
+function normalizeNumberEntries(value: unknown, context: string): readonly EquipmentNumberEntry[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(`[EquipmentGameData] ${context} must be an array`);
+  }
+
+  return value.map((entry, index) => {
+    const record = assertObject(entry, `${context}[${index}]`);
+    const key = assertString(record.key, `${context}[${index}].key`);
+    const amount = Number(record.value);
+    if (!Number.isFinite(amount)) {
+      throw new Error(`[EquipmentGameData] ${context}[${index}].value must be finite`);
+    }
+    return { key, value: amount };
+  }).sort((a, b) => compareStableString(a.key, b.key));
+}
+
+function normalizeSkillBonus(value: unknown, context: string): EquipmentSkillBonus | undefined {
+  if (value === undefined || value === null) return undefined;
+  const record = assertObject(value, context);
+  const skillId = assertString(record.skillId, `${context}.skillId`);
+  if (!VALID_GATHERING_SKILLS.has(skillId)) {
+    throw new Error(`[EquipmentGameData] ${context}.skillId is not a known gathering skill: ${skillId}`);
+  }
+
+  return {
+    skillId: skillId as GatheringSkillId,
+    xpMultiplierPermille: assertInteger(record.xpMultiplierPermille, `${context}.xpMultiplierPermille`, 0),
+    gatherRespawnReductionTicks: assertInteger(
+      record.gatherRespawnReductionTicks,
+      `${context}.gatherRespawnReductionTicks`,
+      0,
+    ),
+  };
+}
+
+function loadEquipmentSlotDefinitions(): readonly EquipmentSlotDefinition[] {
+  const root = assertObject(readGameDataJson("equipment/equipment-slots.json"), "equipment/equipment-slots.json");
+  const slots = root.slots;
+  if (!Array.isArray(slots)) {
+    throw new Error("[EquipmentGameData] equipment/equipment-slots.json slots must be an array");
+  }
+
+  const seenSlots = new Set<EquipmentSlotId>();
+  const seenOrders = new Set<number>();
+
+  const normalized = slots.map((entry, index): EquipmentSlotDefinition => {
+    const record = assertObject(entry, `equipment-slots[${index}]`);
+    const slotId = assertString(record.slotId, `equipment-slots[${index}].slotId`);
+    if (!isEquipmentSlotId(slotId)) {
+      throw new Error(`[EquipmentGameData] Unknown equipment slotId: ${slotId}`);
+    }
+    if (seenSlots.has(slotId)) {
+      throw new Error(`[EquipmentGameData] Duplicate equipment slotId: ${slotId}`);
+    }
+    seenSlots.add(slotId);
+
+    const order = assertInteger(record.order, `equipment-slots[${index}].order`, 0);
+    if (seenOrders.has(order)) {
+      throw new Error(`[EquipmentGameData] Duplicate equipment slot order: ${order}`);
+    }
+    seenOrders.add(order);
+
+    const kind = assertString(record.kind, `equipment-slots[${index}].kind`);
+    if (!VALID_SLOT_KINDS.has(kind)) {
+      throw new Error(`[EquipmentGameData] Unknown equipment slot kind: ${kind}`);
+    }
+
+    return {
+      slotId,
+      title: assertString(record.title, `equipment-slots[${index}].title`),
+      emptyTitle: assertString(record.emptyTitle, `equipment-slots[${index}].emptyTitle`),
+      kind: kind as EquipmentSlotKind,
+      order,
+    };
+  }).sort((a, b) => (a.order - b.order) || compareStableString(a.slotId, b.slotId));
+
+  const missing = KNOWN_EQUIPMENT_SLOT_IDS.filter((slotId) => !seenSlots.has(slotId));
+  if (missing.length > 0) {
+    throw new Error(`[EquipmentGameData] Missing canonical equipment slots: ${missing.join(", ")}`);
+  }
+
+  return normalized;
+}
+
+function loadEquipmentDefinitions(): Readonly<Record<string, EquipmentItemDefinition>> {
+  const root = assertObject(readGameDataJson("equipment/equipment-items.json"), "equipment/equipment-items.json");
+  const items = root.items;
+  if (!Array.isArray(items)) {
+    throw new Error("[EquipmentGameData] equipment/equipment-items.json items must be an array");
+  }
+
+  const byItemId: Record<string, EquipmentItemDefinition> = {};
+
+  for (let index = 0; index < items.length; index++) {
+    const record = assertObject(items[index], `equipment-items[${index}]`);
+    const itemId = assertString(record.itemId, `equipment-items[${index}].itemId`);
+    if (!isInventoryItemId(itemId)) {
+      throw new Error(`[EquipmentGameData] Equipment item is not registered in inventory: ${itemId}`);
+    }
+    if (byItemId[itemId]) {
+      throw new Error(`[EquipmentGameData] Duplicate equipment itemId: ${itemId}`);
+    }
+
+    const slotId = assertString(record.slotId, `equipment-items[${index}].slotId`);
+    if (!isEquipmentSlotId(slotId)) {
+      throw new Error(`[EquipmentGameData] Unknown equipment item slotId: ${slotId}`);
+    }
+
+    byItemId[itemId] = {
+      itemId,
+      slotId,
+      title: assertString(record.title, `equipment-items[${index}].title`),
+      displayId: typeof record.displayId === "string" ? record.displayId.trim() : undefined,
+      iconId: typeof record.iconId === "string" ? record.iconId.trim() : undefined,
+      tier: assertInteger(record.tier, `equipment-items[${index}].tier`, 1),
+      skillBonus: normalizeSkillBonus(record.skillBonus, `equipment-items[${index}].skillBonus`),
+      stats: normalizeNumberEntries(record.stats, `equipment-items[${index}].stats`),
+      requirements: normalizeNumberEntries(record.requirements, `equipment-items[${index}].requirements`),
+    };
+  }
+
+  return Object.fromEntries(
+    Object.entries(byItemId).sort(([a], [b]) => compareStableString(a, b)),
+  );
+}
+
+export const EQUIPMENT_SLOT_DEFINITIONS = loadEquipmentSlotDefinitions();
+export const EQUIPMENT_SLOT_IDS = EQUIPMENT_SLOT_DEFINITIONS.map((slot) => slot.slotId) as readonly EquipmentSlotId[];
+export const EQUIPMENT_SLOT_ORDER = new Map<EquipmentSlotId, number>(
+  EQUIPMENT_SLOT_DEFINITIONS.map((slot, index) => [slot.slotId, index]),
+);
+export const EQUIPMENT_DEFINITIONS = loadEquipmentDefinitions();
+
+export function compareEquipmentSlotIds(a: EquipmentSlotId, b: EquipmentSlotId): number {
+  const orderA = EQUIPMENT_SLOT_ORDER.get(a) ?? Number.MAX_SAFE_INTEGER;
+  const orderB = EQUIPMENT_SLOT_ORDER.get(b) ?? Number.MAX_SAFE_INTEGER;
+  return (orderA - orderB) || compareStableString(a, b);
+}
+
+export function isEquipmentItemId(itemId: string): itemId is InventoryItemId {
+  return Object.prototype.hasOwnProperty.call(EQUIPMENT_DEFINITIONS, itemId);
+}
+
+export function createEquippedSlotFromDefinition(definition: EquipmentItemDefinition): EquippedSlot {
+  return {
+    slotId: definition.slotId,
+    itemId: definition.itemId,
+    title: definition.title,
+    tier: definition.tier,
+    ...(definition.displayId ? { displayId: definition.displayId } : {}),
+    ...(definition.iconId ? { iconId: definition.iconId } : {}),
+    ...(definition.stats ? { stats: [...definition.stats] } : {}),
+    ...(definition.requirements ? { requirements: [...definition.requirements] } : {}),
+  };
 }
 
 export function createDefaultEquipmentState(playerId: string): PlayerEquipmentState {
@@ -160,18 +320,12 @@ export function normalizeEquipmentState(
     if (!isEquipmentItemId(String(raw.itemId))) continue;
 
     const definition = EQUIPMENT_DEFINITIONS[String(raw.itemId)];
-
-    bySlot.set(definition.slotId, {
-      slotId: definition.slotId,
-      itemId: definition.itemId,
-      title: definition.title,
-      tier: definition.tier,
-    });
+    bySlot.set(definition.slotId, createEquippedSlotFromDefinition(definition));
   }
 
   return {
     playerId,
     schemaVersion: 1,
-    slots: [...bySlot.values()].sort((a, b) => a.slotId.localeCompare(b.slotId)),
+    slots: [...bySlot.values()].sort((a, b) => compareEquipmentSlotIds(a.slotId, b.slotId)),
   };
 }

--- a/server/src/routes/equipmentRoute.ts
+++ b/server/src/routes/equipmentRoute.ts
@@ -17,7 +17,7 @@ import { Router } from "express";
 import { json } from "express";
 import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
 import { equipmentService } from "../equipment/equipmentRuntime.js";
-import { EQUIPMENT_DEFINITIONS } from "../equipment/EquipmentTypes.js";
+import { isEquipmentSlotId } from "../equipment/EquipmentTypes.js";
 import { tickContextProvider } from "../core/are/TickSystemContextProvider.js";
 
 const router = Router();
@@ -141,12 +141,7 @@ router.post("/unequip", async (req, res) => {
     return;
   }
 
-  // Validate slotId is a known equipment slot
-  const validSlots = Object.keys(EQUIPMENT_DEFINITIONS).map(
-    (itemId) => EQUIPMENT_DEFINITIONS[itemId as keyof typeof EQUIPMENT_DEFINITIONS].slotId
-  );
-  const uniqueSlots = [...new Set(validSlots)];
-  if (!uniqueSlots.includes(slotId as any)) {
+  if (!isEquipmentSlotId(slotId)) {
     res.status(400).json({ ok: false, error: "invalid_slot" });
     return;
   }
@@ -154,7 +149,7 @@ router.post("/unequip", async (req, res) => {
   try {
     const result = await equipmentService.unequipItem({
       playerId: identity.playerId,
-      slotId: slotId as any,
+      slotId,
     });
 
     // Phase 11: Include deterministic tick context for Ouroboros integration

--- a/server/src/routes/gameplaySnapshotUtils.ts
+++ b/server/src/routes/gameplaySnapshotUtils.ts
@@ -12,11 +12,14 @@
  * - Empty/null states are honest and allowed
  */
 
-import type { EquipmentSlotId } from "../equipment/EquipmentTypes.js";
+import {
+  EQUIPMENT_DEFINITIONS,
+  EQUIPMENT_SLOT_DEFINITIONS,
+  compareEquipmentSlotIds,
+  type EquipmentNumberEntry,
+  type EquipmentSlotId,
+} from "../equipment/EquipmentTypes.js";
 
-/**
- * Quest Objective shape
- */
 export interface QuestObjectiveSnapshot {
   id: string;
   label: string;
@@ -25,9 +28,6 @@ export interface QuestObjectiveSnapshot {
   completed: boolean;
 }
 
-/**
- * Quest shape
- */
 export interface QuestSnapshot {
   id: string;
   title: string;
@@ -36,9 +36,6 @@ export interface QuestSnapshot {
   objectives: QuestObjectiveSnapshot[];
 }
 
-/**
- * Guild shape
- */
 export interface GuildSnapshot {
   id: string | null;
   name: string | null;
@@ -48,9 +45,6 @@ export interface GuildSnapshot {
   treasury: number | null;
 }
 
-/**
- * Faction Standing shape
- */
 export interface FactionStandingSnapshot {
   id: string;
   name: string;
@@ -58,9 +52,6 @@ export interface FactionStandingSnapshot {
   label: "hostile" | "neutral" | "trusted" | "allied";
 }
 
-/**
- * Skill Snapshot shape
- */
 export interface SkillSnapshot {
   id: string;
   title: string;
@@ -70,9 +61,6 @@ export interface SkillSnapshot {
   progressRatio: number;
 }
 
-/**
- * Map shape
- */
 export interface MapSnapshot {
   regionName: string;
   chunkX: number | null;
@@ -82,9 +70,6 @@ export interface MapSnapshot {
   worldPois: WorldPoiSnapshot[];
 }
 
-/**
- * World POI shape
- */
 export interface WorldPoiSnapshot {
   id: string;
   type: "logging_camp" | "mining_camp" | "fishing_camp" | "campfire" | "furnace" | "workbench" | "village_trader";
@@ -95,9 +80,6 @@ export interface WorldPoiSnapshot {
   tags: readonly string[];
 }
 
-/**
- * Resource Node Snapshot shape
- */
 export interface ResourceNodeSnapshot {
   id: string;
   kind: "tree" | "ore" | "fish_spot";
@@ -114,9 +96,6 @@ export interface ResourceNodeSnapshot {
   remainingTicks: number;
 }
 
-/**
- * Inventory Slot shape (server-authoritative)
- */
 export interface InventorySlotSnapshot {
   slotId: string;
   itemId: string;
@@ -127,9 +106,6 @@ export interface InventorySlotSnapshot {
   maxStack: number;
 }
 
-/**
- * Player Inventory Snapshot shape
- */
 export interface PlayerInventorySnapshot {
   playerId: string;
   schemaVersion: 1;
@@ -137,25 +113,16 @@ export interface PlayerInventorySnapshot {
   capacity: number;
 }
 
-/**
- * Crafting Recipe Ingredient Snapshot shape
- */
 export interface CraftingRecipeIngredientSnapshot {
   itemId: string;
   quantity: number;
 }
 
-/**
- * Crafting Recipe Output Snapshot shape
- */
 export interface CraftingRecipeOutputSnapshot {
   itemId: string;
   quantity: number;
 }
 
-/**
- * Crafting Recipe Snapshot shape
- */
 export interface CraftingRecipeSnapshot {
   id: string;
   title: string;
@@ -169,34 +136,27 @@ export interface CraftingRecipeSnapshot {
   blockedReason?: "level_too_low" | "missing_ingredients" | "station_too_far" | "missing_player_position";
 }
 
-/**
- * Crafting Snapshot shape
- */
 export interface CraftingSnapshot {
   recipes: CraftingRecipeSnapshot[];
 }
 
-/**
- * Equipped Slot Snapshot shape
- */
 export interface EquippedSlotSnapshot {
   slotId: EquipmentSlotId;
   itemId: string;
   title: string;
+  tier?: number;
+  displayId?: string;
+  iconId?: string;
+  stats?: readonly EquipmentNumberEntry[];
+  requirements?: readonly EquipmentNumberEntry[];
 }
 
-/**
- * Player Equipment Snapshot shape
- */
 export interface PlayerEquipmentSnapshot {
   playerId: string;
   schemaVersion: 1;
   slots: EquippedSlotSnapshot[];
 }
 
-/**
- * Character Profile Snapshot shape
- */
 export interface CharacterProfileSnapshot {
   playerId: string;
   characterId: string;
@@ -205,26 +165,21 @@ export interface CharacterProfileSnapshot {
   selected: boolean;
 }
 
-/**
- * Paperdoll Slot Snapshot shape
- */
 export interface PaperdollSlotSnapshot {
-  slotId: string;
+  slotId: EquipmentSlotId;
   itemId: string | null;
   title: string;
+  displayId?: string;
+  iconId?: string;
+  stats?: readonly EquipmentNumberEntry[];
+  requirements?: readonly EquipmentNumberEntry[];
 }
 
-/**
- * Paperdoll Snapshot shape
- */
 export interface PaperdollSnapshot {
   character: CharacterProfileSnapshot | null;
   slots: PaperdollSlotSnapshot[];
 }
 
-/**
- * Live Gameplay Snapshot shape (includes skills, resources, inventory, crafting, equipment, character and paperdoll)
- */
 export interface LiveGameplaySnapshot {
   status: "live";
   serverTick: number;
@@ -241,9 +196,6 @@ export interface LiveGameplaySnapshot {
   map: MapSnapshot;
 }
 
-/**
- * Input for creating a gameplay snapshot (includes skills, resources, inventory, crafting, equipment, character and paperdoll)
- */
 export interface GameplaySnapshotInput {
   serverTick: number;
   character?: CharacterProfileSnapshot | null;
@@ -259,27 +211,80 @@ export interface GameplaySnapshotInput {
   map?: Partial<MapSnapshot>;
 }
 
-/**
- * Create a gameplay snapshot from server-authoritative input.
- * Arrays are sorted by id for deterministic output.
- * Empty/null values are honest and allowed.
- */
+function cloneEntries(entries: readonly EquipmentNumberEntry[] | undefined): readonly EquipmentNumberEntry[] | undefined {
+  return entries ? entries.map((entry) => ({ key: entry.key, value: entry.value })) : undefined;
+}
+
+function enrichPaperdollSlot(slot: PaperdollSlotSnapshot): PaperdollSlotSnapshot {
+  if (slot.itemId === null) return slot;
+  const definition = EQUIPMENT_DEFINITIONS[slot.itemId];
+  const stats = cloneEntries(definition?.stats ?? slot.stats);
+  const requirements = cloneEntries(definition?.requirements ?? slot.requirements);
+
+  return {
+    slotId: slot.slotId,
+    itemId: definition?.itemId ?? slot.itemId,
+    title: definition?.title ?? slot.title,
+    ...(definition?.displayId || slot.displayId ? { displayId: definition?.displayId ?? slot.displayId } : {}),
+    ...(definition?.iconId || slot.iconId ? { iconId: definition?.iconId ?? slot.iconId } : {}),
+    ...(stats ? { stats } : {}),
+    ...(requirements ? { requirements } : {}),
+  };
+}
+
+function normalizePaperdoll(input: PaperdollSnapshot | null | undefined, character: CharacterProfileSnapshot | null | undefined): PaperdollSnapshot {
+  const bySlot = new Map<EquipmentSlotId, PaperdollSlotSnapshot>();
+  for (const slot of input?.slots ?? []) {
+    bySlot.set(slot.slotId, slot);
+  }
+
+  return {
+    character: input?.character ?? character ?? null,
+    slots: EQUIPMENT_SLOT_DEFINITIONS.map((definition) => {
+      const existing = bySlot.get(definition.slotId);
+      return enrichPaperdollSlot(existing ?? {
+        slotId: definition.slotId,
+        itemId: null,
+        title: definition.emptyTitle,
+      });
+    }).sort((a, b) => compareEquipmentSlotIds(a.slotId, b.slotId)),
+  };
+}
+
+function normalizeEquipment(equipment: PlayerEquipmentSnapshot | null | undefined): PlayerEquipmentSnapshot | null {
+  if (!equipment) return null;
+
+  return {
+    ...equipment,
+    slots: [...equipment.slots].sort((a, b) => compareEquipmentSlotIds(a.slotId, b.slotId)).map((slot) => {
+      const definition = EQUIPMENT_DEFINITIONS[slot.itemId];
+      const stats = cloneEntries(definition?.stats ?? slot.stats);
+      const requirements = cloneEntries(definition?.requirements ?? slot.requirements);
+
+      return {
+        slotId: definition?.slotId ?? slot.slotId,
+        itemId: definition?.itemId ?? slot.itemId,
+        title: definition?.title ?? slot.title,
+        ...(definition?.tier ?? slot.tier ? { tier: definition?.tier ?? slot.tier } : {}),
+        ...(definition?.displayId || slot.displayId ? { displayId: definition?.displayId ?? slot.displayId } : {}),
+        ...(definition?.iconId || slot.iconId ? { iconId: definition?.iconId ?? slot.iconId } : {}),
+        ...(stats ? { stats } : {}),
+        ...(requirements ? { requirements } : {}),
+      };
+    }),
+  };
+}
+
 export function createGameplaySnapshot(input: GameplaySnapshotInput): LiveGameplaySnapshot {
   const sortedQuests = [...(input.quests ?? [])].sort((a, b) => a.id.localeCompare(b.id));
   const sortedSkills = [...(input.skills ?? [])].sort((a, b) => a.id.localeCompare(b.id));
   const sortedResources = [...(input.resources ?? [])].sort((a, b) => a.id.localeCompare(b.id));
   const sortedFactions = [...(input.factions ?? [])].sort((a, b) => a.id.localeCompare(b.id));
-
-  // Sort inventory slots by itemId for deterministic output
   const sortedSlots = [...(input.inventory?.slots ?? [])].sort((a, b) => a.itemId.localeCompare(b.itemId));
-
-  // Sort crafting recipes by id for deterministic output
   const sortedRecipes = [...(input.crafting?.recipes ?? [])].sort((a, b) => a.id.localeCompare(b.id));
+  const paperdoll = normalizePaperdoll(input.paperdoll, input.character);
+  const equipment = normalizeEquipment(input.equipment);
 
-  // Sort paperdoll slots by slotId for deterministic output
-  const sortedPaperdollSlots = [...(input.paperdoll?.slots ?? [])].sort((a, b) => a.slotId.localeCompare(b.slotId));
-
-  // Sort world POIs by id for deterministic output
   const sortedWorldPois: WorldPoiSnapshot[] = [...(input.map?.worldPois ?? [])].sort((a, b) => a.id.localeCompare(b.id)).map(poi => ({
     ...poi,
     tags: [...poi.tags] as readonly string[],
@@ -289,14 +294,11 @@ export function createGameplaySnapshot(input: GameplaySnapshotInput): LiveGamepl
     status: "live",
     serverTick: input.serverTick,
     character: input.character ?? null,
-    paperdoll: input.paperdoll ?? {
-      character: null,
-      slots: sortedPaperdollSlots,
-    },
+    paperdoll,
     quests: sortedQuests,
     skills: sortedSkills,
     resources: sortedResources,
-    inventory: input.inventory ?? {
+    inventory: input.inventory ? { ...input.inventory, slots: sortedSlots } : {
       playerId: "unknown",
       schemaVersion: 1,
       slots: sortedSlots,
@@ -305,7 +307,7 @@ export function createGameplaySnapshot(input: GameplaySnapshotInput): LiveGamepl
     crafting: {
       recipes: sortedRecipes,
     },
-    equipment: input.equipment ?? null,
+    equipment,
     guild: input.guild ?? {
       id: null,
       name: null,
@@ -326,11 +328,6 @@ export function createGameplaySnapshot(input: GameplaySnapshotInput): LiveGamepl
   };
 }
 
-/**
- * Create an empty gameplay snapshot.
- * Used when server is available but no gameplay data exists yet.
- * status="empty" indicates server is reachable but no data.
- */
 export function createEmptyGameplaySnapshot(serverTick: number): LiveGameplaySnapshot {
   return createGameplaySnapshot({
     serverTick,

--- a/server/src/tests/paperdoll-game-data.test.ts
+++ b/server/src/tests/paperdoll-game-data.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { createPaperdollSnapshot } from "../character/PaperdollTypes.js";
+import {
+  EQUIPMENT_DEFINITIONS,
+  EQUIPMENT_SLOT_IDS,
+  type PlayerEquipmentState,
+} from "../equipment/EquipmentTypes.js";
+import { createGameplaySnapshot, type PaperdollSnapshot } from "../routes/gameplaySnapshotUtils.js";
+
+describe("Paperdoll game-data truth path", () => {
+  it("loads canonical slot order from game-data", () => {
+    expect([...EQUIPMENT_SLOT_IDS]).toEqual([
+      "weapon",
+      "helmet",
+      "armor",
+      "boots",
+      "ring",
+      "amulet",
+      "woodcutting_tool",
+      "mining_tool",
+      "fishing_tool",
+    ]);
+  });
+
+  it("creates explicit empty slots and enriches equipped slots from authored game-data", () => {
+    const equipment: PlayerEquipmentState = {
+      playerId: "player-paperdoll",
+      schemaVersion: 1,
+      slots: [
+        {
+          slotId: "fishing_tool",
+          itemId: "simple_fishing_rod",
+          title: "Client Cannot Override This",
+          tier: 1,
+        },
+      ],
+    };
+
+    const snapshot = createPaperdollSnapshot({ character: null, equipment });
+
+    expect(snapshot.slots.map((slot) => slot.slotId)).toEqual([...EQUIPMENT_SLOT_IDS]);
+    expect(snapshot.slots.find((slot) => slot.slotId === "weapon")).toEqual({
+      slotId: "weapon",
+      itemId: null,
+      title: "Empty Weapon Slot",
+    });
+
+    const fishingSlot = snapshot.slots.find((slot) => slot.slotId === "fishing_tool");
+    expect(fishingSlot).toMatchObject({
+      slotId: "fishing_tool",
+      itemId: "simple_fishing_rod",
+      title: "Simple Fishing Rod",
+      displayId: "equipment.simple_fishing_rod",
+      iconId: "item.simple_fishing_rod",
+    });
+    expect(fishingSlot?.stats?.some((entry) => entry.key === "fishing_xp_permille" && entry.value === 1100)).toBe(true);
+  });
+
+  it("normalizes paperdoll slots inside gameplay snapshots instead of returning unsorted input", () => {
+    const inputPaperdoll: PaperdollSnapshot = {
+      character: null,
+      slots: [
+        {
+          slotId: "fishing_tool",
+          itemId: "simple_fishing_rod",
+          title: "Input Title Should Not Win",
+        },
+        {
+          slotId: "weapon",
+          itemId: null,
+          title: "Input Empty Weapon Label Should Not Win",
+        },
+      ],
+    };
+
+    const snapshot = createGameplaySnapshot({
+      serverTick: 100,
+      paperdoll: inputPaperdoll,
+      quests: [],
+      guild: null,
+      factions: [],
+      map: {},
+    });
+
+    expect(snapshot.paperdoll).not.toBe(inputPaperdoll);
+    expect(snapshot.paperdoll.slots.map((slot) => slot.slotId)).toEqual([...EQUIPMENT_SLOT_IDS]);
+    expect(snapshot.paperdoll.slots.find((slot) => slot.slotId === "weapon")).toEqual({
+      slotId: "weapon",
+      itemId: null,
+      title: "Empty Weapon Slot",
+    });
+    expect(snapshot.paperdoll.slots.find((slot) => slot.slotId === "fishing_tool")).toMatchObject({
+      itemId: "simple_fishing_rod",
+      title: "Simple Fishing Rod",
+      displayId: "equipment.simple_fishing_rod",
+      iconId: "item.simple_fishing_rod",
+    });
+  });
+
+  it("sorts equipment slots by canonical slot order and keeps authored metadata", () => {
+    const snapshot = createGameplaySnapshot({
+      serverTick: 100,
+      equipment: {
+        playerId: "player-equipment",
+        schemaVersion: 1,
+        slots: [
+          {
+            slotId: "fishing_tool",
+            itemId: "simple_fishing_rod",
+            title: "Simple Fishing Rod",
+          },
+          {
+            slotId: "woodcutting_tool",
+            itemId: "wooden_axe",
+            title: "Wooden Axe",
+          },
+        ],
+      },
+      quests: [],
+      guild: null,
+      factions: [],
+      map: {},
+    });
+
+    expect(snapshot.equipment?.slots.map((slot) => slot.slotId)).toEqual([
+      "woodcutting_tool",
+      "fishing_tool",
+    ]);
+    expect(snapshot.equipment?.slots[0]).toMatchObject({
+      itemId: "wooden_axe",
+      title: EQUIPMENT_DEFINITIONS.wooden_axe.title,
+      displayId: "equipment.wooden_axe",
+      iconId: "item.wooden_axe",
+      tier: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Ziel

Advance #1974 with a real server-backed Paperdoll/Equipment truth path rooted in `game-data`, not UI-only state.

## Änderungen

- Adds canonical equipment slots to `game-data/equipment/equipment-slots.json`.
- Adds authored equipment metadata to `game-data/equipment/equipment-items.json`.
- Loads equipment slot/item definitions through the existing content data root.
- Builds Paperdoll snapshots from canonical slot definitions with explicit empty slots.
- Normalizes gameplay snapshot `paperdoll` and `equipment` output instead of returning unsorted input objects.
- Preserves authored display/icon/stat/requirement metadata in server runtime equipment slots.
- Validates unequip slot IDs against canonical equipment slots.
- Updates PaperdollPanel to render all server-backed slot IDs without client truth.
- Documents the game-data authoring path.
- Adds deterministic server tests for game-data-backed Paperdoll normalization.

## ARE Green-State Notes

- No mock paperdoll data added.
- No fake snapshot path added.
- No client-authoritative equipment truth added.
- Empty slots are explicit and deterministic.
- Authored equipment truth now lives in `game-data/equipment` and is consumed by server runtime code.

## Tests

Not run locally in this connector environment. CI should run on this PR.