### PR TITLE
fix(seed): integrate biome terrain seed signals

### DIFF
--- a/docs/CANONICAL_LAYER_SEED_TRUTH.md
+++ b/docs/CANONICAL_LAYER_SEED_TRUTH.md
@@ -2,14 +2,14 @@
 
 ## Purpose
 
-New active WorldBrain chunks must not start from fake zero-state. They start from deterministic Kappa1000 13-layer seeds derived from canonical runtime inputs.
+New active WorldBrain chunks must not start from fake zero-state. They start from deterministic Kappa1000 13-layer seeds derived from canonical runtime inputs and shared world-generation signals.
 
 ## Seed Inputs
 
 The canonical seed formula uses:
 
 ```text
-version + worldSeed + chunkKey + activationTick + layerName
+version + worldSeed + chunkKey + activationTick + layerName + worldgenSignalSignature
 ```
 
 The runtime source order for `worldSeed` is:
@@ -22,6 +22,20 @@ The runtime source order for `worldSeed` is:
 
 The fallback is stable and named. It is not random, not wall-clock based, and not a mock snapshot.
 
+## Worldgen Signal Source
+
+`RuntimeWorldBrainStatePort.registerChunk()` derives seed signals through `deriveCanonicalWorldgenSeedSignals()`.
+
+Signal source:
+
+```text
+deriveChunkBiome()
+  -> generateChunkScenePlan()
+  -> biome / terrain / roads / settlement / props / NPC / collision signals
+```
+
+Signals include biome id, resource density, tree density, settlement intent, terrain mix, road pressure, settlement lots, resource props, structure props, collision pressure, NPC count, and deterministic risk/underworld pressure from terrain structure.
+
 ## Invariant
 
 Each seed creates 13 non-zero Kappa1000 layers with fixed total checksum:
@@ -30,14 +44,15 @@ Each seed creates 13 non-zero Kappa1000 layers with fixed total checksum:
 sum(layers) = 6500
 ```
 
-This preserves a neutral conservation baseline while still giving every chunk a unique deterministic layer vector.
+Worldgen signals bias individual layers, then deterministic conservation adjustment restores the checksum. The invariant is never weakened.
 
 ## Runtime Chain
 
 ```text
 WorldTickThinShell.registerChunk(chunkKey)
   -> RuntimeWorldBrainStatePort.registerChunk(chunkKey)
-  -> deriveCanonicalLayerSeed({ worldSeed, chunkKey, activationTick })
+  -> deriveCanonicalWorldgenSeedSignals({ worldSeed, chunkKey, activationTick })
+  -> deriveCanonicalLayerSeed({ worldSeed, chunkKey, activationTick, signals })
   -> iareLayersToChunkLayerState(seed.layers)
   -> WorldBrainTickSystem reads the seeded layers on the next tick
 ```
@@ -47,8 +62,8 @@ WorldTickThinShell.registerChunk(chunkKey)
 - No `Math.random()`.
 - No `Date.now()`.
 - No empty layer bootstrap for active chunks.
-- Same seed inputs produce identical layers and seed hash.
-- Different `worldSeed`, `chunkKey`, or `activationTick` can produce different layers.
+- No side-channel signal source.
+- Same seed inputs and worldgen signals produce identical layers and seed hash.
 - Seed hashes use existing `hashChunkKappa1000()` verification.
 
 ## Validation
@@ -61,4 +76,4 @@ Covered by:
 
 ## Follow-up
 
-Next step: feed biome/terrain/settlement signals into the canonical seed formula as explicit deterministic inputs, without changing the conservation invariant or introducing side-channel state.
+Next step: promote signal weights into a documented balancing matrix so layer pressure can be tuned without changing the deterministic seed contract.

--- a/server/src/core/are/CanonicalLayerSeed.ts
+++ b/server/src/core/are/CanonicalLayerSeed.ts
@@ -10,7 +10,7 @@ import {
   type KappaLayers,
 } from './KappaLayers.js';
 
-export const CANONICAL_LAYER_SEED_VERSION = 1 as const;
+export const CANONICAL_LAYER_SEED_VERSION = 2 as const;
 export const DEFAULT_ARELORIA_WORLD_SEED = 'areloria:earth_1_1' as const;
 
 const CANONICAL_LAYER_ORDER = Object.freeze(Object.keys(KAPPA_LAYER_NAMES).sort() as KappaLayerKey[]);
@@ -18,12 +18,41 @@ const MIN_LAYER_VALUE = 1;
 const MAX_LAYER_VALUE = Number(KAPPA_LAYER_CONSTANTS.LAYER_MAX) - 1;
 const TARGET_LAYER_SUM = Number(KAPPA_LAYER_CONSTANTS.LAYER_SUM_MIDPOINT);
 const BASE_LAYER_VALUE = Number(KAPPA_LAYER_CONSTANTS.LAYER_MIDPOINT);
-const VARIANCE_RADIUS = 175;
+const VARIANCE_RADIUS = 135;
+
+export type CanonicalSeedBiomeId = 'forest_village' | 'forest' | 'plains' | 'mountain';
+
+export interface CanonicalLayerSeedSignals {
+  readonly signalVersion: 1;
+  readonly source: string;
+  readonly biomeId: CanonicalSeedBiomeId;
+  readonly resourceDensityPerMille: number;
+  readonly treeDensityPerMille: number;
+  readonly settlementChancePerMille: number;
+  readonly heightBaseKappa: number;
+  readonly heightVarianceKappa: number;
+  readonly terrainGrassPerMille: number;
+  readonly terrainForestPerMille: number;
+  readonly terrainStonePerMille: number;
+  readonly terrainRoadPerMille: number;
+  readonly roadCellCount: number;
+  readonly roadEdgeCount: number;
+  readonly settlementLotCount: number;
+  readonly settlementIntentPerMille: number;
+  readonly resourcePropCount: number;
+  readonly structurePropCount: number;
+  readonly collisionCellCount: number;
+  readonly npcCount: number;
+  readonly dangerPressurePerMille: number;
+  readonly dungeonPressurePerMille: number;
+  readonly signature: string;
+}
 
 export interface CanonicalLayerSeedInput {
   readonly worldSeed?: string | number | null;
   readonly chunkKey: ChunkKey;
   readonly activationTick: TickId;
+  readonly signals?: CanonicalLayerSeedSignals | null;
 }
 
 export interface CanonicalLayerSeedResult {
@@ -31,6 +60,7 @@ export interface CanonicalLayerSeedResult {
   readonly worldSeed: string;
   readonly chunkKey: ChunkKey;
   readonly activationTick: TickId;
+  readonly signals: CanonicalLayerSeedSignals | null;
   readonly layers: KappaLayers;
   readonly checksum: KappaInt;
   readonly seedHash: StateHash;
@@ -56,13 +86,80 @@ function clampLayerValue(value: number): number {
   return Math.max(MIN_LAYER_VALUE, Math.min(MAX_LAYER_VALUE, Math.trunc(value)));
 }
 
-function createSeedInput(worldSeed: string, chunkKey: ChunkKey, activationTick: TickId): string {
+function clampPerMille(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1000, Math.trunc(value)));
+}
+
+function signalSignature(signals: CanonicalLayerSeedSignals | null | undefined): string {
+  if (!signals) return 'signals:none';
+  return [
+    `signals:v${signals.signalVersion}`,
+    `source:${signals.source}`,
+    `biome:${signals.biomeId}`,
+    `resource:${clampPerMille(signals.resourceDensityPerMille)}`,
+    `tree:${clampPerMille(signals.treeDensityPerMille)}`,
+    `settlement:${clampPerMille(signals.settlementIntentPerMille)}`,
+    `grass:${clampPerMille(signals.terrainGrassPerMille)}`,
+    `forest:${clampPerMille(signals.terrainForestPerMille)}`,
+    `stone:${clampPerMille(signals.terrainStonePerMille)}`,
+    `road:${clampPerMille(signals.terrainRoadPerMille)}`,
+    `roads:${Math.max(0, Math.trunc(signals.roadCellCount))}`,
+    `lots:${Math.max(0, Math.trunc(signals.settlementLotCount))}`,
+    `resources:${Math.max(0, Math.trunc(signals.resourcePropCount))}`,
+    `structures:${Math.max(0, Math.trunc(signals.structurePropCount))}`,
+    `collision:${Math.max(0, Math.trunc(signals.collisionCellCount))}`,
+    `npcs:${Math.max(0, Math.trunc(signals.npcCount))}`,
+    `danger:${clampPerMille(signals.dangerPressurePerMille)}`,
+    `dungeon:${clampPerMille(signals.dungeonPressurePerMille)}`,
+    `sig:${signals.signature}`,
+  ].join('|');
+}
+
+function createSeedInput(worldSeed: string, chunkKey: ChunkKey, activationTick: TickId, signals?: CanonicalLayerSeedSignals | null): string {
   return [
     `v:${CANONICAL_LAYER_SEED_VERSION}`,
     `seed:${worldSeed}`,
     `chunk:${String(chunkKey)}`,
     `tick:${Number(activationTick)}`,
+    signalSignature(signals),
   ].join('|');
+}
+
+function add(values: Record<KappaLayerKey, number>, key: KappaLayerKey, delta: number): void {
+  values[key] = clampLayerValue(values[key] + Math.trunc(delta));
+}
+
+function perMilleBias(value: number, divisor: number): number {
+  return Math.trunc((clampPerMille(value) - 500) / divisor);
+}
+
+function applySignalBias(values: Record<KappaLayerKey, number>, signals: CanonicalLayerSeedSignals | null | undefined): void {
+  if (!signals) return;
+
+  const resource = signals.resourceDensityPerMille;
+  const tree = signals.treeDensityPerMille;
+  const settlement = signals.settlementIntentPerMille;
+  const grass = signals.terrainGrassPerMille;
+  const forest = signals.terrainForestPerMille;
+  const stone = signals.terrainStonePerMille;
+  const road = signals.terrainRoadPerMille;
+  const danger = signals.dangerPressurePerMille;
+  const dungeon = signals.dungeonPressurePerMille;
+
+  add(values, 'ecology', perMilleBias(tree, 5) + perMilleBias(forest, 8) + perMilleBias(resource, 12));
+  add(values, 'market', perMilleBias(resource, 8) + perMilleBias(settlement, 12));
+  add(values, 'physiology', perMilleBias(grass, 14) + perMilleBias(tree, 16) - Math.max(0, perMilleBias(danger, 18)));
+  add(values, 'trade', perMilleBias(road, 5) + perMilleBias(settlement, 12) + Math.min(45, signals.roadCellCount));
+  add(values, 'memory', perMilleBias(settlement, 10) + signals.npcCount * 3);
+  add(values, 'politics', perMilleBias(settlement, 8) + signals.structurePropCount * 4);
+  add(values, 'conflict', perMilleBias(danger, 6) + perMilleBias(stone, 10));
+  add(values, 'economy', perMilleBias(resource, 9) + perMilleBias(settlement, 15));
+  add(values, 'kingdoms', perMilleBias(settlement, 9) + signals.settlementLotCount * 5);
+  add(values, 'faith', signals.biomeId === 'forest_village' ? 35 : signals.npcCount * 2);
+  add(values, 'dungeon', perMilleBias(dungeon, 5) + perMilleBias(stone, 8));
+  add(values, 'fear', perMilleBias(danger, 5) + perMilleBias(forest, 18));
+  add(values, 'cycles', perMilleBias(forest, 16) + perMilleBias(resource, 20));
 }
 
 function distributeConservationDelta(values: Record<KappaLayerKey, number>, seedInput: string): void {
@@ -88,7 +185,7 @@ function distributeConservationDelta(values: Record<KappaLayerKey, number>, seed
     }
 
     cursor += 1;
-    if (cursor > 4096) {
+    if (cursor > 8192) {
       throw new Error('Canonical layer seed conservation adjustment exceeded safety bound');
     }
   }
@@ -114,7 +211,7 @@ function createLayers(values: Record<KappaLayerKey, number>): KappaLayers {
 
 export function deriveCanonicalLayerSeed(input: CanonicalLayerSeedInput): CanonicalLayerSeedResult {
   const worldSeed = resolveCanonicalWorldSeed(input.worldSeed);
-  const seedInput = createSeedInput(worldSeed, input.chunkKey, input.activationTick);
+  const seedInput = createSeedInput(worldSeed, input.chunkKey, input.activationTick, input.signals);
 
   const values = {} as Record<KappaLayerKey, number>;
   for (const key of CANONICAL_LAYER_ORDER) {
@@ -123,6 +220,7 @@ export function deriveCanonicalLayerSeed(input: CanonicalLayerSeedInput): Canoni
     values[key] = clampLayerValue(BASE_LAYER_VALUE + offset);
   }
 
+  applySignalBias(values, input.signals);
   distributeConservationDelta(values, seedInput);
 
   const layers = createLayers(values);
@@ -137,6 +235,7 @@ export function deriveCanonicalLayerSeed(input: CanonicalLayerSeedInput): Canoni
     worldSeed,
     chunkKey: input.chunkKey,
     activationTick: input.activationTick,
+    signals: input.signals ?? null,
     layers,
     checksum,
     seedHash,

--- a/server/src/core/are/CanonicalLayerSeedSignals.ts
+++ b/server/src/core/are/CanonicalLayerSeedSignals.ts
@@ -53,8 +53,10 @@ export interface CanonicalWorldgenSignalInput {
 export function deriveCanonicalWorldgenSeedSignals(input: CanonicalWorldgenSignalInput): CanonicalLayerSeedSignals {
   const worldSeed = resolveCanonicalWorldSeed(input.worldSeed);
   const parsed = parseChunkKey(input.chunkKey);
-  const biomeId = deriveChunkBiome(parsed.x, parsed.z, worldSeed) as BiomeId;
-  const plan = generateChunkScenePlan({ worldSeed, chunkX: parsed.x, chunkZ: parsed.z, biomeId, kappa: KAPPA_STANDARD });
+  const chunkX = Number(parsed.cx);
+  const chunkZ = Number(parsed.cz);
+  const biomeId = deriveChunkBiome(chunkX, chunkZ, worldSeed) as BiomeId;
+  const plan = generateChunkScenePlan({ worldSeed, chunkX, chunkZ, biomeId, kappa: KAPPA_STANDARD });
 
   const totalTerrain = Math.max(1, plan.terrain.length);
   const roadCellCount = Object.keys(plan.roads.roadCells).length;

--- a/server/src/core/are/CanonicalLayerSeedSignals.ts
+++ b/server/src/core/are/CanonicalLayerSeedSignals.ts
@@ -1,0 +1,103 @@
+import {
+  deriveChunkBiome,
+  generateChunkScenePlan,
+  KAPPA_STANDARD,
+  type BiomeId,
+  type ChunkScenePlan,
+} from '@wasd/shared';
+import type { ChunkKey, TickId } from './types.js';
+import { parseChunkKey } from './types.js';
+import { resolveCanonicalWorldSeed, type CanonicalLayerSeedSignals } from './CanonicalLayerSeed.js';
+
+function clampPerMille(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1000, Math.trunc(value)));
+}
+
+function ratioPerMille(part: number, total: number): number {
+  if (total <= 0) return 0;
+  return clampPerMille((part * 1000) / total);
+}
+
+function countTerrain(plan: ChunkScenePlan, terrainType: ChunkScenePlan['terrain'][number]['terrainType']): number {
+  return plan.terrain.filter((cell) => cell.terrainType === terrainType).length;
+}
+
+function countProps(plan: ChunkScenePlan, densityClass: ChunkScenePlan['props'][number]['densityClass']): number {
+  return plan.props.filter((prop) => prop.densityClass === densityClass).length
+    + plan.settlement.props.filter((prop) => prop.densityClass === densityClass).length;
+}
+
+function pressureFromBiome(plan: ChunkScenePlan): { risk: number; underworld: number } {
+  const totalTerrain = Math.max(1, plan.terrain.length);
+  const stoneRatio = ratioPerMille(countTerrain(plan, 'stone'), totalTerrain);
+  const forestRatio = ratioPerMille(countTerrain(plan, 'forest_floor'), totalTerrain);
+  const collisionRatio = ratioPerMille(Object.keys(plan.collisionCells).length, totalTerrain);
+  const settlementRelief = Math.min(260, plan.settlement.lots.length * 18);
+
+  const riskBase = plan.biome.biomeId === 'mountain' ? 380 : plan.biome.biomeId === 'forest' ? 220 : plan.biome.biomeId === 'forest_village' ? 160 : 90;
+  const underworldBase = plan.biome.biomeId === 'mountain' ? 420 : plan.biome.biomeId === 'forest' ? 120 : 60;
+
+  return {
+    risk: clampPerMille(riskBase + Math.floor(stoneRatio / 2) + Math.floor(forestRatio / 6) - settlementRelief),
+    underworld: clampPerMille(underworldBase + Math.floor(stoneRatio / 3) + Math.floor(collisionRatio / 8)),
+  };
+}
+
+export interface CanonicalWorldgenSignalInput {
+  readonly worldSeed?: string | number | null;
+  readonly chunkKey: ChunkKey;
+  readonly activationTick: TickId;
+}
+
+export function deriveCanonicalWorldgenSeedSignals(input: CanonicalWorldgenSignalInput): CanonicalLayerSeedSignals {
+  const worldSeed = resolveCanonicalWorldSeed(input.worldSeed);
+  const parsed = parseChunkKey(input.chunkKey);
+  const biomeId = deriveChunkBiome(parsed.x, parsed.z, worldSeed) as BiomeId;
+  const plan = generateChunkScenePlan({ worldSeed, chunkX: parsed.x, chunkZ: parsed.z, biomeId, kappa: KAPPA_STANDARD });
+
+  const totalTerrain = Math.max(1, plan.terrain.length);
+  const roadCellCount = Object.keys(plan.roads.roadCells).length;
+  const collisionCellCount = Object.keys(plan.collisionCells).length;
+  const pressure = pressureFromBiome(plan);
+
+  return Object.freeze({
+    signalVersion: 1,
+    source: plan.generatedBy,
+    biomeId: plan.biome.biomeId,
+    resourceDensityPerMille: clampPerMille(plan.biome.resourceDensityPerMille),
+    treeDensityPerMille: clampPerMille(plan.biome.treeDensityPerMille),
+    settlementChancePerMille: clampPerMille(plan.biome.settlementChancePerMille),
+    heightBaseKappa: Number(plan.biome.heightBase),
+    heightVarianceKappa: Number(plan.biome.heightVariance),
+    terrainGrassPerMille: ratioPerMille(countTerrain(plan, 'grass'), totalTerrain),
+    terrainForestPerMille: ratioPerMille(countTerrain(plan, 'forest_floor'), totalTerrain),
+    terrainStonePerMille: ratioPerMille(countTerrain(plan, 'stone'), totalTerrain),
+    terrainRoadPerMille: ratioPerMille(countTerrain(plan, 'road_edge'), totalTerrain),
+    roadCellCount,
+    roadEdgeCount: plan.roads.edges.length,
+    settlementLotCount: plan.settlement.lots.length,
+    settlementIntentPerMille: clampPerMille(plan.biome.settlementChancePerMille + plan.settlement.lots.length * 80 + countProps(plan, 'structure') * 35),
+    resourcePropCount: countProps(plan, 'resource'),
+    structurePropCount: countProps(plan, 'structure'),
+    collisionCellCount,
+    npcCount: plan.npcs.length,
+    dangerPressurePerMille: pressure.risk,
+    dungeonPressurePerMille: pressure.underworld,
+    signature: [
+      plan.generatedBy,
+      worldSeed,
+      String(input.chunkKey),
+      Number(input.activationTick),
+      plan.biome.biomeId,
+      plan.biome.resourceDensityPerMille,
+      plan.biome.treeDensityPerMille,
+      plan.biome.settlementChancePerMille,
+      roadCellCount,
+      plan.roads.edges.length,
+      plan.settlement.lots.length,
+      plan.npcs.length,
+      collisionCellCount,
+    ].join('|'),
+  });
+}

--- a/server/src/core/are/CanonicalLayerSeedSignals.ts
+++ b/server/src/core/are/CanonicalLayerSeedSignals.ts
@@ -1,10 +1,7 @@
-import {
-  deriveChunkBiome,
-  generateChunkScenePlan,
-  KAPPA_STANDARD,
-  type BiomeId,
-  type ChunkScenePlan,
-} from '@wasd/shared';
+import { deriveChunkBiome } from '../../../../packages/shared/src/world/BiomeDirector.js';
+import { generateChunkScenePlan } from '../../../../packages/shared/src/world/WorldDirector.js';
+import { KAPPA_STANDARD } from '../../../../packages/shared/src/world/KappaMath.js';
+import type { BiomeId, ChunkScenePlan } from '../../../../packages/shared/src/world/ScenePlanTypes.js';
 import type { ChunkKey, TickId } from './types.js';
 import { parseChunkKey } from './types.js';
 import { resolveCanonicalWorldSeed, type CanonicalLayerSeedSignals } from './CanonicalLayerSeed.js';

--- a/server/src/core/are/WorldBrainRuntimePort.ts
+++ b/server/src/core/are/WorldBrainRuntimePort.ts
@@ -16,6 +16,7 @@ import {
   deriveCanonicalLayerSeed,
   type CanonicalLayerSeedResult,
 } from './CanonicalLayerSeed.js';
+import { deriveCanonicalWorldgenSeedSignals } from './CanonicalLayerSeedSignals.js';
 import type {
   WorldBrainCanonicalStatePort,
   WorldBrainDelta,
@@ -146,10 +147,16 @@ export class RuntimeWorldBrainStatePort implements WorldBrainCanonicalStatePort 
   registerChunk(chunkKey: ChunkKey): void {
     this.activeChunks.add(chunkKey);
     if (!this.layerStates.has(chunkKey)) {
+      const signals = deriveCanonicalWorldgenSeedSignals({
+        worldSeed: this.options.worldSeed,
+        chunkKey,
+        activationTick: this.currentTick,
+      });
       const seed = deriveCanonicalLayerSeed({
         worldSeed: this.options.worldSeed,
         chunkKey,
         activationTick: this.currentTick,
+        signals,
       });
       this.seedRecords.set(chunkKey, seed);
       this.layerStates.set(chunkKey, iareLayersToChunkLayerState(seed.layers));

--- a/server/src/core/are/__tests__/CanonicalLayerSeed.test.ts
+++ b/server/src/core/are/__tests__/CanonicalLayerSeed.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ARELORIA_WORLD_SEED,
   deriveCanonicalLayerSeed,
 } from '../CanonicalLayerSeed.js';
+import { deriveCanonicalWorldgenSeedSignals } from '../CanonicalLayerSeedSignals.js';
 import { RuntimeWorldBrainStatePort, chunkLayerStateToIARELayers } from '../WorldBrainRuntimePort.js';
 import { createChunkKey, createTickId } from '../types.js';
 
@@ -34,7 +35,25 @@ describe('Canonical layer seed truth', () => {
     expect(Number(seed.checksum)).toBe(6500);
   });
 
-  it('seeds RuntimeWorldBrainStatePort chunks before first tick', () => {
+  it('folds deterministic biome terrain signals into the seed while preserving Kappa conservation', () => {
+    const chunkKey = createChunkKey(3, 4);
+    const activationTick = createTickId(0);
+    const signals = deriveCanonicalWorldgenSeedSignals({ worldSeed: 'signal-seed', chunkKey, activationTick });
+
+    const base = deriveCanonicalLayerSeed({ worldSeed: 'signal-seed', chunkKey, activationTick });
+    const signaled = deriveCanonicalLayerSeed({ worldSeed: 'signal-seed', chunkKey, activationTick, signals });
+    const repeat = deriveCanonicalLayerSeed({ worldSeed: 'signal-seed', chunkKey, activationTick, signals });
+
+    expect(signals.source).toBe('OuroborosWorldDirectorV1');
+    expect(signals.signature).toContain(String(chunkKey));
+    expect(signaled.layers).toEqual(repeat.layers);
+    expect(signaled.layers).not.toEqual(base.layers);
+    expect(signaled.signals?.biomeId).toBe(signals.biomeId);
+    expect(Number(signaled.checksum)).toBe(6500);
+    expect(verifyChunkKappaHash(chunkKey, signaled.layers, activationTick, signaled.seedHash)).toBe(true);
+  });
+
+  it('seeds RuntimeWorldBrainStatePort chunks with worldgen signals before first tick', () => {
     const port = new RuntimeWorldBrainStatePort({ worldSeed: 'runtime-seed' });
     const chunkKey = createChunkKey(1, 2);
 
@@ -45,6 +64,9 @@ describe('Canonical layer seed truth', () => {
     const chunkState = snapshot.layer_states.get(chunkKey);
 
     expect(seedRecord).not.toBeNull();
+    expect(seedRecord!.signals).not.toBeNull();
+    expect(seedRecord!.signals!.source).toBe('OuroborosWorldDirectorV1');
+    expect(Number(seedRecord!.checksum)).toBe(6500);
     expect(chunkState).toBeDefined();
     expect(chunkLayerStateToIARELayers(chunkState!)).toEqual(seedRecord!.layers);
     expect(snapshot.world_hash).not.toBe('0'.repeat(64));

--- a/server/src/core/are/index.ts
+++ b/server/src/core/are/index.ts
@@ -249,9 +249,17 @@ export {
   canonicalLayerSeedHash,
   resolveCanonicalWorldSeed,
   zeroStateHash,
+  type CanonicalSeedBiomeId,
+  type CanonicalLayerSeedSignals,
   type CanonicalLayerSeedInput,
   type CanonicalLayerSeedResult,
 } from './CanonicalLayerSeed.js';
+
+// Phase 11: Canonical Worldgen Seed Signals
+export {
+  deriveCanonicalWorldgenSeedSignals,
+  type CanonicalWorldgenSignalInput,
+} from './CanonicalLayerSeedSignals.js';
 
 // Phase 11: OuroborosTickSystem - Ouroboros autonomous agent integration
 export {


### PR DESCRIPTION
## Summary

This PR implements **Biome/Terrain Seed Signal Integration** after #2012 Canonical Layer Seed Truth.

Canonical Kappa1000 layer seeds now include deterministic world-generation signals from the shared stateless WorldDirector instead of relying only on `worldSeed + chunkKey + activationTick`.

## Changes

| File | Change |
|------|--------|
| `server/src/core/are/CanonicalLayerSeedSignals.ts` | Adds `deriveCanonicalWorldgenSeedSignals()` backed by `@wasd/shared` worldgen |
| `server/src/core/are/CanonicalLayerSeed.ts` | Adds `CanonicalLayerSeedSignals`, folds signal signature and signal-based layer bias into seed derivation |
| `server/src/core/are/WorldBrainRuntimePort.ts` | Feeds worldgen signals into runtime chunk seeding on `registerChunk()` |
| `server/src/core/are/__tests__/CanonicalLayerSeed.test.ts` | Covers signal determinism, layer influence, checksum preservation, runtime signal records |
| `server/src/core/are/index.ts` | Exports signal APIs and types |
| `docs/CANONICAL_LAYER_SEED_TRUTH.md` | Documents worldgen signal inputs and runtime chain |

## Runtime Truth

New active chunk path:

```text
WorldTickThinShell.registerChunk(chunkKey)
  -> RuntimeWorldBrainStatePort.registerChunk(chunkKey)
  -> deriveCanonicalWorldgenSeedSignals({ worldSeed, chunkKey, activationTick })
  -> deriveCanonicalLayerSeed({ worldSeed, chunkKey, activationTick, signals })
  -> iareLayersToChunkLayerState(seed.layers)
  -> WorldBrainTickSystem reads signaled seed layers on next tick
```

## Signal Source

Signals are derived from the existing shared stateless worldgen chain:

```text
deriveChunkBiome()
  -> generateChunkScenePlan()
  -> biome / terrain / roads / settlement / props / NPC / collision signals
```

## Invariant

The 13-layer Kappa1000 conservation invariant remains hard:

```text
sum(layers) = 6500
```

Worldgen signals bias individual layers, then deterministic conservation adjustment restores the checksum.

## No Fake Truth

- No `Math.random()`
- No `Date.now()`
- No side-channel world signal source
- No zero-state active chunk bootstrap
- No workflow changes
- Shared WorldDirector is the signal source

## Follow-up

Next step should promote the signal-to-layer bias weights into a documented balancing matrix so world design can tune pressure without changing the deterministic seed contract.