### PR TITLE
feat(snapshot): derive runtime market state from resources

### DIFF
--- a/docs/KNOWN_GAPS.md
+++ b/docs/KNOWN_GAPS.md
@@ -27,13 +27,13 @@ Use `docs/ROADMAP_TO_RELEASE.md` as the authoritative backlog and `docs/PROJECT_
 ## Integrated runtime points
 
 - #2050 — runtime civic state is derived from server `worldSurface` tick, house groups and lineage/citizen points, then exposed on the live gameplay snapshot as `civicState`.
+- #2047 — runtime market pricing is derived from resource nodes and camp stock counters, then exposed on the live gameplay snapshot as `marketState`.
 
 ---
 
 ## Open integration points
 
 - #2046 — render lineage `worldSurface` in the 3D client
-- #2047 — runtime market pricing from resource state
 - #2048 — item provenance, trading and anti-duplication audit
 - #2049 — runtime observability and release SLO dashboard
 

--- a/server/src/gameplay/LiveGameplaySnapshotComposer.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotComposer.ts
@@ -32,6 +32,7 @@ import type {
   LiveGameplayWorldSurface,
   LiveGameplayCivicState,
   LiveGameplayCivicPressure,
+  LiveGameplayMarketState,
 } from "./LiveGameplaySnapshotTypes.js";
 import { EMPTY_LIVE_GAMEPLAY_WORLD_SURFACE } from "./LiveGameplaySnapshotTypes.js";
 import { RESOURCE_SELL_PRICES } from "../economy/ResourceSellPrices.js";
@@ -132,6 +133,7 @@ export class LiveGameplaySnapshotComposer {
       ? await this.deps.getWorldSurface(playerId, safeLogicalIndex)
       : EMPTY_LIVE_GAMEPLAY_WORLD_SURFACE;
     const civicState = buildCivicStateFromWorldSurface(safeLogicalIndex, worldSurface);
+    const marketState = buildMarketStateFromRuntimeInputs(safeLogicalIndex, resourceNodes, campStocks);
 
     return Object.freeze({
       schemaVersion: "live-gameplay-snapshot.v1" as const,
@@ -146,6 +148,7 @@ export class LiveGameplaySnapshotComposer {
       wallet: Object.freeze(wallet),
       worldPois: Object.freeze([...worldPois].sort((a, b) => a.poiId.localeCompare(b.poiId))),
       vendorEconomy: Object.freeze(vendorEconomy),
+      marketState: Object.freeze(marketState),
       discoveryStats: Object.freeze(discoveryStats),
       recentDiscoveries: Object.freeze([...recentDiscoveries]),
       campNpcs: Object.freeze([...campNpcs].sort((a, b) => a.id.localeCompare(b.id))),
@@ -294,5 +297,68 @@ export function buildCivicStateFromWorldSurface(
     occupancyPermille,
     pressure,
     civicHash,
+  });
+}
+
+function normalizeResourceItemId(resourceId: string): string {
+  const id = resourceId.trim().toLowerCase();
+  if (id === "tree" || id === "wood" || id === "wood_log") return "wood_log";
+  if (id === "ore" || id === "copper" || id === "copper_ore") return "copper_ore";
+  if (id === "fish" || id === "raw_fish") return "raw_fish";
+  return id;
+}
+
+function addCount(counts: Map<string, number>, itemId: string, quantity: number): void {
+  if (!Number.isFinite(quantity) || quantity <= 0) return;
+  if (!(itemId in RESOURCE_SELL_PRICES)) return;
+  counts.set(itemId, (counts.get(itemId) ?? 0) + Math.floor(quantity));
+}
+
+export function buildMarketStateFromRuntimeInputs(
+  logicalIndex: number,
+  resourceNodes: readonly LiveGameplayResourceNode[],
+  campStocks: readonly LiveGameplayCampStock[],
+): LiveGameplayMarketState {
+  const tick = Number.isSafeInteger(logicalIndex) && logicalIndex >= 0 ? logicalIndex : 0;
+  const stockCounts = new Map<string, number>();
+  const nodeCounts = new Map<string, number>();
+
+  for (const stock of campStocks) {
+    for (const item of stock.items) {
+      addCount(stockCounts, item.itemId, item.quantity);
+    }
+  }
+
+  for (const node of resourceNodes) {
+    if (!node.available) continue;
+    const itemId = normalizeResourceItemId(node.resourceId);
+    addCount(nodeCounts, itemId, 1);
+  }
+
+  const prices = Object.keys(RESOURCE_SELL_PRICES)
+    .sort()
+    .map((itemId) => {
+      const resourceNodeCount = nodeCounts.get(itemId) ?? 0;
+      const availableQuantity = (stockCounts.get(itemId) ?? 0) + resourceNodeCount;
+      const priceInfo = calculateDynamicPrice(itemId, availableQuantity);
+      return Object.freeze({
+        itemId,
+        availableQuantity,
+        unitPrice: priceInfo.unitPrice,
+        basePrice: priceInfo.basePrice,
+        demandBand: priceInfo.demandBand,
+        resourceNodeCount,
+      });
+    });
+  const hashInput = prices
+    .map((price) => `${price.itemId}:${price.availableQuantity}:${price.unitPrice}:${price.demandBand}:${price.resourceNodeCount}`)
+    .join("|");
+  const marketHash = `market:${fnv1a32(`${tick}|${hashInput}`)}`;
+
+  return Object.freeze({
+    schemaVersion: "market-state.v1" as const,
+    tick,
+    prices: Object.freeze(prices),
+    marketHash,
   });
 }

--- a/server/src/gameplay/LiveGameplaySnapshotTypes.ts
+++ b/server/src/gameplay/LiveGameplaySnapshotTypes.ts
@@ -157,6 +157,29 @@ export interface LiveGameplayVendorEconomySnapshot {
   readonly vendors: readonly LiveGameplayVendorEconomy[];
 }
 
+export interface LiveGameplayMarketPrice {
+  readonly itemId: string;
+  readonly availableQuantity: number;
+  readonly unitPrice: number;
+  readonly basePrice: number;
+  readonly demandBand: "normal" | "stocked" | "oversupplied";
+  readonly resourceNodeCount: number;
+}
+
+export interface LiveGameplayMarketState {
+  readonly schemaVersion: "market-state.v1";
+  readonly tick: number;
+  readonly prices: readonly LiveGameplayMarketPrice[];
+  readonly marketHash: string;
+}
+
+export const EMPTY_LIVE_GAMEPLAY_MARKET_STATE: LiveGameplayMarketState = Object.freeze({
+  schemaVersion: "market-state.v1",
+  tick: 0,
+  prices: Object.freeze([]),
+  marketHash: "market:00000000",
+});
+
 export type CampNpcActivity = "gathering" | "returning" | "depositing";
 export type CampNpcState = "idle" | "working" | "resting";
 
@@ -251,6 +274,7 @@ export interface LiveGameplaySnapshot {
   readonly wallet: LiveGameplayWallet;
   readonly worldPois: readonly LiveGameplayWorldPoi[];
   readonly vendorEconomy: LiveGameplayVendorEconomySnapshot;
+  readonly marketState: LiveGameplayMarketState;
   readonly discoveryStats: DiscoveryStats;
   readonly recentDiscoveries: readonly RecentDiscovery[];
   readonly campNpcs: readonly LiveGameplayCampNpc[];

--- a/server/src/tests/LiveGameplaySnapshotComposer.test.ts
+++ b/server/src/tests/LiveGameplaySnapshotComposer.test.ts
@@ -11,9 +11,23 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { LiveGameplaySnapshotComposer } from "../gameplay/LiveGameplaySnapshotComposer.js";
+import {
+  LiveGameplaySnapshotComposer,
+  buildMarketStateFromRuntimeInputs,
+} from "../gameplay/LiveGameplaySnapshotComposer.js";
 import { createDefaultStatBlock } from "../equipment/EquipmentStatTypes.js";
 import type { EquipmentStatBlock } from "../equipment/EquipmentStatTypes.js";
+
+function createBaseComposer(overrides: Partial<ConstructorParameters<typeof LiveGameplaySnapshotComposer>[0]> = {}) {
+  return new LiveGameplaySnapshotComposer({
+    getInventoryItems: () => [],
+    getEquipmentSlots: () => [],
+    getSkillStates: () => [],
+    getResourceNodes: () => [],
+    getWallet: () => ({ coin: 0 }),
+    ...overrides,
+  });
+}
 
 describe("LiveGameplaySnapshotComposer", () => {
   it("composes deterministic sorted snapshot", async () => {
@@ -51,41 +65,17 @@ describe("LiveGameplaySnapshotComposer", () => {
   });
 
   it("normalizes invalid logicalIndex to zero", async () => {
-    const composer = new LiveGameplaySnapshotComposer({
-      getInventoryItems: () => [],
-      getEquipmentSlots: () => [],
-      getSkillStates: () => [],
-      getResourceNodes: () => [],
-      getWallet: () => ({ coin: 0 }),
-    });
-
-    const snapshot = await composer.compose("player_test", -1);
+    const snapshot = await createBaseComposer().compose("player_test", -1);
     expect(snapshot.logicalIndex).toBe(0);
   });
 
   it("normalizes non-safe-integer logicalIndex to zero", async () => {
-    const composer = new LiveGameplaySnapshotComposer({
-      getInventoryItems: () => [],
-      getEquipmentSlots: () => [],
-      getSkillStates: () => [],
-      getResourceNodes: () => [],
-      getWallet: () => ({ coin: 0 }),
-    });
-
-    const snapshot = await composer.compose("player_test", Infinity);
+    const snapshot = await createBaseComposer().compose("player_test", Infinity);
     expect(snapshot.logicalIndex).toBe(0);
   });
 
   it("handles empty arrays", async () => {
-    const composer = new LiveGameplaySnapshotComposer({
-      getInventoryItems: () => [],
-      getEquipmentSlots: () => [],
-      getSkillStates: () => [],
-      getResourceNodes: () => [],
-      getWallet: () => ({ coin: 0 }),
-    });
-
-    const snapshot = await composer.compose("player_empty", 0);
+    const snapshot = await createBaseComposer().compose("player_empty", 0);
 
     expect(snapshot.inventory).toEqual([]);
     expect(snapshot.equipment).toEqual([]);
@@ -95,11 +85,8 @@ describe("LiveGameplaySnapshotComposer", () => {
   });
 
   it("returns frozen snapshot object", async () => {
-    const composer = new LiveGameplaySnapshotComposer({
+    const composer = createBaseComposer({
       getInventoryItems: () => [{ itemId: "wood_log", quantity: 1 }],
-      getEquipmentSlots: () => [],
-      getSkillStates: () => [],
-      getResourceNodes: () => [],
       getWallet: () => ({ coin: 42 }),
     });
 
@@ -115,16 +102,12 @@ describe("LiveGameplaySnapshotComposer", () => {
   });
 
   it("sorts multiple inventory items by itemId", async () => {
-    const composer = new LiveGameplaySnapshotComposer({
+    const composer = createBaseComposer({
       getInventoryItems: () => [
         { itemId: "z_item", quantity: 1 },
         { itemId: "a_item", quantity: 1 },
         { itemId: "m_item", quantity: 1 },
       ],
-      getEquipmentSlots: () => [],
-      getSkillStates: () => [],
-      getResourceNodes: () => [],
-      getWallet: () => ({ coin: 0 }),
     });
 
     const snapshot = await composer.compose("player_test", 0);
@@ -133,7 +116,7 @@ describe("LiveGameplaySnapshotComposer", () => {
   });
 
   it("handles async deps", async () => {
-    const composer = new LiveGameplaySnapshotComposer({
+    const composer = createBaseComposer({
       getInventoryItems: async () => [{ itemId: "async_item", quantity: 5 }],
       getEquipmentSlots: async () => [{ slot: "tool", itemId: "axe" }],
       getSkillStates: async () => [{ skillId: "woodcutting", xp: 100, level: 2 }],
@@ -150,15 +133,7 @@ describe("LiveGameplaySnapshotComposer", () => {
   });
 
   it("returns zero stats when getEquipmentStats is not provided", async () => {
-    const composer = new LiveGameplaySnapshotComposer({
-      getInventoryItems: () => [],
-      getEquipmentSlots: () => [],
-      getSkillStates: () => [],
-      getResourceNodes: () => [],
-      getWallet: () => ({ coin: 0 }),
-    });
-
-    const snapshot = await composer.compose("player_no_stats", 0);
+    const snapshot = await createBaseComposer().compose("player_no_stats", 0);
     const defaults = createDefaultStatBlock();
 
     expect(snapshot.equipmentStats.attackPower).toBe(defaults.attackPower);
@@ -182,12 +157,7 @@ describe("LiveGameplaySnapshotComposer", () => {
       criticalChancePerMille: 75,
     });
 
-    const composer = new LiveGameplaySnapshotComposer({
-      getInventoryItems: () => [],
-      getEquipmentSlots: () => [],
-      getSkillStates: () => [],
-      getResourceNodes: () => [],
-      getWallet: () => ({ coin: 0 }),
+    const composer = createBaseComposer({
       getEquipmentStats: () => customStats,
     });
 
@@ -205,16 +175,79 @@ describe("LiveGameplaySnapshotComposer", () => {
   });
 
   it("returns frozen equipmentStats", async () => {
-    const composer = new LiveGameplaySnapshotComposer({
-      getInventoryItems: () => [],
-      getEquipmentSlots: () => [],
-      getSkillStates: () => [],
-      getResourceNodes: () => [],
-      getWallet: () => ({ coin: 0 }),
+    const composer = createBaseComposer({
       getEquipmentStats: () => createDefaultStatBlock(),
     });
 
     const snapshot = await composer.compose("player_test", 0);
     expect(Object.isFrozen(snapshot.equipmentStats)).toBe(true);
+  });
+
+  it("exposes market state from resource and stock inputs", async () => {
+    const composer = createBaseComposer({
+      getResourceNodes: () => [
+        { nodeId: "tree_a", resourceId: "tree", skillId: "woodcutting", x: 0, y: 0, available: true },
+        { nodeId: "tree_b", resourceId: "tree", skillId: "woodcutting", x: 1, y: 0, available: true },
+        { nodeId: "ore_depleted", resourceId: "copper_ore", skillId: "mining", x: 2, y: 0, available: false },
+      ],
+      getCampStocks: () => [
+        {
+          poiId: "camp_market",
+          lastUpdatedTick: 99,
+          items: [
+            { itemId: "wood_log", quantity: 10 },
+            { itemId: "raw_fish", quantity: 25 },
+          ],
+        },
+      ],
+    });
+
+    const snapshot = await composer.compose("market_player", 120);
+    const wood = snapshot.marketState.prices.find((price) => price.itemId === "wood_log");
+    const fish = snapshot.marketState.prices.find((price) => price.itemId === "raw_fish");
+
+    expect(snapshot.marketState.tick).toBe(120);
+    expect(snapshot.marketState.marketHash.startsWith("market:")).toBe(true);
+    expect(wood).toMatchObject({
+      availableQuantity: 12,
+      resourceNodeCount: 2,
+      demandBand: "stocked",
+      basePrice: 1,
+      unitPrice: 1,
+    });
+    expect(fish).toMatchObject({
+      availableQuantity: 25,
+      resourceNodeCount: 0,
+      demandBand: "oversupplied",
+      basePrice: 2,
+      unitPrice: 1,
+    });
+  });
+
+  it("replays the same market state for the same resource counters", () => {
+    const first = buildMarketStateFromRuntimeInputs(
+      77,
+      [
+        { nodeId: "tree_b", resourceId: "tree", skillId: "woodcutting", x: 1, y: 0, available: true },
+        { nodeId: "tree_a", resourceId: "tree", skillId: "woodcutting", x: 0, y: 0, available: true },
+      ],
+      [
+        { poiId: "b", lastUpdatedTick: 1, items: [{ itemId: "copper_ore", quantity: 11 }] },
+        { poiId: "a", lastUpdatedTick: 1, items: [{ itemId: "raw_fish", quantity: 3 }] },
+      ],
+    );
+    const replay = buildMarketStateFromRuntimeInputs(
+      77,
+      [
+        { nodeId: "tree_a", resourceId: "tree", skillId: "woodcutting", x: 0, y: 0, available: true },
+        { nodeId: "tree_b", resourceId: "tree", skillId: "woodcutting", x: 1, y: 0, available: true },
+      ],
+      [
+        { poiId: "a", lastUpdatedTick: 1, items: [{ itemId: "raw_fish", quantity: 3 }] },
+        { poiId: "b", lastUpdatedTick: 1, items: [{ itemId: "copper_ore", quantity: 11 }] },
+      ],
+    );
+
+    expect(replay).toEqual(first);
   });
 });


### PR DESCRIPTION
## Summary

Adds `marketState` to the live gameplay snapshot using resource nodes, camp stock counters and the existing demand pricing function.

Includes replay coverage for identical resource counters.

Closes #2047