### PR TITLE
feat(npc): derive lineage runtime state from visible POIs

### DIFF
--- a/server/src/modules/npc/LineageBirthSnapshotBridge.ts
+++ b/server/src/modules/npc/LineageBirthSnapshotBridge.ts
@@ -2,6 +2,12 @@ import type { HouseState, NPCState, SettlementState } from './FamilyHouseRegistr
 import type { LineageBirthIntegrationResult } from './LineageBirthTickIntegration.js';
 import { createNpcLineageRuntime, type NpcLineageRuntime } from './createNpcLineageRuntime.js';
 import { runLineageBirthTick } from './LineageBirthTickIntegration.js';
+import type { WorldPoiSnapshot } from '../../world/WorldPoiTypes.js';
+
+export interface LineageRuntimeStateContext {
+  readonly worldPois?: readonly WorldPoiSnapshot[];
+  readonly playerPosition?: { readonly x: number; readonly y: number };
+}
 
 export interface LineageRuntimeStateSnapshot {
   readonly tick: number;
@@ -12,13 +18,18 @@ export interface LineageRuntimeStateSnapshot {
 }
 
 export interface LineageRuntimeStateProvider {
-  getLineageRuntimeState(playerId: string, logicalIndex: number): LineageRuntimeStateSnapshot | null | Promise<LineageRuntimeStateSnapshot | null>;
+  getLineageRuntimeState(
+    playerId: string,
+    logicalIndex: number,
+    context?: LineageRuntimeStateContext
+  ): LineageRuntimeStateSnapshot | null | Promise<LineageRuntimeStateSnapshot | null>;
 }
 
 export interface LineageBirthSnapshotBridgeInput {
   readonly playerId: string;
   readonly logicalIndex: number;
   readonly provider?: LineageRuntimeStateProvider;
+  readonly context?: LineageRuntimeStateContext;
   readonly runtime?: NpcLineageRuntime;
 }
 
@@ -49,7 +60,7 @@ export async function runLineageBirthForSnapshot(
     return Object.freeze({ tick, triggered: false, reason: 'no_runtime_provider', birthsCreated: 0, birthsSkipped: 0 });
   }
 
-  const runtimeState = await input.provider.getLineageRuntimeState(input.playerId, tick);
+  const runtimeState = await input.provider.getLineageRuntimeState(input.playerId, tick, input.context);
   if (!runtimeState) {
     return Object.freeze({ tick, triggered: false, reason: 'no_runtime_state', birthsCreated: 0, birthsSkipped: 0 });
   }

--- a/server/src/modules/npc/LineagePoiRuntimeStateProvider.test.ts
+++ b/server/src/modules/npc/LineagePoiRuntimeStateProvider.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getStarterVillagePois } from '../../world/WorldPoiGenerator';
+import { createPoiLineageRuntimeState, LineagePoiRuntimeStateProvider, POI_LINEAGE_HOUSE_ID, POI_LINEAGE_SETTLEMENT_ID } from './LineagePoiRuntimeStateProvider';
+import type { WorldPoiSnapshot } from '../../world/WorldPoiTypes';
+
+function camp(id: string, type: 'logging_camp' | 'mining_camp' | 'fishing_camp'): WorldPoiSnapshot {
+  return {
+    id,
+    type,
+    title: id,
+    position: { x: 1000, y: 2000 },
+    chunk: { x: 0, z: 0 },
+    interactionRadius: 32,
+    tags: [],
+  };
+}
+
+describe('LineagePoiRuntimeStateProvider', () => {
+  it('returns null without real visible poi context', () => {
+    const provider = new LineagePoiRuntimeStateProvider();
+
+    expect(provider.getLineageRuntimeState('player_1', 10)).toBeNull();
+  });
+
+  it('projects visible vendor and camp NPC sources into lineage runtime state', () => {
+    const state = createPoiLineageRuntimeState(100, [
+      ...getStarterVillagePois(),
+      camp('poi:1:0:logging_camp:0', 'logging_camp'),
+    ]);
+
+    expect(state).not.toBeNull();
+    expect(state?.settlements[0].id).toBe(POI_LINEAGE_SETTLEMENT_ID);
+    expect(state?.houses[0].id).toBe(POI_LINEAGE_HOUSE_ID);
+    expect(state?.npcs.map((npc) => npc.id).sort()).toContain('village_trader_001');
+    expect(state?.npcs.some((npc) => npc.traits.includes('camp_worker'))).toBe(true);
+  });
+
+  it('is deterministic for the same tick and poi set regardless of order', () => {
+    const pois = [
+      camp('poi:2:0:mining_camp:0', 'mining_camp'),
+      ...getStarterVillagePois(),
+      camp('poi:1:0:logging_camp:0', 'logging_camp'),
+    ];
+
+    const first = createPoiLineageRuntimeState(100, pois);
+    const second = createPoiLineageRuntimeState(100, [...pois].reverse());
+
+    expect(first).toEqual(second);
+  });
+});

--- a/server/src/modules/npc/LineagePoiRuntimeStateProvider.ts
+++ b/server/src/modules/npc/LineagePoiRuntimeStateProvider.ts
@@ -1,0 +1,124 @@
+import { createARESeed, stableHash32 } from '../../core/determinism/AREDeterminism.js';
+import type { HouseState, LineageStats, NPCState, SettlementState } from './FamilyHouseRegistry.js';
+import type { LineageRuntimeStateContext, LineageRuntimeStateProvider, LineageRuntimeStateSnapshot } from './LineageBirthSnapshotBridge.js';
+import type { WorldPoiSnapshot } from '../../world/WorldPoiTypes.js';
+import { CampNpcService } from '../../npc/CampNpcService.js';
+
+export const POI_LINEAGE_SETTLEMENT_ID = 'settlement:starter_village';
+export const POI_LINEAGE_HOUSE_ID = 'house:starter_village:civic';
+
+export interface LineagePoiRuntimeStateProviderOptions {
+  readonly settlementId?: string;
+  readonly houseId?: string;
+  readonly maxSelectionsPerSettlement?: number;
+}
+
+function stat(seed: string, label: string): number {
+  return 8 + (stableHash32(createARESeed(['poi-lineage-stat', seed, label])) % 8);
+}
+
+function statsFor(seed: string): LineageStats {
+  return {
+    strength: stat(seed, 'strength'),
+    agility: stat(seed, 'agility'),
+    intelligence: stat(seed, 'intelligence'),
+    stamina: stat(seed, 'stamina'),
+    charisma: stat(seed, 'charisma'),
+    luck: stat(seed, 'luck'),
+  };
+}
+
+function vendorNpcFromPoi(poi: WorldPoiSnapshot, settlementId: string, houseId: string): NPCState | null {
+  if (poi.type !== 'village_trader') return null;
+  return {
+    id: poi.id,
+    houseId,
+    settlementId,
+    stats: statsFor(poi.id),
+    traits: ['vendor', 'village', 'runtime_poi'],
+    generation: 0,
+    birthTick: 0,
+  };
+}
+
+function campNpcToLineageNpc(npc: ReturnType<CampNpcService['generateCampNpcs']>[number], settlementId: string, houseId: string): NPCState {
+  return {
+    id: npc.id,
+    houseId,
+    settlementId,
+    stats: statsFor(npc.id),
+    traits: ['camp_worker', npc.type, npc.activity, 'runtime_poi'],
+    generation: 0,
+    birthTick: 0,
+  };
+}
+
+function buildHouse(houseId: string, settlementId: string, population: number): HouseState {
+  return {
+    id: houseId,
+    houseName: 'Starter Village Civic House',
+    houseReputation: 50 + population,
+    inheritancePoints: population * 5,
+    settlementId,
+    foundingTick: 0,
+    territorySize: Math.max(1, population),
+    resourceStored: population * 10,
+    housingCapacity: Math.max(8, population + 4),
+    currentPopulation: population,
+    isActive: true,
+  };
+}
+
+function buildSettlement(settlementId: string, population: number, tick: number): SettlementState {
+  return {
+    id: settlementId,
+    capacity: Math.max(24, population + 12),
+    population,
+    foodSupply: 100 + population * 10,
+    housingUnits: Math.max(8, Math.ceil(population / 2) + 4),
+    settlementType: 'village',
+    tick,
+  };
+}
+
+export function createPoiLineageRuntimeState(
+  tick: number,
+  worldPois: readonly WorldPoiSnapshot[],
+  options: LineagePoiRuntimeStateProviderOptions = {}
+): LineageRuntimeStateSnapshot | null {
+  const settlementId = options.settlementId ?? POI_LINEAGE_SETTLEMENT_ID;
+  const houseId = options.houseId ?? POI_LINEAGE_HOUSE_ID;
+  const orderedPois = [...worldPois].sort((a, b) => a.id.localeCompare(b.id));
+  const campService = new CampNpcService();
+
+  const vendorNpcs = orderedPois
+    .map((poi) => vendorNpcFromPoi(poi, settlementId, houseId))
+    .filter((npc): npc is NPCState => npc !== null);
+
+  const campNpcs = campService
+    .generateCampNpcs(orderedPois, tick)
+    .map((npc) => campNpcToLineageNpc(npc, settlementId, houseId));
+
+  const npcs = [...vendorNpcs, ...campNpcs].sort((a, b) => a.id.localeCompare(b.id));
+  if (npcs.length === 0) return null;
+
+  const house = buildHouse(houseId, settlementId, npcs.length);
+  const settlement = buildSettlement(settlementId, npcs.length, tick);
+
+  return Object.freeze({
+    tick,
+    settlements: Object.freeze([settlement]),
+    houses: Object.freeze([house]),
+    npcs: Object.freeze(npcs),
+    maxSelectionsPerSettlement: Math.max(0, Math.floor(options.maxSelectionsPerSettlement ?? 1)),
+  });
+}
+
+export class LineagePoiRuntimeStateProvider implements LineageRuntimeStateProvider {
+  public constructor(private readonly options: LineagePoiRuntimeStateProviderOptions = {}) {}
+
+  public getLineageRuntimeState(_playerId: string, logicalIndex: number, context?: LineageRuntimeStateContext): LineageRuntimeStateSnapshot | null {
+    const pois = context?.worldPois ?? [];
+    return createPoiLineageRuntimeState(logicalIndex, pois, this.options);
+  }
+}

--- a/server/src/modules/npc/LineageRuntimeStateProviderRegistry.test.ts
+++ b/server/src/modules/npc/LineageRuntimeStateProviderRegistry.test.ts
@@ -3,6 +3,7 @@ import type { LineageRuntimeStateProvider } from './LineageBirthSnapshotBridge';
 import {
   clearLineageRuntimeStateProvider,
   getLineageRuntimeStateProvider,
+  hasCustomLineageRuntimeStateProvider,
   hasLineageRuntimeStateProvider,
   registerLineageRuntimeStateProvider,
 } from './LineageRuntimeStateProviderRegistry';
@@ -16,18 +17,21 @@ describe('LineageRuntimeStateProviderRegistry', () => {
     clearLineageRuntimeStateProvider();
   });
 
-  it('starts empty so no fake birth source exists by default', () => {
-    expect(hasLineageRuntimeStateProvider()).toBe(false);
-    expect(getLineageRuntimeStateProvider()).toBeUndefined();
+  it('starts with a real default provider that creates no fake state without context', async () => {
+    expect(hasLineageRuntimeStateProvider()).toBe(true);
+    expect(hasCustomLineageRuntimeStateProvider()).toBe(false);
+    expect(await getLineageRuntimeStateProvider().getLineageRuntimeState('player_1', 10)).toBeNull();
   });
 
-  it('registers and clears a real runtime state provider', () => {
+  it('registers and clears a custom runtime state provider override', () => {
     registerLineageRuntimeStateProvider(provider);
 
     expect(hasLineageRuntimeStateProvider()).toBe(true);
+    expect(hasCustomLineageRuntimeStateProvider()).toBe(true);
     expect(getLineageRuntimeStateProvider()).toBe(provider);
 
     clearLineageRuntimeStateProvider();
-    expect(hasLineageRuntimeStateProvider()).toBe(false);
+    expect(hasLineageRuntimeStateProvider()).toBe(true);
+    expect(hasCustomLineageRuntimeStateProvider()).toBe(false);
   });
 });

--- a/server/src/modules/npc/LineageRuntimeStateProviderRegistry.ts
+++ b/server/src/modules/npc/LineageRuntimeStateProviderRegistry.ts
@@ -1,5 +1,7 @@
 import type { LineageRuntimeStateProvider } from './LineageBirthSnapshotBridge.js';
+import { LineagePoiRuntimeStateProvider } from './LineagePoiRuntimeStateProvider.js';
 
+const defaultProvider = new LineagePoiRuntimeStateProvider();
 let registeredProvider: LineageRuntimeStateProvider | null = null;
 
 export function registerLineageRuntimeStateProvider(provider: LineageRuntimeStateProvider): void {
@@ -10,10 +12,14 @@ export function clearLineageRuntimeStateProvider(): void {
   registeredProvider = null;
 }
 
-export function getLineageRuntimeStateProvider(): LineageRuntimeStateProvider | undefined {
-  return registeredProvider ?? undefined;
+export function getLineageRuntimeStateProvider(): LineageRuntimeStateProvider {
+  return registeredProvider ?? defaultProvider;
 }
 
 export function hasLineageRuntimeStateProvider(): boolean {
+  return true;
+}
+
+export function hasCustomLineageRuntimeStateProvider(): boolean {
   return registeredProvider !== null;
 }

--- a/server/src/routes/gameplaySnapshot.ts
+++ b/server/src/routes/gameplaySnapshot.ts
@@ -53,12 +53,6 @@ export function createGameplaySnapshotRouter(deps: GameplaySnapshotRouterDeps = 
     }
 
     const serverTick = getCurrentTickId();
-    await runLineageBirthForSnapshot({
-      playerId: identity.playerId,
-      logicalIndex: serverTick,
-      provider: resolveLineageRuntimeStateProvider(deps),
-    });
-
     await questProgressionStore.hydratePlayer(identity.playerId);
     const questState = questProgressionStore.getPlayerQuestState(identity.playerId);
 
@@ -109,6 +103,13 @@ export function createGameplaySnapshotRouter(deps: GameplaySnapshotRouterDeps = 
         });
       }
     }
+
+    await runLineageBirthForSnapshot({
+      playerId: identity.playerId,
+      logicalIndex: serverTick,
+      provider: resolveLineageRuntimeStateProvider(deps),
+      context: { worldPois, playerPosition },
+    });
 
     const discoveryStats = worldDiscoveryService.getStats(identity.playerId);
     const discoveredPoiIds = worldDiscoveryService.getDiscoveredPoiIds(identity.playerId);


### PR DESCRIPTION
## Summary

Adds the next integration layer after PR #2031:

- Extends `LineageRuntimeStateProvider` with optional request context (`worldPois`, `playerPosition`).
- Adds `LineagePoiRuntimeStateProvider`, which derives lineage-compatible runtime state from existing server-authoritative POI/NPC sources:
  - village trader POIs
  - deterministic camp NPCs generated by `CampNpcService`
- Installs the POI provider as the default runtime provider in the registry.
- Updates `/api/gameplay/snapshot` to pass visible POIs and player position into the lineage birth bridge.
- Adds tests for null-without-context behavior, POI projection, deterministic ordering, and registry default override behavior.

## ARE Notes

No fake NPCs are invented. The provider projects existing runtime POI/NPC sources into the lineage runtime state shape. Without visible POI context it returns `null`, so no fake births are created.