### PR TITLE
fix(loot): quarantine legacy item generation authority

### DIFF
--- a/docs/LOOT_CANONICALIZATION.md
+++ b/docs/LOOT_CANONICALIZATION.md
@@ -23,7 +23,17 @@ source event → loot_roll_context → Infinite ARE Loot Machine → loot_delta 
 | `ARELootEngine` | Facade/adapter | Only if preserves full capability |
 | `DefaultLootMatrix` | Fallback/dev seed only | Not runtime truth |
 | `LootDirector` | Context orchestrator + loot_delta writer | Only |
+| `LootSystem` | Quarantined migration shim | Direct runtime construction throws; use explicit migration/test factory only |
 | `LootFeed/LootRenderer` | Snapshot observers only | Display only |
+
+### Runtime Guard Status
+
+Issue #1984 is enforced by code, not just documentation:
+
+- `bootLootSystem()` creates `LootDirector`, not `LootSystem`.
+- `LootDirector` delegates item generation to `ProceduralLootMachine`.
+- `LootSystem` is a legacy adapter only; `new LootSystem()` throws unless an explicit migration/test opt-in is used.
+- Legacy seeds are namespaced with `legacy-*` labels so they cannot be confused with canonical runtime loot seeds.
 
 ### Removal Rule
 
@@ -100,7 +110,7 @@ source event → loot_roll_context → Infinite ARE Loot Machine → loot_delta 
 │ LootDirector                         │
 │ - Writes loot_delta                  │
 │ - Emits loot.delta event             │
-│ - Idempotency guard                   │
+│ - Idempotency guard                  │
 │ - No direct item spawning            │
 └──────────────────────────────────────┘
         │
@@ -202,7 +212,7 @@ Assets are **display-only** - looked up from server metadata with deterministic 
 
 ## Tests
 
-See `server/src/tests/lootCanonicalization.test.ts`:
+See `server/src/tests/lootCanonicalization.test.ts` and `server/src/modules/loot/LootSystemAuthorityGuard.test.ts`:
 
 1. **Determinism Tests**
    - Same context → same loot
@@ -217,6 +227,10 @@ See `server/src/tests/lootCanonicalization.test.ts`:
 3. **Integration Tests**
    - Combat → LootRollContext → loot_delta → items
    - Full chain verification
+
+4. **Authority Tests**
+   - Direct legacy `LootSystem` construction is blocked
+   - Explicit migration/test factory remains available for non-runtime compatibility
 
 ## References
 

--- a/server/src/modules/loot/LootSystem.ts
+++ b/server/src/modules/loot/LootSystem.ts
@@ -5,25 +5,14 @@ import fs from "fs";
 import { resolveContentFile } from "../content/contentDataRoot.js";
 
 /**
- * @deprecated LootSystem.ts - PARALLEL RUNTIME TRUTH (DO NOT USE IN PRODUCTION)
- * 
- * This module exists as a PARALLEL DROP TRUTH and is NOT part of the canonical loot path.
- * 
- * CANONICAL PATH (USE THIS):
- * - ProceduralLootMachine (server/src/loot/ProceduralLootMachine.ts)
- * - LootDirector (server/src/loot/LootDirector.ts)
- * - loot_delta events from server
- * 
- * This module is kept for:
- * - Dev/test compatibility
- * - Migration shim
- * - Legacy code support
- * 
- * DO NOT use this for runtime loot generation.
- * DO NOT create new code that depends on this module for loot.
- * 
- * @see LootDirector for canonical loot handling
- * @see ProceduralLootMachine for the Infinite ARE Loot Machine
+ * @deprecated LootSystem.ts - LEGACY ADAPTER ONLY.
+ *
+ * Canonical runtime loot truth is:
+ *   LootDirector -> ProceduralLootMachine -> loot_delta -> inventory/world-drop consumers.
+ *
+ * This class is intentionally runtime-guarded. Production code must not instantiate
+ * it as a second item-generation authority. Tests or migration scripts must opt in
+ * explicitly through createLegacyLootSystemForMigration().
  */
 
 export interface LootTableEntry {
@@ -40,10 +29,29 @@ export interface LootTable {
   goldMax?: number;
 }
 
+export interface LootSystemOptions {
+  readonly allowLegacyRolls?: boolean;
+  readonly usage?: "migration" | "test";
+}
+
+function assertLegacyAllowed(options: LootSystemOptions): void {
+  if (options.allowLegacyRolls === true) return;
+  throw new Error(
+    "legacy_loot_system_disabled: use LootDirector + ProceduralLootMachine canonical loot path"
+  );
+}
+
+export function createLegacyLootSystemForMigration(usage: "migration" | "test"): LootSystem {
+  return new LootSystem({ allowLegacyRolls: true, usage });
+}
+
 export class LootSystem {
   private lootTables: Map<string, LootTable> = new Map();
+  private readonly options: LootSystemOptions;
 
-  constructor() {
+  constructor(options: LootSystemOptions = {}) {
+    this.options = Object.freeze({ ...options });
+    assertLegacyAllowed(this.options);
     this.loadLootTables();
   }
 
@@ -70,7 +78,8 @@ export class LootSystem {
   rollLoot(
     dropTable: LootTableEntry[],
     rng: ARERng = new SeededARERng(createARESeed([
-      "loot-table-inline",
+      "legacy-loot-table-inline",
+      this.options.usage ?? "unscoped",
       dropTable.map((entry) => `${entry.itemId}:${entry.chance}:${entry.minCount ?? 1}:${entry.maxCount ?? entry.minCount ?? 1}`).join(","),
     ]))
   ): { items: ItemDefinition[]; gold: number } {
@@ -88,7 +97,7 @@ export class LootSystem {
           if (item) {
             const seededItem = {
               ...item,
-              seed: item.seed ?? createARESeed(["loot-visual", entry.itemId, dropIndex, item.rarity ?? "common"]),
+              seed: item.seed ?? createARESeed(["legacy-loot-visual", entry.itemId, dropIndex, item.rarity ?? "common"]),
             };
             items.push((seededItem.type === "weapon"
               ? applyWeaponVisual(seededItem, { rng: rng.fork(`visual:${entry.itemId}:${dropIndex}`), dropIndex })
@@ -102,13 +111,12 @@ export class LootSystem {
     return { items, gold };
   }
 
-  rollFromTable(tableId: string, rng: ARERng = new SeededARERng(createARESeed(["loot-table", tableId]))): { items: ItemDefinition[]; gold: number } {
+  rollFromTable(tableId: string, rng: ARERng = new SeededARERng(createARESeed(["legacy-loot-table", this.options.usage ?? "unscoped", tableId]))): { items: ItemDefinition[]; gold: number } {
     const table = this.lootTables.get(tableId);
     if (!table) return { items: [], gold: 0 };
 
     const result = this.rollLoot(table.entries, rng.fork(`${tableId}:entries`));
 
-    // Roll gold
     if (table.goldMin !== undefined && table.goldMax !== undefined) {
       result.gold = rng.nextRange(table.goldMin, table.goldMax);
     }

--- a/server/src/modules/loot/LootSystemAuthorityGuard.test.ts
+++ b/server/src/modules/loot/LootSystemAuthorityGuard.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { createLegacyLootSystemForMigration, LootSystem } from './LootSystem.js';
+
+describe('LootSystem legacy quarantine', () => {
+  it('blocks direct runtime construction to prevent parallel loot truth', () => {
+    expect(() => new LootSystem()).toThrow(/legacy_loot_system_disabled/);
+  });
+
+  it('allows explicit migration/test construction only', () => {
+    const system = createLegacyLootSystemForMigration('test');
+    expect(system.rollFromTable('missing-table')).toEqual({ items: [], gold: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1984.

This PR makes the existing infinite procedural item generation path the only production runtime authority:

- Keeps `LootDirector -> ProceduralLootMachine -> loot_delta` as the canonical runtime path.
- Quarantines legacy `server/src/modules/loot/LootSystem.ts` behind an explicit migration/test opt-in.
- Makes direct `new LootSystem()` throw with a deterministic runtime error instead of silently creating a second item-generation authority.
- Adds a unit test proving the legacy path is blocked by default and only available via `createLegacyLootSystemForMigration('migration' | 'test')`.
- Updates `docs/LOOT_CANONICALIZATION.md` with the enforced runtime guard status.

## ARE Notes

No workflow files changed. No new production loot truth was added. Legacy seed labels are namespaced with `legacy-*`, and production boot continues through `LootDirector` + `ProceduralLootMachine`.