### PR TITLE
feat(npc): trigger lineage births before gameplay snapshots

### DIFF
--- a/server/src/modules/npc/LineageBirthSnapshotBridge.test.ts
+++ b/server/src/modules/npc/LineageBirthSnapshotBridge.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import type { HouseState, LineageStats, NPCState, SettlementState } from './FamilyHouseRegistry';
+import { createNpcLineageRuntime } from './createNpcLineageRuntime';
+import type { NpcLineageStorageProvider } from './LineageGameDataWriter';
+import { runLineageBirthForSnapshot, type LineageRuntimeStateProvider } from './LineageBirthSnapshotBridge';
+
+class MemoryStorageProvider implements NpcLineageStorageProvider {
+  private readonly data = new Map<string, string>();
+  readonly writes: string[] = [];
+
+  read(target: string): string | null {
+    return this.data.get(target) ?? null;
+  }
+
+  write(target: string, content: string): void {
+    this.data.set(target, content);
+    this.writes.push(content);
+  }
+}
+
+function stats(seed = 10): LineageStats {
+  return { strength: seed, agility: seed + 1, intelligence: seed + 2, stamina: seed + 3, charisma: seed + 4, luck: seed + 5 };
+}
+
+function house(): HouseState {
+  return {
+    id: 'house_1',
+    houseName: 'House One',
+    houseReputation: 50,
+    inheritancePoints: 25,
+    settlementId: 'settlement_1',
+    foundingTick: 0,
+    territorySize: 3,
+    resourceStored: 100,
+    housingCapacity: 10,
+    currentPopulation: 2,
+    isActive: true,
+  };
+}
+
+function settlement(tick: number): SettlementState {
+  return {
+    id: 'settlement_1',
+    capacity: 100,
+    population: 10,
+    foodSupply: 100,
+    housingUnits: 20,
+    settlementType: 'village',
+    tick,
+  };
+}
+
+function npc(id: string): NPCState {
+  return {
+    id,
+    houseId: 'house_1',
+    settlementId: 'settlement_1',
+    stats: stats(id.charCodeAt(0)),
+    traits: ['runtime'],
+    generation: 0,
+    birthTick: 0,
+  };
+}
+
+function provider(tick: number): LineageRuntimeStateProvider {
+  return {
+    getLineageRuntimeState: () => ({
+      tick,
+      settlements: [settlement(tick)],
+      houses: [house()],
+      npcs: [npc('npc_a'), npc('npc_b')],
+      maxSelectionsPerSettlement: 1,
+    }),
+  };
+}
+
+describe('LineageBirthSnapshotBridge', () => {
+  it('does not create fake births without a runtime provider', async () => {
+    const result = await runLineageBirthForSnapshot({ playerId: 'player_1', logicalIndex: 100 });
+
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('no_runtime_provider');
+    expect(result.birthsCreated).toBe(0);
+  });
+
+  it('runs lineage birth from injected runtime state before snapshot composition', async () => {
+    const storage = new MemoryStorageProvider();
+    const runtime = createNpcLineageRuntime({ storageProvider: storage, replay: false });
+
+    const result = await runLineageBirthForSnapshot({
+      playerId: 'player_1',
+      logicalIndex: 100,
+      provider: provider(100),
+      runtime,
+    });
+
+    expect(result.triggered).toBe(true);
+    expect(result.reason).toBe('ran');
+    expect(result.birthsCreated).toBe(1);
+    expect(storage.writes).toHaveLength(1);
+    expect(result.result?.surface.points).toHaveLength(1);
+    expect(result.result?.surface.groups).toHaveLength(1);
+  });
+
+  it('is retry-safe for the same tick and parent lineage identities', async () => {
+    const storage = new MemoryStorageProvider();
+    const runtime = createNpcLineageRuntime({ storageProvider: storage, replay: false });
+
+    const first = await runLineageBirthForSnapshot({ playerId: 'player_1', logicalIndex: 100, provider: provider(100), runtime });
+    const second = await runLineageBirthForSnapshot({ playerId: 'player_1', logicalIndex: 100, provider: provider(100), runtime });
+
+    expect(first.birthsCreated).toBe(1);
+    expect(second.birthsCreated).toBe(0);
+    expect(second.birthsSkipped).toBe(1);
+    expect(storage.writes).toHaveLength(1);
+  });
+});

--- a/server/src/modules/npc/LineageBirthSnapshotBridge.ts
+++ b/server/src/modules/npc/LineageBirthSnapshotBridge.ts
@@ -1,0 +1,77 @@
+import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistry.js';
+import type { LineageBirthIntegrationResult } from './LineageBirthTickIntegration.js';
+import { createNpcLineageRuntime, type NpcLineageRuntime } from './createNpcLineageRuntime.js';
+import { runLineageBirthTick } from './LineageBirthTickIntegration.js';
+
+export interface LineageRuntimeStateSnapshot {
+  readonly tick: number;
+  readonly settlements: readonly SettlementState[];
+  readonly houses: readonly HouseState[];
+  readonly npcs: readonly NPCState[];
+  readonly maxSelectionsPerSettlement?: number;
+}
+
+export interface LineageRuntimeStateProvider {
+  getLineageRuntimeState(playerId: string, logicalIndex: number): LineageRuntimeStateSnapshot | null | Promise<LineageRuntimeStateSnapshot | null>;
+}
+
+export interface LineageBirthSnapshotBridgeInput {
+  readonly playerId: string;
+  readonly logicalIndex: number;
+  readonly provider?: LineageRuntimeStateProvider;
+  readonly runtime?: NpcLineageRuntime;
+}
+
+export interface LineageBirthSnapshotBridgeResult {
+  readonly tick: number;
+  readonly triggered: boolean;
+  readonly reason: 'no_runtime_provider' | 'no_runtime_state' | 'ran';
+  readonly birthsCreated: number;
+  readonly birthsSkipped: number;
+  readonly result?: LineageBirthIntegrationResult;
+}
+
+function normalizeTick(value: number): number {
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}
+
+function seedHouseSnapshots(runtime: NpcLineageRuntime, houses: readonly HouseState[]): void {
+  for (const house of [...houses].sort((a, b) => a.id.localeCompare(b.id))) {
+    runtime.registry.registerHouse(house);
+  }
+}
+
+export async function runLineageBirthForSnapshot(
+  input: LineageBirthSnapshotBridgeInput
+): Promise<LineageBirthSnapshotBridgeResult> {
+  const tick = normalizeTick(input.logicalIndex);
+  if (!input.provider) {
+    return Object.freeze({ tick, triggered: false, reason: 'no_runtime_provider', birthsCreated: 0, birthsSkipped: 0 });
+  }
+
+  const runtimeState = await input.provider.getLineageRuntimeState(input.playerId, tick);
+  if (!runtimeState) {
+    return Object.freeze({ tick, triggered: false, reason: 'no_runtime_state', birthsCreated: 0, birthsSkipped: 0 });
+  }
+
+  const runtime = input.runtime ?? createNpcLineageRuntime();
+  seedHouseSnapshots(runtime, runtimeState.houses);
+
+  const result = runLineageBirthTick({
+    tick,
+    settlements: runtimeState.settlements,
+    houses: runtimeState.houses,
+    npcs: runtimeState.npcs,
+    lineageManager: runtime.manager,
+    maxSelectionsPerSettlement: runtimeState.maxSelectionsPerSettlement,
+  });
+
+  return Object.freeze({
+    tick,
+    triggered: true,
+    reason: 'ran',
+    birthsCreated: result.lineageResult.created.length,
+    birthsSkipped: result.lineageResult.skipped.length,
+    result,
+  });
+}

--- a/server/src/routes/gameplaySnapshot.ts
+++ b/server/src/routes/gameplaySnapshot.ts
@@ -17,6 +17,11 @@ import { generateNPCActivitySnapshot } from "../gameplay/NPCActivitySnapshotGene
 import { generateVisibleChunkPois, getStarterVillagePois } from "../world/WorldPoiGenerator.js";
 import { getVisibleChunkCoords } from "../resources/ChunkResourceGenerator.js";
 import { worldDiscoveryService } from "../world/WorldDiscoveryService.js";
+import { runLineageBirthForSnapshot, type LineageRuntimeStateProvider } from "../modules/npc/LineageBirthSnapshotBridge.js";
+
+export interface GameplaySnapshotRouterDeps {
+  readonly lineageRuntimeStateProvider?: LineageRuntimeStateProvider;
+}
 
 function getCurrentTickId(): number {
   return tickContextProvider.getTickCounter();
@@ -32,7 +37,7 @@ function rejectUnauthenticatedInLockedProduction(identity: { authenticated: bool
   return process.env.NODE_ENV === "production" && !identity.authenticated && !isGuestHttpAllowed();
 }
 
-export function createGameplaySnapshotRouter() {
+export function createGameplaySnapshotRouter(deps: GameplaySnapshotRouterDeps = {}) {
   const router = express.Router();
 
   router.get("/snapshot", async (req, res) => {
@@ -43,6 +48,12 @@ export function createGameplaySnapshotRouter() {
     }
 
     const serverTick = getCurrentTickId();
+    await runLineageBirthForSnapshot({
+      playerId: identity.playerId,
+      logicalIndex: serverTick,
+      provider: deps.lineageRuntimeStateProvider,
+    });
+
     await questProgressionStore.hydratePlayer(identity.playerId);
     const questState = questProgressionStore.getPlayerQuestState(identity.playerId);
 


### PR DESCRIPTION
## Summary

Adds the next integration layer after PR #2029:

- Adds `LineageBirthSnapshotBridge` for executing the lineage birth tick from injected runtime state before snapshot composition.
- Wires `/api/gameplay/snapshot` to call the bridge before `composeLiveGameplaySnapshotFromLegacy()`.
- Keeps ARE truth strict: without a real injected runtime-state provider, no birth is created and no fake state is invented.
- Seeds real `HouseState` snapshots into the lineage runtime registry before running the tick.
- Adds bridge tests for no-provider behavior, successful birth + journal + surface, and same-tick retry idempotency.

## ARE Notes

This PR does not introduce client truth or mock runtime state. The route only triggers lineage births when a real server-side `LineageRuntimeStateProvider` is injected. The client continues to consume server-authoritative `worldSurface` only.