### PR TITLE
docs(release): align roadmap checklist and open integration issues

### DIFF
--- a/docs/KNOWN_GAPS.md
+++ b/docs/KNOWN_GAPS.md
@@ -1,16 +1,36 @@
 # Known Gaps (short list)
 
-High-level gaps remain between this codebase and a shippable MMORPG.
+High-level gaps remain between this codebase and a shippable public MMORPG release.
 
-## Still open
+Use `docs/ROADMAP_TO_RELEASE.md` as the authoritative backlog and `docs/PROJECT_STATUS_2026.md` as the shipped-state snapshot.
 
-- Production database wiring and backup story  
-- Full combat / skill balance and authoritative combat loop  
-- Production-ready UI coverage (many panels exist; not all wired end-to-end)  
-- Strong auth and session hardening for public launch  
-- Final art and asset pipeline (replace placeholders)  
-- Broad integration tests beyond server unit coverage  
+---
 
-## Authoritative backlog
+## Release blockers
 
-Use **`docs/ROADMAP_TO_RELEASE.md`** for the bible-aligned checklist and **`docs/PROJECT_STATUS_2026.md`** for what already works.
+- #2038 — repeatable production deploy and live verification gate
+- #2039 — persistence backup and restore proof
+- #2040 — production auth and session hardening
+- #2041 — remaining deterministic audit violations
+- #2042 — mobile and browser performance budget
+- #2043 — player-facing UI coverage for critical gameplay
+- #2044 — audited release content pack and asset license proof
+- #2045 — required full-loop E2E and release smoke gate
+
+---
+
+## Open integration points
+
+- #2046 — render lineage `worldSurface` in the 3D client
+- #2050 — runtime civic state from tick and house data
+- #2047 — runtime market pricing from resource state
+- #2048 — item provenance, trading and anti-duplication audit
+- #2049 — runtime observability and release SLO dashboard
+
+---
+
+## ARE constraint for all remaining work
+
+No mock truth. No fake snapshots. No workflow tricks. No stub systems in the truth path. No facade that replaces real ARE causality.
+
+Every new integration must either be an existing ARE system logic or interact with one directly: tick, chunk, kappa, hash, manifest, journal, delta, replay, resolver, or real runtime provider.

--- a/docs/PROJECT_STATUS_2026.md
+++ b/docs/PROJECT_STATUS_2026.md
@@ -1,53 +1,99 @@
-# Project status — Areloria / Ouroboros (May 2026)
+# Project status — Areloria / Ouroboros (June 2026)
 
-This file is the practical "what is shipped now" snapshot.
-Use it before trusting older reconstruction or handover docs.
+This file is the practical current-state snapshot. Use it before trusting older reconstruction or handover docs.
+
+---
+
+## ARE truth-path rule
+
+All active runtime work follows this rule:
+
+```text
+No mock truth.
+No fake snapshots.
+No workflow tricks.
+No stub systems in the truth path.
+No facade that replaces real ARE causality.
+```
+
+Valid runtime truth must come from tick/logicalIndex, kappa, chunk/position, hash/manifest, journal/delta/replay, resolver input, or real runtime providers.
+
+---
 
 ## Core runtime architecture
 
 | Item | Status |
 |------|--------|
-| Monorepo layout | `client/` (Vite + Babylon.js), `client-2d/` (PixiJS v7 + React), `server/` (Express + WebSocket), `game-data/` (authoritative JSON content) |
+| Monorepo layout | `client/` (Vite + Babylon.js), `apps/client-2d/` (PixiJS v7 + React), `server/` (Express + WebSocket), `game-data/` (authoritative JSON content) |
 | Main server loop | `server/src/core/WorldTick.ts` at ~100 ms sim tick |
 | Main client entry | `client/src/main.ts` |
 | 2D client entry | `apps/client-2d/src/App.tsx` |
 | Primary rendering (3D) | Babylon.js (`@babylonjs/core` + loaders + materials + addons) |
 | Primary rendering (2D) | PixiJS v7 + React UI (`apps/client-2d/`) |
 | Networking | WebSocket (`ws`) via `server/src/networking/WebSocketServer.ts` |
-| **Manifest System** | Deterministic server-authoritative state via hash chain in `server/src/core/manifest/`; client divergence detection in `apps/client-2d/src/manifest/`; resync API at `/api/manifest/*` |
+| Manifest System | Deterministic server-authoritative state via hash chain in `server/src/core/manifest/`; client divergence detection in `apps/client-2d/src/manifest/`; resync API at `/api/manifest/*` |
 | Data content root | `game-data/` by default, optional published pack via `USE_PUBLISHED_CONTENT` / `CONTENT_PACK_DIR` |
+
+---
 
 ## Authentication and persistence
 
 | Item | Status |
 |------|--------|
-| Server auth verification | Supabase JWT flow (`USE_SUPABASE_WS_LOGIN`, `REQUIRE_SUPABASE_AUTH`, guest/dev toggles) |
-| Client auth provider | `VITE_AUTH_PROVIDER` supports `supabase` or `none`; auto mode resolves to Supabase if `VITE_SUPABASE_*` is configured |
-| Persistence drivers | `PERSISTENCE_DRIVER`: `auto` / `postgres` / `file` (auto prefers Postgres if DB configured, else JSON fallback) |
-| JSON fallback | `PLAYER_SAVE_FILE` (default under `data/`) |
-| Redis usage | Optional (`ioredis`) for cache/chat relay paths, graceful fallback when unset |
-| Health endpoint | `GET /health` includes auth, persistence, playtester, self-healing, and content-root summary |
+| Server auth verification | Supabase JWT flow with guest/dev toggles. Public release lockdown tracked by #2040. |
+| Client auth provider | `VITE_AUTH_PROVIDER` supports `supabase` or `none`; auto mode resolves to Supabase if configured. |
+| Persistence drivers | `PERSISTENCE_DRIVER`: `auto` / `postgres` / `file`. Backup/restore proof tracked by #2039. |
+| JSON fallback | `PLAYER_SAVE_FILE` default under `data/`. |
+| Redis usage | Optional (`ioredis`) for cache/chat relay paths, graceful fallback when unset. |
+| Health endpoint | `GET /health` includes auth, persistence, playtester, self-healing and content-root summary. Release observability tracked by #2049. |
 
-## Gameplay systems (live and wired)
+---
+
+## Gameplay systems live and wired
 
 | Domain | Live status |
 |--------|-------------|
-| Players/combat | Player movement, target selection, attack handling, skill usage, cooldown/mana flow, death/respawn are wired in `WorldTick` + combat/skill modules |
-| Inventory/equipment/loot | Inventory stacks, equip/unequip, loot drop + pickup and sync are active |
-| **Anti-Ninja Loot Lock** | Loot ownership with 60-second kill lock (600 ticks at 10Hz); `LootDirector` enforces causality guard via `ownerId` + `lockedUntilTick` |
-| **Player Stats Sync** | Server-authoritative XP/level tracking via `PlayerStatsDirector`; RuneScape XP formula (50 × level^1.4); `player_stats_snapshot` broadcast via WebSocket |
-| Quest system | Quest start/progression/sync and talk/collect/combat updates are active |
-| Questline system | Questline engine + bridge and unlock propagation are wired |
-| NPC runtime | `NPCSystem` + memory cache/persistence + relationships + proactive chat are wired |
-| Ouroboros agents | `OuroborosEngine` is instantiated and ticked from `WorldTick` |
-| World systems | Chunks, observers, world objects, weather/time, terrain adapters are wired |
-| Resource entities | Deterministic RESOURCE entities with KAPPA-grid alignment via `ChunkModificationDirector` + `ResourcePopulator` |
-| Storage system | `StorageEntity` entities with inventory, `open_storage`/`transfer_item` handlers in WorldTick |
-| Warfront | `WarfrontSystem` lifecycle, status pushes, reward claims are wired |
-| World boss | `WorldBossDungeonSystem` encounter flow and ranking summaries are wired |
-| Vote system | Vote banner/session/status and reward claims are wired |
-| Crafting | Crafting system is wired through server message handlers |
-| Admin content tools | `/api/admin/content/*` routes + `/admin-content.html` are active |
+| Players/combat | Movement, target selection, attack handling, skill usage, cooldown/mana flow, death/respawn are wired. Balance/UI hardening remains open. |
+| Inventory/equipment/loot | Inventory stacks, equip/unequip, loot drop + pickup and sync are active. |
+| Canonical loot truth | Production path is `LootDirector -> ProceduralLootMachine -> loot_delta`. Legacy `LootSystem` is quarantined; PR #2036 restricts its constructor further. |
+| Player Stats Sync | Server-authoritative XP/level tracking via `PlayerStatsDirector`; `player_stats_snapshot` broadcast via WebSocket. |
+| Quest system | Quest start/progression/sync and talk/collect/combat updates are active. |
+| Questline system | Questline engine + bridge and unlock propagation are wired. |
+| NPC runtime | `NPCSystem`, memory cache/persistence, relationships, proactive chat and game-data loading are wired. |
+| Living Duden / NPC speech | Runtime language content loads from `game-data/language`; 2D NPC interaction emits runtime dialogue packets. |
+| Lineage runtime | FamilyHouseRegistry, birth journal, replay, LineageTickRunner, snapshot bridge and visible-POI runtime provider exist. |
+| Lineage worldSurface | Server projects houses/nodes into `liveGameplaySnapshot.worldSurface`; 2D renders markers; 3D rendering tracked by #2046. |
+| Ouroboros agents | `OuroborosEngine` is instantiated and ticked from `WorldTick`. |
+| World systems | Chunks, observers, world objects, weather/time and terrain adapters are wired. |
+| Resource entities | Deterministic resource nodes and chunk coordinates are wired; remaining deterministic audit cleanup tracked by #2041. |
+| Storage system | `StorageEntity` entities with inventory, `open_storage`/`transfer_item` handlers in WorldTick. |
+| Warfront | `WarfrontSystem` lifecycle, status pushes and reward claims are wired. |
+| World boss | `WorldBossDungeonSystem` encounter flow and ranking summaries are wired. |
+| Vote system | Vote banner/session/status and reward claims are wired. |
+| Crafting | Server-authoritative starter crafting loop is wired and visible in snapshots/UI. |
+| Admin content tools | `/api/admin/content/*` routes + `/admin-content.html` are active. |
+
+---
+
+## Release blockers and open integration issues
+
+| Issue | Purpose |
+|---:|---|
+| #2038 | Repeatable production deploy and live verification gate |
+| #2039 | Persistence backup and restore proof |
+| #2040 | Production auth and session hardening |
+| #2041 | Remaining deterministic audit violations |
+| #2042 | Mobile and browser performance budget |
+| #2043 | Player-facing UI coverage for critical gameplay |
+| #2044 | Audited release content pack and asset license proof |
+| #2045 | Required full-loop E2E and release smoke gate |
+| #2046 | Render lineage worldSurface in the 3D client |
+| #2050 | Runtime civic state from tick and house data |
+| #2047 | Runtime market pricing from resource state |
+| #2048 | Item provenance, trading and anti-duplication audit |
+| #2049 | Runtime observability and release SLO dashboard |
+
+---
 
 ## Playtester monitor and WebRTC stream mode
 
@@ -55,19 +101,12 @@ Use it before trusting older reconstruction or handover docs.
 |------|--------|
 | Playtester runtime | `AutonomousPlaytester` enabled by `PLAYTESTER_ENABLED` |
 | Monitor mode default | `PLAYTESTER_MONITOR_MODE=webrtc` |
-| Viewer page | `/playtester-monitor.html` (lightweight stream viewer) |
-| Publisher page | `/playtester-render-publisher.html` (render publisher) |
+| Viewer page | `/playtester-monitor.html` |
+| Publisher page | `/playtester-render-publisher.html` |
 | Signaling | `PlaytesterWebRTCSignaling` at `PLAYTESTER_MONITOR_SIGNAL_PATH` |
-| Legacy dev mode | Optional `?mode=local3d` path kept as dev-only fallback |
+| Release reporting | Open under #2049 |
 
-## New fusion systems (now active)
-
-| Integration | Status |
-|------------|--------|
-| Quest Echo Director | Active via `GameplayFusionDirector` + `WorldTick.tickFusionIntegrations()`; generates quest echo beacons from active quest context |
-| Adaptive Quest Scene Profiles | Active via `GameplayFusionDirector` adaptive profile/override logic; hooked into NPC/world object GLB resolution |
-| Construction Contracts | Active contract lifecycle from admin model needs to NPC assignment/completion flow |
-| Scope | Applies outside playtester as part of live autonomous NPC runtime tick |
+---
 
 ## Content and asset pipeline
 
@@ -78,6 +117,9 @@ Use it before trusting older reconstruction or handover docs.
 | Admin model needs | `GET /api/admin/content/model-needs` provides needed/satisfied model suggestions |
 | Publish snapshot | `pnpm run content:publish` creates `published-content/current` pack |
 | Model audit | `pnpm run audit:model-paths` and admin model-path audit endpoint available |
+| Release content pack | Open under #2044 |
+
+---
 
 ## Testing/build toolchain
 
@@ -87,107 +129,77 @@ Use it before trusting older reconstruction or handover docs.
 | E2E tests | Playwright (`pnpm run test:e2e`, `pnpm run test:e2e:ci`) |
 | Lint | ESLint (`pnpm run lint`) |
 | Build | Root build compiles client then server (`pnpm run build`) |
-| CI baseline | Lint + tests + build + model-path audit + e2e workflow exists |
+| CI baseline | Lint + tests + build + model-path audit + E2E workflows exist |
+| Required release smoke | Open under #2045 |
+| Deterministic hardcode cleanup | Open under #2041 |
 
-## Important clarifications
+---
 
-- Current docs should treat Supabase + Postgres/file persistence as the active production path.
-- Legacy docs may still reference older auth stacks; treat those references as historical unless explicitly marked as currently supported.
-- Root `next` dependency/config exists but is not the active game runtime path; the live game stack is Vite client + Express/WebSocket server.
+## Gameplay Vertical Slice Status
+
+### Complete foundations
+
+- Quest persistence and production ops are merged.
+- Auth-bound player identity is active.
+- Quest, skill and inventory state support persistence paths.
+- Resource gathering connects world interaction to skills and inventory.
+- Crafting loop exists: Gather -> Inventory -> Craft -> XP -> Snapshot/UI.
+- Basic gathering tools exist and can be equipped.
+- Lineage birth journal/replay/surface pipeline exists.
+
+### Current live gameplay loop
+
+```text
+Gather starter resource node
+-> Gain skill XP
+-> Receive persistent resource item
+-> Craft starter recipe/tool
+-> Consume resource item
+-> Receive persistent crafted item
+-> Gain Crafting XP
+-> See updated state in LiveGameplaySnapshot and 2D panels
+```
+
+### Partial systems
+
+| System | Status | Notes |
+|--------|--------|-------|
+| Quest Persistence | Foundation complete | Production backup proof still open in #2039 |
+| Skill Progression | Partial | MVP skills and XP persistence exist |
+| Resource Gathering | Partial | Starter and chunk resources exist; release audit cleanup remains #2041 |
+| Inventory | Partial | Resource/crafted/loot items exist; provenance/trading open #2048 |
+| Crafting | Partial | Starter recipes and tool recipes exist |
+| Guild/Faction | Partial | Snapshot visible, data not fully wired |
+| Equipment | Partial | Basic gathering tools exist; combat equipment open |
+| Lineage | Partial | Server/2D path exists; 3D path open #2046 |
+| Economy | Planned | Runtime pricing open #2047 |
+| Civic world state | Planned | Runtime state open #2050 |
+
+### Not yet complete
+
+- Release deploy verification (#2038)
+- Backup/restore proof (#2039)
+- Production auth lockdown (#2040)
+- Remaining deterministic audit cleanup (#2041)
+- Mobile/browser performance budget (#2042)
+- Player-facing UI coverage (#2043)
+- Release content pack audit (#2044)
+- Required full-loop release gate (#2045)
+- 3D lineage worldSurface rendering (#2046)
+- Runtime market pricing (#2047)
+- Item provenance and trading audit (#2048)
+- Runtime observability dashboard (#2049)
+- Runtime civic state (#2050)
+
+---
 
 ## Maintenance rule
 
 When runtime behavior changes, update this file together with:
 
 - `README.md`
-- `docs/ROADMAP_TO_RELEASE.md` (if release scope changed)
-- Relevant subsystem docs under `docs/`
+- `docs/ROADMAP_TO_RELEASE.md`
+- `docs/RELEASE_CHECKLIST.md`
+- relevant subsystem docs under `docs/`
 
-## Gameplay Vertical Slice Status (June 2026)
-
-### Complete Foundations
-
-- Quest persistence and production ops are merged.
-- Auth-bound player identity is active.
-- Quest, skill and inventory state support persistence paths.
-- Resource gathering connects world interaction to skills and inventory.
-- **Crafting loop complete**: Gather → Inventory → Craft → XP → Snapshot/UI
-
-### Current Live Gameplay Loop
-
-```
-Gather starter resource node
-→ Gain skill XP
-→ Receive persistent resource item
-→ Craft starter recipe
-→ Consume resource item
-→ Receive persistent crafted item
-→ Gain Crafting XP
-→ See updated state in LiveGameplaySnapshot and 2D panels
-```
-
-### Partial Systems
-
-| System | Status | Notes |
-|--------|--------|-------|
-| Quest Persistence | Foundation complete | Production ops and backup policy present |
-| Skill Progression | Partial | MVP skills and XP persistence exist |
-| Resource Gathering | Partial | Static starter nodes only |
-| Inventory | Partial | Resource/crafted items only |
-| Crafting | **Partial** | **Deterministic starter recipes, includes tool recipes** |
-| Guild/Faction | Partial | Snapshot visible, data not fully wired |
-| Equipment | **Partial** | **Basic gathering tools: wooden_axe, copper_pickaxe, simple_fishing_rod** |
-
-### Crafting System Details (MVP)
-
-Recipes:
-- `craft_wood_plank`: 2× wood_log → 1× wood_plank (+20 XP)
-- `smelt_copper_ingot`: 3× copper_ore → 1× copper_ingot (+30 XP)
-- `cook_raw_fish`: 1× raw_fish → 1× cooked_fish (+15 XP)
-- `craft_wooden_axe`: 2× wood_plank + 1× copper_ingot → 1× wooden_axe (+35 XP)
-- `craft_copper_pickaxe`: 1× wood_plank + 2× copper_ingot → 1× copper_pickaxe (+40 XP)
-- `craft_simple_fishing_rod`: 1× wood_plank + 1× raw_fish → 1× simple_fishing_rod (+25 XP)
-
-Features:
-- Server-authoritative crafting flow
-- Persistent inventory consumption
-- Crafting XP grants to player skills
-- LiveGameplaySnapshot visibility
-- 2D Crafting Window (press B)
-
-### Equipment System (Gathering Tools MVP)
-
-Equippable Tools:
-- `wooden_axe`: +10% woodcutting XP, equipped in woodcutting_tool slot
-- `copper_pickaxe`: +10% mining XP, equipped in mining_tool slot
-- `simple_fishing_rod`: +10% fishing XP, equipped in fishing_tool slot
-
-Features:
-- Server-authoritative equipment state
-- Inventory ownership validation before equip
-- JSON/Postgres persistence
-- Equipment appears in LiveGameplaySnapshot
-- 2D Inventory Panel with tool equip buttons
-- Deterministic XP bonus applied during gathering
-
-### Not Yet Complete
-
-- Procedural resource placement
-- Crafting stations
-- Tool durability
-- Tool tiers beyond starter
-- Combat equipment
-- Armor
-- Equipment trading
-- Visual paperdoll
-- Trading
-- NPC economy
-- Item pricing
-- Player-to-player exchange
-- Crafting animations
-
-### Next Real Block
-
-`feat(equipment): craft and equip basic gathering tools`
-
-Then Crafting becomes progression, not just inventory management.
+Last refreshed: 2026-06-15

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,194 +1,160 @@
 # Release Checklist — Areloria / WASD
 
-This document serves as the **source of truth for release readiness**. Before any alpha/beta/public tag, all items below must be green.
+This document is the release sign-off checklist. Before any alpha, beta, or public tag, every release blocker below must be green through real runtime evidence.
 
-Last updated: 2026-06-13
+Last updated: 2026-06-15
 
 ---
 
-## Deployment Issue Found
+## ARE release rule
 
-**CRITICAL: Container is crashing on VPS due to missing game-data mount**
+No mock truth. No fake snapshots. No workflow tricks. No stub truth path. No facade as runtime truth.
 
-The `arelorian-engine` container is in a crash loop because `game-data/npc/npcs.json` is not available inside the container.
-
-**Root Cause:** The `docker-compose.yml` does not mount `game-data` into the container. The VPS has the correct files at `/opt/areloria/game-data/` but the container only has these mounts:
-- `./data:/app/data`
-- `./logs:/app/logs`
-- `./private-assets:/opt/areloria/private-assets:ro`
-
-**Missing mount:** `./game-data:/app/game-data:ro` (or equivalent)
-
-**Impact:** Tier A, item A1 (Production deploy verification) is BLOCKED.
+Release proof must use real server/client runtime sources, deterministic tick/chunk/hash inputs, journals, deltas, manifests, or replayable state.
 
 ---
 
 ## 1. Local Build & Guard Verification
 
-Run these commands locally and confirm all pass:
-
 ```bash
-# 1. Install dependencies
 pnpm install
-
-# 2. Build all packages
 pnpm run build
-
-# 3. Run all guards
 pnpm run guard:all
-
-# 4. Validate Pixi assets
 pnpm run assets:pixi:validate
 pnpm run assets:pixi:validate-batches
-
-# 5. Run server tests
 pnpm --filter @wasd/server --if-present test
-
-# 6. Determinism check
 node scripts/check-are-determinism.mjs
 ```
 
-| Check | Status | Notes |
-|---|---|---|
-| `pnpm run build` | ☐ | |
-| `pnpm run guard:all` | ☐ | |
-| `pnpm run assets:pixi:validate` | ☐ | |
-| `pnpm --filter @wasd/server test` | ☐ | |
-| `node scripts/check-are-determinism.mjs` | ☐ | |
+| Check | Status | Issue |
+|---|---|---:|
+| Root build | ☐ | #2045 |
+| `guard:all` | ☐ | #2045 |
+| Stateless Hardcode Audit | ☐ | #2041 |
+| ARE Determinism Gate | ☐ | #2041 |
+| Server tests | ☐ | #2045 |
+| Client 2D build | ☐ | #2043 |
 
 ---
 
 ## 2. Content & Asset Verification
 
-```bash
-# Audit model paths
-pnpm run audit:model-paths
+Tracked by #2044.
 
-# Validate content
-pnpm run validate --prefix server
-```
-
-| Check | Status | Notes |
-|---|---|---|
-| Model path audit green | ☐ | |
-| Content validation green | ☐ | |
-| Release content pack audited | ☐ | |
-| Asset licenses tracked | ☐ | |
+| Check | Status |
+|---|---|
+| Model path audit green | ☐ |
+| Release content pack created | ☐ |
+| Asset licenses tracked | ☐ |
+| Fallback policy documented | ☐ |
 
 ---
 
 ## 3. E2E Smoke Tests
 
-```bash
-# Install E2E dependencies (one-time)
-pnpm run test:e2e:install
+Tracked by #2045.
 
-# Run E2E tests
-pnpm run test:e2e
-```
-
-| Test | Status | Notes |
-|---|---|---|
-| `e2e/smoke.spec.ts` | ☐ | Health + WebSocket guest login |
-| `e2e/full-loop-smoke.spec.ts` | ☐ | Full loop: login, movement, NPC, quest, combat, loot, reconnect |
-| `e2e/client-2d-real-post-login-flow.spec.ts` | ☐ | Post-login UI shell |
-| `e2e/quest-progression.spec.ts` | ☐ | Quest accept/progression |
-| `e2e/resource-gathering.spec.ts` | ☐ | Resource gathering API |
-| All other E2E tests | ☐ | |
+| Test | Status |
+|---|---|
+| Basic smoke | ☐ |
+| Full-loop smoke | ☐ |
+| 2D post-login flow | ☐ |
+| Quest/resource/crafting flows | ☐ |
+| Live deploy smoke | ☐ |
 
 ---
 
 ## 4. Production Deploy Verification
 
-After a successful VPS Docker deploy:
+Tracked by #2038.
 
-```bash
-# Verify endpoints
-curl -s http://arelorian.de/health | jq '.ok'
-curl -s http://arelorian.de/client-config.json | jq '.'
-curl -s http://arelorian.de/ | head -c 200
-curl -s http://arelorian.de/2d | head -c 200
-curl -s http://arelorian.de/portal | head -c 200
-```
-
-| Endpoint | Expected | Status |
+| Endpoint / check | Expected | Status |
 |---|---|---|
-| `/health` | `ok: true` | ☐ |
-| `/client-config.json` | Valid JSON with Supabase config | ☐ |
-| `/` | HTML landing page | ☐ |
-| `/2d` | 2D client entry | ☐ |
-| `/portal` | Portal page | ☐ |
-| WebSocket upgrade | `101 Switching Protocols` | ☐ |
-
-### Container State
-
-```bash
-# SSH to VPS and check container
-docker ps | grep areloria
-docker logs <container_id> --tail 50
-```
-
-| Check | Status | Notes |
-|---|---|---|
-| Container running | ☐ | |
-| Recent logs clean | ☐ | |
-| No OOM or crash | ☐ | |
+| `/health` | real healthy response | ☐ |
+| `/client-config.json` | valid JSON | ☐ |
+| `/` | page response | ☐ |
+| `/portal` | portal response | ☐ |
+| WebSocket upgrade | accepted upgrade | ☐ |
+| Container | running and healthy | ☐ |
+| Logs | clean recent runtime logs | ☐ |
 
 ---
 
 ## 5. Persistence & Backup Verification
 
-```bash
-# Test backup creation
-curl -s http://arelorian.de/api/admin/backup/create
+Tracked by #2039.
 
-# Verify backup exists
-curl -s http://arelorian.de/api/admin/backup/list
-
-# Test restore drill (staging only)
-```
-
-| Check | Status | Notes |
-|---|---|---|
-| Backup creation works | ☐ | |
-| Backup list accessible | ☐ | |
-| JSON fallback operational | ☐ | |
-| Restore drill recorded | ☐ | |
+| Check | Status |
+|---|---|
+| Migration SOP documented | ☐ |
+| Backup artifact created | ☐ |
+| Restore proof recorded | ☐ |
+| JSON fallback policy documented | ☐ |
+| Health shows actual persistence source | ☐ |
 
 ---
 
 ## 6. Auth/Session Hardening
 
-| Check | Status | Notes |
-|---|---|---|
-| Guest login disabled in production | ☐ | `ALLOW_GUEST_LOGIN=0` |
-| Dev login disabled in production | ☐ | `ALLOW_DEV_LOGIN=0` |
-| Supabase auth required | ☐ | `REQUIRE_SUPABASE_AUTH=1` |
-| Session expiry configured | ☐ | |
-| Rate limits active | ☐ | |
+Tracked by #2040.
+
+| Check | Status |
+|---|---|
+| Guest login policy verified | ☐ |
+| Dev login policy verified | ☐ |
+| Supabase auth policy verified | ☐ |
+| HTTP and WebSocket identity match | ☐ |
+| Session expiry configured | ☐ |
+| Rate limits active | ☐ |
 
 ---
 
-## 7. Documentation Alignment
+## 7. Player-Facing UI Coverage
 
-| Document | Status | Last Updated |
-|---|---|---|
-| `README.md` | ☐ | |
-| `README_START_HERE.md` | ☐ | |
-| `docs/PROJECT_STATUS_2026.md` | ☐ | |
-| `docs/ROADMAP_TO_RELEASE.md` | ☐ | |
-| `docs/DOCUMENTATION_INDEX.md` | ☐ | |
-| `DEPLOYMENT.md` | ☐ | |
-| `deploy/ENV_SETUP.md` | ☐ | |
+Tracked by #2043.
+
+| Flow | Status |
+|---|---|
+| Quest tracker and map | ☐ |
+| Inventory/equipment | ☐ |
+| Crafting/storage | ☐ |
+| Combat log/death/respawn | ☐ |
+| Voting/warfront/boss flows | ☐ |
+| Settings/accessibility | ☐ |
 
 ---
 
-## 8. Release Notes Draft
+## 8. Performance and Observability
 
-- [ ] Player-facing changelog prepared
-- [ ] Internal engineering notes separate
-- [ ] Version tag created: `vX.Y.Z`
-- [ ] GitHub release draft published
+| Check | Status | Issue |
+|---|---|---:|
+| Startup/FPS/memory budget | ☐ | #2042 |
+| Runtime metrics dashboard | ☐ | #2049 |
+| Playtester stream health | ☐ | #2049 |
+| Asset audit failures visible | ☐ | #2049 |
+
+---
+
+## 9. Documentation Alignment
+
+| Document | Status |
+|---|---|
+| `README.md` | ☐ |
+| `README_START_HERE.md` | ☐ |
+| `docs/PROJECT_STATUS_2026.md` | ☐ |
+| `docs/ROADMAP_TO_RELEASE.md` | ☐ |
+| `docs/KNOWN_GAPS.md` | ☐ |
+| `DEPLOYMENT.md` | ☐ |
+| `deploy/ENV_SETUP.md` | ☐ |
+
+---
+
+## 10. Release Notes Draft
+
+- [ ] Player-facing changelog prepared.
+- [ ] Internal engineering notes separate.
+- [ ] Version tag created.
+- [ ] GitHub release draft published.
 
 ---
 
@@ -204,4 +170,4 @@ curl -s http://arelorian.de/api/admin/backup/list
 
 ## Notes
 
-_Add deployment-specific notes, issues encountered, and resolution details here._
+Current release blockers are tracked by #2038 through #2050.

--- a/docs/ROADMAP_TO_RELEASE.md
+++ b/docs/ROADMAP_TO_RELEASE.md
@@ -1,16 +1,44 @@
 # Roadmap to release — current implementation alignment
 
-This roadmap tracks the gap between what is already live in the repository and what still needs to be completed for a stable public release.
+This roadmap tracks what is live in the repository and what still needs to be completed for a stable public release.
 
 Read order:
 
 1. `README_START_HERE.md` — entry point and current-document hierarchy.
-2. `docs/PROJECT_STATUS_2026.md` — authoritative implementation snapshot.
+2. `docs/PROJECT_STATUS_2026.md` — current implementation snapshot.
 3. `docs/ROADMAP_TO_RELEASE.md` — this release backlog.
-4. `docs/MASTER_DESIGN_BIBLE.md` — vision and pillars only.
-5. `docs/DOCUMENTATION_INDEX.md` — current vs historical documentation map.
+4. `docs/RELEASE_CHECKLIST.md` — release sign-off checklist.
+5. `docs/KNOWN_GAPS.md` — compact open-gap index.
+6. `docs/DOCUMENTATION_INDEX.md` — current vs historical documentation map.
 
 Any PR or commit that changes runtime behavior must update `docs/PROJECT_STATUS_2026.md` and this roadmap if release scope changes.
+
+---
+
+## ARE Green-State release rule
+
+Release work must follow the Areloria truth-path rule:
+
+```text
+No mock truth.
+No fake snapshots.
+No workflow tricks.
+No stub systems in the truth path.
+No facade that replaces real runtime causality.
+```
+
+Allowed truth sources:
+
+```text
+Kappa1000
+Tick / logicalIndex
+Chunk / world position
+Hash / manifest / seed input
+Journal / delta / replay
+Real runtime providers
+Deterministic calculation
+Side-channel separation for IO, telemetry, repair and persistence
+```
 
 ---
 
@@ -18,46 +46,30 @@ Any PR or commit that changes runtime behavior must update `docs/PROJECT_STATUS_
 
 **Current state:** working browser-MMORPG foundation, not a finished commercial MMO.
 
-The repo now contains a serious live foundation: authoritative 10 Hz Node/WebSocket simulation, Vite/Babylon 3D client, PixiJS/React 2D client, server-authoritative gameplay modules, Supabase/Postgres/file persistence paths, optional Redis, deterministic manifest checks, admin content tools, autonomous playtester monitoring, and multiple live world systems.
+The repo now contains a serious live foundation: authoritative 10 Hz Node/WebSocket simulation, Vite/Babylon 3D client, PixiJS/React 2D client, server-authoritative gameplay modules, Supabase/Postgres/file persistence paths, optional Redis, deterministic manifest checks, admin content tools, autonomous playtester monitoring, and live world systems.
 
-The release focus is therefore no longer “prove the engine exists”. The focus is:
+Recent release-relevant progress:
 
-1. harden deterministic gameplay correctness,
-2. finish production deploy and backup discipline,
+- VPS game-data mount was fixed and live `/health` was verified.
+- NPC lineage now has journal, replay, surface projection and 2D worldSurface visibility.
+- Snapshot-time lineage birth bridge exists and can consume real runtime state.
+- Visible POI/Camp NPC data can feed lineage runtime state without fake NPCs.
+- Deterministic hardcode cleanup removed several runtime `Date.now()` / `Math.random()` violations.
+- Legacy loot table generation is quarantined; production loot truth remains `LootDirector -> ProceduralLootMachine -> loot_delta`.
+- PR #2036 is open to remove the public legacy-loot boolean bypass after Codex review.
+
+The release focus is now:
+
+1. finish deterministic correctness and hardcode cleanup,
+2. prove deploy, persistence, backup and live verification,
 3. complete player-facing UI coverage,
-4. stabilize mobile performance,
-5. replace placeholder content with audited assets,
-6. validate the whole loop through CI, E2E, replay, and live VPS verification.
-
-### 2026-06-13 release checkpoint
-
-The VPS deployment blocker caused by missing `game-data` inside the `arelorian-engine` container has been fixed and verified live.
-
-Verified chain:
-
-```text
-Host game-data exists
-→ docker-compose mounts ./game-data:/app/game-data:ro
-→ container sees /app/game-data
-→ NPCGameDataStore resolves npc/npcs.json
-→ arelorian-engine starts healthy
-→ /health reports ok
-→ external https://arelorian.de/health reports healthy
-```
-
-Observed runtime evidence:
-
-```text
-Container Status: Up (healthy)
-/health: {"ok":true,"status":"ok",...}
-Content root: "mode":"legacy","root":"/app/game-data"
-```
+4. stabilize mobile and browser performance,
+5. ship an audited release content pack,
+6. promote full-loop E2E/live smoke into a required release gate.
 
 ---
 
 ## Completed / live integrations
-
-These are considered implemented or wired enough to be tracked as live foundations. They can still need balancing, UI polish, load testing, or ops hardening.
 
 | Area | Status | Notes |
 |---|---:|---|
@@ -65,38 +77,20 @@ These are considered implemented or wired enough to be tracked as live foundatio
 | WebSocket networking | DONE | Server networking is wired through `server/src/networking/WebSocketServer.ts`. |
 | 3D client foundation | DONE | Vite + Babylon.js client remains the primary 3D path. |
 | 2D client foundation | DONE | PixiJS v7 + React client is active under `apps/client-2d/`. |
-| 2D interpolation | DONE | `InterpolatedSpriteManager` smooths 10 Hz server state toward render FPS with teleport snap and precision locking. |
 | Manifest system | DONE | Server-authoritative hash-chain state under `server/src/core/manifest/`, client divergence detection under `apps/client-2d/src/manifest/`, resync API at `/api/manifest/*`. |
-| Supabase auth path | DONE | Supabase JWT flow and client auth provider are documented as the active production path. |
-| Persistence drivers | DONE | `PERSISTENCE_DRIVER=auto/postgres/file`, JSON fallback, and health summary are wired. |
-| Redis optional path | DONE | Optional Redis cache/chat relay paths degrade gracefully when unset. |
-| Health endpoint | DONE | `/health` summarizes auth, persistence, playtester, self-healing, and content-root status. |
-| VPS game-data mount | DONE | `docker-compose.yml` mounts `./game-data:/app/game-data:ro`; live VPS health reports content root `/app/game-data`. |
-| Player movement/combat | DONE | Movement, target selection, attacks, skills, cooldown/mana, death/respawn are wired. |
-| Inventory/equipment/loot | DONE | Inventory stacks, equip/unequip, loot drops, pickup, and sync are active. |
-| Anti-Ninja Loot Lock | DONE | Loot ownership lock is active via `LootDirector` with 60-second / 600 tick kill lock. |
-| Player stats sync | DONE | `PlayerStatsDirector` broadcasts server-authoritative XP/level snapshots. |
-| Quest system | DONE | Quest start, progression, sync, talk/collect/combat updates are active. |
-| Questline system | DONE | Questline engine, bridge, and unlock propagation are wired. |
-| NPC runtime | DONE | `NPCSystem`, memory cache/persistence, relationships, proactive chat, game-data loading, and runtime language hooks are wired. |
-| Living Duden / NPC speech | DONE | Living Duden loads from `game-data/language`; 2D NPC interaction emits runtime `npc_dialogue` packets. |
-| Ouroboros agents | DONE | `OuroborosEngine` is instantiated and ticked from `WorldTick`. |
-| Chunk/world foundations | DONE | Chunks, observers, objects, weather/time, and terrain adapters are wired. |
-| Resource entities | DONE | Deterministic resource nodes are aligned through `ChunkModificationDirector` and `ResourcePopulator`. |
-| Storage system | DONE | `StorageEntity`, inventory, `open_storage`, and `transfer_item` handlers are wired. |
-| Warfront | DONE | `WarfrontSystem` lifecycle, status pushes, and reward claims are wired. |
-| World boss | DONE | `WorldBossDungeonSystem` encounter flow and ranking summaries are wired. |
-| Vote system | DONE | Vote banner/session/status and reward claims are wired. |
-| Crafting | DONE | Crafting handlers are wired through server message flow. |
-| Admin content tools | DONE | `/api/admin/content/*` routes and `/admin-content.html` are active. |
-| Playtester monitor | DONE | WebRTC monitor, signaling, viewer page, and publisher page are shipped. |
-| Gameplay Fusion Director | DONE | Quest echo beacons, adaptive quest scene profiles, and construction contracts are active. |
-| Content publish path | DONE | `pnpm run content:publish`, model-path audit, admin model needs, and GLB registry/pools are present. |
-| Pixi asset import scripts | DONE | Cozy/2D asset workflows are represented through import/validate scripts in root `package.json`. |
-| Monorepo/architecture guards | DONE | `guard:monorepo`, `guard:architecture`, `guard:worldtick`, and `guard:all` scripts exist. |
-| ARE deterministic primitives | DONE | `AREClock`, `SystemAREClock`, `FixedAREClock`, `ARERng`, `SeededARERng`, and `createARESeed` are documented primitives. |
-| Full-loop smoke proof | DONE / HARDENING | `e2e/full-loop-smoke.spec.ts` covers login, 2D world entry, snapshot, NPC/quest/movement/resource/combat/inventory checks, and reconnect. |
-| Determinism gate | DONE / HARDENING | Gate exists; Level A/B simulation paths still need strict migration verification before public release. |
+| Persistence drivers | DONE / HARDENING | `PERSISTENCE_DRIVER=auto/postgres/file`, JSON fallback, and health summary are wired; backup/restore proof remains open in #2039. |
+| VPS game-data mount | DONE | `docker-compose.yml` mounts `./game-data:/app/game-data:ro`; live VPS health reported content root `/app/game-data`. |
+| Player movement/combat | DONE / BALANCING | Movement, target selection, attacks, skills, cooldown/mana, death/respawn are wired. |
+| Inventory/equipment/loot | DONE / HARDENING | Inventory stacks, equip/unequip, loot drops, pickup, and sync are active; loot legacy path is quarantined. |
+| Canonical loot truth | DONE / HARDENING | `LootDirector -> ProceduralLootMachine -> loot_delta`; PR #2036 restricts legacy construction further. |
+| Quest and questlines | DONE / CONTENT | Quest start, progression, sync, talk/collect/combat updates and questline unlock propagation are active. |
+| NPC runtime | DONE / EXPANDING | NPC memory, relationships, proactive chat, game-data loading, Living Duden speech, lineage journal/replay and POI-driven lineage runtime state exist. |
+| Lineage worldSurface | DONE / 3D OPEN | Server journal/replay projects lineage houses/nodes into `worldSurface`; 2D consumes it; 3D rendering is tracked by #2046. |
+| Chunk/world foundations | DONE / HARDENING | Chunks, observers, objects, weather/time, terrain adapters and deterministic resource nodes are wired. |
+| Crafting/storage | DONE / UI HARDENING | Crafting and storage handlers are wired; full player-facing flow remains part of #2043 and #2048. |
+| Admin content tools | DONE / HARDENING | `/api/admin/content/*`, content publish path and model-path audit exist; release content pack tracked by #2044. |
+| Playtester monitor | DONE / REPORTING | WebRTC monitor, signaling, viewer page and publisher page are shipped; release observability tracked by #2049. |
+| ARE deterministic primitives | DONE | `AREClock`, fixed clocks, seeded RNG and `createARESeed` exist; remaining audit cleanup tracked by #2041. |
 
 ---
 
@@ -104,36 +98,28 @@ These are considered implemented or wired enough to be tracked as live foundatio
 
 These block a public release tag.
 
-| ID | Area | Release gap | Required outcome |
+| ID | Issue | Area | Required outcome |
 |---|---|---|---|
-| A1 | Production deploy verification | VPS deploy is now proven healthy after the game-data mount fix, but release still needs repeatable deploy verification after each deploy. | One green deploy workflow plus one green final verification workflow against `arelorian.de`, `/`, `/portal`, `/health`, `/client-config.json`, and WebSocket upgrade. |
-| A2 | Persistence + backups | Postgres migration, backup, restore, and rollback story must be operational, not only configurable. | Documented migration SOP, automated backup check, restore drill, and JSON fallback policy. |
-| A3 | Auth/session hardening | Supabase is the live path, but public launch needs strict session rules and dev bypass lockdown. | Production env rejects unintended guest/dev auth; rate limits and session expiry are tested. |
-| A4 | Deterministic simulation hardening | All Level A/B combat, loot, oracle, warfront, boss, and gameplay-result paths must avoid hidden wall-clock/randomness. | Determinism gate passes for simulation-critical paths; exceptions are documented and reviewed. |
-| A5 | Mobile performance | Android/tablet/browser startup and runtime cost must stay stable with real assets. | Measured FPS/memory/startup budget, chunk loading budget, and fallback quality levels. |
-| A6 | Player-facing UI coverage | Many systems exist server-side, but not every critical action has clear player UI. | Quest tracker, map, settings, combat log, inventory/equipment, storage, crafting, voting, warfront, boss, and death/respawn flows usable without dev knowledge. |
-| A7 | Release content pack | Placeholder or broken assets must not be part of the first public impression. | Audited `published-content/current` pack with model-path audit green and asset licenses tracked. |
-| A8 | Smoke/E2E release gate | Full-loop smoke coverage now exists, but release still requires it to run as a stable required gate on every release candidate. | `pnpm run build`, `pnpm run guard:all`, model audit, unit tests, E2E smoke, deploy verification, and live health checks are green on the release commit. |
+| A1 | #2038 | Production deploy verification | One green deploy workflow plus live verification against `/`, `/portal`, `/health`, `/client-config.json`, and WebSocket upgrade. |
+| A2 | #2039 | Persistence + backups | Migration SOP, backup proof, restore proof and JSON fallback policy. |
+| A3 | #2040 | Auth/session hardening | Production env rejects unintended guest/dev auth; sessions and rate limits are tested. |
+| A4 | #2041 | Deterministic simulation hardening | Stateless Hardcode Audit and ARE Determinism Gate pass for runtime-critical paths. |
+| A5 | #2042 | Mobile/browser performance | FPS, memory, startup and chunk-loading budgets are measured with real assets. |
+| A6 | #2043 | Player-facing UI coverage | Critical systems are usable through server-backed UI flows without dev knowledge. |
+| A7 | #2044 | Release content pack | Audited `published-content/current` pack with licenses and model-path audit proof. |
+| A8 | #2045 | Full-loop release gate | Build, guards, model audit, unit tests, E2E, deploy verify and live health are green on release commit. |
 
 ---
 
-## Tier B — major open work
+## Tier B — open integration work
 
-These do not necessarily block a closed alpha, but they define whether the project feels like a real MMORPG instead of a tech demo.
-
-| System | Current | Remaining |
+| Issue | Integration | Required direction |
 |---|---|---|
-| Combat and skills | Server-authoritative combat, skills, cooldown/mana, loot and respawn are wired. | Balance stamina/mana/XP curves, improve combat feedback, revive/party edge cases, boss telegraphs, and combat log clarity. |
-| Quest and questlines | Quest/questline systems are active, with fusion echo hooks. | Add richer objective summaries, map pins, quest tracker, branching outcomes, and QA fixtures for multi-step chains. |
-| NPC autonomy | NPC system, memory, relationships, proactive chat, personality beta, game-data loading, Living Duden speech path, and deterministic genealogy (FamilyHouseRegistry) exist. | Expand deterministic behavior scenarios, bounded shared memory, reputation effects, refusal/help rules, faction memory, and large-NPC load budgets. |
-| Civilization | Bible defines guild -> village -> city -> kingdom -> nation and equal NPC/player civic rights. | Implement settlement lifecycle, law/tax/election flows, NPC/player political parity, territory/biome borders, and protected structure policies. |
-| Economy and Matrix Energy | Economy/Matrix are design pillars; construction contracts are active. | Implement deterministic local markets, scarcity pricing, taxes, trade routes, Matrix Energy sinks/sources, and public works budget flow. |
-| World systems | Chunks, resources, weather/time, terrain adapters, world objects, warfronts, and bosses are wired. | Expand biome depth, dungeon templates, ecological pressure, migration triggers, world boss distance constraints, and streaming boundary tests. |
-| Crafting/storage/trading | Crafting and storage handlers are wired. | Finish UI, permissions, recipe discovery, item provenance, player trading, anti-duplication checks, and audit logs. |
-| Admin/GM content | Admin content API, content page, model needs, publish pack, and audits are active. | Improve audit transparency, content rollback, live moderation tools, edit history, and safe publish preview. |
-| Playtester monitor | WebRTC viewer/publisher and signaling are shipped. | Add stream-health dashboard, alerting, run history, deterministic scenario packs, and release-report export. |
-| Self-healing/runtime safeguards | Health endpoint includes self-healing summary; liveheal docs and patterns exist. | Tie safeguards to release dashboards, quarantine broken GLB/assets, add city-layout validators, and keep repair telemetry outside simulation truth. |
-| Observability | `/health` exists and live VPS verification has proven content-root visibility. | Add SLOs for tick duration, WebSocket load, manifest divergence, playtester stream health, persistence failures, and asset audit failures. |
+| #2046 | 3D lineage worldSurface rendering | 3D client consumes the same server `worldSurface.groups/points` contract as 2D. |
+| #2050 | Runtime civic state | Shared world state derives from tick, house data, population counters and server snapshot. |
+| #2047 | Runtime market pricing | Prices derive from live resource counters, tick and deterministic hash logic. |
+| #2048 | Item provenance / trading / anti-duplication | Item movement uses real uid, source delta, tick/hash audit and server-authoritative inventory. |
+| #2049 | Runtime observability and release SLOs | Tick duration, WS load, manifest divergence, persistence failures, asset audit failures and playtester status are visible. |
 
 ---
 
@@ -150,20 +136,19 @@ These do not necessarily block a closed alpha, but they define whether the proje
 
 ## Planned / vision integrations after release foundation
 
-These belong after the release blockers are controlled, unless a small isolated PR can land safely.
+These belong after release blockers are controlled, unless a small isolated PR can land safely.
 
 | Integration | Target direction | Status |
 |---|---|---|
-| Genealogy and houses | NPC family lines, inheritance, house reputation, and deterministic lineage history. | ✅ **IMPLEMENTED** - `FamilyHouseRegistry.ts`, `NPCCoupleEligibilityEngine`, `DescendantArchetypeEngine`, deterministic `lineageHash`, sim-tick-based `birthTick`, population pressure cap. See `server/src/modules/npc/FamilyHouseRegistry.ts` |
-| Full NPC politics | NPCs vote, tax, declare war, negotiate peace, appoint rulers, rebel, and join/found factions. | Planned |
-| Guild/village/city/kingdom/nation hierarchy | Rule-bound civilization growth from player/NPC organizations through biome-bounded territories. | Planned |
-| Deep economy simulation | Supply/demand, scarcity, taxes, trade routes, public works, war pressure, and NPC merchant personality. |
-| Matrix Energy | Player-facing world/building energy loop with deterministic accounting and protected paid-asset policy. |
-| Housing and protected structures | Build permissions, placement validation, road/wall/gate constraints, ownership, protection tiers, and PvP/world-event policy. |
-| Procedural dungeons | Deterministic dungeon generation, boss distance rules, reward tables, replay-safe seeds, and party flow. |
-| ARE research extensions | Kappa-field replay, AREGuard proof reports, state compression, resonance/plexity scheduling, and deterministic anomaly zones. |
-| 13-point World Brain | Global directive vector from resources, population, conflict, environment, politics, market, culture, threats, opportunities, echoes, oracle resonance, and center aggregator. |
-| Future event layers | Aetheric Leylines, Chronos Anomaly zones, Void Swarm incursions, reality fissures, and oracle-driven world events. |
+| Genealogy and houses | NPC family lines, inheritance, house reputation and deterministic lineage history. | Implemented foundation; 3D rendering open in #2046. |
+| Full NPC politics | NPCs and players participate in shared civic rules. | Future; must build on #2050, not a mock layer. |
+| Guild/village/city/kingdom/nation hierarchy | Rule-bound civilization growth through biome-bounded territories. | Future; must derive from server runtime state. |
+| Deep economy simulation | Supply/demand, scarcity, taxes, trade routes, public works and merchant behavior. | Open foundation in #2047. |
+| Matrix Energy | Player-facing world/building energy loop with deterministic accounting. | Future; must share accounting rules with #2047. |
+| Housing and protected structures | Build permissions, placement validation, ownership and protection tiers. | Future; must not bypass layout validation. |
+| Procedural dungeons | Deterministic dungeon generation, boss distance rules, reward tables and party flow. | Future; must use tick/chunk/hash seeds. |
+| ARE research extensions | Kappa-field replay, AREGuard proof reports, state compression and anomaly scheduling. | Future. |
+| 13-point World Brain | Global directive vector from resources, population, conflict, environment, market and culture. | Future; must consume real runtime signals only. |
 
 ---
 
@@ -194,7 +179,7 @@ Release CI should additionally include:
 - content publish dry-run,
 - VPS deploy verification,
 - live `/health` verification that reports content root `/app/game-data`,
-- restore-drill proof for persistence backups.
+- backup/restore proof for persistence.
 
 ---
 
@@ -208,8 +193,8 @@ Any auth, persistence, infra, deploy, gameplay, or architecture change must be r
 - `README_START_HERE.md`
 - `docs/PROJECT_STATUS_2026.md`
 - `docs/ROADMAP_TO_RELEASE.md`
+- `docs/RELEASE_CHECKLIST.md`
 - `docs/DOCUMENTATION_INDEX.md`
-- `docs/MASTER_DESIGN_BIBLE.md` only when the vision changes
 - `DEPLOYMENT.md`
 - `deploy/ENV_SETUP.md`
 - `.env.example` / production env templates when config changes
@@ -218,16 +203,15 @@ Any auth, persistence, infra, deploy, gameplay, or architecture change must be r
 
 ## Immediate next release sequence
 
-1. Green local build + guards.
-2. Green deterministic gate for Level A/B simulation paths.
-3. Green content/model/asset audits.
-4. Green E2E smoke with guest/login, movement, interaction, combat, loot, quest sync, and WebSocket reconnect.
-5. DONE 2026-06-13: VPS Docker container starts healthy after `game-data` mount fix.
-6. DONE 2026-06-13: Live external `/health` verification confirms healthy response and content root `/app/game-data`.
-7. Promote full-loop E2E smoke into a stable required release gate.
-8. Backup and restore drill recorded.
-9. Public alpha release notes prepared.
+1. Merge #2036 if CI is green to close the legacy-loot constructor bypass.
+2. Finish #2041 deterministic audit cleanup.
+3. Prove #2038 deploy/live verification.
+4. Prove #2039 backup/restore.
+5. Harden #2040 production auth/session rules.
+6. Make #2045 full-loop E2E and live smoke a required release gate.
+7. Complete #2044 release content pack audit.
+8. Prepare public alpha release notes.
 
 ---
 
-Last refreshed: 2026-06-13
+Last refreshed: 2026-06-15


### PR DESCRIPTION
## Summary

Updates the source-of-truth release docs after the latest runtime integrations and creates/links the open release and integration issues.

Updated docs:

- `docs/ROADMAP_TO_RELEASE.md`
- `docs/RELEASE_CHECKLIST.md`
- `docs/KNOWN_GAPS.md`
- `docs/PROJECT_STATUS_2026.md`

New issue references included:

- #2038 deploy/live verification
- #2039 persistence backup/restore proof
- #2040 auth/session hardening
- #2041 deterministic audit cleanup
- #2042 performance budget
- #2043 player-facing UI coverage
- #2044 release content pack audit
- #2045 full-loop release gate
- #2046 3D lineage worldSurface rendering
- #2047 runtime market pricing
- #2048 item provenance/trading audit
- #2049 runtime observability
- #2050 runtime civic state

## ARE Notes

Docs now explicitly state: no mock truth, no fake snapshots, no workflow tricks, no stubs in the truth path, and no facade replacing real ARE causality.