### PR TITLE
refactor(language): share phrase genome registry

### DIFF
--- a/server/src/core/language/DialogueDecisionKernel.ts
+++ b/server/src/core/language/DialogueDecisionKernel.ts
@@ -17,6 +17,8 @@ import { getFactionBaseLanguage } from './DialectStores.js';
 import { buildSentence, createSentenceSeed } from './ProceduralGrammarEngine.js';
 import { getLexemeSuccessRate, getGenomeAverageScore } from './LanguageOutcomeLearner.js';
 import { recordNpcSpeechTelemetry } from './LanguageShadowTelemetry.js';
+import { getRegisteredGenome } from './PhraseGenomeRegistry.js';
+export { clearPhraseGenomeRegistry, getRegisteredGenome, listRegisteredPhraseGenomeIds, registerPhraseGenome } from './PhraseGenomeRegistry.js';
 
 const KERNEL_TAG = 'DIALOGUE_DECISION_KERNEL_V1';
 const DEFAULT_STRUCTURE: readonly SentencePosition[] = Object.freeze(['subject', 'verb', 'object']);
@@ -100,22 +102,6 @@ const FALLBACK_TEXT: Readonly<Record<SpeechIntent, readonly string[]>> = Object.
   brag: Object.freeze(['Meine Spur ist stark.', 'Ich trage den Ruhm.', 'Der Kreis kennt meinen Namen.']),
   mock: Object.freeze(['Dein Stolz stolpert.', 'Der Takt lacht leise.', 'Nicht jeder Schritt ist groß.']),
 });
-
-interface RegisteredGenome {
-  readonly genome: PhraseGenome;
-  readonly lastUsedTick: number;
-  readonly useCount: number;
-}
-
-const genomeRegistry: Map<string, RegisteredGenome> = new Map();
-
-export function registerPhraseGenome(genome: PhraseGenome): void {
-  genomeRegistry.set(genome.id, { genome: Object.freeze(genome), lastUsedTick: 0, useCount: 0 });
-}
-
-export function getRegisteredGenome(genomeId: string): PhraseGenome | undefined {
-  return genomeRegistry.get(genomeId)?.genome;
-}
 
 function createFallbackGenome(intent: SpeechIntent, language: LanguageMode, truthMode: SpeechTruthMode): PhraseGenome {
   return Object.freeze({

--- a/server/src/core/language/LivingLanguageSystem.integration.test.ts
+++ b/server/src/core/language/LivingLanguageSystem.integration.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { initializeDialogueBridge, isDialogueBridgeInitialized, resolveDialogue, getDialogueEntry, getFallbackText, clearDialogueBridge } from './DialogueBridge.js';
-import { decideUtterance, clearAllKernelState, registerPhraseGenome, getRegisteredGenome } from './DialogueDecisionKernel.js';
+import { decideUtterance, clearAllKernelState, registerPhraseGenome, getRegisteredGenome, clearPhraseGenomeRegistry } from './DialogueDecisionKernel.js';
 import { buildNpcLanguageState, processLinguisticUpdate, initializeLinguisticKernel, isLinguisticKernelInitialized, resetLinguisticKernel, shutdownLinguisticKernel } from './ArelorianLinguisticKernel.js';
 import { createKappaInt } from './LanguageTypes.js';
 import { clearArchive, loadSeedData } from './LivingDudenArchive.js';
 import { clearLanguageShadowTelemetry, getLanguageShadowTelemetry } from './LanguageShadowTelemetry.js';
 import { loadLivingDudenGameData } from './LanguageGameDataStore.js';
 import { loadPhraseGenomeGameData } from './PhraseGenomeGameDataStore.js';
+import { getPhraseGenomeOrFallback } from './ProceduralGrammarEngine.js';
 import type { KappaInt } from './LanguageTypes.js';
 import type { TickId } from '../are/types.js';
 
@@ -38,8 +39,8 @@ function seedEmotionGenome(): void {
 }
 
 describe('Living Language System Integration', () => {
-  beforeEach(() => { clearDialogueBridge(); clearAllKernelState(); resetLinguisticKernel(); clearArchive(); clearLanguageShadowTelemetry(); });
-  afterEach(() => { shutdownLinguisticKernel(); clearDialogueBridge(); clearArchive(); clearLanguageShadowTelemetry(); });
+  beforeEach(() => { clearDialogueBridge(); clearAllKernelState(); resetLinguisticKernel(); clearArchive(); clearLanguageShadowTelemetry(); clearPhraseGenomeRegistry(); });
+  afterEach(() => { shutdownLinguisticKernel(); clearDialogueBridge(); clearArchive(); clearLanguageShadowTelemetry(); clearPhraseGenomeRegistry(); });
 
   describe('DialogueBridge', () => {
     it('should initialize with dialogue entries', () => { initializeDialogueBridge([{ id: 'dialogue_test_npc', greeting: 'Hello, traveler!', fallback: '...' }]); expect(isDialogueBridgeInitialized()).toBe(true); });
@@ -52,7 +53,7 @@ describe('Living Language System Integration', () => {
     it('should decide utterance with all required fields', () => { const npcState = buildNpcLanguageState('npc_1', { factionId: 'neutral', role: 'citizen', hunger: 0.3, trust: 0.5, fear: 0.2, duty: 0.6, pride: 0.4, revenge: 0.1 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 100, sequenceId: 1 }); expect(decision.npcId).toBe('npc_1'); expect(decision.speechHash).toBeTruthy(); expect(decision.intent).toBeTruthy(); expect(decision.constructedText).toBeTruthy(); });
     it('should produce deterministic results for same input', () => { const npcState = buildNpcLanguageState('det_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.3, trust: 0.5, fear: 0.2, duty: 0.6, pride: 0.4, revenge: 0.1 }); const ctx = { npcState, worldState: createTestWorldState(), tick: 300, sequenceId: 3 }; const d1 = decideUtterance(ctx); clearAllKernelState(); const d2 = decideUtterance(ctx); expect(d1.speechHash).toBe(d2.speechHash); expect(d1.constructedText).toBe(d2.constructedText); });
     it('should derive emotional tone from selected lexemes instead of neutral fallback', () => { seedEmotionGenome(); const npcState = buildNpcLanguageState('emotion_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 420, sequenceId: 4 }, { forceIntent: 'greet' }); expect(decision.needsFallback).toBe(false); expect(Number(decision.emotionalTone.trust)).toBeGreaterThan(0); expect(Number(decision.emotionalTone.duty)).toBeGreaterThan(0); expect(decision.constructedText).not.toBe('greet.'); });
-    it('should load phrase genomes from game-data and use them in the speech truth path', () => { const dudenReport = loadLivingDudenGameData(); const phraseReport = loadPhraseGenomeGameData(); expect(dudenReport.lexemesLoaded).toBeGreaterThan(0); expect(phraseReport.phraseGenomesLoaded).toBeGreaterThanOrEqual(3); expect(getRegisteredGenome('default_greet')).toBeDefined(); const npcState = buildNpcLanguageState('game_data_phrase_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 820, sequenceId: 9 }, { forceIntent: 'greet' }); expect(decision.needsFallback).toBe(false); expect(decision.phraseGenomeId).toBe('default_greet'); expect(decision.selectedLexemeIds).toContain('arel_greeting_wacht'); expect(decision.selectedLexemeIds).toContain('arel_help_bitt'); });
+    it('should load phrase genomes from game-data and use them in the speech truth path', () => { const dudenReport = loadLivingDudenGameData(); const phraseReport = loadPhraseGenomeGameData(); expect(dudenReport.lexemesLoaded).toBeGreaterThan(0); expect(phraseReport.phraseGenomesLoaded).toBeGreaterThanOrEqual(3); expect(getRegisteredGenome('default_greet')).toBeDefined(); expect(getPhraseGenomeOrFallback('forest_village_greet_guard')?.id).toBe('default_greet'); const npcState = buildNpcLanguageState('game_data_phrase_npc', { factionId: 'neutral', role: 'citizen', hunger: 0.1, trust: 0.7, fear: 0.1, duty: 0.6, pride: 0.2, revenge: 0 }); const decision = decideUtterance({ npcState, worldState: createTestWorldState(), tick: 820, sequenceId: 9 }, { forceIntent: 'greet' }); expect(decision.needsFallback).toBe(false); expect(decision.phraseGenomeId).toBe('default_greet'); expect(decision.selectedLexemeIds).toContain('arel_greeting_wacht'); expect(decision.selectedLexemeIds).toContain('arel_help_bitt'); });
   });
 
   describe('LanguageShadowTelemetry', () => {

--- a/server/src/core/language/PhraseGenomeGameDataStore.ts
+++ b/server/src/core/language/PhraseGenomeGameDataStore.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolveContentFile } from "../../modules/content/contentDataRoot.js";
-import { registerPhraseGenome } from "./DialogueDecisionKernel.js";
+import { registerPhraseGenome } from "./PhraseGenomeRegistry.js";
 import { validatePhraseGenome } from "./ProceduralGrammarEngine.js";
 import { createKappaInt, type PhraseGenome, type PhraseSlot } from "./LanguageTypes.js";
 

--- a/server/src/core/language/PhraseGenomeRegistry.ts
+++ b/server/src/core/language/PhraseGenomeRegistry.ts
@@ -1,0 +1,78 @@
+import type { PhraseGenome, SpeechIntent } from './LanguageTypes.js';
+
+interface RegisteredGenome {
+  readonly genome: PhraseGenome;
+  readonly lastUsedTick: number;
+  readonly useCount: number;
+}
+
+const SPEECH_INTENTS: readonly SpeechIntent[] = Object.freeze([
+  'rumor_share',
+  'apologize',
+  'farewell',
+  'threaten',
+  'comfort',
+  'recruit',
+  'betray',
+  'request',
+  'accuse',
+  'trade',
+  'teach',
+  'thank',
+  'boast',
+  'greet',
+  'warn',
+  'pray',
+  'brag',
+  'mock',
+]);
+
+const registry: Map<string, RegisteredGenome> = new Map();
+
+function keyPart(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'unknown';
+}
+
+function inferIntentFromGenomeId(genomeId: string): SpeechIntent | undefined {
+  const normalized = keyPart(genomeId);
+  for (const intent of SPEECH_INTENTS) {
+    if (
+      normalized === intent
+      || normalized === `default_${intent}`
+      || normalized.startsWith(`${intent}_`)
+      || normalized.endsWith(`_${intent}`)
+      || normalized.includes(`_${intent}_`)
+    ) {
+      return intent;
+    }
+  }
+  return undefined;
+}
+
+export function registerPhraseGenome(genome: PhraseGenome): void {
+  registry.set(genome.id, Object.freeze({
+    genome: Object.freeze(genome),
+    lastUsedTick: 0,
+    useCount: 0,
+  }));
+}
+
+export function getRegisteredGenome(genomeId: string): PhraseGenome | undefined {
+  return registry.get(genomeId)?.genome;
+}
+
+export function getPhraseGenomeOrDefault(genomeId: string): PhraseGenome | undefined {
+  const direct = getRegisteredGenome(genomeId);
+  if (direct) return direct;
+
+  const intent = inferIntentFromGenomeId(genomeId);
+  return intent ? getRegisteredGenome(`default_${intent}`) : undefined;
+}
+
+export function listRegisteredPhraseGenomeIds(): readonly string[] {
+  return Object.freeze([...registry.keys()].sort());
+}
+
+export function clearPhraseGenomeRegistry(): void {
+  registry.clear();
+}

--- a/server/src/core/language/ProceduralGrammarEngine.ts
+++ b/server/src/core/language/ProceduralGrammarEngine.ts
@@ -1,6 +1,7 @@
 import { stableHash32 } from '../determinism/AREDeterminism.js';
 import type { PhraseGenome, LivingLexeme, LanguageCode, SentencePosition } from './LanguageTypes.js';
 import { findLexemeForSlot, getLexeme } from './LivingDudenArchive.js';
+import { getPhraseGenomeOrDefault } from './PhraseGenomeRegistry.js';
 
 const GRAMMAR_TAG = 'PROC_GRAMMAR_V1';
 
@@ -76,5 +77,5 @@ function applyGrammar(lexeme: LivingLexeme, grammar: GrammarRule, position: Sent
 function normalizeSentence(text: string): string { const trimmed = text.replace(/\s+/g, ' ').trim(); if (!trimmed) return trimmed; const capitalized = capitalize(trimmed); return /[.!?]$/.test(capitalized) ? capitalized : `${capitalized}.`; }
 function capitalize(text: string): string { return text.length === 0 ? text : text[0].toUpperCase() + text.slice(1); }
 export function validatePhraseGenome(genome: PhraseGenome): { readonly valid: boolean; readonly errors: string[] } { const errors: string[] = []; const grammar = getGrammarForLanguage(genome.languageMode); for (const required of grammar.requiredSlots) if (!genome.slots.some((slot) => normalizeSlotRole(slot.role) === required)) errors.push(`Missing required slot: ${required}`); const seenSlots = new Set<string>(); for (const slot of genome.slots) { const normalized = normalizeSlotRole(slot.role); if (seenSlots.has(normalized)) errors.push(`Duplicate slot role: ${normalized}`); seenSlots.add(normalized); } return Object.freeze({ valid: errors.length === 0, errors }); }
-export function getPhraseGenomeOrFallback(_genomeId: string): PhraseGenome | undefined { return undefined; }
+export function getPhraseGenomeOrFallback(genomeId: string): PhraseGenome | undefined { return getPhraseGenomeOrDefault(genomeId); }
 export function createSentenceSeed(npcId: string, intent: string, tick: number, sequenceId: number): number { return stableHash32([npcId, intent, tick.toString(), sequenceId.toString()].join('|')); }


### PR DESCRIPTION
## Summary

- Moves phrase genome registration out of `DialogueDecisionKernel` into a shared `PhraseGenomeRegistry`.
- Keeps the existing DialogueDecisionKernel exports for compatibility.
- Makes `ProceduralGrammarEngine.getPhraseGenomeOrFallback()` resolve registered genomes and deterministic `default_<intent>` fallbacks instead of always returning `undefined`.
- Points `PhraseGenomeGameDataStore` at the shared registry instead of the dialogue kernel.
- Adds integration coverage for registry cleanup and fallback lookup from game-data phrase genomes.

## ARE notes

No mock truth path. No generated snapshot. The registry remains deterministic in-memory runtime wiring fed by explicit game-data loading and existing tests clear it between runs.
