### PR TITLE
feat(npc): register lineage runtime state provider

### DIFF
--- a/server/src/modules/npc/LineageRuntimeStateProviderRegistry.test.ts
+++ b/server/src/modules/npc/LineageRuntimeStateProviderRegistry.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { LineageRuntimeStateProvider } from './LineageBirthSnapshotBridge';
+import {
+  clearLineageRuntimeStateProvider,
+  getLineageRuntimeStateProvider,
+  hasLineageRuntimeStateProvider,
+  registerLineageRuntimeStateProvider,
+} from './LineageRuntimeStateProviderRegistry';
+
+const provider: LineageRuntimeStateProvider = {
+  getLineageRuntimeState: () => null,
+};
+
+describe('LineageRuntimeStateProviderRegistry', () => {
+  afterEach(() => {
+    clearLineageRuntimeStateProvider();
+  });
+
+  it('starts empty so no fake birth source exists by default', () => {
+    expect(hasLineageRuntimeStateProvider()).toBe(false);
+    expect(getLineageRuntimeStateProvider()).toBeUndefined();
+  });
+
+  it('registers and clears a real runtime state provider', () => {
+    registerLineageRuntimeStateProvider(provider);
+
+    expect(hasLineageRuntimeStateProvider()).toBe(true);
+    expect(getLineageRuntimeStateProvider()).toBe(provider);
+
+    clearLineageRuntimeStateProvider();
+    expect(hasLineageRuntimeStateProvider()).toBe(false);
+  });
+});

--- a/server/src/modules/npc/LineageRuntimeStateProviderRegistry.ts
+++ b/server/src/modules/npc/LineageRuntimeStateProviderRegistry.ts
@@ -1,0 +1,19 @@
+import type { LineageRuntimeStateProvider } from './LineageBirthSnapshotBridge.js';
+
+let registeredProvider: LineageRuntimeStateProvider | null = null;
+
+export function registerLineageRuntimeStateProvider(provider: LineageRuntimeStateProvider): void {
+  registeredProvider = provider;
+}
+
+export function clearLineageRuntimeStateProvider(): void {
+  registeredProvider = null;
+}
+
+export function getLineageRuntimeStateProvider(): LineageRuntimeStateProvider | undefined {
+  return registeredProvider ?? undefined;
+}
+
+export function hasLineageRuntimeStateProvider(): boolean {
+  return registeredProvider !== null;
+}

--- a/server/src/routes/gameplaySnapshot.ts
+++ b/server/src/routes/gameplaySnapshot.ts
@@ -18,6 +18,7 @@ import { generateVisibleChunkPois, getStarterVillagePois } from "../world/WorldP
 import { getVisibleChunkCoords } from "../resources/ChunkResourceGenerator.js";
 import { worldDiscoveryService } from "../world/WorldDiscoveryService.js";
 import { runLineageBirthForSnapshot, type LineageRuntimeStateProvider } from "../modules/npc/LineageBirthSnapshotBridge.js";
+import { getLineageRuntimeStateProvider } from "../modules/npc/LineageRuntimeStateProviderRegistry.js";
 
 export interface GameplaySnapshotRouterDeps {
   readonly lineageRuntimeStateProvider?: LineageRuntimeStateProvider;
@@ -37,6 +38,10 @@ function rejectUnauthenticatedInLockedProduction(identity: { authenticated: bool
   return process.env.NODE_ENV === "production" && !identity.authenticated && !isGuestHttpAllowed();
 }
 
+function resolveLineageRuntimeStateProvider(deps: GameplaySnapshotRouterDeps): LineageRuntimeStateProvider | undefined {
+  return deps.lineageRuntimeStateProvider ?? getLineageRuntimeStateProvider();
+}
+
 export function createGameplaySnapshotRouter(deps: GameplaySnapshotRouterDeps = {}) {
   const router = express.Router();
 
@@ -51,7 +56,7 @@ export function createGameplaySnapshotRouter(deps: GameplaySnapshotRouterDeps = 
     await runLineageBirthForSnapshot({
       playerId: identity.playerId,
       logicalIndex: serverTick,
-      provider: deps.lineageRuntimeStateProvider,
+      provider: resolveLineageRuntimeStateProvider(deps),
     });
 
     await questProgressionStore.hydratePlayer(identity.playerId);


### PR DESCRIPTION
## Summary

Adds the next integration layer after PR #2030:

- Adds a `LineageRuntimeStateProviderRegistry` as the server-side composition point for real settlement/house/NPC runtime sources.
- Updates `/api/gameplay/snapshot` so it uses an explicitly injected provider first, otherwise the registered provider.
- Keeps no-provider behavior ARE-safe: no provider means no fake births and no stub truth.
- Adds tests proving the registry starts empty, can register a real provider, and can be cleared.

## ARE Notes

This does not invent runtime state. It only exposes a deterministic composition hook. Real providers can now be registered by server modules without mutating the route or creating fake snapshot data.