### PR TITLE
feat(npc): add lineage runtime replay architecture

### DIFF
--- a/server/src/modules/content/GameDataStorageProvider.ts
+++ b/server/src/modules/content/GameDataStorageProvider.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { resolveContentFile } from './contentDataRoot.js';
+import type { NpcLineageStorageProvider } from '../npc/LineageGameDataWriter';
+
+export class GameDataStorageProvider implements NpcLineageStorageProvider {
+  read(target: string): string | null {
+    const filePath = this.resolve(target);
+    if (!fs.existsSync(filePath)) return null;
+    return fs.readFileSync(filePath, 'utf-8');
+  }
+
+  write(target: string, content: string): void {
+    const filePath = this.resolve(target);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf-8');
+  }
+
+  resolve(target: string): string {
+    return resolveContentFile(target);
+  }
+}

--- a/server/src/modules/npc/FamilyHouseRegistry.ts
+++ b/server/src/modules/npc/FamilyHouseRegistry.ts
@@ -48,6 +48,7 @@ export interface LineageBirthEvent {
   pairEligibilityHash: string;
   pressureAtDecision: PopulationPressure;
   cause: 'founder' | 'eligible_pair';
+  nodeSnapshot: LineageNode;
 }
 
 export interface LineageBirthEventSink {
@@ -108,6 +109,51 @@ export interface PairEligibilityResult {
   pressureAtDecision: PopulationPressure;
 }
 
+function cloneLineageNode(node: LineageNode): LineageNode {
+  return {
+    ...node,
+    parentLineageHashes: [...node.parentLineageHashes],
+    stats: { ...node.stats },
+    traits: [...node.traits],
+  };
+}
+
+function cloneBirthEvent(event: LineageBirthEvent): LineageBirthEvent {
+  return {
+    ...event,
+    parentLineageHashes: [...event.parentLineageHashes],
+    pressureAtDecision: { ...event.pressureAtDecision },
+    nodeSnapshot: cloneLineageNode(event.nodeSnapshot),
+  };
+}
+
+function compareBirthEvents(a: LineageBirthEvent, b: LineageBirthEvent): number {
+  if (a.birthTick !== b.birthTick) return a.birthTick - b.birthTick;
+  if (a.settlementId !== b.settlementId) return a.settlementId.localeCompare(b.settlementId);
+  return a.eventHash.localeCompare(b.eventHash);
+}
+
+export function computeLineageBirthEventHash(
+  node: LineageNode,
+  pairEligibilityHash: string,
+  pressure: PopulationPressure,
+  cause: LineageBirthEvent['cause']
+): string {
+  const seed = createARESeed([
+    'lineage-birth-event',
+    node.id,
+    pairEligibilityHash,
+    node.birthTick,
+    node.houseId,
+    node.settlementId,
+    cause,
+    pressure.pressure,
+    pressure.maxPopulation,
+    pressure.limitingFactor ?? 'none',
+  ]);
+  return stableHash32(seed).toString(16).padStart(8, '0');
+}
+
 export class FamilyHouseRegistry {
   private houses: Map<string, HouseState> = new Map();
   private lineages: Map<string, LineageNode> = new Map();
@@ -128,31 +174,42 @@ export class FamilyHouseRegistry {
   }
 
   registerLineage(node: LineageNode, birthEvent?: LineageBirthEvent): void {
-    this.lineages.set(node.id, { ...node });
+    this.lineages.set(node.id, cloneLineageNode(node));
     this.addIndex(this.lineageByHouse, node.houseId, node.id);
     this.addIndex(this.lineageBySettlement, node.settlementId, node.id);
 
     if (birthEvent) {
-      this.birthEvents.push({ ...birthEvent, pressureAtDecision: { ...birthEvent.pressureAtDecision } });
+      this.birthEvents.push(cloneBirthEvent(birthEvent));
+    }
+  }
+
+  replayBirthEvents(events: readonly LineageBirthEvent[]): void {
+    for (const event of [...events].map(cloneBirthEvent).sort(compareBirthEvents)) {
+      const expectedHash = computeLineageBirthEventHash(event.nodeSnapshot, event.pairEligibilityHash, event.pressureAtDecision, event.cause);
+      if (expectedHash !== event.eventHash) {
+        throw new Error(`npc_lineage_birth_event_hash_mismatch:${event.lineageId}`);
+      }
+      this.registerLineage(event.nodeSnapshot, event);
     }
   }
 
   getLineage(id: string): LineageNode | undefined {
-    return this.lineages.get(id);
+    const node = this.lineages.get(id);
+    return node ? cloneLineageNode(node) : undefined;
   }
 
   getLineagesByHouse(houseId: string): LineageNode[] {
     const ids = this.lineageByHouse.get(houseId) ?? [];
-    return ids.map((id) => this.lineages.get(id)).filter((lineage): lineage is LineageNode => lineage !== undefined);
+    return ids.map((id) => this.lineages.get(id)).filter((lineage): lineage is LineageNode => lineage !== undefined).map(cloneLineageNode);
   }
 
   getLineagesBySettlement(settlementId: string): LineageNode[] {
     const ids = this.lineageBySettlement.get(settlementId) ?? [];
-    return ids.map((id) => this.lineages.get(id)).filter((lineage): lineage is LineageNode => lineage !== undefined);
+    return ids.map((id) => this.lineages.get(id)).filter((lineage): lineage is LineageNode => lineage !== undefined).map(cloneLineageNode);
   }
 
   getBirthEvents(): LineageBirthEvent[] {
-    return this.birthEvents.map((event) => ({ ...event, pressureAtDecision: { ...event.pressureAtDecision } }));
+    return this.birthEvents.map(cloneBirthEvent);
   }
 
   getGeneration(lineageId: string): number {
@@ -172,7 +229,7 @@ export class FamilyHouseRegistry {
       const node = this.lineages.get(current.id);
       if (!node) continue;
 
-      ancestors.push(node);
+      ancestors.push(cloneLineageNode(node));
       const parentIds = [...node.parentLineageHashes].sort();
       for (const parentId of parentIds) {
         if (!visited.has(parentId)) queue.push({ id: parentId, depth: current.depth + 1 });
@@ -190,7 +247,7 @@ export class FamilyHouseRegistry {
   serialize(): { houses: HouseState[]; lineages: LineageNode[]; birthEvents: LineageBirthEvent[] } {
     return {
       houses: Array.from(this.houses.values()).map((house) => ({ ...house })),
-      lineages: Array.from(this.lineages.values()).map((lineage) => ({ ...lineage, parentLineageHashes: [...lineage.parentLineageHashes], traits: [...lineage.traits] })),
+      lineages: Array.from(this.lineages.values()).map(cloneLineageNode),
       birthEvents: this.getBirthEvents(),
     };
   }
@@ -204,7 +261,7 @@ export class FamilyHouseRegistry {
 
     for (const house of data.houses) this.houses.set(house.id, { ...house });
     for (const lineage of data.lineages) this.registerLineage(lineage);
-    this.birthEvents = (data.birthEvents ?? []).map((event) => ({ ...event, pressureAtDecision: { ...event.pressureAtDecision } }));
+    this.birthEvents = (data.birthEvents ?? []).map(cloneBirthEvent);
   }
 
   private addIndex(index: Map<string, string[]>, key: string, value: string): void {
@@ -458,7 +515,7 @@ export class NPCLineageManager {
 
     const pressure: PopulationPressure = { pressure: 0, canSpawn: true, limitingFactor: null, maxPopulation: Number.MAX_SAFE_INTEGER };
     const event: LineageBirthEvent = {
-      eventHash: this.generateBirthEventHash(node, lineageHash, pressure, 'founder'),
+      eventHash: computeLineageBirthEventHash(node, lineageHash, pressure, 'founder'),
       lineageId: node.id,
       lineageHash,
       parentLineageHashes: [],
@@ -468,6 +525,7 @@ export class NPCLineageManager {
       pairEligibilityHash: lineageHash,
       pressureAtDecision: pressure,
       cause: 'founder',
+      nodeSnapshot: cloneLineageNode(node),
     };
 
     this.registry.registerLineage(node, event);
@@ -498,7 +556,7 @@ export class NPCLineageManager {
 
   private createBirthEvent(node: LineageNode, eligibility: PairEligibilityResult, cause: 'eligible_pair'): LineageBirthEvent {
     return {
-      eventHash: this.generateBirthEventHash(node, eligibility.lineageHash, eligibility.pressureAtDecision, cause),
+      eventHash: computeLineageBirthEventHash(node, eligibility.lineageHash, eligibility.pressureAtDecision, cause),
       lineageId: node.id,
       lineageHash: node.lineageHash,
       parentLineageHashes: [...node.parentLineageHashes],
@@ -508,27 +566,7 @@ export class NPCLineageManager {
       pairEligibilityHash: eligibility.lineageHash,
       pressureAtDecision: { ...eligibility.pressureAtDecision },
       cause,
+      nodeSnapshot: cloneLineageNode(node),
     };
-  }
-
-  private generateBirthEventHash(
-    node: LineageNode,
-    pairEligibilityHash: string,
-    pressure: PopulationPressure,
-    cause: LineageBirthEvent['cause']
-  ): string {
-    const seed = createARESeed([
-      'lineage-birth-event',
-      node.id,
-      pairEligibilityHash,
-      node.birthTick,
-      node.houseId,
-      node.settlementId,
-      cause,
-      pressure.pressure,
-      pressure.maxPopulation,
-      pressure.limitingFactor ?? 'none',
-    ]);
-    return stableHash32(seed).toString(16).padStart(8, '0');
   }
 }

--- a/server/src/modules/npc/LineageGameDataWriter.ts
+++ b/server/src/modules/npc/LineageGameDataWriter.ts
@@ -1,5 +1,5 @@
 import { createARESeed, stableHash32 } from '../../core/determinism/AREDeterminism';
-import type { LineageBirthEvent } from './FamilyHouseRegistry';
+import type { LineageBirthEvent, LineageNode, LineageStats, PopulationPressure } from './FamilyHouseRegistry';
 
 export interface NpcLineageSink {
   record(value: LineageBirthEvent): void;
@@ -38,9 +38,54 @@ function numberValue(value: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+function boolValue(value: unknown): boolean {
+  return value === true;
+}
+
+function stableStats(value: unknown): LineageStats {
+  const record = isRecord(value) ? value : {};
+  return {
+    strength: numberValue(record.strength),
+    agility: numberValue(record.agility),
+    intelligence: numberValue(record.intelligence),
+    stamina: numberValue(record.stamina),
+    charisma: numberValue(record.charisma),
+    luck: numberValue(record.luck),
+  };
+}
+
+function stablePressure(value: unknown): PopulationPressure {
+  const record = isRecord(value) ? value : {};
+  const limitingFactor = stringValue(record.limitingFactor);
+  return {
+    pressure: numberValue(record.pressure),
+    canSpawn: boolValue(record.canSpawn),
+    limitingFactor: limitingFactor === 'capacity' || limitingFactor === 'food' || limitingFactor === 'housing' || limitingFactor === 'house_state'
+      ? limitingFactor
+      : null,
+    maxPopulation: numberValue(record.maxPopulation),
+  };
+}
+
+function stableNode(value: unknown): LineageNode {
+  if (!isRecord(value)) throw new Error('npc_lineage_event_requires_node_snapshot');
+  return {
+    id: stringValue(value.id),
+    lineageHash: stringValue(value.lineageHash),
+    generation: numberValue(value.generation),
+    birthTick: numberValue(value.birthTick),
+    ...(value.deathTick === undefined ? {} : { deathTick: numberValue(value.deathTick) }),
+    parentLineageHashes: Array.isArray(value.parentLineageHashes) ? value.parentLineageHashes.map((entry) => String(entry)).sort() : [],
+    houseId: stringValue(value.houseId),
+    settlementId: stringValue(value.settlementId),
+    archetypeSeed: numberValue(value.archetypeSeed),
+    stats: stableStats(value.stats),
+    traits: Array.isArray(value.traits) ? value.traits.map((entry) => String(entry)).sort() : [],
+  };
+}
+
 function stableRecord(value: unknown): LineageBirthEvent {
   if (!isRecord(value)) throw new Error('npc_lineage_event_must_be_object');
-  const pressureAtDecision = isRecord(value.pressureAtDecision) ? { ...value.pressureAtDecision } : {};
   const parentLineageHashes = Array.isArray(value.parentLineageHashes)
     ? value.parentLineageHashes.map((entry) => String(entry)).sort()
     : [];
@@ -54,8 +99,9 @@ function stableRecord(value: unknown): LineageBirthEvent {
     settlementId: stringValue(value.settlementId),
     birthTick: numberValue(value.birthTick),
     pairEligibilityHash: stringValue(value.pairEligibilityHash),
-    pressureAtDecision: pressureAtDecision as LineageBirthEvent['pressureAtDecision'],
+    pressureAtDecision: stablePressure(value.pressureAtDecision),
     cause: stringValue(value.cause) === 'founder' ? 'founder' : 'eligible_pair',
+    nodeSnapshot: stableNode(value.nodeSnapshot),
   };
 }
 

--- a/server/src/modules/npc/LineageGameDataWriter.ts
+++ b/server/src/modules/npc/LineageGameDataWriter.ts
@@ -22,6 +22,12 @@ export type LineageJournalRecord = LineageBirthEvent & {
   readonly journalHash: string;
 };
 
+interface StoredLineageJournalRecord {
+  readonly event: LineageBirthEvent;
+  readonly previousJournalHash: string;
+  readonly journalHash: string;
+}
+
 export const NPC_LINEAGE_GAME_DATA_PATH = ['npc', 'lineage-birth-events.json'].join('/');
 export const NPC_LINEAGE_JOURNAL_GENESIS_HASH = 'GENESIS';
 
@@ -117,11 +123,15 @@ function compareRecords(a: LineageBirthEvent, b: LineageBirthEvent): number {
   return recordKey(a).localeCompare(recordKey(b));
 }
 
-function parseRecords(raw: string | null): LineageBirthEvent[] {
+function parseStoredRecords(raw: string | null): StoredLineageJournalRecord[] {
   if (!raw || raw.trim().length === 0) return [];
   const parsed: unknown = JSON.parse(raw);
   if (!Array.isArray(parsed)) throw new Error('npc_lineage_event_store_must_be_array');
-  return parsed.map(stableRecord);
+  return parsed.map((entry) => ({
+    event: stableRecord(entry),
+    previousJournalHash: isRecord(entry) ? stringValue(entry.previousJournalHash) : '',
+    journalHash: isRecord(entry) ? stringValue(entry.journalHash) : '',
+  }));
 }
 
 export function computeLineageJournalHash(event: LineageBirthEvent, previousJournalHash: string): string {
@@ -157,7 +167,21 @@ export function readLineageJournalRecords(
   provider: NpcLineageStorageProvider,
   target: string = NPC_LINEAGE_GAME_DATA_PATH
 ): LineageJournalRecord[] {
-  return buildLineageJournalRecords(parseRecords(provider.read(target)));
+  const stored = parseStoredRecords(provider.read(target));
+  const rebuilt = buildLineageJournalRecords(stored.map((entry) => entry.event));
+
+  for (let index = 0; index < stored.length; index += 1) {
+    const expected = rebuilt[index];
+    const actual = stored[index];
+    if (actual.previousJournalHash && actual.previousJournalHash !== expected.previousJournalHash) {
+      throw new Error(`npc_lineage_previous_journal_hash_mismatch:${index}`);
+    }
+    if (actual.journalHash && actual.journalHash !== expected.journalHash) {
+      throw new Error(`npc_lineage_journal_hash_mismatch:${index}`);
+    }
+  }
+
+  return rebuilt;
 }
 
 export class NpcLineageGameDataWriter implements NpcLineageSink {

--- a/server/src/modules/npc/LineageGameDataWriter.ts
+++ b/server/src/modules/npc/LineageGameDataWriter.ts
@@ -1,5 +1,8 @@
+import { createARESeed, stableHash32 } from '../../core/determinism/AREDeterminism';
+import type { LineageBirthEvent } from './FamilyHouseRegistry';
+
 export interface NpcLineageSink {
-  record(value: unknown): void;
+  record(value: LineageBirthEvent): void;
 }
 
 export interface NpcLineageStorageProvider {
@@ -11,16 +14,23 @@ export interface NpcLineageWriteResult {
   readonly target: string;
   readonly recordsWritten: number;
   readonly inserted: boolean;
+  readonly journalHash: string;
 }
 
-export const NPC_LINEAGE_GAME_DATA_PATH = ["npc", "lineage-birth-events.json"].join("/");
+export type LineageJournalRecord = LineageBirthEvent & {
+  readonly previousJournalHash: string;
+  readonly journalHash: string;
+};
+
+export const NPC_LINEAGE_GAME_DATA_PATH = ['npc', 'lineage-birth-events.json'].join('/');
+export const NPC_LINEAGE_JOURNAL_GENESIS_HASH = 'GENESIS';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function stringValue(value: unknown): string {
-  return typeof value === "string" ? value : "";
+  return typeof value === 'string' ? value : '';
 }
 
 function numberValue(value: unknown): number {
@@ -28,8 +38,8 @@ function numberValue(value: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-function stableRecord(value: unknown): Record<string, unknown> {
-  if (!isRecord(value)) throw new Error("npc_lineage_event_must_be_object");
+function stableRecord(value: unknown): LineageBirthEvent {
+  if (!isRecord(value)) throw new Error('npc_lineage_event_must_be_object');
   const pressureAtDecision = isRecord(value.pressureAtDecision) ? { ...value.pressureAtDecision } : {};
   const parentLineageHashes = Array.isArray(value.parentLineageHashes)
     ? value.parentLineageHashes.map((entry) => String(entry)).sort()
@@ -44,28 +54,64 @@ function stableRecord(value: unknown): Record<string, unknown> {
     settlementId: stringValue(value.settlementId),
     birthTick: numberValue(value.birthTick),
     pairEligibilityHash: stringValue(value.pairEligibilityHash),
-    pressureAtDecision,
-    cause: stringValue(value.cause),
+    pressureAtDecision: pressureAtDecision as LineageBirthEvent['pressureAtDecision'],
+    cause: stringValue(value.cause) === 'founder' ? 'founder' : 'eligible_pair',
   };
 }
 
-function recordKey(value: Record<string, unknown>): string {
-  return stringValue(value.eventHash) || `${stringValue(value.lineageId)}:${numberValue(value.birthTick)}`;
+function recordKey(value: LineageBirthEvent): string {
+  return value.eventHash || `${value.lineageId}:${value.birthTick}`;
 }
 
-function compareRecords(a: Record<string, unknown>, b: Record<string, unknown>): number {
-  const tickDelta = numberValue(a.birthTick) - numberValue(b.birthTick);
+function compareRecords(a: LineageBirthEvent, b: LineageBirthEvent): number {
+  const tickDelta = a.birthTick - b.birthTick;
   if (tickDelta !== 0) return tickDelta;
-  const settlementDelta = stringValue(a.settlementId).localeCompare(stringValue(b.settlementId));
+  const settlementDelta = a.settlementId.localeCompare(b.settlementId);
   if (settlementDelta !== 0) return settlementDelta;
   return recordKey(a).localeCompare(recordKey(b));
 }
 
-function parseRecords(raw: string | null): Record<string, unknown>[] {
+function parseRecords(raw: string | null): LineageBirthEvent[] {
   if (!raw || raw.trim().length === 0) return [];
   const parsed: unknown = JSON.parse(raw);
-  if (!Array.isArray(parsed)) throw new Error("npc_lineage_event_store_must_be_array");
+  if (!Array.isArray(parsed)) throw new Error('npc_lineage_event_store_must_be_array');
   return parsed.map(stableRecord);
+}
+
+export function computeLineageJournalHash(event: LineageBirthEvent, previousJournalHash: string): string {
+  const seed = createARESeed([
+    'lineage-journal-chain',
+    previousJournalHash,
+    event.eventHash,
+    event.lineageId,
+    event.lineageHash,
+    event.birthTick,
+    event.houseId,
+    event.settlementId,
+    event.cause,
+  ]);
+  return stableHash32(seed).toString(16).padStart(8, '0');
+}
+
+export function buildLineageJournalRecords(events: readonly LineageBirthEvent[]): LineageJournalRecord[] {
+  const deduped = new Map<string, LineageBirthEvent>();
+  for (const event of events) deduped.set(recordKey(event), stableRecord(event));
+
+  const records: LineageJournalRecord[] = [];
+  let previousJournalHash = NPC_LINEAGE_JOURNAL_GENESIS_HASH;
+  for (const event of Array.from(deduped.values()).sort(compareRecords)) {
+    const journalHash = computeLineageJournalHash(event, previousJournalHash);
+    records.push(Object.freeze({ ...event, previousJournalHash, journalHash }));
+    previousJournalHash = journalHash;
+  }
+  return records;
+}
+
+export function readLineageJournalRecords(
+  provider: NpcLineageStorageProvider,
+  target: string = NPC_LINEAGE_GAME_DATA_PATH
+): LineageJournalRecord[] {
+  return buildLineageJournalRecords(parseRecords(provider.read(target)));
 }
 
 export class NpcLineageGameDataWriter implements NpcLineageSink {
@@ -74,24 +120,21 @@ export class NpcLineageGameDataWriter implements NpcLineageSink {
     private readonly target = NPC_LINEAGE_GAME_DATA_PATH
   ) {}
 
-  record(value: unknown): void {
+  record(value: LineageBirthEvent): void {
     this.write(value);
   }
 
-  write(value: unknown): NpcLineageWriteResult {
-    const next = stableRecord(value);
-    const byKey = new Map<string, Record<string, unknown>>();
-    for (const existing of parseRecords(this.provider.read(this.target))) {
-      byKey.set(recordKey(existing), existing);
-    }
+  write(value: LineageBirthEvent): NpcLineageWriteResult {
+    const existing = readLineageJournalRecords(this.provider, this.target);
+    const inserted = !existing.some((record) => recordKey(record) === recordKey(value));
+    const records = buildLineageJournalRecords([...existing, value]);
+    this.provider.write(this.target, JSON.stringify(records, null, 2) + '\n');
 
-    const key = recordKey(next);
-    const inserted = !byKey.has(key);
-    byKey.set(key, next);
-
-    const records = Array.from(byKey.values()).sort(compareRecords);
-    this.provider.write(this.target, JSON.stringify(records, null, 2) + "\n");
-
-    return Object.freeze({ target: this.target, recordsWritten: records.length, inserted });
+    return Object.freeze({
+      target: this.target,
+      recordsWritten: records.length,
+      inserted,
+      journalHash: records.at(-1)?.journalHash ?? NPC_LINEAGE_JOURNAL_GENESIS_HASH,
+    });
   }
 }

--- a/server/src/modules/npc/LineageRuntimeReplay.test.ts
+++ b/server/src/modules/npc/LineageRuntimeReplay.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FamilyHouseRegistry,
+  type HouseState,
+  type LineageStats,
+  type NPCState,
+  type SettlementState,
+} from './FamilyHouseRegistry';
+import { NPC_LINEAGE_GAME_DATA_PATH, type NpcLineageStorageProvider } from './LineageGameDataWriter';
+import { LineageTickRunner } from './LineageTickRunner';
+import { createNpcLineageRuntime } from './createNpcLineageRuntime';
+
+class MemoryProvider implements NpcLineageStorageProvider {
+  writes: Array<{ target: string; content: string }> = [];
+  private dataByTarget = new Map<string, string>();
+
+  read(target: string): string | null {
+    return this.dataByTarget.get(target) ?? null;
+  }
+
+  write(target: string, content: string): void {
+    this.dataByTarget.set(target, content);
+    this.writes.push({ target, content });
+  }
+}
+
+function stats(seed = 10): LineageStats {
+  return {
+    strength: seed,
+    agility: seed + 1,
+    intelligence: seed + 2,
+    stamina: seed + 3,
+    charisma: seed + 4,
+    luck: seed + 5,
+  };
+}
+
+function house(id = 'house_1', settlementId = 'settlement_1'): HouseState {
+  return {
+    id,
+    houseName: `House ${id}`,
+    houseReputation: 50,
+    inheritancePoints: 50,
+    settlementId,
+    foundingTick: 0,
+    territorySize: 5,
+    resourceStored: 100,
+    housingCapacity: 10,
+    currentPopulation: 1,
+    isActive: true,
+  };
+}
+
+function settlement(overrides: Partial<SettlementState> = {}): SettlementState {
+  return {
+    id: 'settlement_1',
+    capacity: 100,
+    population: 10,
+    foodSupply: 100,
+    housingUnits: 20,
+    settlementType: 'village',
+    tick: 1000,
+    ...overrides,
+  };
+}
+
+function npc(id: string): NPCState {
+  return {
+    id,
+    houseId: 'house_1',
+    settlementId: 'settlement_1',
+    stats: stats(id.charCodeAt(0)),
+    traits: ['tester'],
+    generation: 0,
+    birthTick: 0,
+  };
+}
+
+describe('lineage runtime replay', () => {
+  it('replays persisted lineage events into a fresh registry projection', () => {
+    const provider = new MemoryProvider();
+    const first = createNpcLineageRuntime({ storageProvider: provider, replay: false });
+    const created = first.manager.createFoundingLineage('founder_1', 'house_1', 'settlement_1', 100, stats());
+
+    const second = createNpcLineageRuntime({ storageProvider: provider });
+
+    expect(provider.writes).toHaveLength(1);
+    expect(provider.writes[0].target).toBe(NPC_LINEAGE_GAME_DATA_PATH);
+    expect(second.replayResult.eventsRead).toBe(1);
+    expect(second.replayResult.lineagesReplayed).toBe(1);
+    expect(second.registry.getLineage(created.id)).toEqual(created);
+  });
+
+  it('runs eligible lineage tick candidates once and skips full settlements without writes', () => {
+    const provider = new MemoryProvider();
+    const registry = new FamilyHouseRegistry();
+    registry.registerHouse(house());
+    const runtime = createNpcLineageRuntime({ registry, storageProvider: provider, replay: false });
+    const runner = new LineageTickRunner(runtime.manager);
+
+    const result = runner.run(2000, [
+      { parentA: npc('parent_full_a'), parentB: npc('parent_full_b'), houseId: 'house_1', settlement: settlement({ population: 100, capacity: 100 }) },
+      { parentA: npc('parent_ok_a'), parentB: npc('parent_ok_b'), houseId: 'house_1', settlement: settlement() },
+    ]);
+
+    expect(result.created).toHaveLength(1);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe('npc_pair_not_eligible:settlement_full');
+    expect(provider.writes).toHaveLength(1);
+  });
+});

--- a/server/src/modules/npc/LineageTickRunner.ts
+++ b/server/src/modules/npc/LineageTickRunner.ts
@@ -1,0 +1,1 @@
+export class LineageTickRunner {}

--- a/server/src/modules/npc/LineageTickRunner.ts
+++ b/server/src/modules/npc/LineageTickRunner.ts
@@ -1,1 +1,62 @@
-export class LineageTickRunner {}
+import { NPCLineageManager, type LineageNode, type NPCState, type SettlementState } from './FamilyHouseRegistry';
+
+export interface LineageTickCandidate {
+  readonly parentA: NPCState;
+  readonly parentB: NPCState;
+  readonly houseId: string;
+  readonly settlement: SettlementState;
+  readonly tick?: number;
+}
+
+export interface LineageTickSkip {
+  readonly parentAId: string;
+  readonly parentBId: string;
+  readonly houseId: string;
+  readonly settlementId: string;
+  readonly tick: number;
+  readonly reason: string;
+}
+
+export interface LineageTickResult {
+  readonly tick: number;
+  readonly created: readonly LineageNode[];
+  readonly skipped: readonly LineageTickSkip[];
+}
+
+function candidateKey(candidate: LineageTickCandidate, tick: number): string {
+  const [firstParentId, secondParentId] = [candidate.parentA.id, candidate.parentB.id].sort();
+  return [tick, candidate.settlement.id, candidate.houseId, firstParentId, secondParentId].join(':');
+}
+
+function reasonFrom(error: unknown): string {
+  return error instanceof Error ? error.message : 'npc_lineage_tick_unknown_skip';
+}
+
+export class LineageTickRunner {
+  constructor(private readonly lineageManager: NPCLineageManager) {}
+
+  run(tick: number, candidates: readonly LineageTickCandidate[]): LineageTickResult {
+    const created: LineageNode[] = [];
+    const skipped: LineageTickSkip[] = [];
+    const ordered = [...candidates].sort((a, b) => candidateKey(a, a.tick ?? tick).localeCompare(candidateKey(b, b.tick ?? tick)));
+
+    for (const candidate of ordered) {
+      const birthTick = candidate.tick ?? tick;
+      const settlement = { ...candidate.settlement, tick: birthTick };
+      try {
+        created.push(this.lineageManager.createDescendant(candidate.parentA, candidate.parentB, candidate.houseId, settlement, birthTick));
+      } catch (error) {
+        skipped.push(Object.freeze({
+          parentAId: candidate.parentA.id,
+          parentBId: candidate.parentB.id,
+          houseId: candidate.houseId,
+          settlementId: settlement.id,
+          tick: birthTick,
+          reason: reasonFrom(error),
+        }));
+      }
+    }
+
+    return Object.freeze({ tick, created: Object.freeze(created), skipped: Object.freeze(skipped) });
+  }
+}

--- a/server/src/modules/npc/createNpcLineageRuntime.ts
+++ b/server/src/modules/npc/createNpcLineageRuntime.ts
@@ -1,0 +1,82 @@
+import { GameDataStorageProvider } from '../content/GameDataStorageProvider';
+import { FamilyHouseRegistry, NPCLineageManager, type LineageBirthEvent } from './FamilyHouseRegistry';
+import {
+  NPC_LINEAGE_GAME_DATA_PATH,
+  NPC_LINEAGE_JOURNAL_GENESIS_HASH,
+  NpcLineageGameDataWriter,
+  readLineageJournalRecords,
+  type LineageJournalRecord,
+  type NpcLineageStorageProvider,
+} from './LineageGameDataWriter';
+
+export interface NpcLineageReplayResult {
+  readonly target: string;
+  readonly eventsRead: number;
+  readonly lineagesReplayed: number;
+  readonly journalHash: string;
+}
+
+export interface NpcLineageRuntimeOptions {
+  readonly registry?: FamilyHouseRegistry;
+  readonly storageProvider?: NpcLineageStorageProvider;
+  readonly target?: string;
+  readonly replay?: boolean;
+}
+
+export interface NpcLineageRuntime {
+  readonly registry: FamilyHouseRegistry;
+  readonly manager: NPCLineageManager;
+  readonly writer: NpcLineageGameDataWriter;
+  readonly storageProvider: NpcLineageStorageProvider;
+  readonly replayResult: NpcLineageReplayResult;
+}
+
+function toBirthEvents(records: readonly LineageJournalRecord[]): LineageBirthEvent[] {
+  return records.map((record) => ({
+    eventHash: record.eventHash,
+    lineageId: record.lineageId,
+    lineageHash: record.lineageHash,
+    parentLineageHashes: [...record.parentLineageHashes],
+    houseId: record.houseId,
+    settlementId: record.settlementId,
+    birthTick: record.birthTick,
+    pairEligibilityHash: record.pairEligibilityHash,
+    pressureAtDecision: { ...record.pressureAtDecision },
+    cause: record.cause,
+    nodeSnapshot: {
+      ...record.nodeSnapshot,
+      parentLineageHashes: [...record.nodeSnapshot.parentLineageHashes],
+      stats: { ...record.nodeSnapshot.stats },
+      traits: [...record.nodeSnapshot.traits],
+    },
+  }));
+}
+
+export function replayNpcLineageRuntime(
+  registry: FamilyHouseRegistry,
+  storageProvider: NpcLineageStorageProvider,
+  target: string = NPC_LINEAGE_GAME_DATA_PATH
+): NpcLineageReplayResult {
+  const records = readLineageJournalRecords(storageProvider, target);
+  const events = toBirthEvents(records);
+  registry.replayBirthEvents(events);
+  return Object.freeze({
+    target,
+    eventsRead: records.length,
+    lineagesReplayed: events.length,
+    journalHash: records.at(-1)?.journalHash ?? NPC_LINEAGE_JOURNAL_GENESIS_HASH,
+  });
+}
+
+export function createNpcLineageRuntime(options: NpcLineageRuntimeOptions = {}): NpcLineageRuntime {
+  const registry = options.registry ?? new FamilyHouseRegistry();
+  const storageProvider = options.storageProvider ?? new GameDataStorageProvider();
+  const target = options.target ?? NPC_LINEAGE_GAME_DATA_PATH;
+  const writer = new NpcLineageGameDataWriter(storageProvider, target);
+  const replayResult = options.replay === false
+    ? Object.freeze({ target, eventsRead: 0, lineagesReplayed: 0, journalHash: NPC_LINEAGE_JOURNAL_GENESIS_HASH })
+    : replayNpcLineageRuntime(registry, storageProvider, target);
+  const manager = new NPCLineageManager(registry, writer);
+
+  return Object.freeze({ registry, manager, writer, storageProvider, replayResult });
+}


### PR DESCRIPTION
## Summary

Adds the lineage runtime architecture layer:

- content-side `GameDataStorageProvider`
- lineage event node snapshots for replay
- deterministic journal chain fields
- runtime composition root
- deterministic lineage tick runner
- replay/tick tests

## Notes

The ARE lineage core stays decoupled from filesystem IO. Runtime wiring happens through injected providers and sinks.