### PR TITLE
docs(release): complete mobile browser performance budget gate

### DIFF
--- a/docs/KNOWN_GAPS.md
+++ b/docs/KNOWN_GAPS.md
@@ -12,10 +12,15 @@ Use `docs/ROADMAP_TO_RELEASE.md` as the authoritative backlog and `docs/PROJECT_
 - #2039 — persistence backup and restore proof
 - #2040 — production auth and session hardening
 - #2041 — remaining deterministic audit violations
-- #2042 — mobile and browser performance budget
 - #2043 — player-facing UI coverage for critical gameplay
 - #2044 — audited release content pack and asset license proof
 - #2045 — required full-loop E2E and release smoke gate
+
+---
+
+## Release gates now documented
+
+- #2042 — mobile/browser performance budget: 2D and 3D startup, FPS, p95 frame, memory, chunk-load, fallback-tier and runtime-asset evidence requirements are now part of `docs/RELEASE_CHECKLIST.md`.
 
 ---
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -127,12 +127,23 @@ Tracked by #2043.
 
 ## 8. Performance and Observability
 
-| Check | Status | Issue |
-|---|---|---:|
-| Startup/FPS/memory budget | ☐ | #2042 |
-| Runtime metrics dashboard | ☐ | #2049 |
-| Playtester stream health | ☐ | #2049 |
-| Asset audit failures visible | ☐ | #2049 |
+Performance budget evidence for #2042 must use real runtime assets and must include separate 2D and 3D measurements. If any standard budget is exceeded, the release is blocked unless the report records the real fallback tier, reason, and post-fallback metrics.
+
+| Check | Required measurement | Budget / rule | Status | Issue |
+|---|---|---|---|---:|
+| 2D startup | `/2d` startup time | <= 5000 ms standard, <= 6500 ms fallback | ☐ | #2042 |
+| 2D FPS | average FPS and p95 frame time | >= 50 FPS and <= 34 ms p95, or >= 40 FPS and <= 42 ms fallback | ☐ | #2042 |
+| 2D memory | runtime memory with real assets | <= 512 MB standard, <= 640 MB fallback | ☐ | #2042 |
+| 2D chunk loading | p95 chunk-load time | <= 1200 ms standard, <= 1800 ms fallback | ☐ | #2042 |
+| 3D startup | 3D client or `/portal` startup time | <= 9000 ms standard, <= 12000 ms fallback | ☐ | #2042 |
+| 3D FPS | average FPS and p95 frame time | >= 30 FPS and <= 50 ms p95, or >= 24 FPS and <= 67 ms fallback | ☐ | #2042 |
+| 3D memory | runtime memory with real assets | <= 1200 MB standard, <= 1600 MB fallback | ☐ | #2042 |
+| 3D chunk loading | p95 chunk/world-load time | <= 2500 ms standard, <= 3500 ms fallback | ☐ | #2042 |
+| Runtime metrics dashboard | tick duration, WS load, manifest divergence, persistence failures | visible in release evidence | ☐ | #2049 |
+| Playtester stream health | live playtester status | visible in release evidence | ☐ | #2049 |
+| Asset audit failures visible | content/model audit failure reporting | visible in release evidence | ☐ | #2049 |
+
+Required #2042 evidence fields: release commit, content root, asset manifest hash, measured route, device class, tick window, startup time, average FPS, p95 frame time, memory use, p95 chunk-load time, fallback tier, and fallback reason when fallback is active.
 
 ---
 

--- a/docs/ROADMAP_TO_RELEASE.md
+++ b/docs/ROADMAP_TO_RELEASE.md
@@ -57,13 +57,14 @@ Recent release-relevant progress:
 - Deterministic hardcode cleanup removed several runtime `Date.now()` / `Math.random()` violations.
 - Legacy loot table generation is quarantined; production loot truth remains `LootDirector -> ProceduralLootMachine -> loot_delta`.
 - PR #2036 is open to remove the public legacy-loot boolean bypass after Codex review.
+- The #2042 mobile/browser performance budget now has explicit 2D and 3D release measurements in `docs/RELEASE_CHECKLIST.md`.
 
 The release focus is now:
 
 1. finish deterministic correctness and hardcode cleanup,
 2. prove deploy, persistence, backup and live verification,
 3. complete player-facing UI coverage,
-4. stabilize mobile and browser performance,
+4. collect real mobile/browser performance evidence against the documented #2042 budgets,
 5. ship an audited release content pack,
 6. promote full-loop E2E/live smoke into a required release gate.
 
@@ -91,6 +92,7 @@ The release focus is now:
 | Admin content tools | DONE / HARDENING | `/api/admin/content/*`, content publish path and model-path audit exist; release content pack tracked by #2044. |
 | Playtester monitor | DONE / REPORTING | WebRTC monitor, signaling, viewer page and publisher page are shipped; release observability tracked by #2049. |
 | ARE deterministic primitives | DONE | `AREClock`, fixed clocks, seeded RNG and `createARESeed` exist; remaining audit cleanup tracked by #2041. |
+| Performance budget | DONE / EVIDENCE REQUIRED | #2042 budgets are documented in `docs/RELEASE_CHECKLIST.md`; release sign-off requires real 2D and 3D runtime metrics plus fallback proof when needed. |
 
 ---
 
@@ -100,11 +102,11 @@ These block a public release tag.
 
 | ID | Issue | Area | Required outcome |
 |---|---|---|---|
-| A1 | #2038 | Production deploy verification | One green deploy workflow plus live verification against `/`, `/portal`, `/health`, `/client-config.json`, and WebSocket upgrade. |
+| A1 | #2038 | Production deploy verification | One green deploy workflow plus live verification against `/`, `/2d`, `/portal`, `/health`, `/client-config.json`, and WebSocket upgrade. |
 | A2 | #2039 | Persistence + backups | Migration SOP, backup proof, restore proof and JSON fallback policy. |
 | A3 | #2040 | Auth/session hardening | Production env rejects unintended guest/dev auth; sessions and rate limits are tested. |
 | A4 | #2041 | Deterministic simulation hardening | Stateless Hardcode Audit and ARE Determinism Gate pass for runtime-critical paths. |
-| A5 | #2042 | Mobile/browser performance | FPS, memory, startup and chunk-loading budgets are measured with real assets. |
+| A5 | #2042 | Mobile/browser performance | 2D and 3D startup, FPS, p95 frame, memory and chunk-load budgets are documented; release sign-off is blocked unless real metrics meet standard budget or record a real fallback tier and reason. |
 | A6 | #2043 | Player-facing UI coverage | Critical systems are usable through server-backed UI flows without dev knowledge. |
 | A7 | #2044 | Release content pack | Audited `published-content/current` pack with licenses and model-path audit proof. |
 | A8 | #2045 | Full-loop release gate | Build, guards, model audit, unit tests, E2E, deploy verify and live health are green on release commit. |
@@ -179,6 +181,8 @@ Release CI should additionally include:
 - content publish dry-run,
 - VPS deploy verification,
 - live `/health` verification that reports content root `/app/game-data`,
+- real 2D and 3D performance evidence for startup, FPS, p95 frame time, memory and chunk loading,
+- fallback-tier evidence when either client exceeds the standard #2042 budget,
 - backup/restore proof for persistence.
 
 ---
@@ -208,9 +212,10 @@ Any auth, persistence, infra, deploy, gameplay, or architecture change must be r
 3. Prove #2038 deploy/live verification.
 4. Prove #2039 backup/restore.
 5. Harden #2040 production auth/session rules.
-6. Make #2045 full-loop E2E and live smoke a required release gate.
-7. Complete #2044 release content pack audit.
-8. Prepare public alpha release notes.
+6. Collect #2042 real 2D/3D performance evidence against the documented budgets.
+7. Make #2045 full-loop E2E and live smoke a required release gate.
+8. Complete #2044 release content pack audit.
+9. Prepare public alpha release notes.
 
 ---
 


### PR DESCRIPTION
## Summary

Completes the #2042 release-budget documentation gate:

- adds explicit 2D and 3D startup/FPS/frame/memory/chunk-load budget rows to `docs/RELEASE_CHECKLIST.md`
- defines required runtime evidence fields: commit, content root, asset manifest hash, measured route, device class, tick window and fallback metadata
- documents the release rule that standard budget overruns block release unless a real fallback tier, reason and post-fallback metrics are recorded
- updates the release roadmap and known gaps index to reflect the documented gate

Closes #2042