### PR TITLE
feat(snapshot): derive runtime civic state from world surface

### DIFF
--- a/docs/KNOWN_GAPS.md
+++ b/docs/KNOWN_GAPS.md
@@ -24,10 +24,15 @@ Use `docs/ROADMAP_TO_RELEASE.md` as the authoritative backlog and `docs/PROJECT_
 
 ---
 
+## Integrated runtime points
+
+- #2050 — runtime civic state is derived from server `worldSurface` tick, house groups and lineage/citizen points, then exposed on the live gameplay snapshot as `civicState`.
+
+---
+
 ## Open integration points
 
 - #2046 — render lineage `worldSurface` in the 3D client
-- #2050 — runtime civic state from tick and house data
 - #2047 — runtime market pricing from resource state
 - #2048 — item provenance, trading and anti-duplication audit
 - #2049 — runtime observability and release SLO dashboard

--- a/server/src/gameplay/LiveGameplaySnapshotComposer.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotComposer.ts
@@ -30,6 +30,8 @@ import type {
   LiveGameplayNpcMemory,
   LiveGameplayNpcRumor,
   LiveGameplayWorldSurface,
+  LiveGameplayCivicState,
+  LiveGameplayCivicPressure,
 } from "./LiveGameplaySnapshotTypes.js";
 import { EMPTY_LIVE_GAMEPLAY_WORLD_SURFACE } from "./LiveGameplaySnapshotTypes.js";
 import { RESOURCE_SELL_PRICES } from "../economy/ResourceSellPrices.js";
@@ -129,6 +131,7 @@ export class LiveGameplaySnapshotComposer {
     const worldSurface = this.deps.getWorldSurface
       ? await this.deps.getWorldSurface(playerId, safeLogicalIndex)
       : EMPTY_LIVE_GAMEPLAY_WORLD_SURFACE;
+    const civicState = buildCivicStateFromWorldSurface(safeLogicalIndex, worldSurface);
 
     return Object.freeze({
       schemaVersion: "live-gameplay-snapshot.v1" as const,
@@ -157,6 +160,7 @@ export class LiveGameplaySnapshotComposer {
       npcMemories: Object.freeze([...npcMemories].sort((a, b) => a.npcId.localeCompare(b.npcId))),
       npcRumors: Object.freeze([...npcRumors].sort((a, b) => a.rumorId.localeCompare(b.rumorId))),
       worldSurface: Object.freeze(worldSurface),
+      civicState: Object.freeze(civicState),
     });
   }
 
@@ -208,5 +212,87 @@ export function buildVendorEconomySnapshot(
         prices: Object.freeze(prices),
       }),
     ]),
+  });
+}
+
+type SurfaceEntry = Record<string, unknown>;
+
+function isSurfaceEntry(value: unknown): value is SurfaceEntry {
+  return typeof value === "object" && value !== null;
+}
+
+function textField(entry: SurfaceEntry, key: string): string {
+  const value = entry[key];
+  return typeof value === "string" ? value : "";
+}
+
+function surfaceIdentity(entry: unknown, fallback: string): string {
+  if (!isSurfaceEntry(entry)) return fallback;
+  return textField(entry, "id") || textField(entry, "houseId") || textField(entry, "npcId") || textField(entry, "lineageId") || fallback;
+}
+
+function surfaceKind(entry: unknown): string {
+  if (!isSurfaceEntry(entry)) return "";
+  return textField(entry, "kind") || textField(entry, "type") || textField(entry, "role");
+}
+
+function isHouseGroup(entry: unknown): boolean {
+  const key = `${surfaceIdentity(entry, "")}:${surfaceKind(entry)}`.toLowerCase();
+  return key.includes("house") || key.includes("settlement") || key.includes("home");
+}
+
+function isPopulationPoint(entry: unknown): boolean {
+  const key = `${surfaceIdentity(entry, "")}:${surfaceKind(entry)}`.toLowerCase();
+  return key.includes("npc") || key.includes("lineage") || key.includes("citizen") || key.includes("resident");
+}
+
+function fnv1a32(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+function pressureFor(population: number, capacity: number, occupancyPermille: number): LiveGameplayCivicPressure {
+  if (population <= 0 || capacity <= 0) return "empty";
+  if (occupancyPermille > 1000) return "over_capacity";
+  if (occupancyPermille >= 750) return "crowded";
+  return "settled";
+}
+
+export function buildCivicStateFromWorldSurface(
+  logicalIndex: number,
+  worldSurface: LiveGameplayWorldSurface,
+): LiveGameplayCivicState {
+  const tick = Number.isSafeInteger(logicalIndex) && logicalIndex >= 0 ? logicalIndex : 0;
+  const groups = [...(worldSurface.groups ?? [])];
+  const points = [...(worldSurface.points ?? [])];
+  const houseKeys = groups
+    .filter(isHouseGroup)
+    .map((entry, index) => surfaceIdentity(entry, `house:${index}`))
+    .sort();
+  const populationKeys = points
+    .filter(isPopulationPoint)
+    .map((entry, index) => surfaceIdentity(entry, `population:${index}`))
+    .sort();
+
+  const houseCount = houseKeys.length;
+  const population = populationKeys.length;
+  const capacity = houseCount * 4;
+  const occupancyPermille = capacity > 0 ? Math.floor((population * 1000) / capacity) : 0;
+  const pressure = pressureFor(population, capacity, occupancyPermille);
+  const civicHash = `civic:${fnv1a32(`${tick}|${houseKeys.join(",")}|${populationKeys.join(",")}`)}`;
+
+  return Object.freeze({
+    schemaVersion: "civic-state.v1" as const,
+    tick,
+    houseCount,
+    population,
+    capacity,
+    occupancyPermille,
+    pressure,
+    civicHash,
   });
 }

--- a/server/src/gameplay/LiveGameplaySnapshotTypes.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotTypes.ts
@@ -214,6 +214,30 @@ export const EMPTY_LIVE_GAMEPLAY_WORLD_SURFACE: LiveGameplayWorldSurface = Objec
   points: Object.freeze([]),
 });
 
+export type LiveGameplayCivicPressure = "empty" | "settled" | "crowded" | "over_capacity";
+
+export interface LiveGameplayCivicState {
+  readonly schemaVersion: "civic-state.v1";
+  readonly tick: number;
+  readonly houseCount: number;
+  readonly population: number;
+  readonly capacity: number;
+  readonly occupancyPermille: number;
+  readonly pressure: LiveGameplayCivicPressure;
+  readonly civicHash: string;
+}
+
+export const EMPTY_LIVE_GAMEPLAY_CIVIC_STATE: LiveGameplayCivicState = Object.freeze({
+  schemaVersion: "civic-state.v1",
+  tick: 0,
+  houseCount: 0,
+  population: 0,
+  capacity: 0,
+  occupancyPermille: 0,
+  pressure: "empty",
+  civicHash: "civic:00000000",
+});
+
 export interface LiveGameplaySnapshot {
   readonly schemaVersion: "live-gameplay-snapshot.v1";
   readonly playerId: string;
@@ -241,6 +265,7 @@ export interface LiveGameplaySnapshot {
   readonly npcMemories: readonly LiveGameplayNpcMemory[];
   readonly npcRumors: readonly LiveGameplayNpcRumor[];
   readonly worldSurface: LiveGameplayWorldSurface;
+  readonly civicState: LiveGameplayCivicState;
 }
 
 export interface GatherResult {

--- a/server/src/tests/LiveGameplayWorldSurface.test.ts
+++ b/server/src/tests/LiveGameplayWorldSurface.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { LiveGameplaySnapshotComposer } from "../gameplay/LiveGameplaySnapshotComposer.js";
+import {
+  LiveGameplaySnapshotComposer,
+  buildCivicStateFromWorldSurface,
+} from "../gameplay/LiveGameplaySnapshotComposer.js";
 
 function createComposer(overrides: Partial<ConstructorParameters<typeof LiveGameplaySnapshotComposer>[0]> = {}) {
   return new LiveGameplaySnapshotComposer({
@@ -22,6 +25,15 @@ describe("LiveGameplaySnapshotComposer worldSurface", () => {
       groups: [],
       points: [],
     });
+    expect(snapshot.civicState).toMatchObject({
+      schemaVersion: "civic-state.v1",
+      tick: 12,
+      houseCount: 0,
+      population: 0,
+      capacity: 0,
+      occupancyPermille: 0,
+      pressure: "empty",
+    });
   });
 
   it("includes server-authoritative world surface from deps", async () => {
@@ -37,5 +49,61 @@ describe("LiveGameplaySnapshotComposer worldSurface", () => {
     expect(snapshot.worldSurface.tick).toBe(42);
     expect(snapshot.worldSurface.groups).toHaveLength(1);
     expect(snapshot.worldSurface.points).toHaveLength(1);
+    expect(snapshot.civicState).toMatchObject({
+      tick: 42,
+      houseCount: 1,
+      population: 1,
+      capacity: 4,
+      occupancyPermille: 250,
+      pressure: "settled",
+    });
+  });
+
+  it("replays the same civic state for the same inputs", () => {
+    const surface = {
+      schemaVersion: "world-surface-model.v1" as const,
+      tick: 88,
+      groups: [
+        { id: "house_b", kind: "lineage_house" },
+        { id: "house_a", kind: "lineage_house" },
+      ],
+      points: [
+        { id: "lineage_b", kind: "lineage_node" },
+        { id: "lineage_a", kind: "lineage_node" },
+      ],
+    };
+
+    const first = buildCivicStateFromWorldSurface(88, surface);
+    const replay = buildCivicStateFromWorldSurface(88, {
+      ...surface,
+      groups: [...surface.groups].reverse(),
+      points: [...surface.points].reverse(),
+    });
+
+    expect(replay).toEqual(first);
+    expect(first.civicHash.startsWith("civic:")).toBe(true);
+  });
+
+  it("reports pressure when population is greater than capacity", () => {
+    const civicState = buildCivicStateFromWorldSurface(101, {
+      schemaVersion: "world-surface-model.v1",
+      tick: 101,
+      groups: [{ id: "house_1", kind: "lineage_house" }],
+      points: [
+        { id: "lineage_1", kind: "lineage_node" },
+        { id: "lineage_2", kind: "lineage_node" },
+        { id: "lineage_3", kind: "lineage_node" },
+        { id: "lineage_4", kind: "lineage_node" },
+        { id: "lineage_5", kind: "lineage_node" },
+      ],
+    });
+
+    expect(civicState).toMatchObject({
+      houseCount: 1,
+      population: 5,
+      capacity: 4,
+      occupancyPermille: 1250,
+      pressure: "over_capacity",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds runtime civic state to the live gameplay snapshot.

- extends the server snapshot contract with `civicState`
- derives house count, population, capacity, occupancy, pressure and civic hash from `worldSurface` plus logical tick
- adds tests for deterministic replay and population/capacity limits
- updates the known gaps index to mark #2050 integrated

Closes #2050