### PR TITLE
feat(language): load phrase genomes from game data

### DIFF
--- a/game-data/language/phrase-genomes.seed.json
+++ b/game-data/language/phrase-genomes.seed.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "kind": "phrase-genome-seed",
+  "description": "Canonical seed phrase genomes loaded by the Living Language runtime through game-data/language.",
+  "phraseGenomes": [
+    {
+      "id": "default_greet",
+      "intent": "greet",
+      "languageMode": "arel",
+      "structure": ["subject", "verb"],
+      "slots": [
+        { "role": "subject", "required": true, "lexemeIds": ["arel_greeting_wacht"] },
+        { "role": "verb", "required": true, "lexemeIds": ["arel_help_bitt"] }
+      ],
+      "truthMode": "known_fact",
+      "outcomeStats": { "uses": 0, "successfulUses": 0, "failedUses": 0, "averageKappaScore": 1 },
+      "mutation": { "parentGenomeIds": [], "generation": 0, "stability": 1, "novelty": 0 }
+    },
+    {
+      "id": "default_request",
+      "intent": "request",
+      "languageMode": "arel",
+      "structure": ["subject", "verb", "object"],
+      "slots": [
+        { "role": "subject", "required": true, "lexemeIds": ["arel_greeting_wacht"] },
+        { "role": "verb", "required": true, "lexemeIds": ["arel_help_bitt"] },
+        { "role": "object", "required": false, "lexemeIds": ["arel_quest_auftrag"] }
+      ],
+      "truthMode": "known_fact",
+      "outcomeStats": { "uses": 0, "successfulUses": 0, "failedUses": 0, "averageKappaScore": 1 },
+      "mutation": { "parentGenomeIds": [], "generation": 0, "stability": 1, "novelty": 0 }
+    },
+    {
+      "id": "default_trade",
+      "intent": "trade",
+      "languageMode": "arel",
+      "structure": ["subject", "verb", "object"],
+      "slots": [
+        { "role": "subject", "required": true, "lexemeIds": ["arel_greeting_wacht"] },
+        { "role": "verb", "required": true, "lexemeIds": ["arel_help_bitt"] },
+        { "role": "object", "required": false, "lexemeIds": ["arel_trade_handel"] }
+      ],
+      "truthMode": "known_fact",
+      "outcomeStats": { "uses": 0, "successfulUses": 0, "failedUses": 0, "averageKappaScore": 1 },
+      "mutation": { "parentGenomeIds": [], "generation": 0, "stability": 1, "novelty": 0 }
+    }
+  ]
+}

--- a/server/src/core/language/LivingLanguageInitializer.ts
+++ b/server/src/core/language/LivingLanguageInitializer.ts
@@ -3,6 +3,7 @@ import { resolveContentFile } from "../../modules/content/contentDataRoot.js";
 import { initializeDialogueBridge, type DialogueEntry } from "./DialogueBridge.js";
 import { initializeLinguisticKernel, isLinguisticKernelInitialized } from "./ArelorianLinguisticKernel.js";
 import { loadLivingDudenGameData } from "./LanguageGameDataStore.js";
+import { loadPhraseGenomeGameData } from "./PhraseGenomeGameDataStore.js";
 
 const INITIALIZATION_TAG = "LIVING_LANGUAGE_INITIALIZER_V1";
 
@@ -46,6 +47,11 @@ export async function initializeLivingLanguageSystem(): Promise<void> {
   const dudenReport = loadLivingDudenGameData();
   console.log(
     `[${INITIALIZATION_TAG}] Loaded ${dudenReport.lexemesLoaded} Living Duden lexeme(s) from ${dudenReport.filesRead} game-data/language file(s)`
+  );
+
+  const phraseGenomeReport = loadPhraseGenomeGameData();
+  console.log(
+    `[${INITIALIZATION_TAG}] Loaded ${phraseGenomeReport.phraseGenomesLoaded} phrase genome(s) from ${phraseGenomeReport.filesRead} game-data/language file(s)`
   );
 
   await initializeLinguisticKernel();

--- a/server/src/core/language/LivingLanguageSystem.integration.test.ts
+++ b/server/src/core/language/LivingLanguageSystem.integration.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { initializeDialogueBridge, isDialogueBridgeInitialized, resolveDialogue, getDialogueEntry, getFallbackText, clearDialogueBridge } from './DialogueBridge.js';
-import { decideUtterance, clearAllKernelState, registerPhraseGenome } from './DialogueDecisionKernel.js';
+import { decideUtterance, clearAllKernelState, registerPhraseGenome, getRegisteredGenome } from './DialogueDecisionKernel.js';
 import { buildNpcLanguageState, processLinguisticUpdate, initializeLinguisticKernel, isLinguisticKernelInitialized, resetLinguisticKernel, shutdownLinguisticKernel } from './ArelorianLinguisticKernel.js';
 import { createKappaInt } from './LanguageTypes.js';
 import { clearArchive, loadSeedData } from './LivingDudenArchive.js';
 import { clearLanguageShadowTelemetry, getLanguageShadowTelemetry } from './LanguageShadowTelemetry.js';
+import { loadLivingDudenGameData } from './LanguageGameDataStore.js';
+import { loadPhraseGenomeGameData } from './PhraseGenomeGameDataStore.js';
 import type { KappaInt } from './LanguageTypes.js';
 import type { TickId } from '../are/types.js';
 
@@ -50,6 +52,7 @@ describe('Living Language System Integration', () => {
     it('should decide utterance with all required fields', () => { const npcState = buildNpcLanguageState('npc_1', { factionId: 'neutral', role: 'citizen', hunger: 0.3, trust: 0.5, fear: 0.2, duty: 0.6, pride: 0.4, revenge: 0.1 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 100, sequenceId: 1 }); expect(decision.npcId).toBe('npc_1'); expect(decision.speechHash).toBeTruthy(); expect(decision.intent).toBeTruthy(); expect(decision.constructedText).toBeTruthy(); });
     it('should produce deterministic results for same input', () => { const npcState = buildNpcLanguageState('det_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.3, trust: 0.5, fear: 0.2, duty: 0.6, pride: 0.4, revenge: 0.1 }); const ctx = { npcState, worldState: createTestWorldState(), tick: 300, sequenceId: 3 }; const d1 = decideUtterance(ctx); clearAllKernelState(); const d2 = decideUtterance(ctx); expect(d1.speechHash).toBe(d2.speechHash); expect(d1.constructedText).toBe(d2.constructedText); });
     it('should derive emotional tone from selected lexemes instead of neutral fallback', () => { seedEmotionGenome(); const npcState = buildNpcLanguageState('emotion_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 420, sequenceId: 4 }, { forceIntent: 'greet' }); expect(decision.needsFallback).toBe(false); expect(Number(decision.emotionalTone.trust)).toBeGreaterThan(0); expect(Number(decision.emotionalTone.duty)).toBeGreaterThan(0); expect(decision.constructedText).not.toBe('greet.'); });
+    it('should load phrase genomes from game-data and use them in the speech truth path', () => { const dudenReport = loadLivingDudenGameData(); const phraseReport = loadPhraseGenomeGameData(); expect(dudenReport.lexemesLoaded).toBeGreaterThan(0); expect(phraseReport.phraseGenomesLoaded).toBeGreaterThanOrEqual(3); expect(getRegisteredGenome('default_greet')).toBeDefined(); const npcState = buildNpcLanguageState('game_data_phrase_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 820, sequenceId: 9 }, { forceIntent: 'greet' }); expect(decision.needsFallback).toBe(false); expect(decision.phraseGenomeId).toBe('default_greet'); expect(decision.selectedLexemeIds).toContain('arel_greeting_wacht'); expect(decision.selectedLexemeIds).toContain('arel_help_bitt'); });
   });
 
   describe('LanguageShadowTelemetry', () => {

--- a/server/src/core/language/PhraseGenomeGameDataStore.ts
+++ b/server/src/core/language/PhraseGenomeGameDataStore.ts
@@ -83,8 +83,8 @@ function normalizeGenome(raw: unknown, source: string, index: number): PhraseGen
     throw new Error(`[${TAG}] ${source}.phraseGenomes[${index}] requires at least one slot`);
   }
 
-  const outcomeStats = isRecord(raw.outcomeStats) ? raw.outcomeStats : {};
-  const mutation = isRecord(raw.mutation) ? raw.mutation : {};
+  const outcomeStats: Record<string, unknown> = isRecord(raw.outcomeStats) ? raw.outcomeStats : {};
+  const mutation: Record<string, unknown> = isRecord(raw.mutation) ? raw.mutation : {};
   const structure = textList(raw.structure, slots.map((slot) => slot.role));
 
   const genome: PhraseGenome = Object.freeze({

--- a/server/src/core/language/PhraseGenomeGameDataStore.ts
+++ b/server/src/core/language/PhraseGenomeGameDataStore.ts
@@ -1,0 +1,156 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolveContentFile } from "../../modules/content/contentDataRoot.js";
+import { registerPhraseGenome } from "./DialogueDecisionKernel.js";
+import { validatePhraseGenome } from "./ProceduralGrammarEngine.js";
+import { createKappaInt, type PhraseGenome, type PhraseSlot } from "./LanguageTypes.js";
+
+const TAG = "PHRASE_GENOME_GAME_DATA_STORE_V1";
+const FILES = Object.freeze([
+  "language/phrase-genomes.seed.json",
+  "language/phrase-genomes.promoted.json",
+]);
+
+export interface PhraseGenomeGameDataLoadReport {
+  readonly filesRead: number;
+  readonly filesMissing: readonly string[];
+  readonly phraseGenomesLoaded: number;
+  readonly sourceFiles: readonly string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function textList(value: unknown, fallback: readonly string[] = []): readonly string[] {
+  if (!Array.isArray(value)) return Object.freeze([...fallback]);
+  return Object.freeze(value.map((entry) => text(entry)).filter(Boolean));
+}
+
+function nonNegativeInteger(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : fallback;
+}
+
+function kappaValue(value: unknown, fallback: number) {
+  const n = Number(value);
+  return createKappaInt(Number.isFinite(n) ? n : fallback);
+}
+
+function normalizeSlot(raw: unknown, source: string, genomeIndex: number, slotIndex: number): PhraseSlot {
+  if (!isRecord(raw)) {
+    throw new Error(`[${TAG}] ${source}.phraseGenomes[${genomeIndex}].slots[${slotIndex}] must be an object`);
+  }
+
+  const role = text(raw.role);
+  if (!role) {
+    throw new Error(`[${TAG}] ${source}.phraseGenomes[${genomeIndex}].slots[${slotIndex}] requires role`);
+  }
+
+  const lexemeIds = textList(raw.lexemeIds);
+  const semanticRequirements = textList(raw.semanticRequirements);
+
+  if (lexemeIds.length === 0 && semanticRequirements.length === 0) {
+    throw new Error(`[${TAG}] ${source}.phraseGenomes[${genomeIndex}].slots[${slotIndex}] requires lexemeIds or semanticRequirements`);
+  }
+
+  return Object.freeze({
+    role: role as PhraseSlot["role"],
+    required: raw.required !== false,
+    ...(lexemeIds.length > 0 ? { lexemeIds } : {}),
+    ...(semanticRequirements.length > 0 ? { semanticRequirements } : {}),
+  });
+}
+
+function normalizeGenome(raw: unknown, source: string, index: number): PhraseGenome {
+  if (!isRecord(raw)) {
+    throw new Error(`[${TAG}] ${source}.phraseGenomes[${index}] must be an object`);
+  }
+
+  const id = text(raw.id);
+  const intent = text(raw.intent);
+  if (!id || !intent) {
+    throw new Error(`[${TAG}] ${source}.phraseGenomes[${index}] requires id and intent`);
+  }
+
+  const slots = Array.isArray(raw.slots)
+    ? raw.slots.map((slot, slotIndex) => normalizeSlot(slot, source, index, slotIndex))
+    : [];
+  if (slots.length === 0) {
+    throw new Error(`[${TAG}] ${source}.phraseGenomes[${index}] requires at least one slot`);
+  }
+
+  const outcomeStats = isRecord(raw.outcomeStats) ? raw.outcomeStats : {};
+  const mutation = isRecord(raw.mutation) ? raw.mutation : {};
+  const structure = textList(raw.structure, slots.map((slot) => slot.role));
+
+  const genome: PhraseGenome = Object.freeze({
+    id,
+    intent: intent as PhraseGenome["intent"],
+    languageMode: (text(raw.languageMode) || "arel") as PhraseGenome["languageMode"],
+    structure: structure as PhraseGenome["structure"],
+    slots: Object.freeze(slots),
+    constraints: Object.freeze({}),
+    outcomeStats: Object.freeze({
+      uses: nonNegativeInteger(outcomeStats.uses, 0),
+      successfulUses: nonNegativeInteger(outcomeStats.successfulUses, 0),
+      failedUses: nonNegativeInteger(outcomeStats.failedUses, 0),
+      averageKappaScore: kappaValue(outcomeStats.averageKappaScore, 1),
+    }),
+    mutation: Object.freeze({
+      parentGenomeIds: textList(mutation.parentGenomeIds),
+      generation: nonNegativeInteger(mutation.generation, 0),
+      stability: kappaValue(mutation.stability, 1),
+      novelty: kappaValue(mutation.novelty, 0),
+    }),
+    truthMode: (text(raw.truthMode) || "known_fact") as PhraseGenome["truthMode"],
+  });
+
+  const validation = validatePhraseGenome(genome);
+  if (!validation.valid) {
+    throw new Error(`[${TAG}] ${source}.phraseGenomes[${index}] invalid: ${validation.errors.join(", ")}`);
+  }
+
+  return genome;
+}
+
+function extractPhraseGenomes(data: unknown, source: string): readonly PhraseGenome[] {
+  const root = Array.isArray(data) ? { phraseGenomes: data } : data;
+  if (!isRecord(root) || !Array.isArray(root.phraseGenomes)) {
+    throw new Error(`[${TAG}] ${source} must contain a phraseGenomes array`);
+  }
+  return Object.freeze(root.phraseGenomes.map((entry, index) => normalizeGenome(entry, source, index)));
+}
+
+export function loadPhraseGenomeGameData(): PhraseGenomeGameDataLoadReport {
+  const missing: string[] = [];
+  const sources: string[] = [];
+  let filesRead = 0;
+  let phraseGenomesLoaded = 0;
+
+  for (const relative of FILES) {
+    const filePath = resolveContentFile(relative);
+    if (!existsSync(filePath)) {
+      missing.push(relative);
+      continue;
+    }
+
+    const phraseGenomes = extractPhraseGenomes(JSON.parse(readFileSync(filePath, "utf-8")), relative);
+    filesRead += 1;
+    sources.push(relative);
+    for (const genome of phraseGenomes) {
+      registerPhraseGenome(genome);
+      phraseGenomesLoaded += 1;
+    }
+  }
+
+  return Object.freeze({
+    filesRead,
+    filesMissing: Object.freeze(missing),
+    phraseGenomesLoaded,
+    sourceFiles: Object.freeze(sources),
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a deterministic `PhraseGenomeGameDataStore` for `game-data/language/phrase-genomes.seed.json` and optional promoted genomes.
- Adds canonical seed phrase genomes for greet, request, and trade using existing Living Duden lexeme IDs.
- Loads phrase genomes during Living Language initialization after Living Duden lexemes are available.
- Adds integration coverage proving game-data phrase genomes are registered and used in the speech truth path.

## ARE notes

No generated snapshot. No mock runtime source. Phrase genomes are loaded from the same content root resolver as other game data and feed the existing deterministic speech construction path.
