### PR TITLE
feat(loot): add production item generation authority

### DIFF
--- a/server/src/loot/ItemGenerationAuthority.ts
+++ b/server/src/loot/ItemGenerationAuthority.ts
@@ -1,0 +1,56 @@
+'use strict';
+
+import { ProceduralLootMachine } from './ProceduralLootMachine.js';
+
+export const ITEM_GENERATION_AUTHORITY_ID = 'procedural-loot-machine.v1' as const;
+
+export interface ItemGenerationAuthorityDeps {
+  readonly db: any;
+  readonly policy?: Record<string, unknown>;
+}
+
+export interface ItemGenerationRequest {
+  readonly playerId: string;
+  readonly tickIndex: number;
+  readonly dropSourceId: string;
+  readonly lootIndex?: number;
+  readonly areaLevel: number;
+  readonly policyVersion?: string;
+  readonly treasureClassId?: string;
+  readonly magicFind?: number;
+  readonly killStreak?: number;
+  readonly sourceRank?: string;
+  readonly biomeId?: string;
+  readonly factionId?: string;
+  readonly socialString?: string;
+  readonly playerReputation?: number;
+}
+
+export interface ItemGenerationResult {
+  readonly authorityId: typeof ITEM_GENERATION_AUTHORITY_ID;
+  readonly seedHash: string;
+  readonly context: unknown;
+  readonly items: readonly unknown[];
+}
+
+export class ItemGenerationAuthority {
+  private readonly machine: ProceduralLootMachine;
+
+  public constructor(deps: ItemGenerationAuthorityDeps) {
+    this.machine = new ProceduralLootMachine(deps.db, deps.policy ?? {});
+  }
+
+  public async generate(request: ItemGenerationRequest): Promise<ItemGenerationResult> {
+    const result = await this.machine.generate(request);
+    return Object.freeze({
+      authorityId: ITEM_GENERATION_AUTHORITY_ID,
+      seedHash: result.seedHash,
+      context: result.context,
+      items: result.items,
+    });
+  }
+}
+
+export function createItemGenerationAuthority(deps: ItemGenerationAuthorityDeps): ItemGenerationAuthority {
+  return new ItemGenerationAuthority(deps);
+}

--- a/server/src/loot/LootDirector.ts
+++ b/server/src/loot/LootDirector.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-import { ProceduralLootMachine } from './ProceduralLootMachine.js';
 import { LootAxioms } from './LootAxioms.js';
+import { createItemGenerationAuthority, type ItemGenerationAuthority } from './ItemGenerationAuthority.js';
 import {
   type LootDelta,
   type LootDeltaItem,
@@ -21,17 +21,6 @@ const MAX_PROCESSED_KEYS = 10_000;
 const TRIM_PROCESSED_KEYS_TO = 5_000;
 const LEGACY_CHUNK_SIZE = 64;
 
-/**
- * LootDirector - Context Orchestrator + Deterministic loot_delta Writer
- *
- * CANONICAL PATH:
- * 1. Receives canonical loot_roll_context from confirmed combat defeat events
- * 2. Delegates to ProceduralLootMachine
- * 3. Writes deterministic loot_delta
- * 4. Applies loot_delta to inventory/world-drop services and emits it downstream
- *
- * DO NOT: Roll own loot, create parallel drop truth, or emit loot before confirmed event.
- */
 class LootDirector {
   private db: any;
   private eventBus: any;
@@ -40,7 +29,7 @@ class LootDirector {
   private auditStore: any;
   private started: boolean = false;
   private processedKeys = new Set<string>();
-  private lootMachine: ProceduralLootMachine | null = null;
+  private itemAuthority: ItemGenerationAuthority | null = null;
   private policy: any = null;
 
   private telemetry: any = {
@@ -135,13 +124,13 @@ class LootDirector {
       return null;
     }
 
-    if (!this.lootMachine) {
+    if (!this.itemAuthority) {
       this.policy = await this.loadPolicy();
-      this.lootMachine = new ProceduralLootMachine(this.db, this.policy);
+      this.itemAuthority = createItemGenerationAuthority({ db: this.db, policy: this.policy });
     }
 
     try {
-      const result = await this.lootMachine.generate({
+      const result = await this.itemAuthority.generate({
         playerId: context.sourceEntityId,
         tickIndex: context.sourceTick,
         dropSourceId: context.defeatedEntityId,
@@ -189,6 +178,7 @@ class LootDirector {
         playerId: context.sourceEntityId,
         tickIndex: context.sourceTick,
         seedHash: result.seedHash,
+        authorityId: result.authorityId,
         items: lootDelta.items.map(item => ({
           uid: item.uid,
           itemId: item.itemId,
@@ -245,18 +235,19 @@ class LootDirector {
     });
   }
 
-  private buildLootDeltaItems(items: readonly any[], context: LootRollContextCanonical): readonly LootDeltaItem[] {
+  private buildLootDeltaItems(items: readonly unknown[], context: LootRollContextCanonical): readonly LootDeltaItem[] {
     const deltaItems: LootDeltaItem[] = items.map((item, index) => {
-      const itemId = this.resolveDeltaItemId(item);
-      const name = this.resolveDeltaItemName(item, itemId);
-      const uid = this.requiredString(item.uid) || `loot-${LootAxioms.shortHash(`${context.worldHash}|${context.chunkHash}|${context.sourceTick}|${itemId}|${index}`, 24)}`;
+      const itemRecord = item && typeof item === 'object' ? item as Record<string, any> : {};
+      const itemId = this.resolveDeltaItemId(itemRecord);
+      const name = this.resolveDeltaItemName(itemRecord, itemId);
+      const uid = this.requiredString(itemRecord.uid) || `loot-${LootAxioms.shortHash(`${context.worldHash}|${context.chunkHash}|${context.sourceTick}|${itemId}|${index}`, 24)}`;
 
       return {
         uid,
         itemId,
         name,
-        rarity: String(item.rarity || (item.kind === 'currency' ? 'CURRENCY' : 'COMMON')),
-        quantity: Math.max(1, this.safeInteger(item.amount ?? item.quantity, 1)),
+        rarity: String(itemRecord.rarity || (itemRecord.kind === 'currency' ? 'CURRENCY' : 'COMMON')),
+        quantity: Math.max(1, this.safeInteger(itemRecord.amount ?? itemRecord.quantity, 1)),
         position: { x: 0, y: 0, z: 0 },
         rollHash: LootAxioms.shortHash(`${context.worldHash}|${context.chunkHash}|${context.sourceTick}|${context.defeatedEntityId}|${context.lootIndex}|${index}|${uid}|${itemId}`)
       };
@@ -350,8 +341,9 @@ class LootDirector {
     return {
       started: this.started,
       axiomVersion: LootAxioms.VERSION,
+      itemGenerationAuthority: 'procedural-loot-machine.v1',
       telemetry: this.telemetry,
-      note: 'LootDirector is canonical - ProceduralLootMachine is the Infinite ARE Loot Machine'
+      note: 'LootDirector is canonical - item generation runs through ItemGenerationAuthority'
     };
   }
 
@@ -375,7 +367,7 @@ class LootDirector {
     return { chunkKey, worldHash, chunkHash, kappa };
   }
 
-  private resolveDeltaItemId(item: any): string {
+  private resolveDeltaItemId(item: Record<string, any>): string {
     return this.requiredString(item.baseId)
       || this.requiredString(item.itemId)
       || this.requiredString(item.currency)
@@ -383,7 +375,7 @@ class LootDirector {
       || 'unknown-loot-item';
   }
 
-  private resolveDeltaItemName(item: any, itemId: string): string {
+  private resolveDeltaItemName(item: Record<string, any>, itemId: string): string {
     return this.requiredString(item.name)
       || this.requiredString(item.currency)
       || itemId;

--- a/server/src/tests/itemGenerationAuthority.test.ts
+++ b/server/src/tests/itemGenerationAuthority.test.ts
@@ -1,0 +1,133 @@
+'use strict';
+
+import { describe, expect, it } from 'vitest';
+import { ITEM_GENERATION_AUTHORITY_ID, createItemGenerationAuthority } from '../loot/ItemGenerationAuthority.js';
+import { LootDirector } from '../loot/LootDirector.js';
+
+function createFakeDb() {
+  return {
+    models: {
+      ItemBase: {
+        async find() {
+          return [{
+            id: 'test_blade',
+            name: 'Test Blade',
+            type: 'weapon',
+            minLevel: 1,
+            maxLevel: 99,
+            reqStr: 1,
+            reqInt: 0,
+            reqDex: 0,
+            icon: 'test_blade.png',
+            baseStats: { damageMin: 2, damageMax: 5 }
+          }];
+        }
+      },
+      AffixPool: {
+        async find() {
+          return [{
+            id: 'pre_clear',
+            name: 'Clear',
+            stat: 'damageMax',
+            type: 'flat',
+            minRoll: 1,
+            maxRoll: 3,
+            requiredLevel: 1,
+            group: 'damage_flat',
+            isPrefix: true,
+            weight: 100
+          }];
+        }
+      }
+    }
+  };
+}
+
+function request() {
+  return {
+    playerId: 'player_authority',
+    tickIndex: 1234,
+    dropSourceId: 'npc_authority',
+    lootIndex: 0,
+    areaLevel: 12,
+    treasureClassId: 'TC_ACT1_BEAST',
+    magicFind: 25,
+    killStreak: 2,
+    sourceRank: 'NORMAL',
+    biomeId: 'forest',
+    factionId: 'neutral',
+    socialString: 'test',
+    playerReputation: 0
+  };
+}
+
+function createEventBus() {
+  const handlers = new Map<string, Array<(payload: unknown) => void | Promise<void>>>();
+  const emitted: Array<{ event: string; payload: any }> = [];
+  return {
+    emitted,
+    onSafe(event: string, handler: (payload: unknown) => void | Promise<void>) {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+    },
+    emitSafe(event: string, payload: any) {
+      emitted.push({ event, payload });
+      for (const handler of handlers.get(event) ?? []) {
+        void handler(payload);
+      }
+    }
+  };
+}
+
+describe('ItemGenerationAuthority', () => {
+  it('is the production facade over deterministic procedural item creation', async () => {
+    const authority = createItemGenerationAuthority({ db: createFakeDb() });
+    const a = await authority.generate(request());
+    const b = await authority.generate(request());
+
+    expect(a.authorityId).toBe(ITEM_GENERATION_AUTHORITY_ID);
+    expect(b.authorityId).toBe(ITEM_GENERATION_AUTHORITY_ID);
+    expect(a.seedHash).toBe(b.seedHash);
+    expect(a.items).toEqual(b.items);
+    expect(Object.isFrozen(a)).toBe(true);
+  });
+
+  it('keeps loot director output tied to the authority id', async () => {
+    const eventBus = createEventBus();
+    const inventoryWrites: unknown[] = [];
+    const director = new LootDirector({
+      db: createFakeDb(),
+      eventBus,
+      inventoryService: {
+        async addItem(payload: unknown) {
+          inventoryWrites.push(payload);
+        }
+      }
+    });
+
+    director.start();
+    const delta = await director.handleDefeatEvent({
+      sourceEntityId: 'player_authority',
+      defeatedEntityId: 'npc_authority',
+      actorId: 'player_authority',
+      sourceTick: 1234,
+      chunkKey: 'chunk:1:2',
+      worldHash: 'world_hash',
+      chunkHash: 'chunk_hash',
+      kappa: 'kappa_hash',
+      lootIndex: 0,
+      treasureClassId: 'TC_ACT1_BEAST',
+      areaLevel: 12,
+      magicFind: 25,
+      killStreak: 2,
+      sourceRank: 'NORMAL',
+      biomeId: 'forest',
+      factionId: 'neutral',
+      socialString: 'test'
+    });
+
+    expect(delta).not.toBeNull();
+    expect(inventoryWrites.length).toBeGreaterThan(0);
+    const generated = eventBus.emitted.find((entry) => entry.event === 'loot.generated');
+    expect(generated?.payload.authorityId).toBe(ITEM_GENERATION_AUTHORITY_ID);
+  });
+});


### PR DESCRIPTION
## Summary

First implementation step for #1984.

- Adds `ItemGenerationAuthority` as the production facade for item generation.
- Routes `LootDirector` through the authority instead of constructing `ProceduralLootMachine` directly.
- Emits `authorityId` on `loot.generated` so downstream consumers can verify the canonical source.
- Adds tests proving deterministic authority output and director event attribution.

## ARE Notes

This does not create a second production truth. `ProceduralLootMachine` remains the deterministic engine, but production runtime now reaches it through the single authority facade. Legacy modules remain helpers/shims only.