### PR TITLE
fix(seed): derive canonical Kappa1000 layer seeds

### DIFF
--- a/docs/CANONICAL_LAYER_SEED_TRUTH.md
+++ b/docs/CANONICAL_LAYER_SEED_TRUTH.md
@@ -1,0 +1,64 @@
+# Canonical Layer Seed Truth
+
+## Purpose
+
+New active WorldBrain chunks must not start from fake zero-state. They start from deterministic Kappa1000 13-layer seeds derived from canonical runtime inputs.
+
+## Seed Inputs
+
+The canonical seed formula uses:
+
+```text
+version + worldSeed + chunkKey + activationTick + layerName
+```
+
+The runtime source order for `worldSeed` is:
+
+1. explicit `WorldTickThinShellOptions.worldSeed` or `RuntimeWorldBrainStatePortOptions.worldSeed`
+2. `WASD_WORLD_SEED`
+3. `ARELORIA_WORLD_SEED`
+4. `WORLD_SEED`
+5. canonical fallback `areloria:earth_1_1`
+
+The fallback is stable and named. It is not random, not wall-clock based, and not a mock snapshot.
+
+## Invariant
+
+Each seed creates 13 non-zero Kappa1000 layers with fixed total checksum:
+
+```text
+sum(layers) = 6500
+```
+
+This preserves a neutral conservation baseline while still giving every chunk a unique deterministic layer vector.
+
+## Runtime Chain
+
+```text
+WorldTickThinShell.registerChunk(chunkKey)
+  -> RuntimeWorldBrainStatePort.registerChunk(chunkKey)
+  -> deriveCanonicalLayerSeed({ worldSeed, chunkKey, activationTick })
+  -> iareLayersToChunkLayerState(seed.layers)
+  -> WorldBrainTickSystem reads the seeded layers on the next tick
+```
+
+## Guarantees
+
+- No `Math.random()`.
+- No `Date.now()`.
+- No empty layer bootstrap for active chunks.
+- Same seed inputs produce identical layers and seed hash.
+- Different `worldSeed`, `chunkKey`, or `activationTick` can produce different layers.
+- Seed hashes use existing `hashChunkKappa1000()` verification.
+
+## Validation
+
+Covered by:
+
+- `server/src/core/are/__tests__/CanonicalLayerSeed.test.ts`
+- `server/src/core/are/__tests__/WorldBrainRuntimeTruth.test.ts`
+- `server/src/core/WorldTickPolicy.guard.ts`
+
+## Follow-up
+
+Next step: feed biome/terrain/settlement signals into the canonical seed formula as explicit deterministic inputs, without changing the conservation invariant or introducing side-channel state.

--- a/server/src/core/are/CanonicalLayerSeed.ts
+++ b/server/src/core/are/CanonicalLayerSeed.ts
@@ -1,0 +1,152 @@
+import type { ChunkKey, KappaInt, StateHash, TickId } from './types.js';
+import { createStateHash } from './types.js';
+import {
+  KAPPA_LAYER_CONSTANTS,
+  KAPPA_LAYER_NAMES,
+  checksumKappaLayers,
+  hashChunkKappa1000,
+  kappa1000Hash,
+  type KappaLayerKey,
+  type KappaLayers,
+} from './KappaLayers.js';
+
+export const CANONICAL_LAYER_SEED_VERSION = 1 as const;
+export const DEFAULT_ARELORIA_WORLD_SEED = 'areloria:earth_1_1' as const;
+
+const CANONICAL_LAYER_ORDER = Object.freeze(Object.keys(KAPPA_LAYER_NAMES).sort() as KappaLayerKey[]);
+const MIN_LAYER_VALUE = 1;
+const MAX_LAYER_VALUE = Number(KAPPA_LAYER_CONSTANTS.LAYER_MAX) - 1;
+const TARGET_LAYER_SUM = Number(KAPPA_LAYER_CONSTANTS.LAYER_SUM_MIDPOINT);
+const BASE_LAYER_VALUE = Number(KAPPA_LAYER_CONSTANTS.LAYER_MIDPOINT);
+const VARIANCE_RADIUS = 175;
+
+export interface CanonicalLayerSeedInput {
+  readonly worldSeed?: string | number | null;
+  readonly chunkKey: ChunkKey;
+  readonly activationTick: TickId;
+}
+
+export interface CanonicalLayerSeedResult {
+  readonly version: typeof CANONICAL_LAYER_SEED_VERSION;
+  readonly worldSeed: string;
+  readonly chunkKey: ChunkKey;
+  readonly activationTick: TickId;
+  readonly layers: KappaLayers;
+  readonly checksum: KappaInt;
+  readonly seedHash: StateHash;
+}
+
+function cleanWorldSeed(value: string | number | null | undefined): string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function resolveCanonicalWorldSeed(value?: string | number | null): string {
+  return cleanWorldSeed(value)
+    ?? cleanWorldSeed(process.env.WASD_WORLD_SEED)
+    ?? cleanWorldSeed(process.env.ARELORIA_WORLD_SEED)
+    ?? cleanWorldSeed(process.env.WORLD_SEED)
+    ?? DEFAULT_ARELORIA_WORLD_SEED;
+}
+
+function clampLayerValue(value: number): number {
+  if (!Number.isFinite(value)) return BASE_LAYER_VALUE;
+  return Math.max(MIN_LAYER_VALUE, Math.min(MAX_LAYER_VALUE, Math.trunc(value)));
+}
+
+function createSeedInput(worldSeed: string, chunkKey: ChunkKey, activationTick: TickId): string {
+  return [
+    `v:${CANONICAL_LAYER_SEED_VERSION}`,
+    `seed:${worldSeed}`,
+    `chunk:${String(chunkKey)}`,
+    `tick:${Number(activationTick)}`,
+  ].join('|');
+}
+
+function distributeConservationDelta(values: Record<KappaLayerKey, number>, seedInput: string): void {
+  let delta = TARGET_LAYER_SUM - CANONICAL_LAYER_ORDER.reduce((sum, key) => sum + values[key], 0);
+  if (delta === 0) return;
+
+  const adjustmentOrder = [...CANONICAL_LAYER_ORDER].sort((a, b) => {
+    const hashA = kappa1000Hash(`${seedInput}|adjust:${a}`);
+    const hashB = kappa1000Hash(`${seedInput}|adjust:${b}`);
+    if (hashA !== hashB) return hashA - hashB;
+    return a.localeCompare(b);
+  });
+
+  let cursor = 0;
+  while (delta !== 0) {
+    const key = adjustmentOrder[cursor % adjustmentOrder.length];
+    const step = delta > 0 ? 1 : -1;
+    const next = values[key] + step;
+
+    if (next >= MIN_LAYER_VALUE && next <= MAX_LAYER_VALUE) {
+      values[key] = next;
+      delta -= step;
+    }
+
+    cursor += 1;
+    if (cursor > 4096) {
+      throw new Error('Canonical layer seed conservation adjustment exceeded safety bound');
+    }
+  }
+}
+
+function createLayers(values: Record<KappaLayerKey, number>): KappaLayers {
+  return Object.freeze({
+    ecology: values.ecology as KappaInt,
+    market: values.market as KappaInt,
+    physiology: values.physiology as KappaInt,
+    trade: values.trade as KappaInt,
+    memory: values.memory as KappaInt,
+    politics: values.politics as KappaInt,
+    conflict: values.conflict as KappaInt,
+    economy: values.economy as KappaInt,
+    kingdoms: values.kingdoms as KappaInt,
+    faith: values.faith as KappaInt,
+    dungeon: values.dungeon as KappaInt,
+    fear: values.fear as KappaInt,
+    cycles: values.cycles as KappaInt,
+  });
+}
+
+export function deriveCanonicalLayerSeed(input: CanonicalLayerSeedInput): CanonicalLayerSeedResult {
+  const worldSeed = resolveCanonicalWorldSeed(input.worldSeed);
+  const seedInput = createSeedInput(worldSeed, input.chunkKey, input.activationTick);
+
+  const values = {} as Record<KappaLayerKey, number>;
+  for (const key of CANONICAL_LAYER_ORDER) {
+    const hash = kappa1000Hash(`${seedInput}|layer:${key}`);
+    const offset = (hash % (VARIANCE_RADIUS * 2 + 1)) - VARIANCE_RADIUS;
+    values[key] = clampLayerValue(BASE_LAYER_VALUE + offset);
+  }
+
+  distributeConservationDelta(values, seedInput);
+
+  const layers = createLayers(values);
+  const checksum = checksumKappaLayers(layers);
+  if (Number(checksum) !== TARGET_LAYER_SUM) {
+    throw new Error(`Canonical layer seed checksum violation: ${Number(checksum)} !== ${TARGET_LAYER_SUM}`);
+  }
+
+  const seedHash = hashChunkKappa1000(input.chunkKey, layers, input.activationTick);
+  return Object.freeze({
+    version: CANONICAL_LAYER_SEED_VERSION,
+    worldSeed,
+    chunkKey: input.chunkKey,
+    activationTick: input.activationTick,
+    layers,
+    checksum,
+    seedHash,
+  });
+}
+
+export function canonicalLayerSeedHash(input: CanonicalLayerSeedInput): StateHash {
+  return deriveCanonicalLayerSeed(input).seedHash;
+}
+
+export function zeroStateHash(): StateHash {
+  return createStateHash('0'.repeat(64));
+}

--- a/server/src/core/are/WorldBrainRuntimePort.ts
+++ b/server/src/core/are/WorldBrainRuntimePort.ts
@@ -3,7 +3,6 @@ import { createKappa, createStateHash } from './types.js';
 import {
   ATTRACTOR_TYPES,
   ChunkLayerIndex,
-  createEmptyLayerState,
   type ChunkLayerState,
   type OmegaAttractorState,
   type WorldBrainSnapshot,
@@ -13,6 +12,10 @@ import {
   createLayerPersistenceEvent,
   type LayerPersistenceQueue,
 } from './LayerPersistenceQueue.js';
+import {
+  deriveCanonicalLayerSeed,
+  type CanonicalLayerSeedResult,
+} from './CanonicalLayerSeed.js';
 import type {
   WorldBrainCanonicalStatePort,
   WorldBrainDelta,
@@ -96,6 +99,10 @@ function createStableOmega(tick: TickId): OmegaAttractorState {
   });
 }
 
+export interface RuntimeWorldBrainStatePortOptions {
+  readonly worldSeed?: string | number | null;
+}
+
 /**
  * Runtime state owner for WorldBrainTickSystem.
  *
@@ -106,9 +113,12 @@ function createStableOmega(tick: TickId): OmegaAttractorState {
 export class RuntimeWorldBrainStatePort implements WorldBrainCanonicalStatePort {
   private readonly activeChunks = new Set<ChunkKey>();
   private readonly layerStates = new Map<ChunkKey, ChunkLayerState>();
+  private readonly seedRecords = new Map<ChunkKey, CanonicalLayerSeedResult>();
   private currentTick = 0 as TickId;
   private worldHash: StateHash = ZERO_STATE_HASH;
   private omegaE: OmegaAttractorState = createStableOmega(0 as TickId);
+
+  constructor(private readonly options: RuntimeWorldBrainStatePortOptions = {}) {}
 
   listActiveChunkKeys(): readonly ChunkKey[] {
     return Object.freeze([...this.activeChunks].sort((a, b) => String(a).localeCompare(String(b))));
@@ -136,7 +146,13 @@ export class RuntimeWorldBrainStatePort implements WorldBrainCanonicalStatePort 
   registerChunk(chunkKey: ChunkKey): void {
     this.activeChunks.add(chunkKey);
     if (!this.layerStates.has(chunkKey)) {
-      this.layerStates.set(chunkKey, createEmptyLayerState());
+      const seed = deriveCanonicalLayerSeed({
+        worldSeed: this.options.worldSeed,
+        chunkKey,
+        activationTick: this.currentTick,
+      });
+      this.seedRecords.set(chunkKey, seed);
+      this.layerStates.set(chunkKey, iareLayersToChunkLayerState(seed.layers));
     }
     this.worldHash = hashRuntimeSnapshot(this.currentTick, this.layerStates);
   }
@@ -144,7 +160,12 @@ export class RuntimeWorldBrainStatePort implements WorldBrainCanonicalStatePort 
   unregisterChunk(chunkKey: ChunkKey): void {
     this.activeChunks.delete(chunkKey);
     this.layerStates.delete(chunkKey);
+    this.seedRecords.delete(chunkKey);
     this.worldHash = hashRuntimeSnapshot(this.currentTick, this.layerStates);
+  }
+
+  getCanonicalSeedRecord(chunkKey: ChunkKey): CanonicalLayerSeedResult | null {
+    return this.seedRecords.get(chunkKey) ?? null;
   }
 
   getSnapshot(): WorldBrainSnapshot {

--- a/server/src/core/are/WorldTickThinShell.ts
+++ b/server/src/core/are/WorldTickThinShell.ts
@@ -16,6 +16,8 @@ import { SnapshotComposer } from "./SnapshotComposer.js";
 import { LayerPersistenceQueue, layerPersistenceQueue } from "./LayerPersistenceQueue.js";
 import { registerCoreTickSystems } from "./CoreTickSystemRegistration.js";
 import { stableSort } from "./DeterministicEventFactory.js";
+import { coerceChunkKey } from "./types.js";
+import type { CanonicalLayerSeedResult } from "./CanonicalLayerSeed.js";
 import {
   SnapshotComposerWorldBrainSink,
   registerWorldBrainTickSystem,
@@ -69,6 +71,10 @@ export interface ThinShellWorldState extends TickContextWorldState {}
 
 export type ThinShellWorldStateProvider = () => WorldStateProviderSlice;
 
+export interface WorldTickThinShellOptions {
+  readonly worldSeed?: string | number | null;
+}
+
 const EMPTY_WORLD_STATE: ThinShellWorldState = Object.freeze({
   npcs: Object.freeze([]),
   players: Object.freeze([]),
@@ -117,10 +123,10 @@ export class WorldTickThinShell {
   /** ARE-RUNTIME-TRUTH: Registry of world state providers - MUST have at least one */
   private worldStateProviders = new Map<string, WorldStateProvider>();
 
-  constructor() {
+  constructor(options: WorldTickThinShellOptions = {}) {
     this.snapshotComposer = new SnapshotComposer();
     this.persistenceQueue = layerPersistenceQueue;
-    this.worldBrainState = new RuntimeWorldBrainStatePort();
+    this.worldBrainState = new RuntimeWorldBrainStatePort({ worldSeed: options.worldSeed });
 
     registerCoreTickSystems();
     this.registerWorldBrainRuntimeSystem();
@@ -271,11 +277,15 @@ export class WorldTickThinShell {
   }
 
   registerChunk(chunkKey: string): void {
-    this.worldBrainState.registerChunk(chunkKey as any);
+    this.worldBrainState.registerChunk(coerceChunkKey(chunkKey));
   }
 
   unregisterChunk(chunkKey: string): void {
-    this.worldBrainState.unregisterChunk(chunkKey as any);
+    this.worldBrainState.unregisterChunk(coerceChunkKey(chunkKey));
+  }
+
+  getWorldBrainSeedRecord(chunkKey: string): CanonicalLayerSeedResult | null {
+    return this.worldBrainState.getCanonicalSeedRecord(coerceChunkKey(chunkKey));
   }
 
   getTickCount(): number {

--- a/server/src/core/are/__tests__/CanonicalLayerSeed.test.ts
+++ b/server/src/core/are/__tests__/CanonicalLayerSeed.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { checksumKappaLayers, verifyChunkKappaHash } from '../KappaLayers.js';
+import {
+  DEFAULT_ARELORIA_WORLD_SEED,
+  deriveCanonicalLayerSeed,
+} from '../CanonicalLayerSeed.js';
+import { RuntimeWorldBrainStatePort, chunkLayerStateToIARELayers } from '../WorldBrainRuntimePort.js';
+import { createChunkKey, createTickId } from '../types.js';
+
+describe('Canonical layer seed truth', () => {
+  it('derives deterministic non-zero Kappa1000 layers from worldSeed + chunkKey + tick', () => {
+    const chunkKey = createChunkKey(7, -3);
+    const activationTick = createTickId(42);
+
+    const a = deriveCanonicalLayerSeed({ worldSeed: 'seed-alpha', chunkKey, activationTick });
+    const b = deriveCanonicalLayerSeed({ worldSeed: 'seed-alpha', chunkKey, activationTick });
+    const c = deriveCanonicalLayerSeed({ worldSeed: 'seed-beta', chunkKey, activationTick });
+
+    expect(a.layers).toEqual(b.layers);
+    expect(a.seedHash).toBe(b.seedHash);
+    expect(a.layers).not.toEqual(c.layers);
+    expect(Number(checksumKappaLayers(a.layers))).toBe(6500);
+    expect(Object.values(a.layers).every((value) => Number(value) > 0)).toBe(true);
+    expect(verifyChunkKappaHash(chunkKey, a.layers, activationTick, a.seedHash)).toBe(true);
+  });
+
+  it('uses the canonical default world seed when no explicit runtime seed exists', () => {
+    const seed = deriveCanonicalLayerSeed({
+      chunkKey: createChunkKey(0, 0),
+      activationTick: createTickId(0),
+    });
+
+    expect(seed.worldSeed).toBe(DEFAULT_ARELORIA_WORLD_SEED);
+    expect(Number(seed.checksum)).toBe(6500);
+  });
+
+  it('seeds RuntimeWorldBrainStatePort chunks before first tick', () => {
+    const port = new RuntimeWorldBrainStatePort({ worldSeed: 'runtime-seed' });
+    const chunkKey = createChunkKey(1, 2);
+
+    port.registerChunk(chunkKey);
+
+    const seedRecord = port.getCanonicalSeedRecord(chunkKey);
+    const snapshot = port.getSnapshot();
+    const chunkState = snapshot.layer_states.get(chunkKey);
+
+    expect(seedRecord).not.toBeNull();
+    expect(chunkState).toBeDefined();
+    expect(chunkLayerStateToIARELayers(chunkState!)).toEqual(seedRecord!.layers);
+    expect(snapshot.world_hash).not.toBe('0'.repeat(64));
+  });
+});

--- a/server/src/core/are/__tests__/WorldBrainRuntimeTruth.test.ts
+++ b/server/src/core/are/__tests__/WorldBrainRuntimeTruth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { checksumKappaLayers } from '../KappaLayers.js';
 import { WorldTickThinShell } from '../WorldTickThinShell.js';
 
 function registerProvider(shell: WorldTickThinShell): void {
@@ -15,11 +16,15 @@ function registerProvider(shell: WorldTickThinShell): void {
 
 describe('WorldBrain runtime truth wiring', () => {
   it('runs WorldBrain through registry ports into snapshot and persistence sinks', () => {
-    const shell = new WorldTickThinShell();
+    const shell = new WorldTickThinShell({ worldSeed: 'runtime-truth-seed' });
     registerProvider(shell);
     shell.registerChunk('0:0');
 
+    const seedRecord = shell.getWorldBrainSeedRecord('0:0');
     const queuedBefore = shell.getPersistenceStats().queuedEvents;
+
+    expect(seedRecord).not.toBeNull();
+    expect(Number(checksumKappaLayers(seedRecord!.layers))).toBe(6500);
 
     shell.tick();
 
@@ -34,10 +39,11 @@ describe('WorldBrain runtime truth wiring', () => {
   });
 
   it('does not require the legacy WorldBrainScheduler direct tick path', () => {
-    const shell = new WorldTickThinShell();
+    const shell = new WorldTickThinShell({ worldSeed: 'runtime-truth-seed' });
     registerProvider(shell);
     shell.registerChunk('2:3');
 
+    expect(shell.getWorldBrainSeedRecord('2:3')).not.toBeNull();
     expect(() => shell.tick()).not.toThrow();
     expect(shell.getWorldBrainSnapshot().active_chunks).toEqual(['2:3']);
   });

--- a/server/src/core/are/index.ts
+++ b/server/src/core/are/index.ts
@@ -188,6 +188,7 @@ export {
   type WorldStateProviderSlice,
   type WorldStateProvider,
   type TickContextWorldState,
+  type WorldTickThinShellOptions,
 } from './WorldTickThinShell.js';
 
 // Deterministic Event Factory (ARE-RUNTIME-TRUTH)
@@ -230,6 +231,27 @@ export {
   type WorldBrainReplaySink,
   type WorldBrainTickSystemOptions,
 } from './WorldBrainTickSystem.js';
+
+// Phase 11: WorldBrain runtime port wiring
+export {
+  RuntimeWorldBrainStatePort,
+  LayerPersistenceWorldBrainReplaySink,
+  chunkLayerStateToIARELayers,
+  iareLayersToChunkLayerState,
+  type RuntimeWorldBrainStatePortOptions,
+} from './WorldBrainRuntimePort.js';
+
+// Phase 11: Canonical Layer Seed Truth
+export {
+  CANONICAL_LAYER_SEED_VERSION,
+  DEFAULT_ARELORIA_WORLD_SEED,
+  deriveCanonicalLayerSeed,
+  canonicalLayerSeedHash,
+  resolveCanonicalWorldSeed,
+  zeroStateHash,
+  type CanonicalLayerSeedInput,
+  type CanonicalLayerSeedResult,
+} from './CanonicalLayerSeed.js';
 
 // Phase 11: OuroborosTickSystem - Ouroboros autonomous agent integration
 export {


### PR DESCRIPTION
## Summary

This PR implements **Canonical Layer Seed Truth** after #2011 WorldBrain Runtime Truth.

New active WorldBrain chunks no longer start from zero-layer bootstrap. They receive deterministic canonical 13-layer Kappa1000 seed vectors derived from:

```text
version + worldSeed + chunkKey + activationTick + layerName
```

## Changes

| File | Change |
|------|--------|
| `server/src/core/are/CanonicalLayerSeed.ts` | Adds deterministic canonical seed derivation, checksum invariant, seed hash helper |
| `server/src/core/are/WorldBrainRuntimePort.ts` | Seeds new active chunks through `deriveCanonicalLayerSeed()` instead of `createEmptyLayerState()` |
| `server/src/core/are/WorldTickThinShell.ts` | Adds explicit `worldSeed` option and seed-record visibility |
| `server/src/core/are/index.ts` | Exports canonical seed APIs and runtime port options |
| `server/src/core/are/__tests__/CanonicalLayerSeed.test.ts` | Covers deterministic seed derivation, checksum, seed hash verification, runtime port seeding |
| `server/src/core/are/__tests__/WorldBrainRuntimeTruth.test.ts` | Asserts WorldBrain runtime chunks are seeded before tick |
| `docs/CANONICAL_LAYER_SEED_TRUTH.md` | Documents seed inputs, invariant, runtime chain, validation |

## Runtime Truth

New active chunk path:

```text
WorldTickThinShell.registerChunk(chunkKey)
  -> RuntimeWorldBrainStatePort.registerChunk(chunkKey)
  -> deriveCanonicalLayerSeed({ worldSeed, chunkKey, activationTick })
  -> iareLayersToChunkLayerState(seed.layers)
  -> WorldBrainTickSystem reads seeded layers on next tick
```

## Invariant

Every canonical seed creates 13 non-zero Kappa1000 layers with:

```text
sum(layers) = 6500
```

This gives every active chunk deterministic substance while preserving the neutral conservation baseline.

## No Fake Truth

- No `Math.random()`
- No `Date.now()`
- No fake snapshots
- No zero-layer active chunk bootstrap
- No workflow changes
- Seed hash uses existing `hashChunkKappa1000()` verification

## Follow-up

Next step should add biome/terrain/settlement signal inputs to the seed formula as explicit deterministic inputs, while keeping the checksum invariant.