### PR TITLE
fix(worldbrain): wire runtime truth through tick registry

### DIFF
--- a/docs/TICK_SYSTEM_REGISTRY.md
+++ b/docs/TICK_SYSTEM_REGISTRY.md
@@ -2,33 +2,39 @@
 
 ## Purpose
 
-The ARE runtime tick path uses `WorldTickThinShell` as a 10-Hz coordinator. Domain logic must run through registered `TickSystem` implementations, not through ad-hoc imports inside the tick loop.
+The ARE runtime tick path uses `WorldTickThinShell` as a 10-Hz coordinator. Domain logic runs through registered `TickSystem` implementations instead of ad-hoc calls inside the tick loop.
 
 ## Runtime Contract
 
 - `WorldTickThinShell` owns the 100 ms cadence.
 - `TickSystemRegistry` owns deterministic execution order.
 - Core tick systems are registered through `registerCoreTickSystems()`.
-- Registration is idempotent per registry instance.
+- `WorldBrainTickSystem` is registered by `WorldTickThinShell` with runtime ports.
 - Equal-priority systems are ordered by stable system identity (`id`/`name`).
-- `WorldStateProvider` remains the runtime source for world slices.
+- `WorldStateProvider` remains the source for tick context world slices.
+- `RuntimeWorldBrainStatePort` remains the source for active world-brain chunks and 13-layer state.
 - No empty world-state fallback is allowed in the truth path.
 
-## Core Registration Order
-
-Current core bootstrap order:
-
-1. `oracle`
-2. `ouroboros`
-
-Execution order is still controlled by priority first, then stable identity. This means bootstrap order is not used as hidden scheduler behavior.
-
-## Registered Core Systems
+## Registered Runtime Systems
 
 | System | Runtime Source | Priority | Notes |
 |--------|----------------|----------|-------|
 | `oracle` | `server/src/core/are/OracleTickSystem.ts` | `INFRASTRUCTURE` | Reads tick context world state and produces oracle report/prophecies |
 | `ouroboros` | `server/src/core/are/OuroborosTickSystem.ts` | `NPC` | Runs on 10-tick heartbeat cadence and reads NPC/player slices from tick context |
+| `world-brain` | `server/src/core/are/WorldBrainTickSystem.ts` + `WorldBrainRuntimePort.ts` | `25` | Reads active chunks/layers, commits deterministic deltas, writes snapshots to `SnapshotComposer`, and records replay/persistence through `LayerPersistenceQueue` |
+
+## WorldBrain Runtime Chain
+
+```text
+WorldTickThinShell.tick()
+  -> create TickSystemContext
+  -> merge WorldStateProvider slices
+  -> TickSystemRegistry.executeAll(context)
+  -> WorldBrainTickSystem.tick(context)
+  -> RuntimeWorldBrainStatePort.commitWorldBrainDelta(delta)
+  -> SnapshotComposerWorldBrainSink.includeWorldBrainChunk(...)
+  -> LayerPersistenceWorldBrainReplaySink.recordWorldBrainDelta(...)
+```
 
 ## Validation
 
@@ -36,8 +42,9 @@ Covered by:
 
 - `server/src/core/WorldTickPolicy.guard.ts`
 - `server/src/core/are/__tests__/TickSystemRegistration.test.ts`
+- `server/src/core/are/__tests__/WorldBrainRuntimeTruth.test.ts`
 - `TickSystemRegistry.getRegistrationSnapshot()` for deterministic inspection
 
 ## Non-Goals
 
-This PR does not move `WorldBrainScheduler` into the registry yet. `WorldTickThinShell` already runs it directly as part of the existing world-brain truth path. Moving it into a `WorldBrainTickSystem` should be a separate PR with canonical state ports and snapshot sinks wired to real runtime sources.
+This PR does not add blocking persistence I/O to the tick path. `LayerPersistenceQueue` remains write-behind and non-blocking. Chunks become active through `WorldTickThinShell.registerChunk()` and evolve through deterministic `WorldBrainTickSystem` deltas.

--- a/server/src/core/are/WorldBrainRuntimePort.ts
+++ b/server/src/core/are/WorldBrainRuntimePort.ts
@@ -1,0 +1,190 @@
+import type { ChunkKey, StateHash, TickId, Kappa, KappaInt } from './types.js';
+import { createKappa, createStateHash } from './types.js';
+import {
+  ATTRACTOR_TYPES,
+  ChunkLayerIndex,
+  createEmptyLayerState,
+  type ChunkLayerState,
+  type OmegaAttractorState,
+  type WorldBrainSnapshot,
+} from './ChunkLayerState.js';
+import type { IARELogicLayers } from './IARELogicLayers.js';
+import {
+  createLayerPersistenceEvent,
+  type LayerPersistenceQueue,
+} from './LayerPersistenceQueue.js';
+import type {
+  WorldBrainCanonicalStatePort,
+  WorldBrainDelta,
+  WorldBrainReplaySink,
+} from './WorldBrainTickSystem.js';
+
+const ZERO_STATE_HASH = createStateHash('0'.repeat(64));
+
+function toKappa(value: KappaInt): Kappa {
+  return createKappa(Number(value));
+}
+
+function toKappaInt(value: Kappa): KappaInt {
+  return Number(value) as KappaInt;
+}
+
+export function chunkLayerStateToIARELayers(state: ChunkLayerState): IARELogicLayers {
+  return Object.freeze({
+    ecology: toKappaInt(state.ecology),
+    market: toKappaInt(state.economy),
+    physiology: toKappaInt(state.npc_vitality),
+    trade: toKappaInt(state.trade),
+    memory: toKappaInt(state.social_memory),
+    politics: toKappaInt(state.politics),
+    conflict: toKappaInt(state.aggression),
+    economy: toKappaInt(state.conjuncture),
+    kingdoms: toKappaInt(state.kingdom),
+    faith: toKappaInt(state.faith),
+    dungeon: toKappaInt(state.dungeon),
+    fear: toKappaInt(state.fear),
+    cycles: toKappaInt(state.resurrection),
+  });
+}
+
+export function iareLayersToChunkLayerState(layers: IARELogicLayers): ChunkLayerState {
+  return {
+    ecology: toKappa(layers.ecology),
+    economy: toKappa(layers.market),
+    npc_vitality: toKappa(layers.physiology),
+    trade: toKappa(layers.trade),
+    social_memory: toKappa(layers.memory),
+    politics: toKappa(layers.politics),
+    aggression: toKappa(layers.conflict),
+    conjuncture: toKappa(layers.economy),
+    kingdom: toKappa(layers.kingdoms),
+    faith: toKappa(layers.faith),
+    dungeon: toKappa(layers.dungeon),
+    fear: toKappa(layers.fear),
+    resurrection: toKappa(layers.cycles),
+  };
+}
+
+function cloneChunkLayerState(state: ChunkLayerState): ChunkLayerState {
+  return iareLayersToChunkLayerState(chunkLayerStateToIARELayers(state));
+}
+
+function hashRuntimeSnapshot(tick: TickId, layerStates: Map<ChunkKey, ChunkLayerState>): StateHash {
+  const parts = [...layerStates.entries()]
+    .sort(([a], [b]) => String(a).localeCompare(String(b)))
+    .map(([chunkKey, state]) => `${String(chunkKey)}:${Object.values(chunkLayerStateToIARELayers(state)).join(',')}`)
+    .join('|');
+
+  let hash = 0x811c9dc5;
+  const input = `tick:${Number(tick)}|${parts}`;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+
+  const hex = hash.toString(16).padStart(8, '0');
+  return createStateHash(hex.repeat(8).slice(0, 64));
+}
+
+function createStableOmega(tick: TickId): OmegaAttractorState {
+  return Object.freeze({
+    attractor_type: ATTRACTOR_TYPES.STABLE,
+    strength: createKappa(0),
+    primary_layer: ChunkLayerIndex.ECOLOGY,
+    last_tick: tick,
+    convergence: createKappa(0),
+  });
+}
+
+/**
+ * Runtime state owner for WorldBrainTickSystem.
+ *
+ * It is not a fake adapter: registerChunk/unregisterChunk mutate the actual
+ * active chunk set used by WorldBrainTickSystem, while deltas commit back into
+ * the same layer-state map that backs getWorldBrainSnapshot().
+ */
+export class RuntimeWorldBrainStatePort implements WorldBrainCanonicalStatePort {
+  private readonly activeChunks = new Set<ChunkKey>();
+  private readonly layerStates = new Map<ChunkKey, ChunkLayerState>();
+  private currentTick = 0 as TickId;
+  private worldHash: StateHash = ZERO_STATE_HASH;
+  private omegaE: OmegaAttractorState = createStableOmega(0 as TickId);
+
+  listActiveChunkKeys(): readonly ChunkKey[] {
+    return Object.freeze([...this.activeChunks].sort((a, b) => String(a).localeCompare(String(b))));
+  }
+
+  readChunkLayers(chunkKey: ChunkKey): IARELogicLayers | null {
+    const state = this.layerStates.get(chunkKey);
+    return state ? chunkLayerStateToIARELayers(state) : null;
+  }
+
+  commitWorldBrainDelta(delta: WorldBrainDelta): void {
+    this.currentTick = delta.tick;
+    this.activeChunks.add(delta.chunkKey);
+    this.layerStates.set(delta.chunkKey, iareLayersToChunkLayerState(delta.nextLayers));
+    this.worldHash = hashRuntimeSnapshot(delta.tick, this.layerStates);
+    this.omegaE = Object.freeze({
+      attractor_type: delta.attractor.type,
+      strength: createKappa(Number(delta.attractor.strength)),
+      primary_layer: layerKeyToChunkLayerIndex(delta.attractor.primaryLayer),
+      last_tick: delta.tick,
+      convergence: createKappa(Number(delta.attractor.convergence)),
+    });
+  }
+
+  registerChunk(chunkKey: ChunkKey): void {
+    this.activeChunks.add(chunkKey);
+    if (!this.layerStates.has(chunkKey)) {
+      this.layerStates.set(chunkKey, createEmptyLayerState());
+    }
+    this.worldHash = hashRuntimeSnapshot(this.currentTick, this.layerStates);
+  }
+
+  unregisterChunk(chunkKey: ChunkKey): void {
+    this.activeChunks.delete(chunkKey);
+    this.layerStates.delete(chunkKey);
+    this.worldHash = hashRuntimeSnapshot(this.currentTick, this.layerStates);
+  }
+
+  getSnapshot(): WorldBrainSnapshot {
+    return Object.freeze({
+      tick: this.currentTick,
+      active_chunks: [...this.listActiveChunkKeys()],
+      layer_states: new Map([...this.layerStates.entries()].map(([key, value]) => [key, cloneChunkLayerState(value)])),
+      omega_e: this.omegaE,
+      world_hash: this.worldHash,
+    });
+  }
+}
+
+export class LayerPersistenceWorldBrainReplaySink implements WorldBrainReplaySink {
+  constructor(private readonly queue: LayerPersistenceQueue) {}
+
+  recordWorldBrainDelta(delta: WorldBrainDelta): void {
+    this.queue.enqueue(createLayerPersistenceEvent(
+      delta.chunkKey,
+      delta.tick,
+      delta.nextLayers,
+      delta.nextHash,
+    ));
+  }
+}
+
+function layerKeyToChunkLayerIndex(layer: keyof IARELogicLayers): ChunkLayerIndex {
+  switch (layer) {
+    case 'ecology': return ChunkLayerIndex.ECOLOGY;
+    case 'market': return ChunkLayerIndex.ECONOMY;
+    case 'physiology': return ChunkLayerIndex.NPC_VITALITY;
+    case 'trade': return ChunkLayerIndex.TRADE;
+    case 'memory': return ChunkLayerIndex.SOCIAL_MEMORY;
+    case 'politics': return ChunkLayerIndex.POLITICS;
+    case 'conflict': return ChunkLayerIndex.AGGRESSION;
+    case 'economy': return ChunkLayerIndex.CONJUNCTURE;
+    case 'kingdoms': return ChunkLayerIndex.KINGDOM;
+    case 'faith': return ChunkLayerIndex.FAITH;
+    case 'dungeon': return ChunkLayerIndex.DUNGEON;
+    case 'fear': return ChunkLayerIndex.FEAR;
+    case 'cycles': return ChunkLayerIndex.RESURRECTION;
+  }
+}

--- a/server/src/core/are/WorldBrainRuntimePort.ts
+++ b/server/src/core/are/WorldBrainRuntimePort.ts
@@ -186,5 +186,9 @@ function layerKeyToChunkLayerIndex(layer: keyof IARELogicLayers): ChunkLayerInde
     case 'dungeon': return ChunkLayerIndex.DUNGEON;
     case 'fear': return ChunkLayerIndex.FEAR;
     case 'cycles': return ChunkLayerIndex.RESURRECTION;
+    default: {
+      const unreachable: never = layer;
+      throw new Error(`Unsupported world-brain layer: ${String(unreachable)}`);
+    }
   }
 }

--- a/server/src/core/are/WorldTickThinShell.ts
+++ b/server/src/core/are/WorldTickThinShell.ts
@@ -1,8 +1,8 @@
 /**
  * WorldTickThinShell - Phase 10: Extremely Slim World Brain Scheduler
  *
- * WorldTick wird zum extrem schlanken World Brain Scheduler.
- * TickSystems führen Fachlogik aus; der ThinShell koordiniert nur.
+ * WorldTick is the 10-Hz coordinator. TickSystems perform runtime logic.
+ * WorldBrain runtime truth is wired through WorldBrainTickSystem ports.
  *
  * ARE Determinism:
  * - WorldStateProvider registry with strict validation
@@ -12,11 +12,19 @@
 
 import { tickSystemRegistry } from "./TickSystemRegistry.js";
 import { createDefaultTickContext, type TickSystemContext } from "./TickSystem.js";
-import { WorldBrainScheduler } from "./WorldBrainScheduler.js";
 import { SnapshotComposer } from "./SnapshotComposer.js";
 import { LayerPersistenceQueue, layerPersistenceQueue } from "./LayerPersistenceQueue.js";
 import { registerCoreTickSystems } from "./CoreTickSystemRegistration.js";
 import { stableSort } from "./DeterministicEventFactory.js";
+import {
+  SnapshotComposerWorldBrainSink,
+  WORLD_BRAIN_TICK_SYSTEM_NAME,
+  registerWorldBrainTickSystem,
+} from "./WorldBrainTickSystem.js";
+import {
+  LayerPersistenceWorldBrainReplaySink,
+  RuntimeWorldBrainStatePort,
+} from "./WorldBrainRuntimePort.js";
 
 /**
  * World state slice provided by a single provider.
@@ -101,9 +109,9 @@ export class WorldTickThinShell {
   private tickCount = 0;
   static readonly TICK_INTERVAL_MS = 100;
 
-  private worldBrain: WorldBrainScheduler;
   private snapshotComposer: SnapshotComposer;
   private persistenceQueue: LayerPersistenceQueue;
+  private worldBrainState: RuntimeWorldBrainStatePort;
   private isRunning = false;
   private timer: ReturnType<typeof setInterval> | null = null;
 
@@ -111,11 +119,12 @@ export class WorldTickThinShell {
   private worldStateProviders = new Map<string, WorldStateProvider>();
 
   constructor() {
-    this.worldBrain = new WorldBrainScheduler();
     this.snapshotComposer = new SnapshotComposer();
     this.persistenceQueue = layerPersistenceQueue;
+    this.worldBrainState = new RuntimeWorldBrainStatePort();
 
     registerCoreTickSystems();
+    this.registerWorldBrainRuntimeSystem();
   }
 
   start(): void {
@@ -138,7 +147,6 @@ export class WorldTickThinShell {
       this.timer = null;
     }
 
-    this.worldBrain.onShutdown();
     await this.persistenceQueue.shutdown();
     tickSystemRegistry.notifyShutdown();
   }
@@ -156,9 +164,7 @@ export class WorldTickThinShell {
     });
 
     tickSystemRegistry.executeAll(context);
-    this.worldBrain.tick(context);
-    this.composeWorldSnapshot();
-    this.queuePersistenceEvents();
+    this.finalizeWorldBrainSnapshot();
     this.persistenceQueue.tick(this.tickCount as any);
   }
 
@@ -265,71 +271,12 @@ export class WorldTickThinShell {
     return this.worldStateProviders.size > 0;
   }
 
-  private composeWorldSnapshot(): void {
-    const snapshot = this.worldBrain.getSnapshot();
-
-    for (const chunkKey of snapshot.active_chunks) {
-      const layerState = this.worldBrain.getChunkLayerState(chunkKey);
-      if (layerState) {
-        const iareLayers = this.convertToIARELayers(layerState);
-        this.snapshotComposer.addChunk(
-          chunkKey,
-          this.tickCount as any,
-          [],
-          iareLayers,
-        );
-      }
-    }
-
-    if (this.snapshotComposer.getChunkCount() > 0) {
-      this.snapshotComposer.finalizeWorldSnapshot(this.tickCount as any);
-    }
-  }
-
-  private convertToIARELayers(chunkLayerState: any): any {
-    return {
-      ecology: chunkLayerState.ecology,
-      market: chunkLayerState.economy,
-      physiology: chunkLayerState.npc_vitality,
-      trade: chunkLayerState.trade,
-      memory: chunkLayerState.social_memory,
-      politics: chunkLayerState.politics,
-      conflict: chunkLayerState.aggression,
-      economy: chunkLayerState.conjuncture,
-      kingdoms: chunkLayerState.kingdom,
-      faith: chunkLayerState.faith,
-      dungeon: chunkLayerState.dungeon,
-      fear: chunkLayerState.fear,
-      cycles: chunkLayerState.resurrection,
-    };
-  }
-
-  private queuePersistenceEvents(): void {
-    const snapshot = this.worldBrain.getSnapshot();
-
-    for (const chunkKey of snapshot.active_chunks) {
-      const layerState = this.worldBrain.getChunkLayerState(chunkKey);
-      if (layerState) {
-        const iareLayers = this.convertToIARELayers(layerState);
-        const event = {
-          chunkKey,
-          tick: this.tickCount as any,
-          layerSnapshot: iareLayers,
-          deltaHash: snapshot.world_hash,
-          timestamp: this.tickCount,
-        };
-
-        this.persistenceQueue.enqueue(event);
-      }
-    }
-  }
-
   registerChunk(chunkKey: string): void {
-    this.worldBrain.registerChunk(chunkKey as any);
+    this.worldBrainState.registerChunk(chunkKey as any);
   }
 
   unregisterChunk(chunkKey: string): void {
-    this.worldBrain.unregisterChunk(chunkKey as any);
+    this.worldBrainState.unregisterChunk(chunkKey as any);
   }
 
   getTickCount(): number {
@@ -337,7 +284,7 @@ export class WorldTickThinShell {
   }
 
   getWorldBrainSnapshot(): any {
-    return this.worldBrain.getSnapshot();
+    return this.worldBrainState.getSnapshot();
   }
 
   getPersistenceStats() {
@@ -348,6 +295,22 @@ export class WorldTickThinShell {
     return {
       chunkCount: this.snapshotComposer.getChunkCount(),
     };
+  }
+
+  private registerWorldBrainRuntimeSystem(): void {
+    if (tickSystemRegistry.has(WORLD_BRAIN_TICK_SYSTEM_NAME)) return;
+
+    registerWorldBrainTickSystem({
+      state: this.worldBrainState,
+      snapshot: new SnapshotComposerWorldBrainSink(this.snapshotComposer),
+      replay: new LayerPersistenceWorldBrainReplaySink(this.persistenceQueue),
+    });
+  }
+
+  private finalizeWorldBrainSnapshot(): void {
+    if (this.snapshotComposer.getChunkCount() > 0) {
+      this.snapshotComposer.finalizeWorldSnapshot(this.tickCount as any);
+    }
   }
 }
 

--- a/server/src/core/are/WorldTickThinShell.ts
+++ b/server/src/core/are/WorldTickThinShell.ts
@@ -18,7 +18,6 @@ import { registerCoreTickSystems } from "./CoreTickSystemRegistration.js";
 import { stableSort } from "./DeterministicEventFactory.js";
 import {
   SnapshotComposerWorldBrainSink,
-  WORLD_BRAIN_TICK_SYSTEM_NAME,
   registerWorldBrainTickSystem,
 } from "./WorldBrainTickSystem.js";
 import {
@@ -298,8 +297,9 @@ export class WorldTickThinShell {
   }
 
   private registerWorldBrainRuntimeSystem(): void {
-    if (tickSystemRegistry.has(WORLD_BRAIN_TICK_SYSTEM_NAME)) return;
-
+    // Registry replacement is intentional here: each ThinShell owns its runtime
+    // WorldBrain ports. Replacement keeps tests and isolated runtimes honest
+    // without ever registering duplicate systems under the same name.
     registerWorldBrainTickSystem({
       state: this.worldBrainState,
       snapshot: new SnapshotComposerWorldBrainSink(this.snapshotComposer),

--- a/server/src/core/are/__tests__/WorldBrainRuntimeTruth.test.ts
+++ b/server/src/core/are/__tests__/WorldBrainRuntimeTruth.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { WorldTickThinShell } from '../WorldTickThinShell.js';
+
+function registerProvider(shell: WorldTickThinShell): void {
+  shell.registerWorldStateProvider({
+    id: 'runtime-truth-provider',
+    getWorldState: () => ({
+      npcs: [{ id: 'npc-runtime-truth' }],
+      players: [{ id: 'player-runtime-truth' }],
+      loot: [],
+      worldEvents: [],
+    }),
+  });
+}
+
+describe('WorldBrain runtime truth wiring', () => {
+  it('runs WorldBrain through registry ports into snapshot and persistence sinks', () => {
+    const shell = new WorldTickThinShell();
+    registerProvider(shell);
+    shell.registerChunk('0:0');
+
+    const queuedBefore = shell.getPersistenceStats().queuedEvents;
+
+    shell.tick();
+
+    const worldBrainSnapshot = shell.getWorldBrainSnapshot();
+
+    expect(shell.getTickCount()).toBe(1);
+    expect(worldBrainSnapshot.active_chunks).toEqual(['0:0']);
+    expect(worldBrainSnapshot.layer_states.size).toBe(1);
+    expect(worldBrainSnapshot.world_hash).not.toBe('0'.repeat(64));
+    expect(shell.getSnapshotStats().chunkCount).toBe(1);
+    expect(shell.getPersistenceStats().queuedEvents).toBeGreaterThan(queuedBefore);
+  });
+
+  it('does not require the legacy WorldBrainScheduler direct tick path', () => {
+    const shell = new WorldTickThinShell();
+    registerProvider(shell);
+    shell.registerChunk('2:3');
+
+    expect(() => shell.tick()).not.toThrow();
+    expect(shell.getWorldBrainSnapshot().active_chunks).toEqual(['2:3']);
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements the next step after deterministic core TickSystem registration: **WorldBrain Runtime Truth**.

It removes the legacy direct `WorldBrainScheduler.tick(context)` call from `WorldTickThinShell` and routes WorldBrain execution through the registered `WorldBrainTickSystem` with real runtime ports.

## Changes

| File | Change |
|------|--------|
| `server/src/core/are/WorldBrainRuntimePort.ts` | Adds `RuntimeWorldBrainStatePort` and `LayerPersistenceWorldBrainReplaySink` |
| `server/src/core/are/WorldTickThinShell.ts` | Registers `WorldBrainTickSystem` with runtime state/snapshot/replay ports and stops calling legacy scheduler directly |
| `server/src/core/are/__tests__/WorldBrainRuntimeTruth.test.ts` | Verifies tick → registry → WorldBrain → snapshot → persistence path |
| `docs/TICK_SYSTEM_REGISTRY.md` | Documents the new WorldBrain runtime chain |

## Runtime Truth

New runtime chain:

```text
WorldTickThinShell.tick()
  -> create TickSystemContext
  -> merge WorldStateProvider slices
  -> TickSystemRegistry.executeAll(context)
  -> WorldBrainTickSystem.tick(context)
  -> RuntimeWorldBrainStatePort.commitWorldBrainDelta(delta)
  -> SnapshotComposerWorldBrainSink.includeWorldBrainChunk(...)
  -> LayerPersistenceWorldBrainReplaySink.recordWorldBrainDelta(...)
```

## Why this is safe

- No mock WorldBrain state source is used.
- Active chunks come from `WorldTickThinShell.registerChunk()`.
- Layer state is owned by `RuntimeWorldBrainStatePort`.
- Deltas are computed by `WorldBrainTickSystem` and committed back to the same runtime port.
- Snapshot output goes to the existing `SnapshotComposer`.
- Replay/persistence output goes to the existing `LayerPersistenceQueue`.
- The old direct `WorldBrainScheduler.tick(context)` call is removed from the ThinShell tick loop, so WorldBrain does not run twice.

## Acceptance Criteria

- [x] `WorldTickThinShell` keeps the 100 ms cadence.
- [x] WorldBrain executes through `TickSystemRegistry.executeAll(context)`.
- [x] No direct legacy WorldBrain tick call remains in `WorldTickThinShell.tick()`.
- [x] WorldBrain state, snapshot, and replay sinks are runtime adapters, not fixtures.
- [x] Runtime test covers the full chain.
- [x] Docs updated.

## Follow-up

After this lands, the next logical step is to feed non-zero canonical layer seeds from real chunk/world generation into `RuntimeWorldBrainStatePort` so newly activated chunks start with meaningful 13-layer vectors instead of zero-state bootstrapping.