### PR TITLE
fix(tick): integrate deterministic core tick registration

### DIFF
--- a/docs/TICK_SYSTEM_REGISTRY.md
+++ b/docs/TICK_SYSTEM_REGISTRY.md
@@ -1,0 +1,43 @@
+# Tick System Registry Truth Path
+
+## Purpose
+
+The ARE runtime tick path uses `WorldTickThinShell` as a 10-Hz coordinator. Domain logic must run through registered `TickSystem` implementations, not through ad-hoc imports inside the tick loop.
+
+## Runtime Contract
+
+- `WorldTickThinShell` owns the 100 ms cadence.
+- `TickSystemRegistry` owns deterministic execution order.
+- Core tick systems are registered through `registerCoreTickSystems()`.
+- Registration is idempotent per registry instance.
+- Equal-priority systems are ordered by stable system identity (`id`/`name`).
+- `WorldStateProvider` remains the runtime source for world slices.
+- No empty world-state fallback is allowed in the truth path.
+
+## Core Registration Order
+
+Current core bootstrap order:
+
+1. `oracle`
+2. `ouroboros`
+
+Execution order is still controlled by priority first, then stable identity. This means bootstrap order is not used as hidden scheduler behavior.
+
+## Registered Core Systems
+
+| System | Runtime Source | Priority | Notes |
+|--------|----------------|----------|-------|
+| `oracle` | `server/src/core/are/OracleTickSystem.ts` | `INFRASTRUCTURE` | Reads tick context world state and produces oracle report/prophecies |
+| `ouroboros` | `server/src/core/are/OuroborosTickSystem.ts` | `NPC` | Runs on 10-tick heartbeat cadence and reads NPC/player slices from tick context |
+
+## Validation
+
+Covered by:
+
+- `server/src/core/WorldTickPolicy.guard.ts`
+- `server/src/core/are/__tests__/TickSystemRegistration.test.ts`
+- `TickSystemRegistry.getRegistrationSnapshot()` for deterministic inspection
+
+## Non-Goals
+
+This PR does not move `WorldBrainScheduler` into the registry yet. `WorldTickThinShell` already runs it directly as part of the existing world-brain truth path. Moving it into a `WorldBrainTickSystem` should be a separate PR with canonical state ports and snapshot sinks wired to real runtime sources.

--- a/server/src/core/are/CoreTickSystemRegistration.ts
+++ b/server/src/core/are/CoreTickSystemRegistration.ts
@@ -1,0 +1,97 @@
+import {
+  ORACLE_TICK_SYSTEM_NAME,
+  registerOracleTickSystem,
+  type OracleTickSystemOptions,
+} from './OracleTickSystem.js';
+import {
+  OUROBOROS_TICK_SYSTEM_NAME,
+  registerOuroborosTickSystem,
+  type OuroborosTickSystemOptions,
+} from './OuroborosTickSystem.js';
+import { tickSystemRegistry, type TickSystemRegistry } from './TickSystemRegistry.js';
+import { sharedWorldEventBus } from '../../modules/ouroboros/sharedWorldEventBus.js';
+
+export const CORE_TICK_SYSTEM_REGISTRATION_ORDER = Object.freeze([
+  ORACLE_TICK_SYSTEM_NAME,
+  OUROBOROS_TICK_SYSTEM_NAME,
+] as const);
+
+export type CoreTickSystemName = typeof CORE_TICK_SYSTEM_REGISTRATION_ORDER[number];
+
+export interface CoreTickSystemRegistrationOptions {
+  readonly oracle?: OracleTickSystemOptions;
+  readonly ouroboros?: OuroborosTickSystemOptions;
+}
+
+export interface CoreTickSystemRegistrationResult {
+  readonly registered: readonly CoreTickSystemName[];
+  readonly alreadyRegistered: readonly CoreTickSystemName[];
+  readonly order: readonly CoreTickSystemName[];
+}
+
+function registerIfMissing(
+  registry: TickSystemRegistry,
+  name: CoreTickSystemName,
+  register: () => void,
+  registered: CoreTickSystemName[],
+  alreadyRegistered: CoreTickSystemName[],
+): void {
+  if (registry.has(name)) {
+    alreadyRegistered.push(name);
+    return;
+  }
+
+  register();
+  registered.push(name);
+}
+
+/**
+ * Registers the core ARE TickSystems exactly once.
+ *
+ * This is the runtime truth entrypoint used by WorldTickThinShell. It avoids
+ * constructor-side duplicate registration while preserving deterministic order.
+ */
+export function registerCoreTickSystems(
+  options: CoreTickSystemRegistrationOptions = {},
+  registry: TickSystemRegistry = tickSystemRegistry,
+): CoreTickSystemRegistrationResult {
+  const registered: CoreTickSystemName[] = [];
+  const alreadyRegistered: CoreTickSystemName[] = [];
+
+  registerIfMissing(
+    registry,
+    ORACLE_TICK_SYSTEM_NAME,
+    () => registerOracleTickSystem({
+      tickInterval: 10,
+      minRecordsForAnalysis: 6,
+      maxStoredRecords: 240,
+      eventBus: sharedWorldEventBus,
+      ...options.oracle,
+    }, registry),
+    registered,
+    alreadyRegistered,
+  );
+
+  registerIfMissing(
+    registry,
+    OUROBOROS_TICK_SYSTEM_NAME,
+    () => registerOuroborosTickSystem({
+      engineConfig: {
+        tickInterval: 10,
+        conflictCheckInterval: 100,
+        enableNPCBrain: true,
+        npcBrainInterval: 10,
+        ...options.ouroboros?.engineConfig,
+      },
+      ...options.ouroboros,
+    }, registry),
+    registered,
+    alreadyRegistered,
+  );
+
+  return Object.freeze({
+    registered: Object.freeze([...registered]),
+    alreadyRegistered: Object.freeze([...alreadyRegistered]),
+    order: CORE_TICK_SYSTEM_REGISTRATION_ORDER,
+  });
+}

--- a/server/src/core/are/CoreTickSystemRegistration.ts
+++ b/server/src/core/are/CoreTickSystemRegistration.ts
@@ -76,6 +76,7 @@ export function registerCoreTickSystems(
     registry,
     OUROBOROS_TICK_SYSTEM_NAME,
     () => registerOuroborosTickSystem({
+      ...options.ouroboros,
       engineConfig: {
         tickInterval: 10,
         conflictCheckInterval: 100,
@@ -83,7 +84,6 @@ export function registerCoreTickSystems(
         npcBrainInterval: 10,
         ...options.ouroboros?.engineConfig,
       },
-      ...options.ouroboros,
     }, registry),
     registered,
     alreadyRegistered,

--- a/server/src/core/are/TickSystemRegistry.ts
+++ b/server/src/core/are/TickSystemRegistry.ts
@@ -1,22 +1,8 @@
 /**
  * TickSystemRegistry - Central registry for all ARE tick systems
- * 
- * Phase 2 of the Core Reality Alignment initiative.
- * 
- * This registry replaces the direct domain imports in WorldTick.ts with
- * a decoupled pattern where systems register themselves and WorldTick
- * iterates the registry to execute ticks.
- * 
- * Architecture:
- * 1. Systems register via TickSystemRegistry.register()
- * 2. WorldTick.tick() calls registry.executeAll(context)
- * 3. Registry sorts by priority and calls each system's tick()
- * 
- * Benefits:
- * - WorldTick no longer needs to import domain systems
- * - Systems can be enabled/disabled at runtime
- * - Execution order is explicit via priority
- * - Testing can mock or replace individual systems
+ *
+ * Systems register themselves once. WorldTickThinShell executes the registry in
+ * deterministic order: priority first, then stable system identity.
  */
 
 import type { TickSystem, TickSystemDescriptor, TickSystemContext, TickSystemPriority } from './TickSystem.js';
@@ -33,40 +19,80 @@ export type TickSystemRegistryEvent =
   | { type: 'tick_end'; tick: number; durationMs: number }
   | { type: 'system_error'; system: string; error: Error };
 
+export interface TickSystemRegistrySnapshotEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly priority: TickSystemPriority;
+  readonly enabled: boolean;
+  readonly dependencies: readonly string[];
+  readonly tags: readonly string[];
+}
+
+function systemIdentity(system: TickSystem): string {
+  const id = typeof system.id === 'string' && system.id.trim().length > 0
+    ? system.id.trim()
+    : system.name.trim();
+  return id;
+}
+
+function normalizeDescriptor(descriptor: TickSystemDescriptor): TickSystemDescriptor {
+  const { system } = descriptor;
+  const name = typeof system.name === 'string' ? system.name.trim() : '';
+  const id = systemIdentity(system);
+
+  if (name.length === 0) {
+    throw new Error('TickSystem requires a stable non-empty name');
+  }
+
+  if (id.length === 0) {
+    throw new Error(`TickSystem "${name}" requires a stable non-empty id/name`);
+  }
+
+  if (!Number.isFinite(Number(system.priority))) {
+    throw new Error(`TickSystem "${name}" requires a finite numeric priority`);
+  }
+
+  return {
+    system,
+    dependencies: [...descriptor.dependencies].map(String).sort(),
+    tags: [...descriptor.tags].map(String).sort(),
+  };
+}
+
+function compareDescriptors(a: TickSystemDescriptor, b: TickSystemDescriptor): number {
+  const byPriority = Number(a.system.priority) - Number(b.system.priority);
+  if (byPriority !== 0) return byPriority;
+
+  const byId = systemIdentity(a.system).localeCompare(systemIdentity(b.system));
+  if (byId !== 0) return byId;
+
+  return a.system.name.localeCompare(b.system.name);
+}
+
 /**
  * TickSystemRegistry maintains all registered tick systems and orchestrates execution.
  */
 export class TickSystemRegistry {
   private systems: Map<string, TickSystemDescriptor> = new Map();
   private sortedSystems: TickSystemDescriptor[] = [];
-  private dirty = true; // Marks when sorting needs to be recalculated
+  private dirty = true;
   private listeners: Set<(event: TickSystemRegistryEvent) => void> = new Set();
   private tickDuration = 0;
 
   /**
    * Register a tick system with the registry.
-   * 
-   * @param descriptor - The system descriptor containing the system and its metadata
-   * 
-   * @example
-   * ```typescript
-   * registry.register({
-   *   system: combatSystem,
-   *   dependencies: ['player-system'],
-   *   tags: ['combat', 'damage']
-   * });
-   * ```
    */
   register(descriptor: TickSystemDescriptor): void {
-    const { system } = descriptor;
-    
+    const normalized = normalizeDescriptor(descriptor);
+    const { system } = normalized;
+
     if (this.systems.has(system.name)) {
       console.warn(`[TickSystemRegistry] System "${system.name}" already registered, replacing.`);
     }
-    
-    this.systems.set(system.name, descriptor);
+
+    this.systems.set(system.name, normalized);
     this.dirty = true;
-    
+
     this.emit({ type: 'registered', system: system.name, priority: system.priority });
   }
 
@@ -90,7 +116,14 @@ export class TickSystemRegistry {
   }
 
   /**
-   * Get all registered systems.
+   * Check whether a system is registered.
+   */
+  has(systemName: string): boolean {
+    return this.systems.has(systemName);
+  }
+
+  /**
+   * Get all registered systems in deterministic execution order.
    */
   getAll(): TickSystem[] {
     this.rebuildSortedList();
@@ -98,7 +131,7 @@ export class TickSystemRegistry {
   }
 
   /**
-   * Get systems by tag.
+   * Get systems by tag in deterministic execution order.
    */
   getByTag(tag: string): TickSystem[] {
     this.rebuildSortedList();
@@ -108,12 +141,27 @@ export class TickSystemRegistry {
   }
 
   /**
+   * Deterministic registry snapshot for probes, tests and docs.
+   */
+  getRegistrationSnapshot(): readonly TickSystemRegistrySnapshotEntry[] {
+    this.rebuildSortedList();
+    return Object.freeze(this.sortedSystems.map((descriptor) => Object.freeze({
+      id: systemIdentity(descriptor.system),
+      name: descriptor.system.name,
+      priority: descriptor.system.priority,
+      enabled: descriptor.system.enabled,
+      dependencies: Object.freeze([...descriptor.dependencies]),
+      tags: Object.freeze([...descriptor.tags]),
+    })));
+  }
+
+  /**
    * Enable a system by name.
    */
   enable(systemName: string): boolean {
     const descriptor = this.systems.get(systemName);
     if (!descriptor) return false;
-    
+
     descriptor.system.enabled = true;
     this.emit({ type: 'enabled', system: systemName });
     return true;
@@ -125,7 +173,7 @@ export class TickSystemRegistry {
   disable(systemName: string): boolean {
     const descriptor = this.systems.get(systemName);
     if (!descriptor) return false;
-    
+
     descriptor.system.enabled = false;
     this.emit({ type: 'disabled', system: systemName });
     return true;
@@ -139,21 +187,19 @@ export class TickSystemRegistry {
   }
 
   /**
-   * Execute all enabled systems in priority order.
-   * 
-   * @param context - The tick context passed to each system
+   * Execute all enabled systems in deterministic priority/id order.
    */
   executeAll(context: TickSystemContext): void {
     this.rebuildSortedList();
-    
+
     const start = performance.now();
     this.emit({ type: 'tick_start', tick: context.tickCount });
-    
+
     for (const descriptor of this.sortedSystems) {
       const { system } = descriptor;
-      
+
       if (!system.enabled) continue;
-      
+
       try {
         system.tick(context);
       } catch (error) {
@@ -161,17 +207,18 @@ export class TickSystemRegistry {
         this.emit({ type: 'system_error', system: system.name, error: error as Error });
       }
     }
-    
+
     const end = performance.now();
     this.tickDuration = end - start;
     this.emit({ type: 'tick_end', tick: context.tickCount, durationMs: this.tickDuration });
   }
 
   /**
-   * Call onStart() for all systems that implement it.
+   * Call onStart() for all systems that implement it in deterministic order.
    */
   notifyStart(): void {
-    for (const descriptor of this.systems.values()) {
+    this.rebuildSortedList();
+    for (const descriptor of this.sortedSystems) {
       const { system } = descriptor;
       if (system.onStart) {
         try {
@@ -184,10 +231,11 @@ export class TickSystemRegistry {
   }
 
   /**
-   * Call onEnd() for all systems that implement it.
+   * Call onEnd() for all systems that implement it in deterministic order.
    */
   notifyEnd(): void {
-    for (const descriptor of this.systems.values()) {
+    this.rebuildSortedList();
+    for (const descriptor of this.sortedSystems) {
       const { system } = descriptor;
       if (system.onEnd) {
         try {
@@ -200,10 +248,11 @@ export class TickSystemRegistry {
   }
 
   /**
-   * Call onShutdown() for all systems that implement it.
+   * Call onShutdown() for all systems that implement it in deterministic order.
    */
   notifyShutdown(): void {
-    for (const descriptor of this.systems.values()) {
+    this.rebuildSortedList();
+    for (const descriptor of this.sortedSystems) {
       const { system } = descriptor;
       if (system.onShutdown) {
         try {
@@ -228,17 +277,16 @@ export class TickSystemRegistry {
     const systemsByPriority: Record<number, string[]> = {};
     let enabled = 0;
     let disabled = 0;
-    
-    for (const descriptor of this.systems.values()) {
-      const { system } = descriptor;
-      const p = system.priority;
+
+    for (const descriptor of this.getRegistrationSnapshot()) {
+      const p = Number(descriptor.priority);
       if (!systemsByPriority[p]) systemsByPriority[p] = [];
-      systemsByPriority[p].push(system.name);
-      
-      if (system.enabled) enabled++;
+      systemsByPriority[p].push(descriptor.name);
+
+      if (descriptor.enabled) enabled++;
       else disabled++;
     }
-    
+
     return {
       totalSystems: this.systems.size,
       enabledSystems: enabled,
@@ -268,10 +316,8 @@ export class TickSystemRegistry {
 
   private rebuildSortedList(): void {
     if (!this.dirty) return;
-    
-    this.sortedSystems = Array.from(this.systems.values())
-      .sort((a, b) => a.system.priority - b.system.priority);
-    
+
+    this.sortedSystems = Array.from(this.systems.values()).sort(compareDescriptors);
     this.dirty = false;
   }
 }

--- a/server/src/core/are/WorldTickThinShell.ts
+++ b/server/src/core/are/WorldTickThinShell.ts
@@ -15,10 +15,8 @@ import { createDefaultTickContext, type TickSystemContext } from "./TickSystem.j
 import { WorldBrainScheduler } from "./WorldBrainScheduler.js";
 import { SnapshotComposer } from "./SnapshotComposer.js";
 import { LayerPersistenceQueue, layerPersistenceQueue } from "./LayerPersistenceQueue.js";
-import { registerOuroborosTickSystem } from "./OuroborosTickSystem.js";
-import { registerOracleTickSystem } from "./OracleTickSystem.js";
+import { registerCoreTickSystems } from "./CoreTickSystemRegistration.js";
 import { stableSort } from "./DeterministicEventFactory.js";
-import { sharedWorldEventBus } from "../../modules/ouroboros/sharedWorldEventBus.js";
 
 /**
  * World state slice provided by a single provider.
@@ -117,21 +115,7 @@ export class WorldTickThinShell {
     this.snapshotComposer = new SnapshotComposer();
     this.persistenceQueue = layerPersistenceQueue;
 
-    registerOuroborosTickSystem({
-      engineConfig: {
-        tickInterval: 10,
-        conflictCheckInterval: 100,
-        enableNPCBrain: true,
-        npcBrainInterval: 10,
-      },
-    });
-
-    registerOracleTickSystem({
-      tickInterval: 10,
-      minRecordsForAnalysis: 6,
-      maxStoredRecords: 240,
-      eventBus: sharedWorldEventBus,
-    });
+    registerCoreTickSystems();
   }
 
   start(): void {

--- a/server/src/core/are/__tests__/TickSystemRegistration.test.ts
+++ b/server/src/core/are/__tests__/TickSystemRegistration.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { registerCoreTickSystems } from '../CoreTickSystemRegistration.js';
+import { OUROBOROS_TICK_SYSTEM_NAME } from '../OuroborosTickSystem.js';
+import { ORACLE_TICK_SYSTEM_NAME } from '../OracleTickSystem.js';
+import { createDefaultTickContext, TickSystemPriority, type TickSystem } from '../TickSystem.js';
+import { TickSystemRegistry } from '../TickSystemRegistry.js';
+
+function createRecordingSystem(
+  name: string,
+  priority: TickSystemPriority,
+  calls: string[],
+): TickSystem {
+  return {
+    id: name,
+    name,
+    priority,
+    enabled: true,
+    tick(): void {
+      calls.push(name);
+    },
+  };
+}
+
+describe('TickSystem registration truth', () => {
+  it('executes equal-priority systems by stable id/name order', () => {
+    const calls: string[] = [];
+    const registry = new TickSystemRegistry();
+
+    registry.register({
+      system: createRecordingSystem('system-beta', TickSystemPriority.NORMAL, calls),
+      dependencies: ['zeta', 'alpha'],
+      tags: ['runtime', 'tick'],
+    });
+
+    registry.register({
+      system: createRecordingSystem('system-alpha', TickSystemPriority.NORMAL, calls),
+      dependencies: ['input'],
+      tags: ['tick'],
+    });
+
+    registry.executeAll(createDefaultTickContext(1));
+
+    expect(calls).toEqual(['system-alpha', 'system-beta']);
+    expect(registry.getRegistrationSnapshot().map((entry) => entry.name)).toEqual([
+      'system-alpha',
+      'system-beta',
+    ]);
+    expect(registry.getRegistrationSnapshot()[1].dependencies).toEqual(['alpha', 'zeta']);
+  });
+
+  it('registers core tick systems once per registry', () => {
+    const registry = new TickSystemRegistry();
+
+    const first = registerCoreTickSystems({}, registry);
+    const second = registerCoreTickSystems({}, registry);
+
+    expect(first.registered).toEqual([ORACLE_TICK_SYSTEM_NAME, OUROBOROS_TICK_SYSTEM_NAME]);
+    expect(first.alreadyRegistered).toEqual([]);
+    expect(second.registered).toEqual([]);
+    expect(second.alreadyRegistered).toEqual([ORACLE_TICK_SYSTEM_NAME, OUROBOROS_TICK_SYSTEM_NAME]);
+
+    expect(registry.getRegistrationSnapshot().map((entry) => entry.name)).toEqual([
+      ORACLE_TICK_SYSTEM_NAME,
+      OUROBOROS_TICK_SYSTEM_NAME,
+    ]);
+  });
+});

--- a/server/src/core/are/index.ts
+++ b/server/src/core/are/index.ts
@@ -92,6 +92,7 @@ export {
   TickSystemRegistry,
   tickSystemRegistry,
   type TickSystemRegistryEvent,
+  type TickSystemRegistrySnapshotEntry,
 } from './TickSystemRegistry.js';
 
 // Pre-built TickSystem Implementations
@@ -254,6 +255,15 @@ export {
   type OracleCriticalEvent,
   type OracleRecommendation,
 } from './OracleTickSystem.js';
+
+// Phase 11: Core TickSystem registration bootstrap
+export {
+  CORE_TICK_SYSTEM_REGISTRATION_ORDER,
+  registerCoreTickSystems,
+  type CoreTickSystemName,
+  type CoreTickSystemRegistrationOptions,
+  type CoreTickSystemRegistrationResult,
+} from './CoreTickSystemRegistration.js';
 
 // Phase 11: WorldTickScheduler - Thin scheduler without wall-clock dependencies
 export {


### PR DESCRIPTION
## Summary

This PR starts #2009 TickSystem Registration Integration after the #2008 route-truth merge.

It moves core TickSystem bootstrapping out of `WorldTickThinShell` constructor details and into a dedicated deterministic registration entrypoint.

## Changes

| File | Change |
|------|--------|
| `server/src/core/are/TickSystemRegistry.ts` | Adds deterministic priority + id/name ordering, stable registration snapshots, `has()` lookup, sorted lifecycle notifications |
| `server/src/core/are/CoreTickSystemRegistration.ts` | New idempotent runtime bootstrap for core systems |
| `server/src/core/are/WorldTickThinShell.ts` | Uses `registerCoreTickSystems()` instead of directly registering Oracle/Ouroboros |
| `server/src/core/are/index.ts` | Exports registration bootstrap and snapshot type |
| `server/src/core/are/__tests__/TickSystemRegistration.test.ts` | Covers deterministic equal-priority order and idempotent core registration |
| `docs/TICK_SYSTEM_REGISTRY.md` | Documents TickSystem truth path and non-goals |

## Runtime Truth

- No mock TickSystem is mounted in production.
- Core registration remains Oracle + Ouroboros only.
- Registration is idempotent per registry instance.
- Equal-priority systems no longer depend on Map insertion order.
- WorldBrain is deliberately not moved into registry in this PR to avoid double-running existing world-brain truth logic.

## Acceptance Criteria

- [x] `WorldTickThinShell` still owns 100ms cadence.
- [x] `TickSystemRegistry.executeAll()` keeps deterministic execution order.
- [x] Oracle/Ouroboros core systems are registered once.
- [x] Duplicate ThinShell construction does not duplicate core systems.
- [x] Unit coverage added for order/idempotency.
- [x] Docs added for current TickSystem truth path.

## Follow-up

Next PR should wire `WorldBrainTickSystem` only after canonical state ports and snapshot sinks are connected to real runtime sources.