### PR TITLE
feat(equipment): atomic equip/unequip transactions

### DIFF
--- a/server/src/equipment/EquipmentService.ts
+++ b/server/src/equipment/EquipmentService.ts
@@ -1,93 +1,246 @@
 /**
  * EQUIPMENT SERVICE
  *
- * Server-authoritative equipment service with inventory ownership validation.
+ * Server-authoritative equipment service with atomic inventory/equipment transactions.
  * Deterministic: No Date.now(), no Math.random().
+ *
+ * Atomicity guarantees:
+ * - equipItem: consumes inventory item, equips to slot. If slot occupied, returns old item to inventory.
+ * - unequipItem: removes from equipment slot, returns item to inventory.
+ * - Both operations persist inventory AND equipment states together.
  */
 
-import { getInventoryService } from "../inventory/inventoryRuntime.js";
+import { getInventoryService as defaultGetInventoryService, createPersistedPlayerInventoryState } from "../inventory/inventoryRuntime.js";
 import { EquipmentStore } from "./EquipmentStore.js";
 import {
   createPersistedPlayerEquipmentState,
   type EquipmentPersistenceAdapter,
 } from "./EquipmentPersistence.js";
-import type { EquipItemResult, PlayerEquipmentState, EquipmentSlotId } from "./EquipmentTypes.js";
+import {
+  EQUIPMENT_DEFINITIONS,
+  isEquipmentItemId,
+  type PlayerEquipmentState,
+  type EquipmentSlotId,
+  type InventoryItemId,
+} from "./EquipmentTypes.js";
+import type { InventoryService } from "../inventory/InventoryService.js";
 
-export interface UnequipItemResult {
+export { createPersistedPlayerInventoryState as createPersistedInventoryState };
+
+export interface InventoryServiceLike {
+  getPlayerInventory(playerId: string): Promise<ReturnType<InventoryService['getPlayerInventory']>>;
+  addItem(input: { playerId: string; itemId: InventoryItemId | string; quantity: number }): Promise<ReturnType<InventoryService['addItem']>>;
+  removeItem(input: { playerId: string; itemId: InventoryItemId | string; quantity: number }): Promise<ReturnType<InventoryService['removeItem']>>;
+  persistInventory(playerId: string, state: ReturnType<InventoryService['getPlayerInventory']>): Promise<void>;
+}
+
+export interface AtomicEquipResult {
+  ok: boolean;
+  playerId: string;
+  itemId: string;
+  reason?: "equipped" | "invalid_item" | "item_not_owned" | "invalid_player";
+  unequippedItemId?: string;
+  equipment?: PlayerEquipmentState;
+  inventoryDelta?: { itemId: InventoryItemId; delta: number };
+}
+
+export interface AtomicUnequipResult {
   ok: boolean;
   playerId: string;
   slotId: EquipmentSlotId;
   reason?: "unequipped" | "slot_empty" | "invalid_player";
+  unequippedItemId?: string;
   equipment?: PlayerEquipmentState;
+  inventoryDelta?: { itemId: InventoryItemId; delta: number };
 }
 
 export class EquipmentService {
   private readonly hydratedPlayers = new Set<string>();
+  private readonly getInventoryService: () => Promise<InventoryServiceLike>;
 
   constructor(
     private readonly store: EquipmentStore,
     private readonly persistence: EquipmentPersistenceAdapter,
-  ) {}
+    getInventoryService?: () => Promise<InventoryServiceLike>,
+  ) {
+    // Use provided inventory service getter or default to runtime singleton
+    this.getInventoryService = getInventoryService ?? defaultGetInventoryService;
+  }
 
   async getPlayerEquipment(playerId: string): Promise<PlayerEquipmentState> {
     await this.hydratePlayer(playerId);
     return this.store.getPlayerEquipment(playerId);
   }
 
+  /**
+   * Atomic equip transaction.
+   * - Validates player and item ownership
+   * - Removes item from inventory
+   * - Equips item to canonical slot
+   * - If slot was occupied, returns old item to inventory
+   * - Persists both inventory and equipment atomically
+   */
   async equipItem(input: {
     playerId: string;
     itemId: string;
-  }): Promise<EquipItemResult> {
-    await this.hydratePlayer(input.playerId);
+  }): Promise<AtomicEquipResult> {
+    const { playerId, itemId } = input;
 
-    const inventoryService = await getInventoryService();
-    const inventory = await inventoryService.getPlayerInventory(input.playerId);
-    const ownsItem = inventory.slots.some(
-      (slot) => slot.itemId === input.itemId && slot.quantity > 0,
-    );
-
-    const result = this.store.equipItem({
-      playerId: input.playerId,
-      itemId: input.itemId,
-      ownsItem,
-    });
-
-    if (result.ok && result.equipment) {
-      await this.persistence.savePlayerEquipment(
-        createPersistedPlayerEquipmentState(input.playerId, result.equipment),
-      );
+    // Reject invalid player
+    if (!playerId || playerId === "anonymous") {
+      return { ok: false, playerId, itemId, reason: "invalid_player" };
     }
 
-    return result;
+    // Reject invalid item
+    if (!isEquipmentItemId(itemId)) {
+      return { ok: false, playerId, itemId, reason: "invalid_item" };
+    }
+
+    await this.hydratePlayer(playerId);
+
+    const inventoryService = await this.getInventoryService();
+    const inventory = await inventoryService.getPlayerInventory(playerId);
+
+    // Check inventory ownership
+    const inventorySlot = inventory.slots.find((slot) => slot.itemId === itemId && slot.quantity > 0);
+    if (!inventorySlot) {
+      return { ok: false, playerId, itemId, reason: "item_not_owned" };
+    }
+
+    // Get current equipment state
+    const equipment = this.store.getPlayerEquipment(playerId);
+    const itemDef = EQUIPMENT_DEFINITIONS[itemId];
+    const targetSlotId = itemDef.slotId;
+
+    // Check if slot is already occupied
+    const existingSlot = equipment.slots.find((s) => s.slotId === targetSlotId);
+    let unequippedItemId: string | undefined;
+
+    // If slot occupied, unequip old item (returns to inventory)
+    if (existingSlot) {
+      unequippedItemId = existingSlot.itemId;
+      const unequipResult = this.store.unequipItem({
+        playerId,
+        slotId: targetSlotId,
+      });
+      if (!unequipResult.ok) {
+        // Slot unexpectedly invalid, shouldn't happen
+        return { ok: false, playerId, itemId, reason: "invalid_item" };
+      }
+      // Add old item back to inventory
+      const addBackResult = await inventoryService.addItem({
+        playerId,
+        itemId: existingSlot.itemId as InventoryItemId,
+        quantity: 1,
+      });
+      if (!addBackResult.ok) {
+        // Inventory full or other error - this is a real failure
+        return { ok: false, playerId, itemId, reason: "item_not_owned" };
+      }
+    }
+
+    // Remove item from inventory
+    const removeResult = await inventoryService.removeItem({
+      playerId,
+      itemId: itemId as InventoryItemId,
+      quantity: 1,
+    });
+    if (!removeResult.ok || !removeResult.state) {
+      return { ok: false, playerId, itemId, reason: "item_not_owned" };
+    }
+
+    // Equip item to slot
+    const equipResult = this.store.equipItem({
+      playerId,
+      itemId,
+      ownsItem: true,
+    });
+    if (!equipResult.ok || !equipResult.equipment) {
+      // This shouldn't happen if we validated correctly
+      return { ok: false, playerId, itemId, reason: "invalid_item" };
+    }
+
+    // Persist both states atomically (best effort ordering)
+    await this.persistence.savePlayerEquipment(
+      createPersistedPlayerEquipmentState(playerId, equipResult.equipment),
+    );
+    await inventoryService.persistInventory(playerId, removeResult.state);
+
+    return {
+      ok: true,
+      playerId,
+      itemId,
+      reason: "equipped",
+      unequippedItemId,
+      equipment: equipResult.equipment,
+      inventoryDelta: { itemId: itemId as InventoryItemId, delta: -1 },
+    };
   }
 
+  /**
+   * Atomic unequip transaction.
+   * - Validates player and slot
+   * - Removes item from equipment slot
+   * - Returns item to inventory
+   * - Persists both inventory and equipment atomically
+   */
   async unequipItem(input: {
     playerId: string;
     slotId: EquipmentSlotId;
-  }): Promise<UnequipItemResult> {
-    await this.hydratePlayer(input.playerId);
+  }): Promise<AtomicUnequipResult> {
+    const { playerId, slotId } = input;
 
-    if (!input.playerId || input.playerId === "anonymous") {
-      return {
-        ok: false,
-        playerId: input.playerId,
-        slotId: input.slotId,
-        reason: "invalid_player",
-      };
+    // Reject invalid player
+    if (!playerId || playerId === "anonymous") {
+      return { ok: false, playerId, slotId, reason: "invalid_player" };
     }
 
-    const result = this.store.unequipItem({
-      playerId: input.playerId,
-      slotId: input.slotId,
+    await this.hydratePlayer(playerId);
+
+    // Get current equipment state and check slot
+    const equipment = this.store.getPlayerEquipment(playerId);
+    const existingSlot = equipment.slots.find((s) => s.slotId === slotId);
+
+    if (!existingSlot) {
+      return { ok: false, playerId, slotId, reason: "slot_empty" };
+    }
+
+    const unequippedItemId = existingSlot.itemId;
+
+    // Remove from equipment
+    const unequipResult = this.store.unequipItem({ playerId, slotId });
+    if (!unequipResult.ok || !unequipResult.equipment) {
+      return { ok: false, playerId, slotId, reason: "slot_empty" };
+    }
+
+    // Add item back to inventory
+    const inventoryService = await this.getInventoryService();
+    const addResult = await inventoryService.addItem({
+      playerId,
+      itemId: unequippedItemId as InventoryItemId,
+      quantity: 1,
     });
 
-    if (result.ok && result.equipment) {
-      await this.persistence.savePlayerEquipment(
-        createPersistedPlayerEquipmentState(input.playerId, result.equipment),
-      );
+    if (!addResult.ok || !addResult.state) {
+      // Inventory full - rollback equipment change
+      return { ok: false, playerId, slotId, reason: "slot_empty" };
     }
 
-    return result;
+    // Persist both states atomically (best effort ordering)
+    await this.persistence.savePlayerEquipment(
+      createPersistedPlayerEquipmentState(playerId, unequipResult.equipment),
+    );
+    await inventoryService.persistInventory(playerId, addResult.state);
+
+    return {
+      ok: true,
+      playerId,
+      slotId,
+      reason: "unequipped",
+      unequippedItemId,
+      equipment: unequipResult.equipment,
+      inventoryDelta: { itemId: unequippedItemId as InventoryItemId, delta: +1 },
+    };
   }
 
   async hydratePlayer(playerId: string): Promise<void> {
@@ -105,3 +258,8 @@ export class EquipmentService {
     this.hydratedPlayers.clear();
   }
 }
+
+// Re-export types for convenience
+export type { PlayerEquipmentState, EquipmentSlotId };
+export type EquipItemResult = AtomicEquipResult;
+export type UnequipItemResult = AtomicUnequipResult;

--- a/server/src/equipment/EquipmentService.ts
+++ b/server/src/equipment/EquipmentService.ts
@@ -1,44 +1,42 @@
 /**
  * EQUIPMENT SERVICE
  *
- * Server-authoritative equipment service with atomic inventory/equipment transactions.
+ * Server-authoritative equipment service with staged inventory/equipment transactions.
  * Deterministic: No Date.now(), no Math.random().
- *
- * Atomicity guarantees:
- * - equipItem: consumes inventory item, equips to slot. If slot occupied, returns old item to inventory.
- * - unequipItem: removes from equipment slot, returns item to inventory.
- * - Both operations persist inventory AND equipment states together.
  */
 
 import { getInventoryService as defaultGetInventoryService, createPersistedPlayerInventoryState } from "../inventory/inventoryRuntime.js";
-import { EquipmentStore } from "./EquipmentStore.js";
+import type { InventoryService } from "../inventory/InventoryService.js";
+import type { InventoryItemId, PlayerInventoryState } from "../inventory/InventoryTypes.js";
 import {
   createPersistedPlayerEquipmentState,
   type EquipmentPersistenceAdapter,
 } from "./EquipmentPersistence.js";
+import { EquipmentStore } from "./EquipmentStore.js";
 import {
   EQUIPMENT_DEFINITIONS,
   isEquipmentItemId,
-  type PlayerEquipmentState,
   type EquipmentSlotId,
-  type InventoryItemId,
+  type PlayerEquipmentState,
 } from "./EquipmentTypes.js";
-import type { InventoryService } from "../inventory/InventoryService.js";
+import {
+  planEquipTransaction,
+  planUnequipTransaction,
+} from "./EquipmentTransactionPlanner.js";
 
 export { createPersistedPlayerInventoryState as createPersistedInventoryState };
 
 export interface InventoryServiceLike {
-  getPlayerInventory(playerId: string): Promise<ReturnType<InventoryService['getPlayerInventory']>>;
-  addItem(input: { playerId: string; itemId: InventoryItemId | string; quantity: number }): Promise<ReturnType<InventoryService['addItem']>>;
-  removeItem(input: { playerId: string; itemId: InventoryItemId | string; quantity: number }): Promise<ReturnType<InventoryService['removeItem']>>;
-  persistInventory(playerId: string, state: ReturnType<InventoryService['getPlayerInventory']>): Promise<void>;
+  getPlayerInventory(playerId: string): Promise<PlayerInventoryState>;
+  persistInventory(playerId: string, state: PlayerInventoryState): Promise<void>;
+  replacePlayerInventory(playerId: string, state: PlayerInventoryState): void | Promise<void>;
 }
 
 export interface AtomicEquipResult {
   ok: boolean;
   playerId: string;
   itemId: string;
-  reason?: "equipped" | "invalid_item" | "item_not_owned" | "invalid_player";
+  reason?: "equipped" | "invalid_item" | "item_not_owned" | "invalid_player" | "inventory_full";
   unequippedItemId?: string;
   equipment?: PlayerEquipmentState;
   inventoryDelta?: { itemId: InventoryItemId; delta: number };
@@ -48,7 +46,7 @@ export interface AtomicUnequipResult {
   ok: boolean;
   playerId: string;
   slotId: EquipmentSlotId;
-  reason?: "unequipped" | "slot_empty" | "invalid_player";
+  reason?: "unequipped" | "slot_empty" | "invalid_player" | "inventory_full";
   unequippedItemId?: string;
   equipment?: PlayerEquipmentState;
   inventoryDelta?: { itemId: InventoryItemId; delta: number };
@@ -63,7 +61,6 @@ export class EquipmentService {
     private readonly persistence: EquipmentPersistenceAdapter,
     getInventoryService?: () => Promise<InventoryServiceLike>,
   ) {
-    // Use provided inventory service getter or default to runtime singleton
     this.getInventoryService = getInventoryService ?? defaultGetInventoryService;
   }
 
@@ -72,26 +69,16 @@ export class EquipmentService {
     return this.store.getPlayerEquipment(playerId);
   }
 
-  /**
-   * Atomic equip transaction.
-   * - Validates player and item ownership
-   * - Removes item from inventory
-   * - Equips item to canonical slot
-   * - If slot was occupied, returns old item to inventory
-   * - Persists both inventory and equipment atomically
-   */
   async equipItem(input: {
     playerId: string;
     itemId: string;
   }): Promise<AtomicEquipResult> {
     const { playerId, itemId } = input;
 
-    // Reject invalid player
     if (!playerId || playerId === "anonymous") {
       return { ok: false, playerId, itemId, reason: "invalid_player" };
     }
 
-    // Reject invalid item
     if (!isEquipmentItemId(itemId)) {
       return { ok: false, playerId, itemId, reason: "invalid_item" };
     }
@@ -99,147 +86,89 @@ export class EquipmentService {
     await this.hydratePlayer(playerId);
 
     const inventoryService = await this.getInventoryService();
-    const inventory = await inventoryService.getPlayerInventory(playerId);
+    const currentInventory = await inventoryService.getPlayerInventory(playerId);
+    const currentEquipment = this.store.getPlayerEquipment(playerId);
+    const targetSlotId = EQUIPMENT_DEFINITIONS[itemId].slotId;
+    const slotWasOccupied = currentEquipment.slots.some((slot) => slot.slotId === targetSlotId);
 
-    // Check inventory ownership
-    const inventorySlot = inventory.slots.find((slot) => slot.itemId === itemId && slot.quantity > 0);
-    if (!inventorySlot) {
-      return { ok: false, playerId, itemId, reason: "item_not_owned" };
-    }
-
-    // Get current equipment state
-    const equipment = this.store.getPlayerEquipment(playerId);
-    const itemDef = EQUIPMENT_DEFINITIONS[itemId];
-    const targetSlotId = itemDef.slotId;
-
-    // Check if slot is already occupied
-    const existingSlot = equipment.slots.find((s) => s.slotId === targetSlotId);
-    let unequippedItemId: string | undefined;
-
-    // If slot occupied, unequip old item (returns to inventory)
-    if (existingSlot) {
-      unequippedItemId = existingSlot.itemId;
-      const unequipResult = this.store.unequipItem({
-        playerId,
-        slotId: targetSlotId,
-      });
-      if (!unequipResult.ok) {
-        // Slot unexpectedly invalid, shouldn't happen
-        return { ok: false, playerId, itemId, reason: "invalid_item" };
-      }
-      // Add old item back to inventory
-      const addBackResult = await inventoryService.addItem({
-        playerId,
-        itemId: existingSlot.itemId as InventoryItemId,
-        quantity: 1,
-      });
-      if (!addBackResult.ok) {
-        // Inventory full or other error - this is a real failure
-        return { ok: false, playerId, itemId, reason: "item_not_owned" };
-      }
-    }
-
-    // Remove item from inventory
-    const removeResult = await inventoryService.removeItem({
-      playerId,
-      itemId: itemId as InventoryItemId,
-      quantity: 1,
-    });
-    if (!removeResult.ok || !removeResult.state) {
-      return { ok: false, playerId, itemId, reason: "item_not_owned" };
-    }
-
-    // Equip item to slot
-    const equipResult = this.store.equipItem({
+    const planned = planEquipTransaction({
       playerId,
       itemId,
-      ownsItem: true,
+      inventory: currentInventory,
+      equipment: currentEquipment,
     });
-    if (!equipResult.ok || !equipResult.equipment) {
-      // This shouldn't happen if we validated correctly
-      return { ok: false, playerId, itemId, reason: "invalid_item" };
+
+    if (!planned) {
+      return { ok: false, playerId, itemId, reason: slotWasOccupied ? "inventory_full" : "item_not_owned" };
     }
 
-    // Persist both states atomically (best effort ordering)
-    await this.persistence.savePlayerEquipment(
-      createPersistedPlayerEquipmentState(playerId, equipResult.equipment),
-    );
-    await inventoryService.persistInventory(playerId, removeResult.state);
+    await this.commitStagedStates({
+      playerId,
+      inventoryService,
+      currentInventory,
+      nextInventory: planned.nextInventory,
+      nextEquipment: planned.nextEquipment,
+    });
 
     return {
       ok: true,
       playerId,
       itemId,
       reason: "equipped",
-      unequippedItemId,
-      equipment: equipResult.equipment,
-      inventoryDelta: { itemId: itemId as InventoryItemId, delta: -1 },
+      unequippedItemId: planned.replacedItemId,
+      equipment: planned.nextEquipment,
+      inventoryDelta: { itemId, delta: -1 },
     };
   }
 
-  /**
-   * Atomic unequip transaction.
-   * - Validates player and slot
-   * - Removes item from equipment slot
-   * - Returns item to inventory
-   * - Persists both inventory and equipment atomically
-   */
   async unequipItem(input: {
     playerId: string;
     slotId: EquipmentSlotId;
   }): Promise<AtomicUnequipResult> {
     const { playerId, slotId } = input;
 
-    // Reject invalid player
     if (!playerId || playerId === "anonymous") {
       return { ok: false, playerId, slotId, reason: "invalid_player" };
     }
 
     await this.hydratePlayer(playerId);
 
-    // Get current equipment state and check slot
-    const equipment = this.store.getPlayerEquipment(playerId);
-    const existingSlot = equipment.slots.find((s) => s.slotId === slotId);
-
-    if (!existingSlot) {
-      return { ok: false, playerId, slotId, reason: "slot_empty" };
-    }
-
-    const unequippedItemId = existingSlot.itemId;
-
-    // Remove from equipment
-    const unequipResult = this.store.unequipItem({ playerId, slotId });
-    if (!unequipResult.ok || !unequipResult.equipment) {
-      return { ok: false, playerId, slotId, reason: "slot_empty" };
-    }
-
-    // Add item back to inventory
     const inventoryService = await this.getInventoryService();
-    const addResult = await inventoryService.addItem({
+    const currentInventory = await inventoryService.getPlayerInventory(playerId);
+    const currentEquipment = this.store.getPlayerEquipment(playerId);
+    const slotExists = currentEquipment.slots.some((slot) => slot.slotId === slotId);
+
+    if (!slotExists) {
+      return { ok: false, playerId, slotId, reason: "slot_empty" };
+    }
+
+    const planned = planUnequipTransaction({
       playerId,
-      itemId: unequippedItemId as InventoryItemId,
-      quantity: 1,
+      slotId,
+      inventory: currentInventory,
+      equipment: currentEquipment,
     });
 
-    if (!addResult.ok || !addResult.state) {
-      // Inventory full - rollback equipment change
-      return { ok: false, playerId, slotId, reason: "slot_empty" };
+    if (!planned) {
+      return { ok: false, playerId, slotId, reason: "inventory_full" };
     }
 
-    // Persist both states atomically (best effort ordering)
-    await this.persistence.savePlayerEquipment(
-      createPersistedPlayerEquipmentState(playerId, unequipResult.equipment),
-    );
-    await inventoryService.persistInventory(playerId, addResult.state);
+    await this.commitStagedStates({
+      playerId,
+      inventoryService,
+      currentInventory,
+      nextInventory: planned.nextInventory,
+      nextEquipment: planned.nextEquipment,
+    });
 
     return {
       ok: true,
       playerId,
       slotId,
       reason: "unequipped",
-      unequippedItemId,
-      equipment: unequipResult.equipment,
-      inventoryDelta: { itemId: unequippedItemId as InventoryItemId, delta: +1 },
+      unequippedItemId: planned.removedItemId,
+      equipment: planned.nextEquipment,
+      inventoryDelta: { itemId: planned.removedItemId, delta: +1 },
     };
   }
 
@@ -257,9 +186,34 @@ export class EquipmentService {
   clearForTests(): void {
     this.hydratedPlayers.clear();
   }
+
+  private async commitStagedStates(input: {
+    playerId: string;
+    inventoryService: InventoryServiceLike;
+    currentInventory: PlayerInventoryState;
+    nextInventory: PlayerInventoryState;
+    nextEquipment: PlayerEquipmentState;
+  }): Promise<void> {
+    let inventoryPersisted = false;
+
+    try {
+      await input.inventoryService.persistInventory(input.playerId, input.nextInventory);
+      inventoryPersisted = true;
+      await this.persistence.savePlayerEquipment(
+        createPersistedPlayerEquipmentState(input.playerId, input.nextEquipment),
+      );
+    } catch (error) {
+      if (inventoryPersisted) {
+        await input.inventoryService.persistInventory(input.playerId, input.currentInventory).catch(() => undefined);
+      }
+      throw error;
+    }
+
+    await input.inventoryService.replacePlayerInventory(input.playerId, input.nextInventory);
+    this.store.replacePlayerEquipment(input.playerId, input.nextEquipment);
+  }
 }
 
-// Re-export types for convenience
 export type { PlayerEquipmentState, EquipmentSlotId };
 export type EquipItemResult = AtomicEquipResult;
 export type UnequipItemResult = AtomicUnequipResult;

--- a/server/src/equipment/EquipmentTransactionPlanner.ts
+++ b/server/src/equipment/EquipmentTransactionPlanner.ts
@@ -1,0 +1,152 @@
+import {
+  INVENTORY_CAPACITY,
+  ITEM_DEFINITIONS,
+  normalizePlayerInventoryState,
+  type InventoryItemId,
+  type PlayerInventoryState,
+} from "../inventory/InventoryTypes.js";
+import {
+  EQUIPMENT_DEFINITIONS,
+  compareEquipmentSlotIds,
+  createEquippedSlotFromDefinition,
+  normalizeEquipmentState,
+  type EquipmentSlotId,
+  type PlayerEquipmentState,
+} from "./EquipmentTypes.js";
+
+export interface StagedEquipTransaction {
+  readonly nextInventory: PlayerInventoryState;
+  readonly nextEquipment: PlayerEquipmentState;
+  readonly replacedItemId?: InventoryItemId;
+}
+
+export interface StagedUnequipTransaction {
+  readonly nextInventory: PlayerInventoryState;
+  readonly nextEquipment: PlayerEquipmentState;
+  readonly removedItemId: InventoryItemId;
+}
+
+function removeOneInventoryItem(
+  state: PlayerInventoryState,
+  itemId: InventoryItemId,
+): PlayerInventoryState | null {
+  const existing = state.slots.find((slot) => slot.itemId === itemId);
+  if (!existing || existing.quantity <= 0) return null;
+
+  const nextSlots = existing.quantity === 1
+    ? state.slots.filter((slot) => slot.itemId !== itemId)
+    : state.slots.map((slot) =>
+        slot.itemId === itemId
+          ? { ...slot, quantity: slot.quantity - 1 }
+          : slot,
+      );
+
+  return normalizePlayerInventoryState({ ...state, slots: nextSlots }, state.playerId);
+}
+
+function addOneInventoryItem(
+  state: PlayerInventoryState,
+  itemId: InventoryItemId,
+): PlayerInventoryState | null {
+  const definition = ITEM_DEFINITIONS[itemId];
+  const existing = state.slots.find((slot) => slot.itemId === itemId);
+
+  if (existing && definition.stackable) {
+    return normalizePlayerInventoryState(
+      {
+        ...state,
+        slots: state.slots.map((slot) =>
+          slot.itemId === itemId
+            ? { ...slot, quantity: Math.min(slot.quantity + 1, definition.maxStack) }
+            : slot,
+        ),
+      },
+      state.playerId,
+    );
+  }
+
+  if (state.slots.length >= (state.capacity || INVENTORY_CAPACITY)) return null;
+
+  return normalizePlayerInventoryState(
+    {
+      ...state,
+      slots: [
+        ...state.slots,
+        {
+          slotId: definition.stackable
+            ? `slot_${definition.id}`
+            : `slot_${definition.id}_${String(state.slots.filter((slot) => slot.itemId === definition.id).length + 1).padStart(3, "0")}`,
+          itemId: definition.id,
+          name: definition.name,
+          quantity: 1,
+          category: definition.category,
+          stackable: definition.stackable,
+          maxStack: definition.maxStack,
+        },
+      ],
+    },
+    state.playerId,
+  );
+}
+
+export function planEquipTransaction(input: {
+  readonly playerId: string;
+  readonly itemId: InventoryItemId;
+  readonly inventory: PlayerInventoryState;
+  readonly equipment: PlayerEquipmentState;
+}): StagedEquipTransaction | null {
+  const definition = EQUIPMENT_DEFINITIONS[input.itemId];
+  const inventoryAfterConsume = removeOneInventoryItem(input.inventory, input.itemId);
+  if (!inventoryAfterConsume) return null;
+
+  const existingSlot = input.equipment.slots.find((slot) => slot.slotId === definition.slotId);
+  const nextInventory = existingSlot
+    ? addOneInventoryItem(inventoryAfterConsume, existingSlot.itemId)
+    : inventoryAfterConsume;
+
+  if (!nextInventory) return null;
+
+  const nextEquipment = normalizeEquipmentState(
+    {
+      ...input.equipment,
+      slots: [
+        ...input.equipment.slots.filter((slot) => slot.slotId !== definition.slotId),
+        createEquippedSlotFromDefinition(definition),
+      ].sort((a, b) => compareEquipmentSlotIds(a.slotId, b.slotId)),
+    },
+    input.playerId,
+  );
+
+  return {
+    nextInventory,
+    nextEquipment,
+    ...(existingSlot ? { replacedItemId: existingSlot.itemId } : {}),
+  };
+}
+
+export function planUnequipTransaction(input: {
+  readonly playerId: string;
+  readonly slotId: EquipmentSlotId;
+  readonly inventory: PlayerInventoryState;
+  readonly equipment: PlayerEquipmentState;
+}): StagedUnequipTransaction | null {
+  const existingSlot = input.equipment.slots.find((slot) => slot.slotId === input.slotId);
+  if (!existingSlot) return null;
+
+  const nextInventory = addOneInventoryItem(input.inventory, existingSlot.itemId);
+  if (!nextInventory) return null;
+
+  const nextEquipment = normalizeEquipmentState(
+    {
+      ...input.equipment,
+      slots: input.equipment.slots.filter((slot) => slot.slotId !== input.slotId),
+    },
+    input.playerId,
+  );
+
+  return {
+    nextInventory,
+    nextEquipment,
+    removedItemId: existingSlot.itemId,
+  };
+}

--- a/server/src/inventory/InventoryService.ts
+++ b/server/src/inventory/InventoryService.ts
@@ -74,6 +74,16 @@ export class InventoryService {
     return this.store.hasItems(input);
   }
 
+  /**
+   * Persist inventory state. Used by atomic transactions that need to persist
+   * the inventory state after multiple operations.
+   */
+  async persistInventory(playerId: string, state: PlayerInventoryState): Promise<void> {
+    await this.persistence.savePlayerInventory(
+      createPersistedPlayerInventoryState(playerId, state),
+    );
+  }
+
   async hydratePlayer(playerId: string): Promise<void> {
     if (this.hydratedPlayers.has(playerId)) return;
 

--- a/server/src/inventory/InventoryService.ts
+++ b/server/src/inventory/InventoryService.ts
@@ -74,14 +74,15 @@ export class InventoryService {
     return this.store.hasItems(input);
   }
 
-  /**
-   * Persist inventory state. Used by atomic transactions that need to persist
-   * the inventory state after multiple operations.
-   */
   async persistInventory(playerId: string, state: PlayerInventoryState): Promise<void> {
     await this.persistence.savePlayerInventory(
       createPersistedPlayerInventoryState(playerId, state),
     );
+  }
+
+  replacePlayerInventory(playerId: string, state: PlayerInventoryState): void {
+    this.store.replacePlayerInventory(playerId, state);
+    this.hydratedPlayers.add(playerId);
   }
 
   async hydratePlayer(playerId: string): Promise<void> {

--- a/server/src/inventory/inventoryRuntime.ts
+++ b/server/src/inventory/inventoryRuntime.ts
@@ -13,6 +13,7 @@
 import { InventoryStore } from "./InventoryStore.js";
 import { InventoryService } from "./InventoryService.js";
 import { createInventoryPersistenceAdapter } from "./createInventoryPersistenceAdapter.js";
+import { createPersistedPlayerInventoryState } from "./InventoryPersistence.js";
 
 // Initialize persistence adapter and service
 const store = new InventoryStore();
@@ -50,4 +51,5 @@ export function getInventoryStore(): InventoryStore {
 
 // Re-export for convenience
 export { InventoryStore } from "./InventoryStore.js";
+export { createPersistedPlayerInventoryState } from "./InventoryPersistence.js";
 export type { InventoryItemId, PlayerInventoryState, InventoryAddResult, InventoryRemoveResult } from "./InventoryTypes.js";

--- a/server/tests/equipment-service.test.ts
+++ b/server/tests/equipment-service.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Equipment Service Tests
+ *
+ * Integration tests for EquipmentService with atomic inventory/equipment transactions.
+ * Deterministic: No Math.random(), no Date.now().
+ *
+ * Test coverage:
+ * - equip consumes one inventory item and fills the canonical equipment slot
+ * - replacing a slot returns the replaced item to inventory
+ * - unequip removes the equipment slot and restores inventory
+ * - invalid item / item_not_owned / slot_empty do not mutate either state
+ * - repeated same input from same initial state gives identical output
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { EquipmentStore } from "../src/equipment/EquipmentStore.js";
+import { InventoryStore } from "../src/inventory/InventoryStore.js";
+import { EquipmentService } from "../src/equipment/EquipmentService.js";
+import type { EquipmentPersistenceAdapter } from "../src/equipment/EquipmentPersistence.js";
+import type { InventoryPersistenceAdapter } from "../src/inventory/InventoryPersistence.js";
+import type { PlayerInventoryState, InventoryItemId } from "../src/inventory/InventoryTypes.js";
+import type { InventoryServiceLike } from "../src/equipment/EquipmentService.js";
+
+// Mock persistence adapters for testing
+const noopInventoryPersistence: InventoryPersistenceAdapter = {
+  async loadPlayerInventory() { return null; },
+  async savePlayerInventory() {},
+};
+
+const noopEquipmentPersistence: EquipmentPersistenceAdapter = {
+  async loadPlayerEquipment() { return null; },
+  async savePlayerEquipment() {},
+};
+
+// Test utilities - creates a synchronous inventory service wrapper for testing
+function createTestInventoryService(store: InventoryStore): InventoryServiceLike {
+  return {
+    async getPlayerInventory(playerId: string) {
+      return store.getPlayerInventory(playerId);
+    },
+    async addItem(input) {
+      return store.addItem(input);
+    },
+    async removeItem(input) {
+      return store.removeItem(input);
+    },
+    async persistInventory(playerId: string, state: PlayerInventoryState) {
+      // Update in-memory state for testing
+      store.replacePlayerInventory(playerId, state);
+    },
+  };
+}
+
+describe("EquipmentService", () => {
+  let equipmentStore: EquipmentStore;
+  let inventoryStore: InventoryStore;
+  let service: EquipmentService;
+
+  beforeEach(() => {
+    equipmentStore = new EquipmentStore();
+    inventoryStore = new InventoryStore();
+    
+    // Create service with test inventory service via dependency injection
+    const testInventoryService = createTestInventoryService(inventoryStore);
+    service = new EquipmentService(
+      equipmentStore,
+      noopEquipmentPersistence,
+      () => Promise.resolve(testInventoryService),
+    );
+    
+    // Reset internal hydration tracking
+    service.clearForTests();
+  });
+
+  describe("equipItem - atomic inventory consumption", () => {
+    it("equips owned item and consumes one inventory unit", async () => {
+      // Setup: add wooden axe to inventory
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+
+      // Act: equip the axe
+      const result = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+
+      // Assert: success
+      expect(result.ok).toBe(true);
+      expect(result.reason).toBe("equipped");
+      expect(result.itemId).toBe("wooden_axe");
+      expect(result.equipment?.slots).toContainEqual(
+        expect.objectContaining({ slotId: "woodcutting_tool", itemId: "wooden_axe" }),
+      );
+
+      // Assert: inventory consumed
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      const axeSlot = inventory.slots.find((s) => s.itemId === "wooden_axe");
+      expect(axeSlot).toBeUndefined();
+
+      // Assert: inventory delta
+      expect(result.inventoryDelta).toEqual({ itemId: "wooden_axe", delta: -1 });
+    });
+
+    it("rejects equip of unowned item", async () => {
+      // Act: try to equip item not in inventory
+      const result = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+
+      // Assert: failure
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("item_not_owned");
+
+      // Assert: no equipment change
+      const equipment = equipmentStore.getPlayerEquipment("player1");
+      expect(equipment.slots).toEqual([]);
+
+      // Assert: no inventory change
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      expect(inventory.slots).toEqual([]);
+    });
+
+    it("rejects equip of invalid item", async () => {
+      // Act: try to equip non-equipment item
+      const result = await service.equipItem({ playerId: "player1", itemId: "invalid_item" });
+
+      // Assert: failure
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_item");
+    });
+
+    it("rejects equip for invalid player", async () => {
+      const result = await service.equipItem({ playerId: "", itemId: "wooden_axe" });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_player");
+    });
+
+    it("rejects equip for anonymous player", async () => {
+      const result = await service.equipItem({ playerId: "anonymous", itemId: "wooden_axe" });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_player");
+    });
+  });
+
+  describe("equipItem - slot replacement", () => {
+    it("unequips old item and returns it to inventory when replacing slot", async () => {
+      // Setup: add wooden axe and copper axe to inventory
+      const woodenAxeResult = inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      const copperAxeResult = inventoryStore.addItem({ playerId: "player1", itemId: "copper_axe", quantity: 1 });
+
+      // Verify both items were added
+      expect(woodenAxeResult.ok).toBe(true);
+      expect(copperAxeResult.ok).toBe(true);
+
+      // Act: equip copper axe first (since it's in the same slot as wooden_axe)
+      const result = await service.equipItem({ playerId: "player1", itemId: "copper_axe" });
+
+      // Assert: success
+      expect(result.ok).toBe(true);
+      expect(result.reason).toBe("equipped");
+
+      // Assert: equipment has copper axe
+      const equipment = equipmentStore.getPlayerEquipment("player1");
+      expect(equipment.slots).toContainEqual(
+        expect.objectContaining({ slotId: "woodcutting_tool", itemId: "copper_axe" }),
+      );
+
+      // Assert: wooden axe is back in inventory
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      expect(inventory.slots).toContainEqual(
+        expect.objectContaining({ itemId: "wooden_axe", quantity: 1 }),
+      );
+    });
+
+    it("can equip items in different slots independently", async () => {
+      // Setup: add all three tools
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      inventoryStore.addItem({ playerId: "player1", itemId: "copper_pickaxe", quantity: 1 });
+      inventoryStore.addItem({ playerId: "player1", itemId: "simple_fishing_rod", quantity: 1 });
+
+      // Act: equip all three
+      await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+      await service.equipItem({ playerId: "player1", itemId: "copper_pickaxe" });
+      await service.equipItem({ playerId: "player1", itemId: "simple_fishing_rod" });
+
+      // Assert: all slots filled
+      const equipment = equipmentStore.getPlayerEquipment("player1");
+      expect(equipment.slots).toHaveLength(3);
+      expect(equipment.slots).toContainEqual(
+        expect.objectContaining({ slotId: "woodcutting_tool", itemId: "wooden_axe" }),
+      );
+      expect(equipment.slots).toContainEqual(
+        expect.objectContaining({ slotId: "mining_tool", itemId: "copper_pickaxe" }),
+      );
+      expect(equipment.slots).toContainEqual(
+        expect.objectContaining({ slotId: "fishing_tool", itemId: "simple_fishing_rod" }),
+      );
+
+      // Assert: no items left in inventory
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      expect(inventory.slots).toHaveLength(0);
+    });
+  });
+
+  describe("unequipItem - atomic inventory restoration", () => {
+    it("unequips item and returns it to inventory", async () => {
+      // Setup: equip wooden axe
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+
+      // Act: unequip
+      const result = await service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" });
+
+      // Assert: success
+      expect(result.ok).toBe(true);
+      expect(result.reason).toBe("unequipped");
+      expect(result.unequippedItemId).toBe("wooden_axe");
+      expect(result.slotId).toBe("woodcutting_tool");
+
+      // Assert: equipment slot empty
+      const equipment = equipmentStore.getPlayerEquipment("player1");
+      expect(equipment.slots).toHaveLength(0);
+
+      // Assert: item returned to inventory
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      expect(inventory.slots).toContainEqual(
+        expect.objectContaining({ itemId: "wooden_axe", quantity: 1 }),
+      );
+
+      // Assert: inventory delta
+      expect(result.inventoryDelta).toEqual({ itemId: "wooden_axe", delta: +1 });
+    });
+
+    it("rejects unequip of empty slot", async () => {
+      // Act: try to unequip empty slot
+      const result = await service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" });
+
+      // Assert: failure
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("slot_empty");
+
+      // Assert: no state change
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      expect(inventory.slots).toEqual([]);
+    });
+
+    it("rejects unequip for invalid player", async () => {
+      const result = await service.unequipItem({ playerId: "", slotId: "woodcutting_tool" });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_player");
+    });
+
+    it("rejects unequip for anonymous player", async () => {
+      const result = await service.unequipItem({ playerId: "anonymous", slotId: "woodcutting_tool" });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_player");
+    });
+
+    it("unequip then re-equip returns to same state", async () => {
+      // Setup
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+
+      // Act: unequip then re-equip
+      await service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" });
+      const result = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+
+      // Assert: success
+      expect(result.ok).toBe(true);
+      expect(result.reason).toBe("equipped");
+
+      // Assert: original state restored
+      const equipment = equipmentStore.getPlayerEquipment("player1");
+      expect(equipment.slots).toContainEqual(
+        expect.objectContaining({ slotId: "woodcutting_tool", itemId: "wooden_axe" }),
+      );
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      expect(inventory.slots).toHaveLength(0);
+    });
+  });
+
+  describe("determinism", () => {
+    it("repeated equip from same initial state produces identical output", async () => {
+      // Setup: same initial state
+      const setup = () => {
+        equipmentStore.clearForTests();
+        inventoryStore.clearForTests();
+        service.clearForTests();
+        inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      };
+
+      // First equip
+      setup();
+      const result1 = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+      const equipment1 = equipmentStore.getPlayerEquipment("player1");
+      const inventory1 = inventoryStore.getPlayerInventory("player1");
+
+      // Second equip (from scratch)
+      setup();
+      const result2 = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+      const equipment2 = equipmentStore.getPlayerEquipment("player1");
+      const inventory2 = inventoryStore.getPlayerInventory("player1");
+
+      // Assert: identical results
+      expect(result1.ok).toBe(result2.ok);
+      expect(result1.reason).toBe(result2.reason);
+      expect(result1.itemId).toBe(result2.itemId);
+      expect(result1.equipment?.slots).toEqual(result2.equipment?.slots);
+      expect(equipment1.slots).toEqual(equipment2.slots);
+      expect(inventory1.slots).toEqual(inventory2.slots);
+    });
+
+    it("identical equip+unequip sequence produces identical final state", async () => {
+      const runSequence = async () => {
+        equipmentStore.clearForTests();
+        inventoryStore.clearForTests();
+        service.clearForTests();
+        
+        inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+        inventoryStore.addItem({ playerId: "player1", itemId: "copper_axe", quantity: 1 });
+        
+        await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+        await service.equipItem({ playerId: "player1", itemId: "copper_axe" });
+        await service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" });
+        
+        return {
+          equipment: JSON.parse(JSON.stringify(equipmentStore.getPlayerEquipment("player1"))),
+          inventory: JSON.parse(JSON.stringify(inventoryStore.getPlayerInventory("player1"))),
+        };
+      };
+
+      const result1 = await runSequence();
+      const result2 = await runSequence();
+
+      // Assert: identical final states
+      expect(result1.equipment.slots).toEqual(result2.equipment.slots);
+      expect(result1.inventory.slots).toEqual(result2.inventory.slots);
+    });
+  });
+
+  describe("no partial state mutations", () => {
+    it("failed equip does not mutate equipment state", async () => {
+      // Setup: have wooden axe in inventory
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+
+      // Act: try to equip invalid item
+      const result = await service.equipItem({ playerId: "player1", itemId: "invalid_item" });
+
+      // Assert: failure
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_item");
+
+      // Assert: no equipment state change
+      const equipment = equipmentStore.getPlayerEquipment("player1");
+      expect(equipment.slots).toHaveLength(0);
+
+      // Assert: no inventory state change
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      expect(inventory.slots).toContainEqual(
+        expect.objectContaining({ itemId: "wooden_axe", quantity: 1 }),
+      );
+    });
+
+    it("successful equip produces consistent equipment + inventory", async () => {
+      // Setup
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+
+      // Act
+      const result = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+
+      // Assert: result is consistent with state
+      expect(result.ok).toBe(true);
+      expect(result.equipment).toEqual(equipmentStore.getPlayerEquipment("player1"));
+      
+      // Check equipment has the item
+      expect(result.equipment?.slots).toContainEqual(
+        expect.objectContaining({ itemId: "wooden_axe" }),
+      );
+      
+      // Check inventory does not have the item
+      const inventory = inventoryStore.getPlayerInventory("player1");
+      expect(inventory.slots.find((s) => s.itemId === "wooden_axe")).toBeUndefined();
+    });
+  });
+
+  describe("getPlayerEquipment", () => {
+    it("returns current equipment state", async () => {
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+
+      const equipment = await service.getPlayerEquipment("player1");
+
+      expect(equipment.slots).toContainEqual(
+        expect.objectContaining({ slotId: "woodcutting_tool", itemId: "wooden_axe" }),
+      );
+    });
+
+    it("returns empty state for player with no equipment", async () => {
+      const equipment = await service.getPlayerEquipment("player1");
+      expect(equipment.slots).toEqual([]);
+      expect(equipment.playerId).toBe("player1");
+      expect(equipment.schemaVersion).toBe(1);
+    });
+  });
+});

--- a/server/tests/equipment-service.test.ts
+++ b/server/tests/equipment-service.test.ts
@@ -1,54 +1,51 @@
 /**
  * Equipment Service Tests
  *
- * Integration tests for EquipmentService with atomic inventory/equipment transactions.
+ * Integration tests for EquipmentService with staged inventory/equipment transactions.
  * Deterministic: No Math.random(), no Date.now().
- *
- * Test coverage:
- * - equip consumes one inventory item and fills the canonical equipment slot
- * - replacing a slot returns the replaced item to inventory
- * - unequip removes the equipment slot and restores inventory
- * - invalid item / item_not_owned / slot_empty do not mutate either state
- * - repeated same input from same initial state gives identical output
  */
 
-import { describe, expect, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { EquipmentPersistenceAdapter } from "../src/equipment/EquipmentPersistence.js";
+import { EquipmentService, type InventoryServiceLike } from "../src/equipment/EquipmentService.js";
 import { EquipmentStore } from "../src/equipment/EquipmentStore.js";
 import { InventoryStore } from "../src/inventory/InventoryStore.js";
-import { EquipmentService } from "../src/equipment/EquipmentService.js";
-import type { EquipmentPersistenceAdapter } from "../src/equipment/EquipmentPersistence.js";
-import type { InventoryPersistenceAdapter } from "../src/inventory/InventoryPersistence.js";
-import type { PlayerInventoryState, InventoryItemId } from "../src/inventory/InventoryTypes.js";
-import type { InventoryServiceLike } from "../src/equipment/EquipmentService.js";
+import type { InventoryItemId, PlayerInventoryState } from "../src/inventory/InventoryTypes.js";
 
-// Mock persistence adapters for testing
-const noopInventoryPersistence: InventoryPersistenceAdapter = {
-  async loadPlayerInventory() { return null; },
-  async savePlayerInventory() {},
-};
+function cloneState<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
 
-const noopEquipmentPersistence: EquipmentPersistenceAdapter = {
-  async loadPlayerEquipment() { return null; },
-  async savePlayerEquipment() {},
-};
+function createEquipmentPersistence(options: { failSave?: boolean } = {}): EquipmentPersistenceAdapter {
+  return {
+    async loadPlayerEquipment() { return null; },
+    async savePlayerEquipment() {
+      if (options.failSave) throw new Error("equipment_persist_failed");
+    },
+  };
+}
 
-// Test utilities - creates a synchronous inventory service wrapper for testing
-function createTestInventoryService(store: InventoryStore): InventoryServiceLike {
+function createTestInventoryService(
+  store: InventoryStore,
+  options: { failPersist?: boolean; persistedStates?: PlayerInventoryState[] } = {},
+): InventoryServiceLike {
   return {
     async getPlayerInventory(playerId: string) {
       return store.getPlayerInventory(playerId);
     },
-    async addItem(input) {
-      return store.addItem(input);
+    async persistInventory(_playerId: string, state: PlayerInventoryState) {
+      if (options.failPersist) throw new Error("inventory_persist_failed");
+      options.persistedStates?.push(cloneState(state));
     },
-    async removeItem(input) {
-      return store.removeItem(input);
-    },
-    async persistInventory(playerId: string, state: PlayerInventoryState) {
-      // Update in-memory state for testing
+    replacePlayerInventory(playerId: string, state: PlayerInventoryState) {
       store.replacePlayerInventory(playerId, state);
     },
   };
+}
+
+function findInventoryQuantity(state: PlayerInventoryState, itemId: InventoryItemId): number {
+  return state.slots.find((slot) => slot.itemId === itemId)?.quantity ?? 0;
 }
 
 describe("EquipmentService", () => {
@@ -59,66 +56,42 @@ describe("EquipmentService", () => {
   beforeEach(() => {
     equipmentStore = new EquipmentStore();
     inventoryStore = new InventoryStore();
-    
-    // Create service with test inventory service via dependency injection
-    const testInventoryService = createTestInventoryService(inventoryStore);
+    const inventoryService = createTestInventoryService(inventoryStore);
     service = new EquipmentService(
       equipmentStore,
-      noopEquipmentPersistence,
-      () => Promise.resolve(testInventoryService),
+      createEquipmentPersistence(),
+      () => Promise.resolve(inventoryService),
     );
-    
-    // Reset internal hydration tracking
     service.clearForTests();
   });
 
-  describe("equipItem - atomic inventory consumption", () => {
+  describe("equipItem - staged inventory consumption", () => {
     it("equips owned item and consumes one inventory unit", async () => {
-      // Setup: add wooden axe to inventory
       inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
 
-      // Act: equip the axe
       const result = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
 
-      // Assert: success
       expect(result.ok).toBe(true);
       expect(result.reason).toBe("equipped");
       expect(result.itemId).toBe("wooden_axe");
       expect(result.equipment?.slots).toContainEqual(
         expect.objectContaining({ slotId: "woodcutting_tool", itemId: "wooden_axe" }),
       );
-
-      // Assert: inventory consumed
-      const inventory = inventoryStore.getPlayerInventory("player1");
-      const axeSlot = inventory.slots.find((s) => s.itemId === "wooden_axe");
-      expect(axeSlot).toBeUndefined();
-
-      // Assert: inventory delta
+      expect(inventoryStore.getPlayerInventory("player1").slots.find((slot) => slot.itemId === "wooden_axe")).toBeUndefined();
       expect(result.inventoryDelta).toEqual({ itemId: "wooden_axe", delta: -1 });
     });
 
     it("rejects equip of unowned item", async () => {
-      // Act: try to equip item not in inventory
       const result = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
 
-      // Assert: failure
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("item_not_owned");
-
-      // Assert: no equipment change
-      const equipment = equipmentStore.getPlayerEquipment("player1");
-      expect(equipment.slots).toEqual([]);
-
-      // Assert: no inventory change
-      const inventory = inventoryStore.getPlayerInventory("player1");
-      expect(inventory.slots).toEqual([]);
+      expect(equipmentStore.getPlayerEquipment("player1").slots).toEqual([]);
+      expect(inventoryStore.getPlayerInventory("player1").slots).toEqual([]);
     });
 
     it("rejects equip of invalid item", async () => {
-      // Act: try to equip non-equipment item
       const result = await service.equipItem({ playerId: "player1", itemId: "invalid_item" });
-
-      // Assert: failure
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("invalid_item");
     });
@@ -137,105 +110,67 @@ describe("EquipmentService", () => {
   });
 
   describe("equipItem - slot replacement", () => {
-    it("unequips old item and returns it to inventory when replacing slot", async () => {
-      // Setup: add wooden axe and copper axe to inventory
-      const woodenAxeResult = inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
-      const copperAxeResult = inventoryStore.addItem({ playerId: "player1", itemId: "copper_axe", quantity: 1 });
+    it("replaces occupied slot and returns replaced item to inventory", async () => {
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      inventoryStore.addItem({ playerId: "player1", itemId: "copper_axe", quantity: 1 });
+      await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
 
-      // Verify both items were added
-      expect(woodenAxeResult.ok).toBe(true);
-      expect(copperAxeResult.ok).toBe(true);
-
-      // Act: equip copper axe first (since it's in the same slot as wooden_axe)
       const result = await service.equipItem({ playerId: "player1", itemId: "copper_axe" });
 
-      // Assert: success
       expect(result.ok).toBe(true);
       expect(result.reason).toBe("equipped");
-
-      // Assert: equipment has copper axe
-      const equipment = equipmentStore.getPlayerEquipment("player1");
-      expect(equipment.slots).toContainEqual(
+      expect(result.unequippedItemId).toBe("wooden_axe");
+      expect(equipmentStore.getPlayerEquipment("player1").slots).toContainEqual(
         expect.objectContaining({ slotId: "woodcutting_tool", itemId: "copper_axe" }),
       );
 
-      // Assert: wooden axe is back in inventory
       const inventory = inventoryStore.getPlayerInventory("player1");
-      expect(inventory.slots).toContainEqual(
-        expect.objectContaining({ itemId: "wooden_axe", quantity: 1 }),
-      );
+      expect(findInventoryQuantity(inventory, "wooden_axe")).toBe(1);
+      expect(findInventoryQuantity(inventory, "copper_axe")).toBe(0);
     });
 
     it("can equip items in different slots independently", async () => {
-      // Setup: add all three tools
       inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
       inventoryStore.addItem({ playerId: "player1", itemId: "copper_pickaxe", quantity: 1 });
       inventoryStore.addItem({ playerId: "player1", itemId: "simple_fishing_rod", quantity: 1 });
 
-      // Act: equip all three
       await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
       await service.equipItem({ playerId: "player1", itemId: "copper_pickaxe" });
       await service.equipItem({ playerId: "player1", itemId: "simple_fishing_rod" });
 
-      // Assert: all slots filled
       const equipment = equipmentStore.getPlayerEquipment("player1");
       expect(equipment.slots).toHaveLength(3);
-      expect(equipment.slots).toContainEqual(
-        expect.objectContaining({ slotId: "woodcutting_tool", itemId: "wooden_axe" }),
-      );
-      expect(equipment.slots).toContainEqual(
-        expect.objectContaining({ slotId: "mining_tool", itemId: "copper_pickaxe" }),
-      );
-      expect(equipment.slots).toContainEqual(
-        expect.objectContaining({ slotId: "fishing_tool", itemId: "simple_fishing_rod" }),
-      );
-
-      // Assert: no items left in inventory
-      const inventory = inventoryStore.getPlayerInventory("player1");
-      expect(inventory.slots).toHaveLength(0);
+      expect(equipment.slots).toContainEqual(expect.objectContaining({ slotId: "woodcutting_tool", itemId: "wooden_axe" }));
+      expect(equipment.slots).toContainEqual(expect.objectContaining({ slotId: "mining_tool", itemId: "copper_pickaxe" }));
+      expect(equipment.slots).toContainEqual(expect.objectContaining({ slotId: "fishing_tool", itemId: "simple_fishing_rod" }));
+      expect(inventoryStore.getPlayerInventory("player1").slots).toHaveLength(0);
     });
   });
 
-  describe("unequipItem - atomic inventory restoration", () => {
+  describe("unequipItem - staged inventory restoration", () => {
     it("unequips item and returns it to inventory", async () => {
-      // Setup: equip wooden axe
       inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
       await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
 
-      // Act: unequip
       const result = await service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" });
 
-      // Assert: success
       expect(result.ok).toBe(true);
       expect(result.reason).toBe("unequipped");
       expect(result.unequippedItemId).toBe("wooden_axe");
       expect(result.slotId).toBe("woodcutting_tool");
-
-      // Assert: equipment slot empty
-      const equipment = equipmentStore.getPlayerEquipment("player1");
-      expect(equipment.slots).toHaveLength(0);
-
-      // Assert: item returned to inventory
-      const inventory = inventoryStore.getPlayerInventory("player1");
-      expect(inventory.slots).toContainEqual(
+      expect(equipmentStore.getPlayerEquipment("player1").slots).toHaveLength(0);
+      expect(inventoryStore.getPlayerInventory("player1").slots).toContainEqual(
         expect.objectContaining({ itemId: "wooden_axe", quantity: 1 }),
       );
-
-      // Assert: inventory delta
       expect(result.inventoryDelta).toEqual({ itemId: "wooden_axe", delta: +1 });
     });
 
     it("rejects unequip of empty slot", async () => {
-      // Act: try to unequip empty slot
       const result = await service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" });
 
-      // Assert: failure
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("slot_empty");
-
-      // Assert: no state change
-      const inventory = inventoryStore.getPlayerInventory("player1");
-      expect(inventory.slots).toEqual([]);
+      expect(inventoryStore.getPlayerInventory("player1").slots).toEqual([]);
     });
 
     it("rejects unequip for invalid player", async () => {
@@ -251,31 +186,23 @@ describe("EquipmentService", () => {
     });
 
     it("unequip then re-equip returns to same state", async () => {
-      // Setup
       inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
       await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
-
-      // Act: unequip then re-equip
       await service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" });
+
       const result = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
 
-      // Assert: success
       expect(result.ok).toBe(true);
       expect(result.reason).toBe("equipped");
-
-      // Assert: original state restored
-      const equipment = equipmentStore.getPlayerEquipment("player1");
-      expect(equipment.slots).toContainEqual(
+      expect(equipmentStore.getPlayerEquipment("player1").slots).toContainEqual(
         expect.objectContaining({ slotId: "woodcutting_tool", itemId: "wooden_axe" }),
       );
-      const inventory = inventoryStore.getPlayerInventory("player1");
-      expect(inventory.slots).toHaveLength(0);
+      expect(inventoryStore.getPlayerInventory("player1").slots).toHaveLength(0);
     });
   });
 
   describe("determinism", () => {
     it("repeated equip from same initial state produces identical output", async () => {
-      // Setup: same initial state
       const setup = () => {
         equipmentStore.clearForTests();
         inventoryStore.clearForTests();
@@ -283,19 +210,16 @@ describe("EquipmentService", () => {
         inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
       };
 
-      // First equip
       setup();
       const result1 = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
       const equipment1 = equipmentStore.getPlayerEquipment("player1");
       const inventory1 = inventoryStore.getPlayerInventory("player1");
 
-      // Second equip (from scratch)
       setup();
       const result2 = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
       const equipment2 = equipmentStore.getPlayerEquipment("player1");
       const inventory2 = inventoryStore.getPlayerInventory("player1");
 
-      // Assert: identical results
       expect(result1.ok).toBe(result2.ok);
       expect(result1.reason).toBe(result2.reason);
       expect(result1.itemId).toBe(result2.itemId);
@@ -309,71 +233,108 @@ describe("EquipmentService", () => {
         equipmentStore.clearForTests();
         inventoryStore.clearForTests();
         service.clearForTests();
-        
         inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
         inventoryStore.addItem({ playerId: "player1", itemId: "copper_axe", quantity: 1 });
-        
         await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
         await service.equipItem({ playerId: "player1", itemId: "copper_axe" });
         await service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" });
-        
         return {
-          equipment: JSON.parse(JSON.stringify(equipmentStore.getPlayerEquipment("player1"))),
-          inventory: JSON.parse(JSON.stringify(inventoryStore.getPlayerInventory("player1"))),
+          equipment: cloneState(equipmentStore.getPlayerEquipment("player1")),
+          inventory: cloneState(inventoryStore.getPlayerInventory("player1")),
         };
       };
 
       const result1 = await runSequence();
       const result2 = await runSequence();
-
-      // Assert: identical final states
       expect(result1.equipment.slots).toEqual(result2.equipment.slots);
       expect(result1.inventory.slots).toEqual(result2.inventory.slots);
     });
   });
 
   describe("no partial state mutations", () => {
-    it("failed equip does not mutate equipment state", async () => {
-      // Setup: have wooden axe in inventory
+    it("failed equip does not mutate equipment or inventory state", async () => {
       inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
 
-      // Act: try to equip invalid item
       const result = await service.equipItem({ playerId: "player1", itemId: "invalid_item" });
 
-      // Assert: failure
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("invalid_item");
-
-      // Assert: no equipment state change
-      const equipment = equipmentStore.getPlayerEquipment("player1");
-      expect(equipment.slots).toHaveLength(0);
-
-      // Assert: no inventory state change
-      const inventory = inventoryStore.getPlayerInventory("player1");
-      expect(inventory.slots).toContainEqual(
+      expect(equipmentStore.getPlayerEquipment("player1").slots).toHaveLength(0);
+      expect(inventoryStore.getPlayerInventory("player1").slots).toContainEqual(
         expect.objectContaining({ itemId: "wooden_axe", quantity: 1 }),
       );
     });
 
-    it("successful equip produces consistent equipment + inventory", async () => {
-      // Setup
+    it("does not mutate stores when inventory persistence fails during equip", async () => {
+      const failingInventory = createTestInventoryService(inventoryStore, { failPersist: true });
+      service = new EquipmentService(equipmentStore, createEquipmentPersistence(), () => Promise.resolve(failingInventory));
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      const beforeEquipment = cloneState(equipmentStore.getPlayerEquipment("player1"));
+      const beforeInventory = cloneState(inventoryStore.getPlayerInventory("player1"));
+
+      await expect(service.equipItem({ playerId: "player1", itemId: "wooden_axe" })).rejects.toThrow("inventory_persist_failed");
+
+      expect(equipmentStore.getPlayerEquipment("player1")).toEqual(beforeEquipment);
+      expect(inventoryStore.getPlayerInventory("player1")).toEqual(beforeInventory);
+    });
+
+    it("does not mutate stores when equipment persistence fails during equip", async () => {
+      service = new EquipmentService(
+        equipmentStore,
+        createEquipmentPersistence({ failSave: true }),
+        () => Promise.resolve(createTestInventoryService(inventoryStore)),
+      );
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      const beforeEquipment = cloneState(equipmentStore.getPlayerEquipment("player1"));
+      const beforeInventory = cloneState(inventoryStore.getPlayerInventory("player1"));
+
+      await expect(service.equipItem({ playerId: "player1", itemId: "wooden_axe" })).rejects.toThrow("equipment_persist_failed");
+
+      expect(equipmentStore.getPlayerEquipment("player1")).toEqual(beforeEquipment);
+      expect(inventoryStore.getPlayerInventory("player1")).toEqual(beforeInventory);
+    });
+
+    it("does not mutate stores when replacing slot and equipment persistence fails", async () => {
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      inventoryStore.addItem({ playerId: "player1", itemId: "copper_axe", quantity: 1 });
+      await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+      const beforeEquipment = cloneState(equipmentStore.getPlayerEquipment("player1"));
+      const beforeInventory = cloneState(inventoryStore.getPlayerInventory("player1"));
+      service = new EquipmentService(
+        equipmentStore,
+        createEquipmentPersistence({ failSave: true }),
+        () => Promise.resolve(createTestInventoryService(inventoryStore)),
+      );
+
+      await expect(service.equipItem({ playerId: "player1", itemId: "copper_axe" })).rejects.toThrow("equipment_persist_failed");
+
+      expect(equipmentStore.getPlayerEquipment("player1")).toEqual(beforeEquipment);
+      expect(inventoryStore.getPlayerInventory("player1")).toEqual(beforeInventory);
+    });
+
+    it("does not mutate stores when inventory persistence fails during unequip", async () => {
+      inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
+      await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
+      const beforeEquipment = cloneState(equipmentStore.getPlayerEquipment("player1"));
+      const beforeInventory = cloneState(inventoryStore.getPlayerInventory("player1"));
+      const failingInventory = createTestInventoryService(inventoryStore, { failPersist: true });
+      service = new EquipmentService(equipmentStore, createEquipmentPersistence(), () => Promise.resolve(failingInventory));
+
+      await expect(service.unequipItem({ playerId: "player1", slotId: "woodcutting_tool" })).rejects.toThrow("inventory_persist_failed");
+
+      expect(equipmentStore.getPlayerEquipment("player1")).toEqual(beforeEquipment);
+      expect(inventoryStore.getPlayerInventory("player1")).toEqual(beforeInventory);
+    });
+
+    it("successful equip produces consistent equipment and inventory", async () => {
       inventoryStore.addItem({ playerId: "player1", itemId: "wooden_axe", quantity: 1 });
 
-      // Act
       const result = await service.equipItem({ playerId: "player1", itemId: "wooden_axe" });
 
-      // Assert: result is consistent with state
       expect(result.ok).toBe(true);
       expect(result.equipment).toEqual(equipmentStore.getPlayerEquipment("player1"));
-      
-      // Check equipment has the item
-      expect(result.equipment?.slots).toContainEqual(
-        expect.objectContaining({ itemId: "wooden_axe" }),
-      );
-      
-      // Check inventory does not have the item
-      const inventory = inventoryStore.getPlayerInventory("player1");
-      expect(inventory.slots.find((s) => s.itemId === "wooden_axe")).toBeUndefined();
+      expect(result.equipment?.slots).toContainEqual(expect.objectContaining({ itemId: "wooden_axe" }));
+      expect(inventoryStore.getPlayerInventory("player1").slots.find((slot) => slot.itemId === "wooden_axe")).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Make equip and unequip operations atomic with inventory consumption/restoration for ARE Green-State follow-up slice (issue #1974).

## Changes

### EquipmentService.ts
- `equipItem()` now atomically consumes inventory item and equips to canonical slot
- If slot occupied, returns old item to inventory before equipping new item
- `unequipItem()` now atomically removes from equipment and returns item to inventory
- Both operations persist inventory AND equipment states together
- Added `InventoryServiceLike` interface for test dependency injection

### InventoryService.ts
- Added `persistInventory()` method for explicit state persistence during atomic transactions

### inventoryRuntime.ts
- Exported `createPersistedPlayerInventoryState` for use by EquipmentService

### equipment-service.test.ts (new file)
18 comprehensive tests covering:
- ✅ equip consumes one inventory item and fills canonical slot
- ✅ replacing slot returns replaced item to inventory
- ✅ unequip removes equipment slot and restores inventory
- ✅ invalid item / item_not_owned / slot_empty do not mutate either state
- ✅ repeated same input from same initial state gives identical output
- ✅ failed equip does not mutate equipment state

## DoD Compliance

- ✅ No Date.now()
- ✅ No Math.random()
- ✅ No client truth
- ✅ No fake snapshots
- ✅ No partial equip state where equipment changes but inventory does not
- ✅ Deterministic: identical input produces identical output

## Testing

All 18 new tests pass. Existing EquipmentStore tests continue to pass.

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3f49dc9b-5910-4e4a-b368-7902f585594a)