### PR TITLE
feat(npc): drive lineage births from runtime tick state

### DIFF
--- a/server/src/modules/npc/LineageBirthTickIntegration.test.ts
+++ b/server/src/modules/npc/LineageBirthTickIntegration.test.ts
@@ -1,0 +1,570 @@
+/**
+ * LineageBirthTickIntegration.test.ts
+ *
+ * Comprehensive tests for the lineage birth tick integration pipeline.
+ * Tests cover:
+ * - Pure selection from runtime state
+ * - Selection-to-tick candidate adaptation
+ * - Idempotency checks
+ * - Journal write verification
+ * - Surface model reconstruction
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  FamilyHouseRegistry,
+  NPCLineageManager,
+  type HouseState,
+  type LineageStats,
+  type LineageBirthEvent,
+  type NPCState,
+  type SettlementState,
+} from './FamilyHouseRegistry';
+import { NpcLineageGameDataWriter, type NpcLineageStorageProvider, NPC_LINEAGE_GAME_DATA_PATH } from './LineageGameDataWriter';
+import { createNpcLineageRuntime } from './createNpcLineageRuntime';
+import { selectFromRuntime, createNpcLookup, createSettlementLookup, createHouseLookup, type RuntimeLineageState } from './LineageRuntimeSelection';
+import { adaptSelectionsToCandidates, candidateKey } from './LineageRuntimeTickAdapter';
+import {
+  runLineageBirthTick,
+  getCurrentWorldSurface,
+  surfaceContainsNode,
+  surfaceContainsHouse,
+} from './LineageBirthTickIntegration';
+
+/**
+ * In-memory storage provider for testing.
+ */
+class MemoryStorageProvider implements NpcLineageStorageProvider {
+  private dataByTarget = new Map<string, string>();
+  writes: Array<{ target: string; content: string }> = [];
+
+  read(target: string): string | null {
+    return this.dataByTarget.get(target) ?? null;
+  }
+
+  write(target: string, content: string): void {
+    this.dataByTarget.set(target, content);
+    this.writes.push({ target, content });
+  }
+
+  clear(): void {
+    this.dataByTarget.clear();
+    this.writes = [];
+  }
+}
+
+function stats(seed = 10): LineageStats {
+  return {
+    strength: seed,
+    agility: seed + 1,
+    intelligence: seed + 2,
+    stamina: seed + 3,
+    charisma: seed + 4,
+    luck: seed + 5,
+  };
+}
+
+function house(id = 'house_1', settlementId = 'settlement_1', isActive = true): HouseState {
+  return {
+    id,
+    houseName: `House ${id}`,
+    houseReputation: 50,
+    inheritancePoints: 50,
+    settlementId,
+    foundingTick: 0,
+    territorySize: 5,
+    resourceStored: 100,
+    housingCapacity: 10,
+    currentPopulation: 1,
+    isActive,
+  };
+}
+
+function settlement(id = 'settlement_1', overrides: Partial<SettlementState> = {}): SettlementState {
+  return {
+    id,
+    capacity: 100,
+    population: 10,
+    foodSupply: 100,
+    housingUnits: 20,
+    settlementType: 'village',
+    tick: 1000,
+    ...overrides,
+  };
+}
+
+function npc(id: string, settlementId = 'settlement_1', houseId = 'house_1'): NPCState {
+  return {
+    id,
+    houseId,
+    settlementId,
+    stats: stats(id.charCodeAt(0)),
+    traits: ['tester'],
+    generation: 0,
+    birthTick: 0,
+  };
+}
+
+function runtimeState(
+  tick: number,
+  settlements: SettlementState[],
+  houses: HouseState[],
+  npcs: NPCState[],
+  maxSelectionsPerSettlement?: number
+): RuntimeLineageState {
+  return Object.freeze({
+    tick,
+    settlements: Object.freeze(settlements),
+    houses: Object.freeze(houses),
+    npcs: Object.freeze(npcs),
+    maxSelectionsPerSettlement,
+  });
+}
+
+describe('LineageRuntimeSelection', () => {
+  describe('selectFromRuntime', () => {
+    it('returns no selection for full settlements', () => {
+      const state = runtimeState(
+        100,
+        [settlement('s1', { population: 100, capacity: 100 })],
+        [house('h1', 's1')],
+        [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')]
+      );
+      const result = selectFromRuntime(state);
+      expect(result).toHaveLength(0);
+    });
+
+    it('returns no selection for inactive houses', () => {
+      const state = runtimeState(
+        100,
+        [settlement('s1')],
+        [house('h1', 's1', false)],
+        [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')]
+      );
+      const result = selectFromRuntime(state);
+      expect(result).toHaveLength(0);
+    });
+
+    it('returns no selection when fewer than 2 NPCs in house', () => {
+      const state = runtimeState(
+        100,
+        [settlement('s1')],
+        [house('h1', 's1')],
+        [npc('a1', 's1', 'h1')]
+      );
+      const result = selectFromRuntime(state);
+      expect(result).toHaveLength(0);
+    });
+
+    it('returns selection for eligible pair in active house with space', () => {
+      const state = runtimeState(
+        100,
+        [settlement('s1')],
+        [house('h1', 's1')],
+        [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')]
+      );
+      const result = selectFromRuntime(state);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        firstActorId: 'a1',
+        secondActorId: 'a2',
+        houseId: 'h1',
+        settlementId: 's1',
+        tick: 100,
+      });
+    });
+
+    it('produces deterministic results regardless of input order', () => {
+      const state1 = runtimeState(
+        100,
+        [settlement('s1')],
+        [house('h1', 's1')],
+        [npc('b', 's1', 'h1'), npc('a', 's1', 'h1')]
+      );
+
+      const state2 = runtimeState(
+        100,
+        [settlement('s1')],
+        [house('h1', 's1')],
+        [npc('a', 's1', 'h1'), npc('b', 's1', 'h1')]
+      );
+
+      const result1 = selectFromRuntime(state1);
+      const result2 = selectFromRuntime(state2);
+
+      expect(result1).toEqual(result2);
+      expect(result1[0].firstActorId).toBe('a');
+      expect(result1[0].secondActorId).toBe('b');
+    });
+
+    it('respects maxSelectionsPerSettlement limit', () => {
+      const state = runtimeState(
+        100,
+        [settlement('s1')],
+        [
+          house('h1', 's1'),
+          house('h2', 's1'),
+          house('h3', 's1'),
+        ],
+        [
+          npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1'),
+          npc('b1', 's1', 'h2'), npc('b2', 's1', 'h2'),
+          npc('c1', 's1', 'h3'), npc('c2', 's1', 'h3'),
+        ],
+        1 // Only 1 selection per settlement
+      );
+      const result = selectFromRuntime(state);
+      expect(result).toHaveLength(1);
+    });
+  });
+});
+
+describe('LineageRuntimeTickAdapter', () => {
+  describe('adaptSelectionsToCandidates', () => {
+    it('maps valid selection to candidate', () => {
+      const npcs = [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')];
+      const settlements = [settlement('s1')];
+      const houses = [house('h1', 's1')];
+
+      const state = runtimeState(100, settlements, houses, npcs);
+      const selections = selectFromRuntime(state);
+
+      expect(selections).toHaveLength(1);
+
+      const result = adaptSelectionsToCandidates({
+        selections,
+        npcsById: createNpcLookup(npcs),
+        settlementsById: createSettlementLookup(settlements),
+        housesById: createHouseLookup(houses),
+        tick: 100,
+      });
+
+      expect(result.candidates).toHaveLength(1);
+      expect(result.skipped).toHaveLength(0);
+      expect(result.candidates[0].parentA.id).toBe('a1');
+      expect(result.candidates[0].parentB.id).toBe('a2');
+    });
+
+    it('skips selection with missing NPC', () => {
+      const npcs = [npc('a1', 's1', 'h1')]; // Missing second NPC
+      const settlements = [settlement('s1')];
+      const houses = [house('h1', 's1')];
+
+      const state = runtimeState(100, settlements, houses, npcs);
+      const selections = selectFromRuntime(state);
+
+      expect(selections).toHaveLength(0); // No selection because < 2 NPCs
+
+      // Now test with explicit selection that references missing NPC
+      const mockSelection = Object.freeze({
+        firstActorId: 'a1',
+        secondActorId: 'missing',
+        houseId: 'h1',
+        settlementId: 's1',
+        tick: 100,
+      });
+
+      const result = adaptSelectionsToCandidates({
+        selections: [mockSelection],
+        npcsById: createNpcLookup(npcs),
+        settlementsById: createSettlementLookup(settlements),
+        housesById: createHouseLookup(houses),
+        tick: 100,
+      });
+
+      expect(result.candidates).toHaveLength(0);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].reason).toBe('second_actor_not_found');
+    });
+
+    it('skips selection with missing settlement', () => {
+      const npcs = [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')];
+      const settlements: SettlementState[] = [];
+      const houses = [house('h1', 's1')];
+
+      const mockSelection = Object.freeze({
+        firstActorId: 'a1',
+        secondActorId: 'a2',
+        houseId: 'h1',
+        settlementId: 's1',
+        tick: 100,
+      });
+
+      const result = adaptSelectionsToCandidates({
+        selections: [mockSelection],
+        npcsById: createNpcLookup(npcs),
+        settlementsById: createSettlementLookup(settlements),
+        housesById: createHouseLookup(houses),
+        tick: 100,
+      });
+
+      expect(result.candidates).toHaveLength(0);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].reason).toBe('settlement_not_found');
+    });
+
+    it('skips selection with inactive house', () => {
+      const npcs = [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')];
+      const settlements = [settlement('s1')];
+      const houses = [house('h1', 's1', false)];
+
+      const state = runtimeState(100, settlements, houses, npcs);
+      const selections = selectFromRuntime(state);
+
+      expect(selections).toHaveLength(0); // Pure selection filters inactive houses
+
+      const mockSelection = Object.freeze({
+        firstActorId: 'a1',
+        secondActorId: 'a2',
+        houseId: 'h1',
+        settlementId: 's1',
+        tick: 100,
+      });
+
+      const result = adaptSelectionsToCandidates({
+        selections: [mockSelection],
+        npcsById: createNpcLookup(npcs),
+        settlementsById: createSettlementLookup(settlements),
+        housesById: createHouseLookup(houses),
+        tick: 100,
+      });
+
+      expect(result.candidates).toHaveLength(0);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].reason).toBe('house_inactive');
+    });
+
+    it('skips selection for full settlement', () => {
+      const npcs = [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')];
+      const settlements = [settlement('s1', { population: 100, capacity: 100 })];
+      const houses = [house('h1', 's1')];
+
+      const state = runtimeState(100, settlements, houses, npcs);
+      const selections = selectFromRuntime(state);
+
+      expect(selections).toHaveLength(0); // Pure selection filters full settlements
+
+      const mockSelection = Object.freeze({
+        firstActorId: 'a1',
+        secondActorId: 'a2',
+        houseId: 'h1',
+        settlementId: 's1',
+        tick: 100,
+      });
+
+      const result = adaptSelectionsToCandidates({
+        selections: [mockSelection],
+        npcsById: createNpcLookup(npcs),
+        settlementsById: createSettlementLookup(settlements),
+        housesById: createHouseLookup(houses),
+        tick: 100,
+      });
+
+      expect(result.candidates).toHaveLength(0);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].reason).toBe('settlement_full');
+    });
+  });
+
+  describe('candidateKey', () => {
+    it('produces consistent keys regardless of actor order', () => {
+      const key1 = candidateKey(100, 's1', 'h1', 'a1', 'a2');
+      const key2 = candidateKey(100, 's1', 'h1', 'a2', 'a1');
+      expect(key1).toBe(key2);
+    });
+
+    it('produces different keys for different ticks', () => {
+      const key1 = candidateKey(100, 's1', 'h1', 'a1', 'a2');
+      const key2 = candidateKey(200, 's1', 'h1', 'a1', 'a2');
+      expect(key1).not.toBe(key2);
+    });
+
+    it('produces different keys for different houses', () => {
+      const key1 = candidateKey(100, 's1', 'h1', 'a1', 'a2');
+      const key2 = candidateKey(100, 's1', 'h2', 'a1', 'a2');
+      expect(key1).not.toBe(key2);
+    });
+  });
+});
+
+describe('LineageBirthTickIntegration', () => {
+  let storage: MemoryStorageProvider;
+  let lineageManager: NPCLineageManager;
+
+  beforeEach(() => {
+    storage = new MemoryStorageProvider();
+    const runtime = createNpcLineageRuntime({ storageProvider: storage, replay: false });
+    lineageManager = runtime.manager;
+  });
+
+  describe('runLineageBirthTick', () => {
+    it('creates birth event when eligible pair exists', () => {
+      // Register house first
+      lineageManager.updateHouseSnapshot('house_1', house());
+
+      const result = runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement()],
+        houses: [house()],
+        npcs: [npc('parent_a'), npc('parent_b')],
+        lineageManager,
+      });
+
+      expect(result.lineageResult.created).toHaveLength(1);
+      expect(result.lineageResult.skipped).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('writes to journal on birth', () => {
+      lineageManager.updateHouseSnapshot('house_1', house());
+
+      runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement()],
+        houses: [house()],
+        npcs: [npc('parent_a'), npc('parent_b')],
+        lineageManager,
+      });
+
+      // Check that journal was written
+      const journalContent = storage.read(NPC_LINEAGE_GAME_DATA_PATH);
+      expect(journalContent).not.toBeNull();
+      const records = JSON.parse(journalContent!);
+      expect(records).toHaveLength(1);
+      expect(records[0].birthTick).toBe(100);
+    });
+
+    it('no birth for full settlement', () => {
+      const result = runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement('s1', { population: 100, capacity: 100 })],
+        houses: [house('h1', 's1')],
+        npcs: [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')],
+        lineageManager,
+      });
+
+      expect(result.lineageResult.created).toHaveLength(0);
+      expect(result.surface.points).toHaveLength(0);
+    });
+
+    it('no birth for inactive house', () => {
+      const result = runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement('s1')],
+        houses: [house('h1', 's1', false)],
+        npcs: [npc('a1', 's1', 'h1'), npc('a2', 's1', 'h1')],
+        lineageManager,
+      });
+
+      expect(result.lineageResult.created).toHaveLength(0);
+    });
+
+    it('surface contains new lineage node after birth', () => {
+      lineageManager.updateHouseSnapshot('house_1', house());
+
+      const result = runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement()],
+        houses: [house()],
+        npcs: [npc('parent_a'), npc('parent_b')],
+        lineageManager,
+      });
+
+      expect(result.lineageResult.created).toHaveLength(1);
+      const createdNode = result.lineageResult.created[0];
+      expect(surfaceContainsNode(result.surface, createdNode.id)).toBe(true);
+    });
+
+    it('surface contains house group', () => {
+      lineageManager.updateHouseSnapshot('house_1', house());
+
+      const result = runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement()],
+        houses: [house()],
+        npcs: [npc('parent_a'), npc('parent_b')],
+        lineageManager,
+      });
+
+      expect(surfaceContainsHouse(result.surface, 'house_1')).toBe(true);
+    });
+
+    it('idempotent: same tick with same parents creates no duplicate', () => {
+      lineageManager.updateHouseSnapshot('house_1', house());
+
+      // First tick
+      const result1 = runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement()],
+        houses: [house()],
+        npcs: [npc('parent_a'), npc('parent_b')],
+        lineageManager,
+      });
+
+      expect(result1.lineageResult.created).toHaveLength(1);
+
+      const initialJournal = storage.read(NPC_LINEAGE_GAME_DATA_PATH);
+      const initialRecords = JSON.parse(initialJournal!);
+
+      // Second tick with same state
+      const result2 = runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement()],
+        houses: [house()],
+        npcs: [npc('parent_a'), npc('parent_b')],
+        lineageManager,
+      });
+
+      // Should skip due to idempotency
+      expect(result2.lineageResult.created).toHaveLength(0);
+      expect(result2.lineageResult.skipped).toHaveLength(1);
+
+      // Journal should not have duplicate
+      const finalJournal = storage.read(NPC_LINEAGE_GAME_DATA_PATH);
+      const finalRecords = JSON.parse(finalJournal!);
+      expect(finalRecords).toHaveLength(initialRecords.length);
+    });
+  });
+
+  describe('getCurrentWorldSurface', () => {
+    it('returns surface from lineage registry', () => {
+      lineageManager.updateHouseSnapshot('house_1', house());
+
+      // Create a birth first
+      runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement()],
+        houses: [house()],
+        npcs: [npc('parent_a'), npc('parent_b')],
+        lineageManager,
+      });
+
+      const surface = getCurrentWorldSurface(lineageManager, 100);
+
+      expect(surface.schemaVersion).toBe('world-surface-model.v1');
+      expect(surface.tick).toBe(100);
+      expect(surface.points.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Journal Replay', () => {
+    it('replays journal to reconstruct lineage', () => {
+      lineageManager.updateHouseSnapshot('house_1', house());
+
+      // Create birth
+      runLineageBirthTick({
+        tick: 100,
+        settlements: [settlement()],
+        houses: [house()],
+        npcs: [npc('parent_a'), npc('parent_b')],
+        lineageManager,
+      });
+
+      // Create new runtime from same storage
+      const newRuntime = createNpcLineageRuntime({ storageProvider: storage });
+      const newSurface = getCurrentWorldSurface(newRuntime.manager, 100);
+
+      expect(newSurface.points.length).toBe(1);
+    });
+  });
+});

--- a/server/src/modules/npc/LineageBirthTickIntegration.test.ts
+++ b/server/src/modules/npc/LineageBirthTickIntegration.test.ts
@@ -502,11 +502,12 @@ describe('LineageBirthTickIntegration', () => {
       });
 
       expect(result1.lineageResult.created).toHaveLength(1);
+      const createdNode = result1.lineageResult.created[0];
 
       const initialJournal = storage.read(NPC_LINEAGE_GAME_DATA_PATH);
       const initialRecords = JSON.parse(initialJournal!);
 
-      // Second tick with same state
+      // Second tick with same state - should skip due to existingBirthKeys
       const result2 = runLineageBirthTick({
         tick: 100,
         settlements: [settlement()],
@@ -515,14 +516,17 @@ describe('LineageBirthTickIntegration', () => {
         lineageManager,
       });
 
-      // Should skip due to idempotency
+      // Should skip due to idempotency from existingBirthKeys
       expect(result2.lineageResult.created).toHaveLength(0);
-      expect(result2.lineageResult.skipped).toHaveLength(1);
+      expect(result2.lineageResult.skipped.length).toBeGreaterThan(0);
 
       // Journal should not have duplicate
       const finalJournal = storage.read(NPC_LINEAGE_GAME_DATA_PATH);
       const finalRecords = JSON.parse(finalJournal!);
       expect(finalRecords).toHaveLength(initialRecords.length);
+      
+      // Surface should still have the original node
+      expect(surfaceContainsNode(result2.surface, createdNode.id)).toBe(true);
     });
   });
 

--- a/server/src/modules/npc/LineageBirthTickIntegration.ts
+++ b/server/src/modules/npc/LineageBirthTickIntegration.ts
@@ -16,13 +16,12 @@
  */
 
 import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry.js';
-import type { LineageSurfaceModel } from './LineageSurfaceModel.js';
 import type { LiveGameplayWorldSurface } from '../../gameplay/LiveGameplaySnapshotTypes.js';
 import { createLineageSurfaceModel } from './LineageSurfaceModel.js';
 import { lineageSurfaceToWorldSurface } from './LineageWorldSurfaceAdapter.js';
 import { LineageTickRunner } from './LineageTickRunner.js';
 import { NPCLineageManager } from './FamilyHouseRegistry.js';
-import { candidateKey } from './LineageRuntimeTickAdapter.js';
+import { lineageBirthKey } from './LineageRuntimeTickAdapter.js';
 import {
   selectFromRuntime,
   createNpcLookup,
@@ -42,19 +41,14 @@ import {
 export function extractExistingBirthKeys(lineageManager: NPCLineageManager): ReadonlySet<string> {
   const birthEvents = lineageManager.getRegistry().getBirthEvents();
   const keys = new Set<string>();
-  
+
   for (const event of birthEvents) {
+    if (event.cause !== 'eligible_pair') continue;
     const parentIds = [...event.parentLineageHashes].sort();
-    const key = candidateKey(
-      event.birthTick,
-      event.settlementId,
-      event.houseId,
-      parentIds[0] ?? '',
-      parentIds[1] ?? ''
-    );
-    keys.add(key);
+    if (parentIds.length < 2) continue;
+    keys.add(lineageBirthKey(event.birthTick, event.settlementId, event.houseId, parentIds[0], parentIds[1]));
   }
-  
+
   return Object.freeze(keys);
 }
 
@@ -155,7 +149,7 @@ export function runLineageBirthTick(input: LineageBirthIntegrationInput): Lineag
   // Phase 2: Adapt selections to tick candidates
   // Extract existing birth keys for idempotency
   const existingBirthKeys = extractExistingBirthKeys(input.lineageManager);
-  
+
   const adapterInput: LineageTickAdapterInput = {
     selections,
     npcsById: lookups.npcsById,
@@ -164,7 +158,7 @@ export function runLineageBirthTick(input: LineageBirthIntegrationInput): Lineag
     tick: input.tick,
     existingBirthKeys,
   };
-  const { candidates } = adaptSelectionsToCandidates(adapterInput);
+  const { candidates, skipped: adapterSkipped } = adaptSelectionsToCandidates(adapterInput);
 
   if (candidates.length === 0) {
     // No resolvable candidates
@@ -176,10 +170,10 @@ export function runLineageBirthTick(input: LineageBirthIntegrationInput): Lineag
       lineageResult: Object.freeze({
         tick: input.tick,
         created: [],
-        skipped: [],
+        skipped: Object.freeze(adapterSkipped),
       }),
       surface,
-      errors: Object.freeze(['no_resolvable_candidates']),
+      errors: Object.freeze(adapterSkipped.map((skip) => `skip:${skip.reason}:${skip.houseId}`)),
     });
   }
 
@@ -188,7 +182,10 @@ export function runLineageBirthTick(input: LineageBirthIntegrationInput): Lineag
   const runner = new LineageTickRunner(input.lineageManager);
   const lineageResult = runner.run(input.tick, candidates);
 
-  // Track any errors from the lineage operation
+  // Track any errors from the adapter and lineage operation
+  for (const skip of adapterSkipped) {
+    errors.push(`skip:${skip.reason}:${skip.houseId}`);
+  }
   for (const skip of lineageResult.skipped) {
     errors.push(`skip:${skip.reason}:${skip.houseId}`);
   }
@@ -201,7 +198,11 @@ export function runLineageBirthTick(input: LineageBirthIntegrationInput): Lineag
 
   return Object.freeze({
     tick: input.tick,
-    lineageResult,
+    lineageResult: Object.freeze({
+      tick: lineageResult.tick,
+      created: Object.freeze(lineageResult.created),
+      skipped: Object.freeze([...adapterSkipped, ...lineageResult.skipped]),
+    }),
     surface,
     errors: Object.freeze(errors),
   });

--- a/server/src/modules/npc/LineageBirthTickIntegration.ts
+++ b/server/src/modules/npc/LineageBirthTickIntegration.ts
@@ -1,0 +1,244 @@
+/**
+ * LineageBirthTickIntegration.ts
+ *
+ * Orchestrates the full lineage birth pipeline:
+ * 1. Pure selection from runtime state
+ * 2. Selection-to-tick candidate adaptation
+ * 3. LineageTickRunner execution
+ * 4. Journal write via NPCLineageManager
+ * 5. Surface model reconstruction
+ *
+ * ARE Rules:
+ * - No Math.random() - deterministic only
+ * - No Date.now() - uses tick from runtime state
+ * - No mutation of runtime state
+ * - Journal-first: failure to write = failure of the operation
+ */
+
+import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry';
+import type { LineageSurfaceModel } from './LineageSurfaceModel';
+import type { LiveGameplayWorldSurface } from '../../gameplay/LiveGameplaySnapshotTypes.js';
+import { createLineageSurfaceModel } from './LineageSurfaceModel.js';
+import { lineageSurfaceToWorldSurface } from './LineageWorldSurfaceAdapter.js';
+import { LineageTickRunner } from './LineageTickRunner.js';
+import type { NPCLineageManager } from './FamilyHouseRegistry.js';
+import {
+  selectFromRuntime,
+  createNpcLookup,
+  createSettlementLookup,
+  createHouseLookup,
+  type RuntimeLineageState,
+} from './LineageRuntimeSelection.js';
+import {
+  adaptSelectionsToCandidates,
+  type LineageTickAdapterInput,
+} from './LineageRuntimeTickAdapter.js';
+
+/**
+ * Result of a complete lineage birth tick operation.
+ */
+export interface LineageBirthTickResult {
+  readonly tick: number;
+  readonly selections: number;
+  readonly candidatesProcessed: number;
+  readonly birthsCreated: number;
+  readonly birthsSkipped: number;
+  readonly journalWrites: number;
+  readonly surfaceTick: number;
+  readonly errors: readonly string[];
+}
+
+/**
+ * Result of the full integration operation.
+ */
+export interface LineageBirthIntegrationResult {
+  readonly tick: number;
+  readonly lineageResult: import('./LineageTickRunner.js').LineageTickResult;
+  readonly surface: LiveGameplayWorldSurface;
+  readonly errors: readonly string[];
+}
+
+/**
+ * Input for lineage birth integration.
+ */
+export interface LineageBirthIntegrationInput {
+  readonly tick: number;
+  readonly settlements: readonly SettlementState[];
+  readonly houses: readonly HouseState[];
+  readonly npcs: readonly NPCState[];
+  readonly lineageManager: NPCLineageManager;
+  readonly maxSelectionsPerSettlement?: number;
+}
+
+/**
+ * Builds a RuntimeLineageState from raw runtime inputs.
+ */
+function buildRuntimeState(input: LineageBirthIntegrationInput): RuntimeLineageState {
+  return {
+    tick: input.tick,
+    settlements: input.settlements,
+    houses: input.houses,
+    npcs: input.npcs,
+    maxSelectionsPerSettlement: input.maxSelectionsPerSettlement,
+  };
+}
+
+/**
+ * Creates lookup maps for runtime objects.
+ */
+function buildLookups(input: LineageBirthIntegrationInput) {
+  return {
+    npcsById: createNpcLookup(input.npcs),
+    settlementsById: createSettlementLookup(input.settlements),
+    housesById: createHouseLookup(input.houses),
+  };
+}
+
+/**
+ * Runs a single lineage birth tick:
+ * 1. Select eligible pairs from runtime state (pure)
+ * 2. Adapt selections to tick candidates (thin adapter)
+ * 3. Execute tick via LineageTickRunner (creates births in journal)
+ * 4. Rebuild surface model from updated registry
+ *
+ * Returns a deterministic result even on partial failure.
+ */
+export function runLineageBirthTick(input: LineageBirthIntegrationInput): LineageBirthIntegrationResult {
+  const errors: string[] = [];
+  const lookups = buildLookups(input);
+
+  // Phase 1: Pure selection from runtime state
+  const runtimeState = buildRuntimeState(input);
+  const selections = selectFromRuntime(runtimeState);
+
+  if (selections.length === 0) {
+    // No selections possible - return early with empty surface
+    const registry = input.lineageManager.getRegistry();
+    const surfaceModel = createLineageSurfaceModel(registry, input.tick);
+    const surface = lineageSurfaceToWorldSurface(surfaceModel);
+    return Object.freeze({
+      tick: input.tick,
+      lineageResult: Object.freeze({
+        tick: input.tick,
+        created: [],
+        skipped: [],
+      }),
+      surface,
+      errors: Object.freeze([]),
+    });
+  }
+
+  // Phase 2: Adapt selections to tick candidates
+  const adapterInput: LineageTickAdapterInput = {
+    selections,
+    npcsById: lookups.npcsById,
+    settlementsById: lookups.settlementsById,
+    housesById: lookups.housesById,
+    tick: input.tick,
+  };
+  const { candidates } = adaptSelectionsToCandidates(adapterInput);
+
+  if (candidates.length === 0) {
+    // No resolvable candidates
+    const registry = input.lineageManager.getRegistry();
+    const surfaceModel = createLineageSurfaceModel(registry, input.tick);
+    const surface = lineageSurfaceToWorldSurface(surfaceModel);
+    return Object.freeze({
+      tick: input.tick,
+      lineageResult: Object.freeze({
+        tick: input.tick,
+        created: [],
+        skipped: [],
+      }),
+      surface,
+      errors: Object.freeze(['no_resolvable_candidates']),
+    });
+  }
+
+  // Phase 3: Execute tick via LineageTickRunner
+  // This creates births via NPCLineageManager, which writes to journal via sink
+  const runner = new LineageTickRunner(input.lineageManager);
+  const lineageResult = runner.run(input.tick, candidates);
+
+  // Track any errors from the lineage operation
+  for (const skip of lineageResult.skipped) {
+    errors.push(`skip:${skip.reason}:${skip.houseId}`);
+  }
+
+  // Phase 4: Rebuild surface model from updated registry
+  // The registry now contains the new births (if any)
+  const registry = input.lineageManager.getRegistry();
+  const surfaceModel = createLineageSurfaceModel(registry, input.tick);
+  const surface = lineageSurfaceToWorldSurface(surfaceModel);
+
+  return Object.freeze({
+    tick: input.tick,
+    lineageResult,
+    surface,
+    errors: Object.freeze(errors),
+  });
+}
+
+/**
+ * Runs multiple lineage birth ticks in sequence.
+ * Each tick sees the state from the previous tick.
+ */
+export function runLineageBirthTicks(
+  ticks: readonly number[],
+  getStateForTick: (tick: number) => LineageBirthIntegrationInput
+): LineageBirthIntegrationResult[] {
+  const results: LineageBirthIntegrationResult[] = [];
+
+  for (const tick of ticks) {
+    const input = getStateForTick(tick);
+    const result = runLineageBirthTick(input);
+    results.push(result);
+  }
+
+  return results;
+}
+
+/**
+ * Gets the current world surface from a lineage manager.
+ * Pure function - reads from existing registry state.
+ */
+export function getCurrentWorldSurface(
+  lineageManager: NPCLineageManager,
+  tick: number
+): LiveGameplayWorldSurface {
+  const registry = lineageManager.getRegistry();
+  const surfaceModel = createLineageSurfaceModel(registry, tick);
+  return lineageSurfaceToWorldSurface(surfaceModel);
+}
+
+/**
+ * Verifies that a surface contains the expected lineage node.
+ */
+export function surfaceContainsNode(
+  surface: LiveGameplayWorldSurface,
+  lineageId: string
+): boolean {
+  return surface.points.some(
+    (point: unknown) =>
+      typeof point === 'object' &&
+      point !== null &&
+      'id' in point &&
+      (point as Record<string, unknown>).id === lineageId
+  );
+}
+
+/**
+ * Verifies that a surface contains the expected house group.
+ */
+export function surfaceContainsHouse(
+  surface: LiveGameplayWorldSurface,
+  houseId: string
+): boolean {
+  return surface.groups.some(
+    (group: unknown) =>
+      typeof group === 'object' &&
+      group !== null &&
+      'id' in group &&
+      (group as Record<string, unknown>).id === houseId
+  );
+}

--- a/server/src/modules/npc/LineageBirthTickIntegration.ts
+++ b/server/src/modules/npc/LineageBirthTickIntegration.ts
@@ -15,13 +15,14 @@
  * - Journal-first: failure to write = failure of the operation
  */
 
-import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry';
-import type { LineageSurfaceModel } from './LineageSurfaceModel';
+import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry.js';
+import type { LineageSurfaceModel } from './LineageSurfaceModel.js';
 import type { LiveGameplayWorldSurface } from '../../gameplay/LiveGameplaySnapshotTypes.js';
 import { createLineageSurfaceModel } from './LineageSurfaceModel.js';
 import { lineageSurfaceToWorldSurface } from './LineageWorldSurfaceAdapter.js';
 import { LineageTickRunner } from './LineageTickRunner.js';
-import type { NPCLineageManager } from './FamilyHouseRegistry.js';
+import { NPCLineageManager } from './FamilyHouseRegistry.js';
+import { candidateKey } from './LineageRuntimeTickAdapter.js';
 import {
   selectFromRuntime,
   createNpcLookup,
@@ -33,6 +34,29 @@ import {
   adaptSelectionsToCandidates,
   type LineageTickAdapterInput,
 } from './LineageRuntimeTickAdapter.js';
+
+/**
+ * Extracts existing birth event keys from the lineage manager's registry.
+ * Used for idempotency: prevents duplicate births on retry.
+ */
+export function extractExistingBirthKeys(lineageManager: NPCLineageManager): ReadonlySet<string> {
+  const birthEvents = lineageManager.getRegistry().getBirthEvents();
+  const keys = new Set<string>();
+  
+  for (const event of birthEvents) {
+    const parentIds = [...event.parentLineageHashes].sort();
+    const key = candidateKey(
+      event.birthTick,
+      event.settlementId,
+      event.houseId,
+      parentIds[0] ?? '',
+      parentIds[1] ?? ''
+    );
+    keys.add(key);
+  }
+  
+  return Object.freeze(keys);
+}
 
 /**
  * Result of a complete lineage birth tick operation.
@@ -129,12 +153,16 @@ export function runLineageBirthTick(input: LineageBirthIntegrationInput): Lineag
   }
 
   // Phase 2: Adapt selections to tick candidates
+  // Extract existing birth keys for idempotency
+  const existingBirthKeys = extractExistingBirthKeys(input.lineageManager);
+  
   const adapterInput: LineageTickAdapterInput = {
     selections,
     npcsById: lookups.npcsById,
     settlementsById: lookups.settlementsById,
     housesById: lookups.housesById,
     tick: input.tick,
+    existingBirthKeys,
   };
   const { candidates } = adaptSelectionsToCandidates(adapterInput);
 

--- a/server/src/modules/npc/LineageRuntimeSelection.ts
+++ b/server/src/modules/npc/LineageRuntimeSelection.ts
@@ -10,13 +10,14 @@
  * - No side effects (no writes, no registry mutations)
  */
 
-import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry';
+import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry.js';
 import type {
   LineageSelection,
   LineageSelectableActor,
   LineageSelectableHouse,
   LineageSelectableSettlement,
-} from './LineageSelectionPure';
+} from './LineageSelectionPure.js';
+import { selectLineageInputs } from './LineageSelectionPure.js';
 
 /**
  * Runtime state source for lineage selection.
@@ -174,9 +175,6 @@ export function selectFromRuntime(state: RuntimeLineageState): LineageSelection[
     maxSelectionsPerSettlement: state.maxSelectionsPerSettlement,
   };
 
-  // Import the existing pure selection function
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { selectLineageInputs } = require('./LineageSelectionPure');
   return selectLineageInputs(input);
 }
 

--- a/server/src/modules/npc/LineageRuntimeSelection.ts
+++ b/server/src/modules/npc/LineageRuntimeSelection.ts
@@ -1,0 +1,233 @@
+/**
+ * LineageRuntimeSelection.ts
+ *
+ * Pure function that transforms runtime state into lineage selection candidates.
+ *
+ * ARE Rules:
+ * - No Math.random() - deterministic sorting only
+ * - No Date.now() - uses tick from input
+ * - No mutation of input state
+ * - No side effects (no writes, no registry mutations)
+ */
+
+import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry';
+import type {
+  LineageSelection,
+  LineageSelectableActor,
+  LineageSelectableHouse,
+  LineageSelectableSettlement,
+} from './LineageSelectionPure';
+
+/**
+ * Runtime state source for lineage selection.
+ * All IDs must be deterministic strings.
+ */
+export interface RuntimeLineageState {
+  readonly tick: number;
+  readonly settlements: readonly SettlementState[];
+  readonly houses: readonly HouseState[];
+  readonly npcs: readonly NPCState[];
+  readonly maxSelectionsPerSettlement?: number;
+}
+
+/**
+ * Result of attempting to resolve a selection to runtime objects.
+ * Used by adapter to determine if a selection can become a tick candidate.
+ */
+export interface SelectionResolution {
+  readonly selection: LineageSelection;
+  readonly resolved: boolean;
+  readonly firstActor: NPCState | undefined;
+  readonly secondActor: NPCState | undefined;
+  readonly house: HouseState | undefined;
+  readonly settlement: SettlementState | undefined;
+  readonly reason?: string;
+}
+
+/**
+ * Deterministic key for a selection, used for idempotency checks.
+ * Format: tick:settlementId:houseId:firstActorId:secondActorId
+ */
+export function selectionKey(selection: LineageSelection): string {
+  const firstId = selection.firstActorId < selection.secondActorId
+    ? selection.firstActorId
+    : selection.secondActorId;
+  const secondId = selection.firstActorId < selection.secondActorId
+    ? selection.secondActorId
+    : selection.firstActorId;
+  return [selection.tick, selection.settlementId, selection.houseId, firstId, secondId].join(':');
+}
+
+/**
+ * Converts runtime state to lineage-selectable types.
+ * Pure function - no side effects.
+ */
+function toSelectableSettlements(settlements: readonly SettlementState[]): LineageSelectableSettlement[] {
+  return settlements
+    .filter((s) => s.population < s.capacity && s.foodSupply >= 0)
+    .map((s) => ({
+      id: s.id,
+      tick: s.tick,
+      population: s.population,
+      capacity: s.capacity,
+      foodSupply: s.foodSupply,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Converts runtime houses to lineage-selectable types.
+ * Only active houses are selectable.
+ * Pure function - no side effects.
+ */
+function toSelectableHouses(houses: readonly HouseState[]): LineageSelectableHouse[] {
+  return houses
+    .filter((h) => h.isActive)
+    .map((h) => ({
+      id: h.id,
+      settlementId: h.settlementId,
+      isActive: h.isActive,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Converts runtime NPCs to lineage-selectable actors.
+ * NPCs must have settlementId and houseId to be selectable.
+ * Pure function - no side effects.
+ */
+function toSelectableActors(npcs: readonly NPCState[]): LineageSelectableActor[] {
+  return npcs
+    .filter((n) => n.settlementId && n.houseId)
+    .map((n) => ({
+      id: n.id,
+      settlementId: n.settlementId!,
+      houseId: n.houseId!,
+    }))
+    .sort((a, b) => {
+      const keyA = `${a.settlementId}:${a.houseId}:${a.id}`;
+      const keyB = `${b.settlementId}:${b.houseId}:${b.id}`;
+      return keyA.localeCompare(keyB);
+    });
+}
+
+/**
+ * Creates a lookup map from NPC ID to NPCState.
+ * Pure function - no side effects.
+ */
+export function createNpcLookup(npcs: readonly NPCState[]): Map<string, NPCState> {
+  const map = new Map<string, NPCState>();
+  for (const npc of npcs) {
+    map.set(npc.id, npc);
+  }
+  return map;
+}
+
+/**
+ * Creates a lookup map from settlement ID to SettlementState.
+ * Pure function - no side effects.
+ */
+export function createSettlementLookup(settlements: readonly SettlementState[]): Map<string, SettlementState> {
+  const map = new Map<string, SettlementState>();
+  for (const settlement of settlements) {
+    map.set(settlement.id, settlement);
+  }
+  return map;
+}
+
+/**
+ * Creates a lookup map from house ID to HouseState.
+ * Pure function - no side effects.
+ */
+export function createHouseLookup(houses: readonly HouseState[]): Map<string, HouseState> {
+  const map = new Map<string, HouseState>();
+  for (const house of houses) {
+    map.set(house.id, house);
+  }
+  return map;
+}
+
+/**
+ * Main selection function: RuntimeLineageState → LineageSelection[]
+ *
+ * This is a pure function that:
+ * - Reads runtime state
+ * - Computes deterministic selections
+ * - Does NOT write to any store or registry
+ *
+ * Rules enforced:
+ * - Full settlements produce no selections
+ * - Inactive houses produce no selections
+ * - NPCs without matching settlement are excluded
+ * - All outputs are deterministically sorted by ID
+ */
+export function selectFromRuntime(state: RuntimeLineageState): LineageSelection[] {
+  const settlements = toSelectableSettlements(state.settlements);
+  const houses = toSelectableHouses(state.houses);
+  const actors = toSelectableActors(state.npcs);
+
+  const input = {
+    tick: state.tick,
+    settlements,
+    houses,
+    actors,
+    maxSelectionsPerSettlement: state.maxSelectionsPerSettlement,
+  };
+
+  // Import the existing pure selection function
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { selectLineageInputs } = require('./LineageSelectionPure');
+  return selectLineageInputs(input);
+}
+
+/**
+ * Resolves selections to runtime objects.
+ * Returns a deterministic result even when some lookups fail.
+ * Pure function - no side effects.
+ */
+export function resolveSelections(
+  selections: readonly LineageSelection[],
+  npcsById: Map<string, NPCState>,
+  settlementsById: Map<string, SettlementState>,
+  housesById: Map<string, HouseState>
+): SelectionResolution[] {
+  return selections.map((selection) => {
+    const firstActor = npcsById.get(selection.firstActorId);
+    const secondActor = npcsById.get(selection.secondActorId);
+    const house = housesById.get(selection.houseId);
+    const settlement = settlementsById.get(selection.settlementId);
+
+    let resolved = true;
+    let reason: string | undefined;
+
+    if (!firstActor) {
+      resolved = false;
+      reason = 'first_actor_not_found';
+    } else if (!secondActor) {
+      resolved = false;
+      reason = 'second_actor_not_found';
+    } else if (!house) {
+      resolved = false;
+      reason = 'house_not_found';
+    } else if (!settlement) {
+      resolved = false;
+      reason = 'settlement_not_found';
+    } else if (!house.isActive) {
+      resolved = false;
+      reason = 'house_inactive';
+    } else if (settlement.population >= settlement.capacity) {
+      resolved = false;
+      reason = 'settlement_full';
+    }
+
+    return Object.freeze({
+      selection,
+      resolved,
+      firstActor,
+      secondActor,
+      house,
+      settlement,
+      reason,
+    });
+  });
+}

--- a/server/src/modules/npc/LineageRuntimeTickAdapter.ts
+++ b/server/src/modules/npc/LineageRuntimeTickAdapter.ts
@@ -15,10 +15,11 @@
  * - No side effects
  */
 
-import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry';
-import type { LineageTickCandidate, LineageTickSkip } from './LineageTickRunner';
-import type { LineageSelection } from './LineageSelectionPure';
-import type { SelectionResolution } from './LineageRuntimeSelection';
+import { createARESeed, stableHash32 } from '../../core/determinism/AREDeterminism.js';
+import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry.js';
+import type { LineageTickCandidate, LineageTickSkip } from './LineageTickRunner.js';
+import type { LineageSelection } from './LineageSelectionPure.js';
+import type { SelectionResolution } from './LineageRuntimeSelection.js';
 
 /**
  * Result of adaptation operation.
@@ -41,14 +42,14 @@ export interface LineageTickAdapterInput {
   /**
    * Existing birth event keys from the journal/registry.
    * Used for idempotency: if a key is already present, skip the candidate.
-   * Format: tick:settlementId:houseId:firstActorId:secondActorId (actors sorted)
+   * Format: tick:settlementId:houseId:firstParentLineageId:secondParentLineageId (parents sorted)
    */
   readonly existingBirthKeys?: ReadonlySet<string>;
 }
 
 /**
- * Deterministic key for tick candidate/skip, used for idempotency.
- * Format: tick:settlementId:houseId:firstActorId:secondActorId
+ * Legacy deterministic key helper for plain actor IDs.
+ * Kept for tests and non-registry comparisons. Runtime birth idempotency uses lineageBirthKey().
  */
 export function candidateKey(
   tick: number,
@@ -61,9 +62,40 @@ export function candidateKey(
   return [tick, settlementId, houseId, sorted[0], sorted[1]].join(':');
 }
 
+export function initialLineageIdentity(npcId: string, tick: number): string {
+  const seed = createARESeed(['founder-lineage', npcId, tick]);
+  return stableHash32(seed).toString(16).padStart(8, '0');
+}
+
+export function parentLineageIdentity(npc: NPCState, tick: number): string {
+  return npc.lineageId ?? initialLineageIdentity(npc.id, tick);
+}
+
+export function lineageBirthKey(
+  tick: number,
+  settlementId: string,
+  houseId: string,
+  firstParentLineageId: string,
+  secondParentLineageId: string
+): string {
+  const sorted = [firstParentLineageId, secondParentLineageId].sort();
+  return [tick, settlementId, houseId, sorted[0], sorted[1]].join(':');
+}
+
+export function candidateLineageBirthKey(candidate: LineageTickCandidate): string {
+  const tick = candidate.tick ?? candidate.settlement.tick;
+  return lineageBirthKey(
+    tick,
+    candidate.settlement.id,
+    candidate.houseId,
+    parentLineageIdentity(candidate.parentA, tick),
+    parentLineageIdentity(candidate.parentB, tick)
+  );
+}
+
 /**
  * Converts a resolved selection to a tick candidate.
- * Returns undefined if the resolution indicates the selection cannot proceed.
+ * Returns a skip if the resolution indicates the selection cannot proceed.
  */
 function toCandidate(
   resolution: SelectionResolution,
@@ -71,13 +103,23 @@ function toCandidate(
 ): LineageTickCandidate | LineageTickSkip | null {
   const { selection, resolved, firstActor, secondActor, house, settlement, reason } = resolution;
 
-  // Check for idempotency: same tick + same actors + same house = skip
-  const key = candidateKey(
+  if (!resolved || !firstActor || !secondActor || !house || !settlement) {
+    return {
+      parentAId: selection.firstActorId,
+      parentBId: selection.secondActorId,
+      houseId: selection.houseId,
+      settlementId: selection.settlementId,
+      tick: selection.tick,
+      reason: reason ?? 'unresolved',
+    };
+  }
+
+  const key = lineageBirthKey(
     selection.tick,
     selection.settlementId,
     selection.houseId,
-    selection.firstActorId,
-    selection.secondActorId
+    parentLineageIdentity(firstActor, selection.tick),
+    parentLineageIdentity(secondActor, selection.tick)
   );
 
   if (existingKeys.has(key)) {
@@ -88,17 +130,6 @@ function toCandidate(
       settlementId: selection.settlementId,
       tick: selection.tick,
       reason: 'idempotent_duplicate',
-    };
-  }
-
-  if (!resolved || !firstActor || !secondActor || !house || !settlement) {
-    return {
-      parentAId: selection.firstActorId,
-      parentBId: selection.secondActorId,
-      houseId: selection.houseId,
-      settlementId: selection.settlementId,
-      tick: selection.tick,
-      reason: reason ?? 'unresolved',
     };
   }
 
@@ -127,7 +158,7 @@ function toCandidate(
  * - Create lineage nodes
  */
 export function adaptSelectionsToCandidates(input: LineageTickAdapterInput): LineageTickAdaptResult {
-  const { selections, npcsById, settlementsById, housesById, tick, existingBirthKeys } = input;
+  const { selections, npcsById, settlementsById, housesById, existingBirthKeys } = input;
 
   // Use provided existing keys for idempotency, or empty set if not provided
   const processedKeys = new Set<string>(existingBirthKeys ?? []);
@@ -166,15 +197,7 @@ export function adaptSelectionsToCandidates(input: LineageTickAdapterInput): Lin
 
     if (result && 'parentA' in result) {
       candidates.push(result);
-      // Track this key as processed for idempotency
-      const key = candidateKey(
-        selection.tick,
-        selection.settlementId,
-        selection.houseId,
-        selection.firstActorId,
-        selection.secondActorId
-      );
-      processedKeys.add(key);
+      processedKeys.add(candidateLineageBirthKey(result));
     } else if (result && 'parentAId' in result) {
       skipped.push(result);
     }

--- a/server/src/modules/npc/LineageRuntimeTickAdapter.ts
+++ b/server/src/modules/npc/LineageRuntimeTickAdapter.ts
@@ -1,0 +1,203 @@
+/**
+ * LineageRuntimeTickAdapter.ts
+ *
+ * Thin adapter that maps LineageSelection[] to LineageTickCandidate[].
+ *
+ * This adapter:
+ * - Resolves selection IDs to actual runtime objects
+ * - Does NOT decide eligibility (that stays in NPCLineageManager/LineageTickRunner)
+ * - Skips selections that cannot be resolved deterministically
+ *
+ * ARE Rules:
+ * - No Math.random() - deterministic only
+ * - No Date.now() - uses tick from input
+ * - No mutation of runtime state
+ * - No side effects
+ */
+
+import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry';
+import type { LineageTickCandidate, LineageTickSkip } from './LineageTickRunner';
+import type { LineageSelection } from './LineageSelectionPure';
+import type { SelectionResolution } from './LineageRuntimeSelection';
+
+/**
+ * Result of adaptation operation.
+ * Contains either successful candidates or skipped selections with reasons.
+ */
+export interface LineageTickAdaptResult {
+  readonly candidates: readonly LineageTickCandidate[];
+  readonly skipped: readonly LineageTickSkip[];
+}
+
+/**
+ * Input for the adapter, combining selections with runtime lookups.
+ */
+export interface LineageTickAdapterInput {
+  readonly selections: readonly LineageSelection[];
+  readonly npcsById: ReadonlyMap<string, NPCState>;
+  readonly settlementsById: ReadonlyMap<string, SettlementState>;
+  readonly housesById: ReadonlyMap<string, HouseState>;
+  readonly tick: number;
+}
+
+/**
+ * Deterministic key for tick candidate/skip, used for idempotency.
+ * Format: tick:settlementId:houseId:firstActorId:secondActorId
+ */
+export function candidateKey(
+  tick: number,
+  settlementId: string,
+  houseId: string,
+  firstActorId: string,
+  secondActorId: string
+): string {
+  const sorted = [firstActorId, secondActorId].sort();
+  return [tick, settlementId, houseId, sorted[0], sorted[1]].join(':');
+}
+
+/**
+ * Converts a resolved selection to a tick candidate.
+ * Returns undefined if the resolution indicates the selection cannot proceed.
+ */
+function toCandidate(
+  resolution: SelectionResolution,
+  existingKeys: ReadonlySet<string>
+): LineageTickCandidate | LineageTickSkip | null {
+  const { selection, resolved, firstActor, secondActor, house, settlement, reason } = resolution;
+
+  // Check for idempotency: same tick + same actors + same house = skip
+  const key = candidateKey(
+    selection.tick,
+    selection.settlementId,
+    selection.houseId,
+    selection.firstActorId,
+    selection.secondActorId
+  );
+
+  if (existingKeys.has(key)) {
+    return {
+      parentAId: selection.firstActorId,
+      parentBId: selection.secondActorId,
+      houseId: selection.houseId,
+      settlementId: selection.settlementId,
+      tick: selection.tick,
+      reason: 'idempotent_duplicate',
+    };
+  }
+
+  if (!resolved || !firstActor || !secondActor || !house || !settlement) {
+    return {
+      parentAId: selection.firstActorId,
+      parentBId: selection.secondActorId,
+      houseId: selection.houseId,
+      settlementId: selection.settlementId,
+      tick: selection.tick,
+      reason: reason ?? 'unresolved',
+    };
+  }
+
+  // Adapter does not check eligibility - that is the job of LineageTickRunner
+  return {
+    parentA: firstActor,
+    parentB: secondActor,
+    houseId: house.id,
+    settlement,
+    tick: selection.tick,
+  };
+}
+
+/**
+ * Adapts lineage selections to tick candidates using runtime lookups.
+ *
+ * This function:
+ * - Takes selections from pure selection phase
+ * - Maps IDs to runtime objects using provided lookup maps
+ * - Produces LineageTickCandidate[] for LineageTickRunner
+ * - Records skipped selections with deterministic reasons
+ *
+ * The adapter does NOT:
+ * - Decide if a pair is eligible
+ * - Write to any store
+ * - Create lineage nodes
+ */
+export function adaptSelectionsToCandidates(input: LineageTickAdapterInput): LineageTickAdaptResult {
+  const { selections, npcsById, settlementsById, housesById, tick } = input;
+
+  // Build existing key set for idempotency tracking
+  // In production, this would be derived from the journal
+  const existingKeys = new Set<string>();
+
+  const candidates: LineageTickCandidate[] = [];
+  const skipped: LineageTickSkip[] = [];
+
+  // Process selections in deterministic order (already sorted from pure selection)
+  for (const selection of selections) {
+    const firstActor = npcsById.get(selection.firstActorId);
+    const secondActor = npcsById.get(selection.secondActorId);
+    const house = housesById.get(selection.houseId);
+    const settlement = settlementsById.get(selection.settlementId);
+
+    const resolved = firstActor && secondActor && house && settlement;
+    let reason: string | undefined;
+
+    if (!firstActor) reason = 'first_actor_not_found';
+    else if (!secondActor) reason = 'second_actor_not_found';
+    else if (!house) reason = 'house_not_found';
+    else if (!settlement) reason = 'settlement_not_found';
+    else if (!house.isActive) reason = 'house_inactive';
+    else if (settlement.population >= settlement.capacity) reason = 'settlement_full';
+
+    const resolution: SelectionResolution = {
+      selection,
+      resolved: !!resolved,
+      firstActor,
+      secondActor,
+      house,
+      settlement,
+      reason,
+    };
+
+    const result = toCandidate(resolution, existingKeys);
+
+    if (result && 'parentA' in result) {
+      candidates.push(result);
+      // Track this key as processed for idempotency
+      const key = candidateKey(
+        selection.tick,
+        selection.settlementId,
+        selection.houseId,
+        selection.firstActorId,
+        selection.secondActorId
+      );
+      existingKeys.add(key);
+    } else if (result && 'parentAId' in result) {
+      skipped.push(result);
+    }
+  }
+
+  return Object.freeze({
+    candidates: Object.freeze(candidates),
+    skipped: Object.freeze(skipped),
+  });
+}
+
+/**
+ * Filters candidates to only those with unique settlement+house combinations.
+ * Used when multiple candidates exist for the same settlement.
+ */
+export function deduplicateCandidatesBySettlement(
+  candidates: readonly LineageTickCandidate[]
+): LineageTickCandidate[] {
+  const seen = new Set<string>();
+  const result: LineageTickCandidate[] = [];
+
+  for (const candidate of candidates) {
+    const key = `${candidate.settlement.id}:${candidate.houseId}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(candidate);
+    }
+  }
+
+  return result;
+}

--- a/server/src/modules/npc/LineageRuntimeTickAdapter.ts
+++ b/server/src/modules/npc/LineageRuntimeTickAdapter.ts
@@ -38,6 +38,12 @@ export interface LineageTickAdapterInput {
   readonly settlementsById: ReadonlyMap<string, SettlementState>;
   readonly housesById: ReadonlyMap<string, HouseState>;
   readonly tick: number;
+  /**
+   * Existing birth event keys from the journal/registry.
+   * Used for idempotency: if a key is already present, skip the candidate.
+   * Format: tick:settlementId:houseId:firstActorId:secondActorId (actors sorted)
+   */
+  readonly existingBirthKeys?: ReadonlySet<string>;
 }
 
 /**
@@ -121,11 +127,10 @@ function toCandidate(
  * - Create lineage nodes
  */
 export function adaptSelectionsToCandidates(input: LineageTickAdapterInput): LineageTickAdaptResult {
-  const { selections, npcsById, settlementsById, housesById, tick } = input;
+  const { selections, npcsById, settlementsById, housesById, tick, existingBirthKeys } = input;
 
-  // Build existing key set for idempotency tracking
-  // In production, this would be derived from the journal
-  const existingKeys = new Set<string>();
+  // Use provided existing keys for idempotency, or empty set if not provided
+  const processedKeys = new Set<string>(existingBirthKeys ?? []);
 
   const candidates: LineageTickCandidate[] = [];
   const skipped: LineageTickSkip[] = [];
@@ -157,7 +162,7 @@ export function adaptSelectionsToCandidates(input: LineageTickAdapterInput): Lin
       reason,
     };
 
-    const result = toCandidate(resolution, existingKeys);
+    const result = toCandidate(resolution, processedKeys);
 
     if (result && 'parentA' in result) {
       candidates.push(result);
@@ -169,7 +174,7 @@ export function adaptSelectionsToCandidates(input: LineageTickAdapterInput): Lin
         selection.firstActorId,
         selection.secondActorId
       );
-      existingKeys.add(key);
+      processedKeys.add(key);
     } else if (result && 'parentAId' in result) {
       skipped.push(result);
     }


### PR DESCRIPTION
## Summary

Implements the active deterministic lineage birth cycle from real runtime state sources:

- **Pure LineageSelection** from `RuntimeLineageState` (settlements, houses, NPCs)
- **Selection-to-TickRunner Adapter** for mapping selections to tick candidates
- **LineageBirthTickIntegration** orchestrator for the full pipeline
- **Journal-first truth**: births land in `npc/lineage-birth-events.json` via `NPCLineageManager` sink
- **Idempotency**: same tick + same parents + same house = no duplicate birth
- **Surface model**: new births appear in `worldSurface.groups` and `worldSurface.points`
- **Replay**: journal reconstructs lineage on new runtime

## Architecture

```
RuntimeLineageState (settlements, houses, NPCs)
  ↓ pure selectFromRuntime()
LineageSelection[]
  ↓ adaptSelectionsToCandidates()
LineageTickCandidate[]
  ↓ LineageTickRunner.run()
LineageBirthEvent[]
  ↓ NPCLineageManager.createDescendant()
  ↓ NpcLineageGameDataWriter
  ↓ npc/lineage-birth-events.json
  ↓ createLineageSurfaceModel()
  ↓ lineageSurfaceToWorldSurface()
LiveGameplayWorldSurface
  ↓
client-2d worldSurface (groups + points)
```

## ARE Rules Enforced

- ✅ No `Math.random()` in truth path
- ✅ No `Date.now()` in truth path
- ✅ No mock truth / fake snapshots
- ✅ No stub systems in truth path
- ✅ No direct client truth
- ✅ No birth without journal
- ✅ No visible NPC/House projection without server-authoritative origin
- ✅ Only `Kappa/Tick/LogicalIndex` for temporal identity
- ✅ Deterministic sorting by settlementId, houseId, actorId, lineageId, tick

## Files Changed

| File | Purpose |
|------|---------|
| `server/src/modules/npc/LineageRuntimeSelection.ts` | Pure selection from runtime state |
| `server/src/modules/npc/LineageRuntimeTickAdapter.ts` | Thin adapter for selection → candidate |
| `server/src/modules/npc/LineageBirthTickIntegration.ts` | Orchestrator for full pipeline |
| `server/src/modules/npc/LineageBirthTickIntegration.test.ts` | Comprehensive tests |

## Tests Added

- Pure Selection: full settlement → [], inactive house → [], order-independent determinism, maxSelectionsPerSettlement cap
- Adapter: valid selection → candidate, missing NPC/settlement/house → deterministic skip
- Idempotency: same tick twice → no duplicate journal entry
- Journal: birth event written, runtime replay reconstructs lineage
- Surface: worldSurface contains new node point and house group

---

*This PR was created by an AI agent (OpenHands) on behalf of the contributor.*

@OuroborosCollective can click here to [continue refining the PR](https://app.all-hands.dev/conversations/11b311c2-7187-474b-9823-f26f3f9e7879)