### PR TITLE
fix(language): mark shadow telemetry as side channel

### DIFF
--- a/client/src/dashboard/components/LivingDudenShadowWindow.types.ts
+++ b/client/src/dashboard/components/LivingDudenShadowWindow.types.ts
@@ -6,15 +6,10 @@ export interface LivingDudenArchive {
   readonly byLanguageCount: Readonly<Record<string, number>>;
 }
 
-export interface TermAlert {
-  readonly term: string;
-  readonly alertType: 'term' | 'honorific' | 'watch';
-  readonly severity: 'low' | 'medium' | 'high';
-}
-
 export interface SpeechEvent {
   readonly eventHash: string;
   readonly tick: number;
+  readonly sequenceId?: number;
   readonly npcId: string;
   readonly factionId: string;
   readonly role: string;
@@ -22,7 +17,8 @@ export interface SpeechEvent {
   readonly truthMode?: string;
   readonly speechHash: string;
   readonly constructedText: string;
-  readonly sentenceStructure: string;
+  readonly phraseGenomeId?: string;
+  readonly sentenceStructure: string | ReadonlyArray<string>;
   readonly selectedLexemeIds: ReadonlyArray<string>;
   readonly selectedWords: ReadonlyArray<string>;
   readonly thoughtVector: Readonly<{
@@ -36,7 +32,11 @@ export interface SpeechEvent {
   readonly reactionLane: string;
   readonly confidence: number;
   readonly needsFallback?: boolean;
-  readonly termAlerts: ReadonlyArray<TermAlert>;
+  readonly termAlerts: ReadonlyArray<string>;
+  readonly source?: 'language_shadow_telemetry';
+  readonly telemetryTruthMode?: 'telemetry_side_channel';
+  readonly authoritative?: false;
+  readonly sideChannel?: true;
 }
 
 export interface WordFactorRanking {
@@ -56,7 +56,8 @@ export interface WordFactorRanking {
 export interface TermWatchEntry {
   readonly factionId: string;
   readonly factionName?: string;
-  readonly watchedTerms: ReadonlyArray<string>;
+  readonly watchedTerms?: ReadonlyArray<string>;
+  readonly tabooTerms?: ReadonlyArray<string>;
   readonly honorifics: ReadonlyArray<string>;
 }
 
@@ -67,12 +68,17 @@ export interface StructureRanking {
 
 export interface LivingDudenTelemetry {
   readonly ok: boolean;
+  readonly source?: 'language_shadow_telemetry';
+  readonly telemetryTruthMode?: 'telemetry_side_channel';
+  readonly authoritative?: false;
+  readonly sideChannel?: true;
   readonly archive: LivingDudenArchive;
   readonly speech: ReadonlyArray<SpeechEvent>;
   readonly wordFactorRankings: ReadonlyArray<WordFactorRanking>;
   readonly termWatch: ReadonlyArray<TermWatchEntry>;
   readonly structureRankings: ReadonlyArray<StructureRanking>;
   readonly outcomeHistorySize: number;
+  readonly quarantinedTelemetryEvents?: number;
 }
 
 export type ShadowStatus = 'loading' | 'live' | 'empty' | 'error';

--- a/server/src/core/language/LanguageShadowTelemetry.ts
+++ b/server/src/core/language/LanguageShadowTelemetry.ts
@@ -6,6 +6,8 @@ import { exportArchiveState, getAllLexemes, getLexeme } from './LivingDudenArchi
 import { getLexemeSuccessRate, getOutcomeHistorySize } from './LanguageOutcomeLearner.js';
 
 const HISTORY_LIMIT = 250;
+const SHADOW_SOURCE = 'language_shadow_telemetry' as const;
+const SHADOW_TRUTH_MODE = 'telemetry_side_channel' as const;
 
 export interface NpcSpeechTelemetryEvent {
   readonly eventHash: string;
@@ -27,19 +29,39 @@ export interface NpcSpeechTelemetryEvent {
   readonly confidence: number;
   readonly needsFallback: boolean;
   readonly termAlerts: readonly string[];
+  readonly source: typeof SHADOW_SOURCE;
+  readonly telemetryTruthMode: typeof SHADOW_TRUTH_MODE;
+  readonly authoritative: false;
+  readonly sideChannel: true;
 }
 
 const speechHistory: NpcSpeechTelemetryEvent[] = [];
+let quarantinedTelemetryEvents = 0;
 
 function ratio(value: number): number { return Number.isFinite(value) ? Math.round((value / KAPPA) * 1000) / 1000 : 0; }
 function rankLexeme(id: string): number { const lexeme = getLexeme(id); if (!lexeme) return 0; const u = lexeme.usage; const w = lexeme.weighting; return Number(w.baseWeight) + Number(w.contextWeight) + Number(w.successWeight) - Number(w.riskPenalty) + u.totalUses * 10 + u.playerReactionSuccess * 25 - u.playerReactionFailure * 25; }
 function reactionLane(npcState: NpcLanguageState, decision: UtteranceDecision): string { if (decision.needsFallback) return 'fallback_recovery'; if (Number(npcState.currentFear) >= 600) return 'fear_response'; if (Number(npcState.currentHunger) >= 600) return 'need_response'; if (Number(npcState.currentTrust) >= 650) return 'trust_response'; if (Number(npcState.currentDuty) >= 650) return 'duty_response'; if (Number(npcState.currentPride) >= 650) return 'pride_response'; return 'neutral_response'; }
 function termAlerts(factionId: string, text: string): readonly string[] { const dialect = getFactionDialect(factionId); if (!dialect) return Object.freeze([]); const lower = text.toLowerCase(); return Object.freeze([...new Set(dialect.tabooWords.map((word) => word.toLowerCase()).filter((word) => word.length > 0 && lower.includes(word)))]); }
 
+function validTelemetryInput(input: { readonly tick: number; readonly sequenceId: number; readonly npcState: NpcLanguageState; readonly decision: UtteranceDecision; readonly phraseGenome: PhraseGenome }): boolean {
+  return Number.isSafeInteger(input.tick)
+    && input.tick >= 0
+    && Number.isSafeInteger(input.sequenceId)
+    && input.sequenceId >= 0
+    && String(input.npcState.npcId).trim().length > 0
+    && input.decision.speechHash.trim().length > 0
+    && input.decision.phraseGenomeId.trim().length > 0;
+}
+
 export function recordNpcSpeechTelemetry(input: { readonly tick: number; readonly sequenceId: number; readonly npcState: NpcLanguageState; readonly decision: UtteranceDecision; readonly phraseGenome: PhraseGenome }): void {
+  if (!validTelemetryInput(input)) {
+    quarantinedTelemetryEvents += 1;
+    return;
+  }
+
   const selectedWords = input.decision.selectedLexemeIds.map((id) => getLexeme(id)?.lemma ?? id);
   const eventHash = stableHash32(['LANG_SHADOW_V1', input.tick, input.sequenceId, input.decision.speechHash, input.npcState.npcId].join('|')).toString(16);
-  speechHistory.push(Object.freeze({ eventHash, tick: input.tick, sequenceId: input.sequenceId, npcId: input.npcState.npcId, factionId: input.npcState.factionId, role: input.npcState.role, intent: input.decision.intent, truthMode: input.decision.truthMode, speechHash: input.decision.speechHash, constructedText: input.decision.constructedText, phraseGenomeId: input.decision.phraseGenomeId, sentenceStructure: Object.freeze([...input.phraseGenome.structure]), selectedLexemeIds: Object.freeze([...input.decision.selectedLexemeIds]), selectedWords: Object.freeze(selectedWords), thoughtVector: Object.freeze({ hunger: ratio(Number(input.npcState.currentHunger)), trust: ratio(Number(input.npcState.currentTrust)), fear: ratio(Number(input.npcState.currentFear)), duty: ratio(Number(input.npcState.currentDuty)), pride: ratio(Number(input.npcState.currentPride)) }), reactionLane: reactionLane(input.npcState, input.decision), confidence: ratio(Number(input.decision.confidence)), needsFallback: input.decision.needsFallback, termAlerts: termAlerts(input.npcState.factionId, input.decision.constructedText) }));
+  speechHistory.push(Object.freeze({ eventHash, tick: input.tick, sequenceId: input.sequenceId, npcId: input.npcState.npcId, factionId: input.npcState.factionId, role: input.npcState.role, intent: input.decision.intent, truthMode: input.decision.truthMode, speechHash: input.decision.speechHash, constructedText: input.decision.constructedText, phraseGenomeId: input.decision.phraseGenomeId, sentenceStructure: Object.freeze([...input.phraseGenome.structure]), selectedLexemeIds: Object.freeze([...input.decision.selectedLexemeIds]), selectedWords: Object.freeze(selectedWords), thoughtVector: Object.freeze({ hunger: ratio(Number(input.npcState.currentHunger)), trust: ratio(Number(input.npcState.currentTrust)), fear: ratio(Number(input.npcState.currentFear)), duty: ratio(Number(input.npcState.currentDuty)), pride: ratio(Number(input.npcState.currentPride)), revenge: ratio(Number(input.npcState.currentRevenge)) }), reactionLane: reactionLane(input.npcState, input.decision), confidence: ratio(Number(input.decision.confidence)), needsFallback: input.decision.needsFallback, termAlerts: termAlerts(input.npcState.factionId, input.decision.constructedText), source: SHADOW_SOURCE, telemetryTruthMode: SHADOW_TRUTH_MODE, authoritative: false, sideChannel: true }));
   if (speechHistory.length > HISTORY_LIMIT) speechHistory.shift();
 }
 
@@ -50,7 +72,7 @@ export function getLanguageShadowTelemetry(limit = 80) {
   const structureMap = new Map<string, number>();
   for (const event of speechHistory) { const key = event.sentenceStructure.join(' -> '); structureMap.set(key, (structureMap.get(key) ?? 0) + 1); }
   const structureRankings = Array.from(structureMap.entries()).map(([structure, count]) => Object.freeze({ structure, count })).sort((a, b) => b.count - a.count);
-  return Object.freeze({ ok: true, archive: exportArchiveState(), speech: Object.freeze(speechHistory.slice(-safeLimit)), wordFactorRankings: Object.freeze(wordFactorRankings), termWatch: Object.freeze(termWatch), structureRankings: Object.freeze(structureRankings), outcomeHistorySize: getOutcomeHistorySize() });
+  return Object.freeze({ ok: true, source: SHADOW_SOURCE, telemetryTruthMode: SHADOW_TRUTH_MODE, authoritative: false, sideChannel: true, archive: exportArchiveState(), speech: Object.freeze(speechHistory.slice(-safeLimit)), wordFactorRankings: Object.freeze(wordFactorRankings), termWatch: Object.freeze(termWatch), structureRankings: Object.freeze(structureRankings), outcomeHistorySize: getOutcomeHistorySize(), quarantinedTelemetryEvents });
 }
 
-export function clearLanguageShadowTelemetry(): void { speechHistory.length = 0; }
+export function clearLanguageShadowTelemetry(): void { speechHistory.length = 0; quarantinedTelemetryEvents = 0; }

--- a/server/src/core/language/LivingLanguageSystem.integration.test.ts
+++ b/server/src/core/language/LivingLanguageSystem.integration.test.ts
@@ -4,6 +4,7 @@ import { decideUtterance, clearAllKernelState, registerPhraseGenome } from './Di
 import { buildNpcLanguageState, processLinguisticUpdate, initializeLinguisticKernel, isLinguisticKernelInitialized, resetLinguisticKernel, shutdownLinguisticKernel } from './ArelorianLinguisticKernel.js';
 import { createKappaInt } from './LanguageTypes.js';
 import { clearArchive, loadSeedData } from './LivingDudenArchive.js';
+import { clearLanguageShadowTelemetry, getLanguageShadowTelemetry } from './LanguageShadowTelemetry.js';
 import type { KappaInt } from './LanguageTypes.js';
 import type { TickId } from '../are/types.js';
 
@@ -35,8 +36,8 @@ function seedEmotionGenome(): void {
 }
 
 describe('Living Language System Integration', () => {
-  beforeEach(() => { clearDialogueBridge(); clearAllKernelState(); resetLinguisticKernel(); clearArchive(); });
-  afterEach(() => { shutdownLinguisticKernel(); clearDialogueBridge(); clearArchive(); });
+  beforeEach(() => { clearDialogueBridge(); clearAllKernelState(); resetLinguisticKernel(); clearArchive(); clearLanguageShadowTelemetry(); });
+  afterEach(() => { shutdownLinguisticKernel(); clearDialogueBridge(); clearArchive(); clearLanguageShadowTelemetry(); });
 
   describe('DialogueBridge', () => {
     it('should initialize with dialogue entries', () => { initializeDialogueBridge([{ id: 'dialogue_test_npc', greeting: 'Hello, traveler!', fallback: '...' }]); expect(isDialogueBridgeInitialized()).toBe(true); });
@@ -49,6 +50,10 @@ describe('Living Language System Integration', () => {
     it('should decide utterance with all required fields', () => { const npcState = buildNpcLanguageState('npc_1', { factionId: 'neutral', role: 'citizen', hunger: 0.3, trust: 0.5, fear: 0.2, duty: 0.6, pride: 0.4, revenge: 0.1 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 100, sequenceId: 1 }); expect(decision.npcId).toBe('npc_1'); expect(decision.speechHash).toBeTruthy(); expect(decision.intent).toBeTruthy(); expect(decision.constructedText).toBeTruthy(); });
     it('should produce deterministic results for same input', () => { const npcState = buildNpcLanguageState('det_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.3, trust: 0.5, fear: 0.2, duty: 0.6, pride: 0.4, revenge: 0.1 }); const ctx = { npcState, worldState: createTestWorldState(), tick: 300, sequenceId: 3 }; const d1 = decideUtterance(ctx); clearAllKernelState(); const d2 = decideUtterance(ctx); expect(d1.speechHash).toBe(d2.speechHash); expect(d1.constructedText).toBe(d2.constructedText); });
     it('should derive emotional tone from selected lexemes instead of neutral fallback', () => { seedEmotionGenome(); const npcState = buildNpcLanguageState('emotion_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 420, sequenceId: 4 }, { forceIntent: 'greet' }); expect(decision.needsFallback).toBe(false); expect(Number(decision.emotionalTone.trust)).toBeGreaterThan(0); expect(Number(decision.emotionalTone.duty)).toBeGreaterThan(0); expect(decision.constructedText).not.toBe('greet.'); });
+  });
+
+  describe('LanguageShadowTelemetry', () => {
+    it('should expose speech telemetry as non-authoritative side channel', () => { seedEmotionGenome(); const npcState = buildNpcLanguageState('shadow_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); decideUtterance({ npcState, worldState: createTestWorldState(), tick: 720, sequenceId: 8 }, { forceIntent: 'greet' }); const telemetry = getLanguageShadowTelemetry(); expect(telemetry.authoritative).toBe(false); expect(telemetry.sideChannel).toBe(true); expect(telemetry.telemetryTruthMode).toBe('telemetry_side_channel'); expect(telemetry.speech.at(-1)?.authoritative).toBe(false); expect(telemetry.speech.at(-1)?.sideChannel).toBe(true); expect(telemetry.quarantinedTelemetryEvents).toBe(0); });
   });
 
   describe('ArelorianLinguisticKernel', () => {

--- a/server/src/core/language/LivingLanguageSystem.integration.test.ts
+++ b/server/src/core/language/LivingLanguageSystem.integration.test.ts
@@ -53,7 +53,7 @@ describe('Living Language System Integration', () => {
   });
 
   describe('LanguageShadowTelemetry', () => {
-    it('should expose speech telemetry as non-authoritative side channel', () => { seedEmotionGenome(); const npcState = buildNpcLanguageState('shadow_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); decideUtterance({ npcState, worldState: createTestWorldState(), tick: 720, sequenceId: 8 }, { forceIntent: 'greet' }); const telemetry = getLanguageShadowTelemetry(); expect(telemetry.authoritative).toBe(false); expect(telemetry.sideChannel).toBe(true); expect(telemetry.telemetryTruthMode).toBe('telemetry_side_channel'); expect(telemetry.speech.at(-1)?.authoritative).toBe(false); expect(telemetry.speech.at(-1)?.sideChannel).toBe(true); expect(telemetry.quarantinedTelemetryEvents).toBe(0); });
+    it('should expose speech telemetry as non-authoritative side channel', () => { seedEmotionGenome(); const npcState = buildNpcLanguageState('shadow_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); decideUtterance({ npcState, worldState: createTestWorldState(), tick: 720, sequenceId: 8 }, { forceIntent: 'greet' }); const telemetry = getLanguageShadowTelemetry(); const latest = telemetry.speech[telemetry.speech.length - 1]; expect(telemetry.authoritative).toBe(false); expect(telemetry.sideChannel).toBe(true); expect(telemetry.telemetryTruthMode).toBe('telemetry_side_channel'); expect(latest?.authoritative).toBe(false); expect(latest?.sideChannel).toBe(true); expect(telemetry.quarantinedTelemetryEvents).toBe(0); });
   });
 
   describe('ArelorianLinguisticKernel', () => {


### PR DESCRIPTION
## Summary

- Marks Living Duden shadow telemetry as non-authoritative side-channel data.
- Adds telemetry input validation and quarantines invalid telemetry records instead of recording malformed events.
- Includes `source`, `telemetryTruthMode`, `authoritative: false`, and `sideChannel: true` at telemetry root and speech-event level.
- Aligns dashboard telemetry types with the server payload.
- Adds integration coverage for the side-channel truth contract.

## ARE notes

No gameplay state is derived from telemetry. No mock snapshots. No wall-clock truth path. Telemetry remains read-only observation data.
