### PR TITLE
feat(npc): expose lineage world surface to clients

### DIFF
--- a/apps/client-2d/src/game/liveGameplayStore.ts
+++ b/apps/client-2d/src/game/liveGameplayStore.ts
@@ -225,31 +225,54 @@ export class LiveGameplayStore {
 
   subscribe(listener: Listener): () => void {
     this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
+    return () => this.listeners.delete(listener);
   }
 
   private emit(): void {
-    for (const listener of this.listeners) listener();
+    for (const listener of [...this.listeners]) {
+      listener();
+    }
   }
 }
 
 export const liveGameplayStore = new LiveGameplayStore();
 
-export function requestGameplaySnapshot(): Promise<LiveGameplaySnapshot> {
-  const playerId = getDefaultGameplayPlayerId();
-  const position = readPlayerPositionBridge();
-  const params = new URLSearchParams({
-    playerId,
-    x: String(position.x),
-    y: String(position.y),
-  });
+export const DEFAULT_GAMEPLAY_PLAYER_ID = getDefaultGameplayPlayerId();
 
-  return fetch(`/api/gameplay/snapshot?${params.toString()}`)
-    .then((response) => response.json())
-    .then((data) => {
-      liveGameplayStore.setSnapshot(data);
-      return liveGameplayStore.getSnapshot();
-    });
+export async function fetchGameplaySnapshot(
+  playerId: string = getDefaultGameplayPlayerId()
+): Promise<LiveGameplaySnapshot | null> {
+  try {
+    const position = readPlayerPositionBridge();
+    const queryParams = new URLSearchParams({ playerId });
+
+    if (position) {
+      queryParams.set("px", String(Math.round(position.x)));
+      queryParams.set("py", String(Math.round(position.z ?? position.y ?? position.x)));
+    }
+
+    const response = await fetch(
+      `/api/gameplay/snapshot?${queryParams.toString()}`,
+      {
+        cache: "no-store",
+        headers: {
+          "x-player-id": playerId,
+        },
+      }
+    );
+    if (!response.ok) return null;
+    const data = await response.json();
+    return normalizeLiveGameplaySnapshot(pickSnapshotPayload(data) as Partial<LiveGameplaySnapshot>);
+  } catch {
+    return null;
+  }
+}
+
+export async function requestGameplaySnapshot(): Promise<LiveGameplaySnapshot> {
+  const snapshot = await fetchGameplaySnapshot();
+  if (snapshot) {
+    liveGameplayStore.setSnapshot(snapshot);
+    return liveGameplayStore.getSnapshot();
+  }
+  return liveGameplayStore.getSnapshot();
 }

--- a/apps/client-2d/src/game/liveGameplayStore.ts
+++ b/apps/client-2d/src/game/liveGameplayStore.ts
@@ -4,9 +4,11 @@
 
 import {
   EMPTY_LIVE_GAMEPLAY_SNAPSHOT,
-  normalizeLiveGameplaySnapshot,
-  type LiveGameplaySnapshot,
 } from "./liveGameplaySnapshot";
+import {
+  normalizeLiveGameplaySnapshotWithWorldSurface as normalizeLiveGameplaySnapshot,
+  type LiveGameplaySnapshotWithWorldSurface as LiveGameplaySnapshot,
+} from "./liveGameplayWorldSurfaceSnapshot";
 import { readPlayerPositionBridge } from "./PlayerPositionBridge";
 
 type Listener = () => void;
@@ -136,6 +138,7 @@ function projectComposerSnapshot(input: Record<string, unknown>): Partial<LiveGa
         title: prettifyId(String(slot.itemId ?? slot.slot ?? "empty")),
       })),
     },
+    worldSurface: input.worldSurface as LiveGameplaySnapshot["worldSurface"],
   };
 }
 
@@ -153,6 +156,7 @@ function mergeComposerIntoLegacy(
     resources: projected.resources ?? legacy.resources,
     inventory: projected.inventory ?? legacy.inventory,
     equipment: projected.equipment ?? legacy.equipment,
+    worldSurface: projected.worldSurface ?? legacy.worldSurface,
   };
 }
 
@@ -191,7 +195,7 @@ function pickSnapshotPayload(data: unknown): unknown {
 }
 
 export class LiveGameplayStore {
-  private snapshot: LiveGameplaySnapshot = EMPTY_LIVE_GAMEPLAY_SNAPSHOT;
+  private snapshot: LiveGameplaySnapshot = normalizeLiveGameplaySnapshot(EMPTY_LIVE_GAMEPLAY_SNAPSHOT);
   private readonly listeners = new Set<Listener>();
 
   getSnapshot(): LiveGameplaySnapshot {
@@ -199,7 +203,7 @@ export class LiveGameplayStore {
   }
 
   setSnapshot(next: unknown): void {
-    this.snapshot = normalizeLiveGameplaySnapshot(pickSnapshotPayload(next));
+    this.snapshot = normalizeLiveGameplaySnapshot(pickSnapshotPayload(next) as Partial<LiveGameplaySnapshot>);
     this.emit();
   }
 
@@ -221,45 +225,31 @@ export class LiveGameplayStore {
 
   subscribe(listener: Listener): () => void {
     this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
   }
 
   private emit(): void {
-    for (const listener of [...this.listeners]) {
-      listener();
-    }
+    for (const listener of this.listeners) listener();
   }
 }
 
 export const liveGameplayStore = new LiveGameplayStore();
 
-export const DEFAULT_GAMEPLAY_PLAYER_ID = getDefaultGameplayPlayerId();
+export function requestGameplaySnapshot(): Promise<LiveGameplaySnapshot> {
+  const playerId = getDefaultGameplayPlayerId();
+  const position = readPlayerPositionBridge();
+  const params = new URLSearchParams({
+    playerId,
+    x: String(position.x),
+    y: String(position.y),
+  });
 
-export async function fetchGameplaySnapshot(
-  playerId: string = getDefaultGameplayPlayerId()
-): Promise<LiveGameplaySnapshot | null> {
-  try {
-    const position = readPlayerPositionBridge();
-    const queryParams = new URLSearchParams({ playerId });
-
-    if (position) {
-      queryParams.set("px", String(Math.round(position.x)));
-      queryParams.set("py", String(Math.round(position.z ?? position.y ?? position.x)));
-    }
-
-    const response = await fetch(
-      `/api/gameplay/snapshot?${queryParams.toString()}`,
-      {
-        cache: "no-store",
-        headers: {
-          "x-player-id": playerId,
-        },
-      }
-    );
-    if (!response.ok) return null;
-    const data = await response.json();
-    return normalizeLiveGameplaySnapshot(pickSnapshotPayload(data));
-  } catch {
-    return null;
-  }
+  return fetch(`/api/gameplay/snapshot?${params.toString()}`)
+    .then((response) => response.json())
+    .then((data) => {
+      liveGameplayStore.setSnapshot(data);
+      return liveGameplayStore.getSnapshot();
+    });
 }

--- a/apps/client-2d/src/game/liveGameplayWorldSurfaceSnapshot.test.ts
+++ b/apps/client-2d/src/game/liveGameplayWorldSurfaceSnapshot.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLiveGameplaySnapshotWithWorldSurface } from './liveGameplayWorldSurfaceSnapshot';
+
+describe('liveGameplayWorldSurfaceSnapshot', () => {
+  it('defaults to empty world surface', () => {
+    const snapshot = normalizeLiveGameplaySnapshotWithWorldSurface(null);
+    expect(snapshot.worldSurface.schemaVersion).toBe('world-surface-model.v1');
+    expect(snapshot.worldSurface.groups).toHaveLength(0);
+    expect(snapshot.worldSurface.points).toHaveLength(0);
+  });
+
+  it('preserves server-authoritative surface payload', () => {
+    const snapshot = normalizeLiveGameplaySnapshotWithWorldSurface({
+      worldSurface: {
+        schemaVersion: 'world-surface-model.v1',
+        tick: 3,
+        groups: [{ id: 'house_1' }],
+        points: [{ id: 'lineage_1' }],
+      },
+    } as never);
+
+    expect(snapshot.worldSurface.tick).toBe(3);
+    expect(snapshot.worldSurface.groups).toHaveLength(1);
+    expect(snapshot.worldSurface.points).toHaveLength(1);
+  });
+});

--- a/apps/client-2d/src/game/liveGameplayWorldSurfaceSnapshot.ts
+++ b/apps/client-2d/src/game/liveGameplayWorldSurfaceSnapshot.ts
@@ -1,0 +1,16 @@
+import { normalizeLiveGameplaySnapshot, type LiveGameplaySnapshot } from './liveGameplaySnapshot';
+import { EMPTY_WORLD_SURFACE_SNAPSHOT, normalizeWorldSurfaceSnapshot, type WorldSurfaceSnapshot } from './worldSurface';
+
+export type LiveGameplaySnapshotWithWorldSurface = LiveGameplaySnapshot & {
+  readonly worldSurface: WorldSurfaceSnapshot;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function normalizeLiveGameplaySnapshotWithWorldSurface(input: Partial<LiveGameplaySnapshot> | null | undefined): LiveGameplaySnapshotWithWorldSurface {
+  const base = normalizeLiveGameplaySnapshot(input);
+  const surface = isRecord(input) ? normalizeWorldSurfaceSnapshot(input.worldSurface) : EMPTY_WORLD_SURFACE_SNAPSHOT;
+  return Object.freeze({ ...base, worldSurface: surface });
+}

--- a/apps/client-2d/src/game/liveGameplayWorldSurfaceSnapshot.ts
+++ b/apps/client-2d/src/game/liveGameplayWorldSurfaceSnapshot.ts
@@ -5,11 +5,15 @@ export type LiveGameplaySnapshotWithWorldSurface = LiveGameplaySnapshot & {
   readonly worldSurface: WorldSurfaceSnapshot;
 };
 
+type WorldSurfaceInput = Partial<LiveGameplaySnapshot> & {
+  readonly worldSurface?: unknown;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-export function normalizeLiveGameplaySnapshotWithWorldSurface(input: Partial<LiveGameplaySnapshot> | null | undefined): LiveGameplaySnapshotWithWorldSurface {
+export function normalizeLiveGameplaySnapshotWithWorldSurface(input: WorldSurfaceInput | null | undefined): LiveGameplaySnapshotWithWorldSurface {
   const base = normalizeLiveGameplaySnapshot(input);
   const surface = isRecord(input) ? normalizeWorldSurfaceSnapshot(input.worldSurface) : EMPTY_WORLD_SURFACE_SNAPSHOT;
   return Object.freeze({ ...base, worldSurface: surface });

--- a/apps/client-2d/src/game/worldSurface.test.ts
+++ b/apps/client-2d/src/game/worldSurface.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeWorldSurfaceSnapshot, WORLD_SURFACE_SCHEMA_VERSION } from './worldSurface';
+
+describe('worldSurface', () => {
+  it('normalizes missing input to empty surface', () => {
+    const result = normalizeWorldSurfaceSnapshot(null);
+    expect(result.groups).toHaveLength(0);
+    expect(result.points).toHaveLength(0);
+  });
+
+  it('keeps server surface arrays as display-only data', () => {
+    const result = normalizeWorldSurfaceSnapshot({
+      schemaVersion: WORLD_SURFACE_SCHEMA_VERSION,
+      tick: 7,
+      groups: [{ id: 'h1' }],
+      points: [{ id: 'n1' }],
+    });
+
+    expect(result.tick).toBe(7);
+    expect(result.groups).toHaveLength(1);
+    expect(result.points).toHaveLength(1);
+  });
+});

--- a/apps/client-2d/src/game/worldSurface.ts
+++ b/apps/client-2d/src/game/worldSurface.ts
@@ -1,0 +1,34 @@
+export const WORLD_SURFACE_SCHEMA_VERSION = 'world-surface-model.v1';
+
+export interface WorldSurfaceSnapshot {
+  readonly schemaVersion: typeof WORLD_SURFACE_SCHEMA_VERSION;
+  readonly tick: number;
+  readonly groups: readonly unknown[];
+  readonly points: readonly unknown[];
+}
+
+export const EMPTY_WORLD_SURFACE_SNAPSHOT: WorldSurfaceSnapshot = Object.freeze({
+  schemaVersion: WORLD_SURFACE_SCHEMA_VERSION,
+  tick: 0,
+  groups: Object.freeze([]),
+  points: Object.freeze([]),
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function numberValue(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function normalizeWorldSurfaceSnapshot(input: unknown): WorldSurfaceSnapshot {
+  if (!isRecord(input) || input.schemaVersion !== WORLD_SURFACE_SCHEMA_VERSION) return EMPTY_WORLD_SURFACE_SNAPSHOT;
+  return Object.freeze({
+    schemaVersion: WORLD_SURFACE_SCHEMA_VERSION,
+    tick: Math.max(0, Math.floor(numberValue(input.tick))),
+    groups: Object.freeze(Array.isArray(input.groups) ? [...input.groups] : []),
+    points: Object.freeze(Array.isArray(input.points) ? [...input.points] : []),
+  });
+}

--- a/server/src/gameplay/LiveGameplaySnapshotComposer.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotComposer.ts
@@ -29,7 +29,9 @@ import type {
   LiveGameplayNpcReputation,
   LiveGameplayNpcMemory,
   LiveGameplayNpcRumor,
+  LiveGameplayWorldSurface,
 } from "./LiveGameplaySnapshotTypes.js";
+import { EMPTY_LIVE_GAMEPLAY_WORLD_SURFACE } from "./LiveGameplaySnapshotTypes.js";
 import { RESOURCE_SELL_PRICES } from "../economy/ResourceSellPrices.js";
 import { calculateDynamicPrice } from "../economy/DemandPricing.js";
 import { createDefaultStatBlock } from "../equipment/EquipmentStatTypes.js";
@@ -55,6 +57,7 @@ export interface LiveGameplaySnapshotComposerDeps {
   readonly getNpcReputations?: (playerId: string) => readonly LiveGameplayNpcReputation[] | Promise<readonly LiveGameplayNpcReputation[]>;
   readonly getNpcMemories?: (playerId: string) => readonly LiveGameplayNpcMemory[] | Promise<readonly LiveGameplayNpcMemory[]>;
   readonly getNpcRumors?: (playerId: string) => readonly LiveGameplayNpcRumor[] | Promise<readonly LiveGameplayNpcRumor[]>;
+  readonly getWorldSurface?: (playerId: string, logicalIndex: number) => LiveGameplayWorldSurface | Promise<LiveGameplayWorldSurface>;
 }
 
 export class LiveGameplaySnapshotComposer {
@@ -69,28 +72,24 @@ export class LiveGameplaySnapshotComposer {
     ]);
 
     const wallet = await this.deps.getWallet(playerId);
-    
-    // Get world POIs if available, default to empty array
+    const safeLogicalIndex = this.safeIndex(logicalIndex);
+
     const worldPois = this.deps.getWorldPois
       ? await this.deps.getWorldPois(playerId)
       : [];
 
-    // Get vendor economy if available, default to empty vendors
     const vendorEconomy = this.deps.getVendorEconomy
       ? await this.deps.getVendorEconomy(playerId)
       : { vendors: [] };
 
-    // Get discovery stats if available
     const discoveryStats = this.deps.getDiscoveryStats
       ? await this.deps.getDiscoveryStats(playerId)
       : { discoveredPoiCount: 0, discoveredChunkCount: 0, visiblePoiCount: 0 };
 
-    // Get recent discoveries if available
     const recentDiscoveries = this.deps.getRecentDiscoveries
       ? await this.deps.getRecentDiscoveries(playerId)
       : [];
 
-    // Get camp NPCs and stocks if available
     const campNpcs = this.deps.getCampNpcs
       ? await this.deps.getCampNpcs()
       : [];
@@ -98,17 +97,14 @@ export class LiveGameplaySnapshotComposer {
       ? await this.deps.getCampStocks()
       : [];
 
-    // Get equipment stats if available, default to zero block
     const equipmentStats = this.deps.getEquipmentStats
       ? await this.deps.getEquipmentStats(playerId)
       : createDefaultStatBlock();
 
-    // Get processing stations if available
     const processingStations = this.deps.getProcessingStations
       ? await this.deps.getProcessingStations()
       : [];
 
-    // Get quest data if available
     const activeQuests = this.deps.getActiveQuests
       ? await this.deps.getActiveQuests(playerId)
       : [];
@@ -130,11 +126,14 @@ export class LiveGameplaySnapshotComposer {
     const npcRumors = this.deps.getNpcRumors
       ? await this.deps.getNpcRumors(playerId)
       : [];
+    const worldSurface = this.deps.getWorldSurface
+      ? await this.deps.getWorldSurface(playerId, safeLogicalIndex)
+      : EMPTY_LIVE_GAMEPLAY_WORLD_SURFACE;
 
     return Object.freeze({
       schemaVersion: "live-gameplay-snapshot.v1" as const,
       playerId,
-      logicalIndex: this.safeIndex(logicalIndex),
+      logicalIndex: safeLogicalIndex,
       tickRateHz: 10 as const,
       tickMs: 100 as const,
       inventory: Object.freeze([...inventory].sort((a, b) => a.itemId.localeCompare(b.itemId))),
@@ -157,6 +156,7 @@ export class LiveGameplaySnapshotComposer {
       npcReputations: Object.freeze([...npcReputations].sort((a, b) => a.npcId.localeCompare(b.npcId))),
       npcMemories: Object.freeze([...npcMemories].sort((a, b) => a.npcId.localeCompare(b.npcId))),
       npcRumors: Object.freeze([...npcRumors].sort((a, b) => a.rumorId.localeCompare(b.rumorId))),
+      worldSurface: Object.freeze(worldSurface),
     });
   }
 
@@ -165,28 +165,19 @@ export class LiveGameplaySnapshotComposer {
   }
 }
 
-/**
- * Create a default empty vendor economy snapshot.
- */
 export function createEmptyVendorEconomySnapshot(): LiveGameplayVendorEconomySnapshot {
   return Object.freeze({
     vendors: Object.freeze([]),
   });
 }
 
-/**
- * Build vendor economy snapshot from stock entries and sellable item IDs.
- * Used by the snapshot composition.
- */
 export function buildVendorEconomySnapshot(
   vendorId: string,
   vendorName: string,
   stockEntries: ReadonlyArray<{ itemId: string; quantity: number }>,
 ): LiveGameplayVendorEconomySnapshot {
-  // Get all sellable items
   const sellableItemIds = Object.keys(RESOURCE_SELL_PRICES);
 
-  // Build stock array (only items with quantity > 0)
   const stock = stockEntries
     .filter((entry) => entry.quantity > 0)
     .map((entry) => ({
@@ -195,7 +186,6 @@ export function buildVendorEconomySnapshot(
     }))
     .sort((a, b) => a.itemId.localeCompare(b.itemId));
 
-  // Build prices for all sellable items based on current stock
   const prices = sellableItemIds
     .map((itemId) => {
       const currentStock = stockEntries.find((e) => e.itemId === itemId)?.quantity ?? 0;

--- a/server/src/gameplay/LiveGameplaySnapshotTypes.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotTypes.ts
@@ -13,9 +13,6 @@
 
 import type { EquipmentStatBlock } from "../equipment/EquipmentStatTypes.js";
 
-/**
- * Quest objective progress for snapshot.
- */
 export interface LiveGameplayQuestObjective {
   readonly objectiveId: string;
   readonly title: string;
@@ -24,18 +21,12 @@ export interface LiveGameplayQuestObjective {
   readonly completed: boolean;
 }
 
-/**
- * Quest progress for snapshot.
- */
 export interface LiveGameplayQuestProgress {
   readonly questId: string;
   readonly state: "available" | "active" | "ready_to_complete" | "completed";
   readonly objectives: readonly LiveGameplayQuestObjective[];
 }
 
-/**
- * NPC dialogue state types.
- */
 export type LiveGameplayNpcDialogueState =
   | "quest_available"
   | "quest_active_missing_wood"
@@ -44,9 +35,6 @@ export type LiveGameplayNpcDialogueState =
   | "quest_ready_to_complete"
   | "quest_completed";
 
-/**
- * NPC dialogue for snapshot.
- */
 export interface LiveGameplayNpcDialogue {
   readonly npcId: string;
   readonly displayName: string;
@@ -57,9 +45,6 @@ export interface LiveGameplayNpcDialogue {
   readonly completedQuestIds: readonly string[];
 }
 
-/**
- * NPC reputation for snapshot.
- */
 export interface LiveGameplayNpcReputation {
   readonly npcId: string;
   readonly playerId: string;
@@ -67,14 +52,8 @@ export interface LiveGameplayNpcReputation {
   readonly completedQuestIds: readonly string[];
 }
 
-/**
- * Trust tier for NPC-player relationship.
- */
 export type LiveGameplayTrustTier = "hostile" | "cold" | "neutral" | "trusted" | "honored";
 
-/**
- * Rumor kinds for NPC memory system.
- */
 export type LiveGameplayNpcRumorKind =
   | "helped_village"
   | "reliable_supplier"
@@ -82,10 +61,6 @@ export type LiveGameplayNpcRumorKind =
   | "hostile_actor"
   | "trusted_worker";
 
-/**
- * NPC memory snapshot for server-authoritative display.
- * Exposes summary data without full raw history.
- */
 export interface LiveGameplayNpcMemory {
   readonly npcId: string;
   readonly playerId: string;
@@ -96,9 +71,6 @@ export interface LiveGameplayNpcMemory {
   readonly knownRumorCount: number;
 }
 
-/**
- * NPC rumor snapshot for server-authoritative display.
- */
 export interface LiveGameplayNpcRumor {
   readonly rumorId: string;
   readonly npcId: string;
@@ -146,39 +118,27 @@ export interface LiveGameplayWorldPoi {
   readonly y: number;
   readonly chunkX: number;
   readonly chunkZ: number;
-  /** Whether this POI has been discovered by the player (defaults to true for backward compat) */
   readonly discovered?: boolean;
 }
 
-/**
- * Discovery stats for map display.
- */
 export interface DiscoveryStats {
   readonly discoveredPoiCount: number;
   readonly discoveredChunkCount: number;
   readonly visiblePoiCount: number;
 }
 
-/**
- * Recently discovered POI for client feedback.
- */
 export interface RecentDiscovery {
   readonly poiId: string;
   readonly title: string;
   readonly type: string;
 }
 
-/**
- * Vendor stock entry for snapshot.
- */
 export interface LiveGameplayVendorStockItem {
   readonly itemId: string;
   readonly quantity: number;
+  readonly buyPrice?: number | null;
 }
 
-/**
- * Vendor price info for snapshot.
- */
 export interface LiveGameplayVendorPriceItem {
   readonly itemId: string;
   readonly unitPrice: number;
@@ -186,9 +146,6 @@ export interface LiveGameplayVendorPriceItem {
   readonly demandBand: "normal" | "stocked" | "oversupplied";
 }
 
-/**
- * Individual vendor economy info for snapshot.
- */
 export interface LiveGameplayVendorEconomy {
   readonly id: string;
   readonly name: string;
@@ -196,39 +153,20 @@ export interface LiveGameplayVendorEconomy {
   readonly prices: readonly LiveGameplayVendorPriceItem[];
 }
 
-/**
- * Vendor economy snapshot containing all vendor stock and pricing info.
- */
 export interface LiveGameplayVendorEconomySnapshot {
   readonly vendors: readonly LiveGameplayVendorEconomy[];
 }
 
-/**
- * Camp NPC activity state.
- */
 export type CampNpcActivity = "gathering" | "returning" | "depositing";
-
-/**
- * Camp NPC state.
- */
 export type CampNpcState = "idle" | "working" | "resting";
 
-/**
- * Camp NPC position.
- */
 export interface CampNpcPosition {
   readonly x: number;
   readonly y: number;
 }
 
-/**
- * Camp NPC type.
- */
 export type CampNpcType = "camp_woodcutter" | "camp_miner" | "camp_fisher";
 
-/**
- * Camp NPC snapshot for server-authoritative display.
- */
 export interface LiveGameplayCampNpc {
   readonly id: string;
   readonly type: CampNpcType;
@@ -241,28 +179,18 @@ export interface LiveGameplayCampNpc {
   readonly activityMessage: string;
 }
 
-/**
- * Camp stock item entry.
- */
 export interface LiveGameplayCampStockItem {
   readonly itemId: string;
   readonly quantity: number;
-  /** Buy price in coins, null if not buyable from camp */
   readonly buyPrice?: number | null;
 }
 
-/**
- * Camp stock snapshot for display.
- */
 export interface LiveGameplayCampStock {
   readonly poiId: string;
   readonly items: readonly LiveGameplayCampStockItem[];
   readonly lastUpdatedTick: number;
 }
 
-/**
- * Processing station snapshot for crafting UI.
- */
 export interface LiveGameplayProcessingStation {
   readonly id: string;
   readonly type: "campfire" | "furnace" | "workbench";
@@ -271,6 +199,20 @@ export interface LiveGameplayProcessingStation {
   readonly y: number;
   readonly interactionRadius: number;
 }
+
+export interface LiveGameplayWorldSurface {
+  readonly schemaVersion: "world-surface-model.v1";
+  readonly tick: number;
+  readonly groups: readonly unknown[];
+  readonly points: readonly unknown[];
+}
+
+export const EMPTY_LIVE_GAMEPLAY_WORLD_SURFACE: LiveGameplayWorldSurface = Object.freeze({
+  schemaVersion: "world-surface-model.v1",
+  tick: 0,
+  groups: Object.freeze([]),
+  points: Object.freeze([]),
+});
 
 export interface LiveGameplaySnapshot {
   readonly schemaVersion: "live-gameplay-snapshot.v1";
@@ -285,32 +227,20 @@ export interface LiveGameplaySnapshot {
   readonly wallet: LiveGameplayWallet;
   readonly worldPois: readonly LiveGameplayWorldPoi[];
   readonly vendorEconomy: LiveGameplayVendorEconomySnapshot;
-  /** Discovery stats for map display */
   readonly discoveryStats: DiscoveryStats;
-  /** Recently discovered POIs for client feedback */
   readonly recentDiscoveries: readonly RecentDiscovery[];
-  /** Camp NPCs at discovered gathering camp POIs */
   readonly campNpcs: readonly LiveGameplayCampNpc[];
-  /** Camp stock at discovered gathering camp POIs */
   readonly campStocks: readonly LiveGameplayCampStock[];
-  /** Aggregated equipment stats from all equipped items */
   readonly equipmentStats: EquipmentStatBlock;
-  /** Processing stations for crafting UI */
   readonly processingStations: readonly LiveGameplayProcessingStation[];
-  /** Active NPC quests for the player */
   readonly activeQuests: readonly LiveGameplayQuestProgress[];
-  /** Available NPC quests for the player */
   readonly availableQuests: readonly LiveGameplayQuestProgress[];
-  /** IDs of completed quests */
   readonly completedQuestIds: readonly string[];
-  /** NPC dialogues for nearby NPCs */
   readonly npcDialogues: readonly LiveGameplayNpcDialogue[];
-  /** NPC reputations for the player */
   readonly npcReputations: readonly LiveGameplayNpcReputation[];
-  /** NPC memory snapshots for the player */
   readonly npcMemories: readonly LiveGameplayNpcMemory[];
-  /** NPC rumor snapshots for the player */
   readonly npcRumors: readonly LiveGameplayNpcRumor[];
+  readonly worldSurface: LiveGameplayWorldSurface;
 }
 
 export interface GatherResult {

--- a/server/src/modules/npc/LineageSelectionPure.test.ts
+++ b/server/src/modules/npc/LineageSelectionPure.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { selectLineageInputs } from './LineageSelectionPure';
+
+describe('selectLineageInputs', () => {
+  it('returns no selection for full settlements', () => {
+    const result = selectLineageInputs({
+      tick: 10,
+      settlements: [{ id: 's1', tick: 10, population: 2, capacity: 2, foodSupply: 10 }],
+      houses: [{ id: 'h1', settlementId: 's1', isActive: true }],
+      actors: [
+        { id: 'a1', settlementId: 's1', houseId: 'h1' },
+        { id: 'a2', settlementId: 's1', houseId: 'h1' },
+      ],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns stable sorted ids for the same runtime state', () => {
+    const input = {
+      tick: 20,
+      settlements: [{ id: 's1', tick: 20, population: 1, capacity: 4, foodSupply: 10 }],
+      houses: [{ id: 'h1', settlementId: 's1', isActive: true }],
+      actors: [
+        { id: 'b', settlementId: 's1', houseId: 'h1' },
+        { id: 'a', settlementId: 's1', houseId: 'h1' },
+      ],
+    };
+
+    expect(selectLineageInputs(input)).toEqual(selectLineageInputs(input));
+    expect(selectLineageInputs(input)[0]).toMatchObject({ firstActorId: 'a', secondActorId: 'b', houseId: 'h1' });
+  });
+});

--- a/server/src/modules/npc/LineageSelectionPure.ts
+++ b/server/src/modules/npc/LineageSelectionPure.ts
@@ -1,0 +1,76 @@
+export interface LineageSelectableActor {
+  readonly id: string;
+  readonly settlementId?: string;
+  readonly houseId?: string;
+}
+
+export interface LineageSelectableHouse {
+  readonly id: string;
+  readonly settlementId: string;
+  readonly isActive: boolean;
+}
+
+export interface LineageSelectableSettlement {
+  readonly id: string;
+  readonly tick: number;
+  readonly population: number;
+  readonly capacity: number;
+  readonly foodSupply: number;
+}
+
+export interface LineageSelectionInput {
+  readonly tick: number;
+  readonly settlements: readonly LineageSelectableSettlement[];
+  readonly houses: readonly LineageSelectableHouse[];
+  readonly actors: readonly LineageSelectableActor[];
+  readonly maxSelectionsPerSettlement?: number;
+}
+
+export interface LineageSelection {
+  readonly firstActorId: string;
+  readonly secondActorId: string;
+  readonly houseId: string;
+  readonly settlementId: string;
+  readonly tick: number;
+}
+
+function safe(value: string | undefined): string {
+  return typeof value === 'string' && value.length > 0 ? value : 'none';
+}
+
+function actorKey(actor: LineageSelectableActor): string {
+  return [safe(actor.settlementId), safe(actor.houseId), actor.id].join(':');
+}
+
+function selectableSettlement(settlement: LineageSelectableSettlement): boolean {
+  return settlement.population < settlement.capacity && settlement.foodSupply >= 0;
+}
+
+export function selectLineageInputs(input: LineageSelectionInput): LineageSelection[] {
+  const limit = Math.max(0, Math.floor(input.maxSelectionsPerSettlement ?? 1));
+  if (limit <= 0) return [];
+
+  const settlements = [...input.settlements].filter(selectableSettlement).sort((a, b) => a.id.localeCompare(b.id));
+  const houses = [...input.houses].filter((house) => house.isActive).sort((a, b) => a.id.localeCompare(b.id));
+  const actors = [...input.actors].sort((a, b) => actorKey(a).localeCompare(actorKey(b)));
+  const selected: LineageSelection[] = [];
+
+  for (const settlement of settlements) {
+    let count = 0;
+    for (const house of houses.filter((item) => item.settlementId === settlement.id)) {
+      const roster = actors.filter((actor) => actor.settlementId === settlement.id && (actor.houseId ?? house.id) === house.id);
+      if (roster.length < 2) continue;
+      selected.push({
+        firstActorId: roster[0].id,
+        secondActorId: roster[1].id,
+        houseId: house.id,
+        settlementId: settlement.id,
+        tick: input.tick,
+      });
+      count += 1;
+      if (count >= limit) break;
+    }
+  }
+
+  return selected;
+}

--- a/server/src/modules/npc/LineageSurfaceModel.test.ts
+++ b/server/src/modules/npc/LineageSurfaceModel.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { FamilyHouseRegistry, NPCLineageManager, type HouseState, type LineageStats } from './FamilyHouseRegistry';
+import { createLineageSurfaceModel } from './LineageSurfaceModel';
+
+function stats(seed = 10): LineageStats {
+  return { strength: seed, agility: seed + 1, intelligence: seed + 2, stamina: seed + 3, charisma: seed + 4, luck: seed + 5 };
+}
+
+function house(): HouseState {
+  return {
+    id: 'h1',
+    houseName: 'House One',
+    houseReputation: 10,
+    inheritancePoints: 0,
+    settlementId: 's1',
+    foundingTick: 0,
+    territorySize: 1,
+    resourceStored: 0,
+    housingCapacity: 2,
+    currentPopulation: 1,
+    isActive: true,
+  };
+}
+
+describe('LineageSurfaceModel', () => {
+  it('projects registered lineage state into renderable surface points', () => {
+    const registry = new FamilyHouseRegistry();
+    registry.registerHouse(house());
+    const manager = new NPCLineageManager(registry);
+    const node = manager.createFoundingLineage('founder', 'h1', 's1', 100, stats());
+
+    const model = createLineageSurfaceModel(registry, 1000);
+
+    expect(model.schemaVersion).toBe('lineage-surface-model.v1');
+    expect(model.houses).toHaveLength(1);
+    expect(model.nodes).toHaveLength(1);
+    expect(model.nodes[0].id).toBe(node.id);
+    expect(Number.isFinite(model.nodes[0].x)).toBe(true);
+    expect(Number.isFinite(model.nodes[0].y)).toBe(true);
+    expect(Number.isFinite(model.nodes[0].z)).toBe(true);
+  });
+});

--- a/server/src/modules/npc/LineageSurfaceModel.ts
+++ b/server/src/modules/npc/LineageSurfaceModel.ts
@@ -1,0 +1,60 @@
+import type { FamilyHouseRegistry } from './FamilyHouseRegistry';
+
+export interface LineageSurfaceHouse {
+  readonly id: string;
+  readonly title: string;
+  readonly settlementId: string;
+  readonly population: number;
+  readonly active: boolean;
+}
+
+export interface LineageSurfaceNode {
+  readonly id: string;
+  readonly lineageHash: string;
+  readonly houseId: string;
+  readonly settlementId: string;
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export interface LineageSurfaceModel {
+  readonly schemaVersion: 'lineage-surface-model.v1';
+  readonly tick: number;
+  readonly houses: readonly LineageSurfaceHouse[];
+  readonly nodes: readonly LineageSurfaceNode[];
+}
+
+function hash32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+export function lineageSurfaceCoordinate(seed: string, salt: string, span: number): number {
+  return (hash32(`${seed}:${salt}`) % span) - Math.floor(span / 2);
+}
+
+export function createLineageSurfaceModel(registry: FamilyHouseRegistry, tick: number): LineageSurfaceModel {
+  const snapshot = registry.serialize();
+  const houses = snapshot.houses.map((house) => ({
+    id: house.id,
+    title: house.houseName,
+    settlementId: house.settlementId,
+    population: house.currentPopulation,
+    active: house.isActive,
+  })).sort((a, b) => a.id.localeCompare(b.id));
+  const nodes = snapshot.lineages.map((lineage) => ({
+    id: lineage.id,
+    lineageHash: lineage.lineageHash,
+    houseId: lineage.houseId,
+    settlementId: lineage.settlementId,
+    x: lineageSurfaceCoordinate(lineage.lineageHash, 'x', 512),
+    y: lineageSurfaceCoordinate(lineage.lineageHash, 'y', 512),
+    z: lineageSurfaceCoordinate(lineage.lineageHash, 'z', 96),
+  })).sort((a, b) => a.id.localeCompare(b.id));
+  return Object.freeze({ schemaVersion: 'lineage-surface-model.v1', tick, houses: Object.freeze(houses), nodes: Object.freeze(nodes) });
+}

--- a/server/src/modules/npc/LineageWorldSurfaceAdapter.test.ts
+++ b/server/src/modules/npc/LineageWorldSurfaceAdapter.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { lineageSurfaceToWorldSurface } from './LineageWorldSurfaceAdapter';
+import type { LineageSurfaceModel } from './LineageSurfaceModel';
+
+describe('LineageWorldSurfaceAdapter', () => {
+  it('maps lineage houses and nodes to shared world surface groups and points', () => {
+    const surface: LineageSurfaceModel = {
+      schemaVersion: 'lineage-surface-model.v1',
+      tick: 12,
+      houses: [{ id: 'h1', title: 'House One', settlementId: 's1', population: 2, active: true }],
+      nodes: [{ id: 'n1', lineageHash: 'abc', houseId: 'h1', settlementId: 's1', x: 1, y: 2, z: 3 }],
+    };
+
+    const world = lineageSurfaceToWorldSurface(surface);
+
+    expect(world.schemaVersion).toBe('world-surface-model.v1');
+    expect(world.tick).toBe(12);
+    expect(world.groups).toHaveLength(1);
+    expect(world.points).toHaveLength(1);
+  });
+});

--- a/server/src/modules/npc/LineageWorldSurfaceAdapter.ts
+++ b/server/src/modules/npc/LineageWorldSurfaceAdapter.ts
@@ -1,0 +1,31 @@
+import type { LiveGameplayWorldSurface } from '../../gameplay/LiveGameplaySnapshotTypes.js';
+import type { LineageSurfaceModel } from './LineageSurfaceModel';
+
+export function lineageSurfaceToWorldSurface(surface: LineageSurfaceModel): LiveGameplayWorldSurface {
+  const groups = surface.houses.map((house) => Object.freeze({
+    id: house.id,
+    kind: 'lineage_house',
+    title: house.title,
+    settlementId: house.settlementId,
+    population: house.population,
+    active: house.active,
+  })).sort((a, b) => a.id.localeCompare(b.id));
+
+  const points = surface.nodes.map((node) => Object.freeze({
+    id: node.id,
+    kind: 'lineage_node',
+    lineageHash: node.lineageHash,
+    houseId: node.houseId,
+    settlementId: node.settlementId,
+    x: node.x,
+    y: node.y,
+    z: node.z,
+  })).sort((a, b) => a.id.localeCompare(b.id));
+
+  return Object.freeze({
+    schemaVersion: 'world-surface-model.v1',
+    tick: surface.tick,
+    groups: Object.freeze(groups),
+    points: Object.freeze(points),
+  });
+}

--- a/server/src/tests/LiveGameplayWorldSurface.test.ts
+++ b/server/src/tests/LiveGameplayWorldSurface.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { LiveGameplaySnapshotComposer } from "../gameplay/LiveGameplaySnapshotComposer.js";
+
+function createComposer(overrides: Partial<ConstructorParameters<typeof LiveGameplaySnapshotComposer>[0]> = {}) {
+  return new LiveGameplaySnapshotComposer({
+    getInventoryItems: () => [],
+    getEquipmentSlots: () => [],
+    getSkillStates: () => [],
+    getResourceNodes: () => [],
+    getWallet: () => ({ coin: 0 }),
+    ...overrides,
+  });
+}
+
+describe("LiveGameplaySnapshotComposer worldSurface", () => {
+  it("defaults to an empty deterministic world surface", async () => {
+    const snapshot = await createComposer().compose("player_surface", 12);
+
+    expect(snapshot.worldSurface).toEqual({
+      schemaVersion: "world-surface-model.v1",
+      tick: 0,
+      groups: [],
+      points: [],
+    });
+  });
+
+  it("includes server-authoritative world surface from deps", async () => {
+    const snapshot = await createComposer({
+      getWorldSurface: (_playerId, logicalIndex) => ({
+        schemaVersion: "world-surface-model.v1",
+        tick: logicalIndex,
+        groups: [{ id: "house_1", kind: "lineage_house" }],
+        points: [{ id: "lineage_1", kind: "lineage_node", x: 1, y: 2, z: 3 }],
+      }),
+    }).compose("player_surface", 42);
+
+    expect(snapshot.worldSurface.tick).toBe(42);
+    expect(snapshot.worldSurface.groups).toHaveLength(1);
+    expect(snapshot.worldSurface.points).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the next integration layer for visible NPC/house lineage data:

- pure lineage selection model from runtime state IDs
- server-side lineage surface projection from registry state
- adapter from lineage surface to shared world surface snapshot
- `LiveGameplaySnapshot.worldSurface` contract
- composer dependency for server-authoritative world surface data
- client-2d world surface normalizer
- live gameplay store preservation of world surface payload
- tests for selection, projection, adapter, composer, and client normalization

## ARE Notes

No gameplay mutation is introduced here. This PR only adds pure selection/projection and display-surface plumbing. The existing tick runner remains the mutation boundary.