### PR TITLE
docs(release): restore 2d deploy verification

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -73,6 +73,7 @@ Tracked by #2038.
 | `/health` | real healthy response | ☐ |
 | `/client-config.json` | valid JSON | ☐ |
 | `/` | page response | ☐ |
+| `/2d` | primary 2D client page/boot response | ☐ |
 | `/portal` | portal response | ☐ |
 | WebSocket upgrade | accepted upgrade | ☐ |
 | Container | running and healthy | ☐ |


### PR DESCRIPTION
## Summary

Restores the `/2d` production deploy verification row in `docs/RELEASE_CHECKLIST.md`.

## Fixes

Addresses Codex review comment from #2051: https://github.com/OuroborosCollective/Wasd/pull/2051#discussion_r3410747418

## ARE Notes

No mock truth, no fake snapshots, no workflow tricks. This is documentation-only and keeps the release gate aligned with the real 2D-first runtime path.