### PR TITLE
feat(inventory): add origin movement audit trail

### DIFF
--- a/server/src/inventory/InventoryStore.ts
+++ b/server/src/inventory/InventoryStore.ts
@@ -5,21 +5,91 @@
  * Deterministic: No Math.random(), stable ordering, no Date.now().
  */
 
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
 import {
   INVENTORY_CAPACITY,
   ITEM_DEFINITIONS,
   createDefaultInventoryState,
   isInventoryItemId,
+  isInventoryOriginSource,
   normalizePlayerInventoryState,
   normalizeQuantity,
   type InventoryAddResult,
-  type InventoryRemoveResult,
   type InventoryItemId,
+  type InventoryItemOrigin,
+  type InventoryMovementEvent,
+  type InventoryRemoveResult,
   type PlayerInventoryState,
 } from "./InventoryTypes.js";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeOrigin(value: unknown): InventoryItemOrigin | null | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) return null;
+
+  const uid = typeof value.uid === "string" ? value.uid.trim() : "";
+  const sourceHash = typeof value.sourceHash === "string" ? value.sourceHash.trim() : "";
+  const tick = Number(value.tick);
+
+  if (!uid || !sourceHash || !Number.isSafeInteger(tick) || tick < 0 || !isInventoryOriginSource(value.source)) {
+    return null;
+  }
+
+  return Object.freeze({ uid, tick, source: value.source, sourceHash });
+}
+
+function inventoryStateHash(state: PlayerInventoryState): string {
+  const slots = state.slots
+    .map((slot) => `${slot.slotId}:${slot.itemId}:${slot.quantity}`)
+    .sort()
+    .join(",");
+  return stableHash32(["INV_STATE_V1", state.playerId, state.schemaVersion, state.capacity, slots].join("|")).toString(16);
+}
+
+function createMovementEvent(input: {
+  sequence: number;
+  playerId: string;
+  itemId: InventoryItemId;
+  quantity: number;
+  movement: "add" | "remove";
+  beforeStateHash: string;
+  afterStateHash: string;
+  origin?: InventoryItemOrigin;
+}): InventoryMovementEvent {
+  const seed = [
+    "INV_MOVE_V1",
+    input.sequence,
+    input.playerId,
+    input.itemId,
+    input.quantity,
+    input.movement,
+    input.beforeStateHash,
+    input.afterStateHash,
+    input.origin?.uid ?? "",
+    input.origin?.tick ?? 0,
+    input.origin?.source ?? "",
+    input.origin?.sourceHash ?? "",
+  ].join("|");
+
+  return Object.freeze({
+    movementHash: stableHash32(seed).toString(16),
+    playerId: input.playerId,
+    itemId: input.itemId,
+    quantity: input.quantity,
+    movement: input.movement,
+    beforeStateHash: input.beforeStateHash,
+    afterStateHash: input.afterStateHash,
+    ...(input.origin ? { origin: input.origin } : {}),
+  });
+}
+
 export class InventoryStore {
   private readonly inventories = new Map<string, PlayerInventoryState>();
+  private readonly seenOriginUids = new Set<string>();
+  private readonly movementEvents: InventoryMovementEvent[] = [];
 
   getPlayerInventory(playerId: string): PlayerInventoryState {
     const existing = this.inventories.get(playerId);
@@ -34,112 +104,90 @@ export class InventoryStore {
     playerId: string;
     itemId: InventoryItemId | string;
     quantity: number;
+    origin?: InventoryItemOrigin;
   }): InventoryAddResult {
     if (!input.playerId || input.playerId === "anonymous") {
-      return {
-        ok: false,
-        playerId: input.playerId,
-        itemId: "wood_log",
-        quantity: 0,
-        reason: "invalid_item",
-      };
+      return { ok: false, playerId: input.playerId, itemId: "wood_log", quantity: 0, reason: "invalid_item" };
     }
 
     if (!isInventoryItemId(input.itemId)) {
-      return {
-        ok: false,
-        playerId: input.playerId,
-        itemId: "wood_log",
-        quantity: 0,
-        reason: "invalid_item",
-      };
+      return { ok: false, playerId: input.playerId, itemId: "wood_log", quantity: 0, reason: "invalid_item" };
     }
 
     const quantity = normalizeQuantity(input.quantity);
     if (quantity <= 0) {
-      return {
-        ok: false,
-        playerId: input.playerId,
-        itemId: input.itemId,
-        quantity: 0,
-        reason: "invalid_quantity",
-      };
+      return { ok: false, playerId: input.playerId, itemId: input.itemId, quantity: 0, reason: "invalid_quantity" };
     }
 
+    const origin = normalizeOrigin(input.origin);
     const definition = ITEM_DEFINITIONS[input.itemId];
     const state = this.getPlayerInventory(input.playerId);
+
+    if (origin === null) {
+      return { ok: false, playerId: input.playerId, itemId: definition.id, quantity, reason: "invalid_origin", state };
+    }
+
+    if (origin && this.seenOriginUids.has(origin.uid)) {
+      return { ok: false, playerId: input.playerId, itemId: definition.id, quantity, reason: "duplicate_origin", state };
+    }
+
+    const beforeStateHash = inventoryStateHash(state);
     const existing = state.slots.find((slot) => slot.itemId === definition.id);
+    let nextState: PlayerInventoryState;
 
     if (existing && definition.stackable) {
-      const nextState = normalizePlayerInventoryState(
+      nextState = normalizePlayerInventoryState(
         {
           ...state,
           slots: state.slots.map((slot) =>
             slot.itemId === definition.id
-              ? {
-                  ...slot,
-                  quantity: Math.min(slot.quantity + quantity, definition.maxStack),
-                }
+              ? { ...slot, quantity: Math.min(slot.quantity + quantity, definition.maxStack) }
               : slot,
           ),
         },
         input.playerId,
       );
+    } else {
+      if (state.slots.length >= INVENTORY_CAPACITY) {
+        return { ok: false, playerId: input.playerId, itemId: definition.id, quantity, reason: "inventory_full", state };
+      }
 
-      this.inventories.set(input.playerId, nextState);
-
-      return {
-        ok: true,
-        playerId: input.playerId,
-        itemId: definition.id,
-        quantity,
-        reason: "added",
-        state: nextState,
-      };
+      nextState = normalizePlayerInventoryState(
+        {
+          ...state,
+          slots: [
+            ...state.slots,
+            {
+              slotId: definition.stackable
+                ? `slot_${definition.id}`
+                : `slot_${definition.id}_${String(state.slots.filter((s) => s.itemId === definition.id).length + 1).padStart(3, "0")}`,
+              itemId: definition.id,
+              name: definition.name,
+              quantity,
+              category: definition.category,
+              stackable: definition.stackable,
+              maxStack: definition.maxStack,
+            },
+          ],
+        },
+        input.playerId,
+      );
     }
-
-    if (state.slots.length >= INVENTORY_CAPACITY) {
-      return {
-        ok: false,
-        playerId: input.playerId,
-        itemId: definition.id,
-        quantity,
-        reason: "inventory_full",
-        state,
-      };
-    }
-
-    const nextState = normalizePlayerInventoryState(
-      {
-        ...state,
-        slots: [
-          ...state.slots,
-          {
-            slotId: definition.stackable
-              ? `slot_${definition.id}`
-              : `slot_${definition.id}_${String(state.slots.filter(s => s.itemId === definition.id).length + 1).padStart(3, "0")}`,
-            itemId: definition.id,
-            name: definition.name,
-            quantity,
-            category: definition.category,
-            stackable: definition.stackable,
-            maxStack: definition.maxStack,
-          },
-        ],
-      },
-      input.playerId,
-    );
 
     this.inventories.set(input.playerId, nextState);
-
-    return {
-      ok: true,
+    if (origin) this.seenOriginUids.add(origin.uid);
+    this.movementEvents.push(createMovementEvent({
+      sequence: this.movementEvents.length,
       playerId: input.playerId,
       itemId: definition.id,
       quantity,
-      reason: "added",
-      state: nextState,
-    };
+      movement: "add",
+      beforeStateHash,
+      afterStateHash: inventoryStateHash(nextState),
+      ...(origin ? { origin } : {}),
+    }));
+
+    return { ok: true, playerId: input.playerId, itemId: definition.id, quantity, reason: "added", state: nextState };
   }
 
   replacePlayerInventory(playerId: string, state: PlayerInventoryState): void {
@@ -152,67 +200,39 @@ export class InventoryStore {
     quantity: number;
   }): InventoryRemoveResult {
     if (!isInventoryItemId(input.itemId)) {
-      return {
-        ok: false,
-        playerId: input.playerId,
-        itemId: "wood_log",
-        quantity: 0,
-        reason: "invalid_item",
-      };
+      return { ok: false, playerId: input.playerId, itemId: "wood_log", quantity: 0, reason: "invalid_item" };
     }
 
     const quantity = normalizeQuantity(input.quantity);
     if (quantity <= 0) {
-      return {
-        ok: false,
-        playerId: input.playerId,
-        itemId: input.itemId,
-        quantity: 0,
-        reason: "invalid_quantity",
-      };
+      return { ok: false, playerId: input.playerId, itemId: input.itemId, quantity: 0, reason: "invalid_quantity" };
     }
 
     const state = this.getPlayerInventory(input.playerId);
     const existing = state.slots.find((slot) => slot.itemId === input.itemId);
 
     if (!existing || existing.quantity < quantity) {
-      return {
-        ok: false,
-        playerId: input.playerId,
-        itemId: input.itemId,
-        quantity,
-        reason: "not_enough_items",
-        state,
-      };
+      return { ok: false, playerId: input.playerId, itemId: input.itemId, quantity, reason: "not_enough_items", state };
     }
 
-    const nextSlots =
-      existing.quantity === quantity
-        ? state.slots.filter((slot) => slot.itemId !== input.itemId)
-        : state.slots.map((slot) =>
-            slot.itemId === input.itemId
-              ? { ...slot, quantity: slot.quantity - quantity }
-              : slot,
-          );
+    const beforeStateHash = inventoryStateHash(state);
+    const nextSlots = existing.quantity === quantity
+      ? state.slots.filter((slot) => slot.itemId !== input.itemId)
+      : state.slots.map((slot) => slot.itemId === input.itemId ? { ...slot, quantity: slot.quantity - quantity } : slot);
 
-    const nextState = normalizePlayerInventoryState(
-      {
-        ...state,
-        slots: nextSlots,
-      },
-      input.playerId,
-    );
-
+    const nextState = normalizePlayerInventoryState({ ...state, slots: nextSlots }, input.playerId);
     this.inventories.set(input.playerId, nextState);
-
-    return {
-      ok: true,
+    this.movementEvents.push(createMovementEvent({
+      sequence: this.movementEvents.length,
       playerId: input.playerId,
       itemId: input.itemId,
       quantity,
-      reason: "removed",
-      state: nextState,
-    };
+      movement: "remove",
+      beforeStateHash,
+      afterStateHash: inventoryStateHash(nextState),
+    }));
+
+    return { ok: true, playerId: input.playerId, itemId: input.itemId, quantity, reason: "removed", state: nextState };
   }
 
   hasItems(input: {
@@ -220,14 +240,20 @@ export class InventoryStore {
     items: Array<{ itemId: InventoryItemId; quantity: number }>;
   }): boolean {
     const state = this.getPlayerInventory(input.playerId);
-
     return input.items.every((required) => {
       const slot = state.slots.find((candidate) => candidate.itemId === required.itemId);
       return Boolean(slot && slot.quantity >= required.quantity);
     });
   }
 
+  getMovementEvents(playerId?: string): readonly InventoryMovementEvent[] {
+    const events = playerId ? this.movementEvents.filter((event) => event.playerId === playerId) : this.movementEvents;
+    return Object.freeze(events.map((event) => Object.freeze({ ...event, ...(event.origin ? { origin: Object.freeze({ ...event.origin }) } : {}) })));
+  }
+
   clearForTests(): void {
     this.inventories.clear();
+    this.seenOriginUids.clear();
+    this.movementEvents.length = 0;
   }
 }

--- a/server/src/inventory/InventoryTypes.ts
+++ b/server/src/inventory/InventoryTypes.ts
@@ -37,6 +37,32 @@ export interface InventorySlot {
   maxStack: number;
 }
 
+export type InventoryOriginSource =
+  | "loot_delta"
+  | "crafting_delta"
+  | "trade_delta"
+  | "storage_delta"
+  | "quest_delta"
+  | "system_delta";
+
+export interface InventoryItemOrigin {
+  uid: string;
+  tick: number;
+  source: InventoryOriginSource;
+  sourceHash: string;
+}
+
+export interface InventoryMovementEvent {
+  movementHash: string;
+  playerId: string;
+  itemId: InventoryItemId;
+  quantity: number;
+  movement: "add" | "remove";
+  beforeStateHash: string;
+  afterStateHash: string;
+  origin?: InventoryItemOrigin;
+}
+
 export interface PlayerInventoryState {
   playerId: string;
   schemaVersion: 1;
@@ -49,7 +75,7 @@ export interface InventoryAddResult {
   playerId: string;
   itemId: InventoryItemId;
   quantity: number;
-  reason?: "added" | "invalid_item" | "invalid_quantity" | "inventory_full";
+  reason?: "added" | "invalid_item" | "invalid_quantity" | "inventory_full" | "invalid_origin" | "duplicate_origin";
   state?: PlayerInventoryState;
 }
 
@@ -65,94 +91,26 @@ export interface InventoryRemoveResult {
 export const INVENTORY_CAPACITY = 32;
 
 export const ITEM_DEFINITIONS: Record<InventoryItemId, InventoryItemDefinition> = {
-  wood_log: {
-    id: "wood_log",
-    name: "Wood Log",
-    stackable: true,
-    maxStack: 999,
-    category: "resource",
-  },
-  copper_ore: {
-    id: "copper_ore",
-    name: "Copper Ore",
-    stackable: true,
-    maxStack: 999,
-    category: "resource",
-  },
-  raw_fish: {
-    id: "raw_fish",
-    name: "Raw Fish",
-    stackable: true,
-    maxStack: 999,
-    category: "resource",
-  },
-  wood_plank: {
-    id: "wood_plank",
-    name: "Wood Plank",
-    stackable: true,
-    maxStack: 999,
-    category: "resource",
-  },
-  copper_ingot: {
-    id: "copper_ingot",
-    name: "Copper Ingot",
-    stackable: true,
-    maxStack: 999,
-    category: "resource",
-  },
-  cooked_fish: {
-    id: "cooked_fish",
-    name: "Cooked Fish",
-    stackable: true,
-    maxStack: 999,
-    category: "consumable",
-  },
-  wooden_axe: {
-    id: "wooden_axe",
-    name: "Wooden Axe",
-    stackable: false,
-    maxStack: 1,
-    category: "equipment",
-  },
-  copper_pickaxe: {
-    id: "copper_pickaxe",
-    name: "Copper Pickaxe",
-    stackable: false,
-    maxStack: 1,
-    category: "equipment",
-  },
-  simple_fishing_rod: {
-    id: "simple_fishing_rod",
-    name: "Simple Fishing Rod",
-    stackable: false,
-    maxStack: 1,
-    category: "equipment",
-  },
-  copper_axe: {
-    id: "copper_axe",
-    name: "Copper Axe",
-    stackable: false,
-    maxStack: 1,
-    category: "equipment",
-  },
-  reinforced_pickaxe: {
-    id: "reinforced_pickaxe",
-    name: "Reinforced Pickaxe",
-    stackable: false,
-    maxStack: 1,
-    category: "equipment",
-  },
-  reinforced_fishing_rod: {
-    id: "reinforced_fishing_rod",
-    name: "Reinforced Fishing Rod",
-    stackable: false,
-    maxStack: 1,
-    category: "equipment",
-  },
+  wood_log: { id: "wood_log", name: "Wood Log", stackable: true, maxStack: 999, category: "resource" },
+  copper_ore: { id: "copper_ore", name: "Copper Ore", stackable: true, maxStack: 999, category: "resource" },
+  raw_fish: { id: "raw_fish", name: "Raw Fish", stackable: true, maxStack: 999, category: "resource" },
+  wood_plank: { id: "wood_plank", name: "Wood Plank", stackable: true, maxStack: 999, category: "resource" },
+  copper_ingot: { id: "copper_ingot", name: "Copper Ingot", stackable: true, maxStack: 999, category: "resource" },
+  cooked_fish: { id: "cooked_fish", name: "Cooked Fish", stackable: true, maxStack: 999, category: "consumable" },
+  wooden_axe: { id: "wooden_axe", name: "Wooden Axe", stackable: false, maxStack: 1, category: "equipment" },
+  copper_pickaxe: { id: "copper_pickaxe", name: "Copper Pickaxe", stackable: false, maxStack: 1, category: "equipment" },
+  simple_fishing_rod: { id: "simple_fishing_rod", name: "Simple Fishing Rod", stackable: false, maxStack: 1, category: "equipment" },
+  copper_axe: { id: "copper_axe", name: "Copper Axe", stackable: false, maxStack: 1, category: "equipment" },
+  reinforced_pickaxe: { id: "reinforced_pickaxe", name: "Reinforced Pickaxe", stackable: false, maxStack: 1, category: "equipment" },
+  reinforced_fishing_rod: { id: "reinforced_fishing_rod", name: "Reinforced Fishing Rod", stackable: false, maxStack: 1, category: "equipment" },
 };
 
 export function isInventoryItemId(value: unknown): value is InventoryItemId {
   return typeof value === "string" && value in ITEM_DEFINITIONS;
+}
+
+export function isInventoryOriginSource(value: unknown): value is InventoryOriginSource {
+  return typeof value === "string" && ["loot_delta", "crafting_delta", "trade_delta", "storage_delta", "quest_delta", "system_delta"].includes(value);
 }
 
 export function normalizeQuantity(value: unknown): number {
@@ -162,22 +120,14 @@ export function normalizeQuantity(value: unknown): number {
 }
 
 export function createDefaultInventoryState(playerId: string): PlayerInventoryState {
-  return {
-    playerId,
-    schemaVersion: 1,
-    slots: [],
-    capacity: INVENTORY_CAPACITY,
-  };
+  return { playerId, schemaVersion: 1, slots: [], capacity: INVENTORY_CAPACITY };
 }
 
 export function normalizeInventorySlot(slot: Partial<InventorySlot>): InventorySlot | null {
   if (!isInventoryItemId(slot.itemId)) return null;
-
   const definition = ITEM_DEFINITIONS[slot.itemId];
   const quantity = normalizeQuantity(slot.quantity);
-
   if (quantity <= 0) return null;
-
   return {
     slotId: String(slot.slotId || `slot_${definition.id}`),
     itemId: definition.id,
@@ -189,31 +139,17 @@ export function normalizeInventorySlot(slot: Partial<InventorySlot>): InventoryS
   };
 }
 
-export function normalizePlayerInventoryState(
-  input: Partial<PlayerInventoryState> | null | undefined,
-  playerId: string,
-): PlayerInventoryState {
+export function normalizePlayerInventoryState(input: Partial<PlayerInventoryState> | null | undefined, playerId: string): PlayerInventoryState {
   const slots = new Map<InventoryItemId, InventorySlot>();
-
   for (const rawSlot of input?.slots ?? []) {
     const slot = normalizeInventorySlot(rawSlot);
     if (!slot) continue;
-
     const existing = slots.get(slot.itemId);
     if (existing && slot.stackable) {
-      slots.set(slot.itemId, {
-        ...existing,
-        quantity: Math.min(existing.quantity + slot.quantity, slot.maxStack),
-      });
+      slots.set(slot.itemId, { ...existing, quantity: Math.min(existing.quantity + slot.quantity, slot.maxStack) });
     } else {
       slots.set(slot.itemId, slot);
     }
   }
-
-  return {
-    playerId,
-    schemaVersion: 1,
-    capacity: INVENTORY_CAPACITY,
-    slots: [...slots.values()].sort((a, b) => a.itemId.localeCompare(b.itemId)),
-  };
+  return { playerId, schemaVersion: 1, capacity: INVENTORY_CAPACITY, slots: [...slots.values()].sort((a, b) => a.itemId.localeCompare(b.itemId)) };
 }

--- a/server/src/tests/inventory-store.test.ts
+++ b/server/src/tests/inventory-store.test.ts
@@ -24,11 +24,11 @@ describe("InventoryStore", () => {
       expect(state.capacity).toBe(32);
     });
 
-    it("returns same state for same playerId", () => {
+    it("returns equivalent state for same playerId", () => {
       const state1 = store.getPlayerInventory("p1");
       const state2 = store.getPlayerInventory("p1");
 
-      expect(state1).toBe(state2);
+      expect(state2).toEqual(state1);
     });
 
     it("has correct schema version", () => {
@@ -54,17 +54,9 @@ describe("InventoryStore", () => {
     });
 
     it("stacks same item deterministically", () => {
-      store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 1,
-      });
+      store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 1 });
 
-      const result = store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 2,
-      });
+      const result = store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 2 });
 
       expect(result.ok).toBe(true);
       expect(result.state?.slots).toHaveLength(1);
@@ -73,36 +65,73 @@ describe("InventoryStore", () => {
     });
 
     it("respects maxStack limit", () => {
-      store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 998,
-      });
+      store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 998 });
 
+      const result = store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 5 });
+
+      expect(result.ok).toBe(true);
+      expect(result.state?.slots[0].quantity).toBe(999);
+    });
+  });
+
+  describe("addItem - origin checks", () => {
+    it("records deterministic add movement events with origin evidence", () => {
       const result = store.addItem({
         playerId: "p1",
         itemId: "wood_log",
-        quantity: 5,
+        quantity: 2,
+        origin: { uid: "loot:p1:tick10:wood:001", tick: 10, source: "loot_delta", sourceHash: "loot_hash_001" },
       });
 
       expect(result.ok).toBe(true);
-      expect(result.state?.slots[0].quantity).toBe(999); // capped at maxStack
+      const events = store.getMovementEvents("p1");
+      expect(events).toHaveLength(1);
+      expect(events[0].movement).toBe("add");
+      expect(events[0].movementHash).toMatch(/^[0-9a-f]+$/);
+      expect(events[0].beforeStateHash).not.toBe(events[0].afterStateHash);
+      expect(events[0].origin?.uid).toBe("loot:p1:tick10:wood:001");
+    });
+
+    it("rejects duplicate origin uid without mutating inventory", () => {
+      const first = store.addItem({
+        playerId: "p1",
+        itemId: "wood_log",
+        quantity: 1,
+        origin: { uid: "loot:p1:tick10:wood:002", tick: 10, source: "loot_delta", sourceHash: "loot_hash_002" },
+      });
+      const second = store.addItem({
+        playerId: "p1",
+        itemId: "wood_log",
+        quantity: 99,
+        origin: { uid: "loot:p1:tick10:wood:002", tick: 10, source: "loot_delta", sourceHash: "loot_hash_002" },
+      });
+
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(false);
+      expect(second.reason).toBe("duplicate_origin");
+      expect(store.getPlayerInventory("p1").slots[0].quantity).toBe(1);
+      expect(store.getMovementEvents("p1")).toHaveLength(1);
+    });
+
+    it("rejects malformed origin data", () => {
+      const result = store.addItem({
+        playerId: "p1",
+        itemId: "wood_log",
+        quantity: 1,
+        origin: { uid: "", tick: -1, source: "loot_delta", sourceHash: "" },
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("invalid_origin");
+      expect(store.getPlayerInventory("p1").slots).toEqual([]);
+      expect(store.getMovementEvents("p1")).toEqual([]);
     });
   });
 
   describe("addItem - different items", () => {
     it("creates separate slots for different items", () => {
-      store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 1,
-      });
-
-      store.addItem({
-        playerId: "p1",
-        itemId: "copper_ore",
-        quantity: 1,
-      });
+      store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 1 });
+      store.addItem({ playerId: "p1", itemId: "copper_ore", quantity: 1 });
 
       const state = store.getPlayerInventory("p1");
 
@@ -114,86 +143,60 @@ describe("InventoryStore", () => {
 
   describe("addItem - validation", () => {
     it("rejects invalid item ids", () => {
-      const result = store.addItem({
-        playerId: "p1",
-        itemId: "admin_sword",
-        quantity: 1,
-      });
-
+      const result = store.addItem({ playerId: "p1", itemId: "admin_sword", quantity: 1 });
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("invalid_item");
     });
 
     it("rejects zero quantity", () => {
-      const result = store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 0,
-      });
-
+      const result = store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 0 });
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("invalid_quantity");
     });
 
     it("rejects negative quantity", () => {
-      const result = store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: -5,
-      });
-
+      const result = store.addItem({ playerId: "p1", itemId: "wood_log", quantity: -5 });
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("invalid_quantity");
     });
 
     it("rejects anonymous playerId", () => {
-      const result = store.addItem({
-        playerId: "anonymous",
-        itemId: "wood_log",
-        quantity: 1,
-      });
-
+      const result = store.addItem({ playerId: "anonymous", itemId: "wood_log", quantity: 1 });
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("invalid_item");
     });
 
     it("rejects empty playerId", () => {
-      const result = store.addItem({
-        playerId: "",
-        itemId: "wood_log",
-        quantity: 1,
-      });
-
+      const result = store.addItem({ playerId: "", itemId: "wood_log", quantity: 1 });
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("invalid_item");
     });
   });
 
+  describe("removeItem", () => {
+    it("records remove movement events", () => {
+      store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 5 });
+      const result = store.removeItem({ playerId: "p1", itemId: "wood_log", quantity: 2 });
+
+      expect(result.ok).toBe(true);
+      const events = store.getMovementEvents("p1");
+      expect(events).toHaveLength(2);
+      expect(events[1].movement).toBe("remove");
+      expect(events[1].beforeStateHash).not.toBe(events[1].afterStateHash);
+      expect(result.state?.slots[0].quantity).toBe(3);
+    });
+  });
+
   describe("player isolation", () => {
     it("isolates player inventory by playerId", () => {
-      store.addItem({
-        playerId: "p1",
-        itemId: "raw_fish",
-        quantity: 5,
-      });
-
+      store.addItem({ playerId: "p1", itemId: "raw_fish", quantity: 5 });
       const p2Inventory = store.getPlayerInventory("p2");
-
       expect(p2Inventory.slots).toEqual([]);
     });
 
     it("each player has independent inventory", () => {
-      store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 10,
-      });
-
-      store.addItem({
-        playerId: "p2",
-        itemId: "copper_ore",
-        quantity: 3,
-      });
+      store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 10 });
+      store.addItem({ playerId: "p2", itemId: "copper_ore", quantity: 3 });
 
       const p1State = store.getPlayerInventory("p1");
       const p2State = store.getPlayerInventory("p2");
@@ -201,7 +204,6 @@ describe("InventoryStore", () => {
       expect(p1State.slots).toHaveLength(1);
       expect(p1State.slots[0].itemId).toBe("wood_log");
       expect(p1State.slots[0].quantity).toBe(10);
-
       expect(p2State.slots).toHaveLength(1);
       expect(p2State.slots[0].itemId).toBe("copper_ore");
       expect(p2State.slots[0].quantity).toBe(3);
@@ -210,82 +212,30 @@ describe("InventoryStore", () => {
 
   describe("replacePlayerInventory", () => {
     it("replaces player inventory from persistence", () => {
-      store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 1,
-      });
-
+      store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 1 });
       store.replacePlayerInventory("p1", {
         playerId: "p1",
         schemaVersion: 1,
         capacity: 32,
-        slots: [
-          {
-            slotId: "slot_wood_log",
-            itemId: "wood_log",
-            name: "Wood Log",
-            quantity: 50,
-            category: "resource",
-            stackable: true,
-            maxStack: 999,
-          },
-        ],
+        slots: [{ slotId: "slot_wood_log", itemId: "wood_log", name: "Wood Log", quantity: 50, category: "resource", stackable: true, maxStack: 999 }],
       });
 
       const state = store.getPlayerInventory("p1");
-
       expect(state.slots).toHaveLength(1);
       expect(state.slots[0].quantity).toBe(50);
     });
   });
 
   describe("clearForTests", () => {
-    it("clears all player inventory", () => {
-      store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 10,
-      });
-
-      store.addItem({
-        playerId: "p2",
-        itemId: "copper_ore",
-        quantity: 5,
-      });
+    it("clears all player inventory and movement events", () => {
+      store.addItem({ playerId: "p1", itemId: "wood_log", quantity: 10 });
+      store.addItem({ playerId: "p2", itemId: "copper_ore", quantity: 5 });
 
       store.clearForTests();
 
       expect(store.getPlayerInventory("p1").slots).toEqual([]);
       expect(store.getPlayerInventory("p2").slots).toEqual([]);
-    });
-  });
-
-  describe("deterministic ordering", () => {
-    it("slots are sorted by itemId", () => {
-      store.addItem({
-        playerId: "p1",
-        itemId: "raw_fish",
-        quantity: 1,
-      });
-
-      store.addItem({
-        playerId: "p1",
-        itemId: "wood_log",
-        quantity: 1,
-      });
-
-      store.addItem({
-        playerId: "p1",
-        itemId: "copper_ore",
-        quantity: 1,
-      });
-
-      const state = store.getPlayerInventory("p1");
-
-      expect(state.slots[0].itemId).toBe("copper_ore");
-      expect(state.slots[1].itemId).toBe("raw_fish");
-      expect(state.slots[2].itemId).toBe("wood_log");
+      expect(store.getMovementEvents()).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements a concrete server-authoritative slice of #2048.

- Adds deterministic item origin metadata (`uid`, `tick`, `source`, `sourceHash`) for inventory additions.
- Rejects duplicate origin UIDs before mutating inventory.
- Records deterministic add/remove movement events with before/after inventory state hashes.
- Exposes `getMovementEvents()` for audit reads without promoting logs into gameplay state.
- Extends inventory tests for duplicate-origin rejection, malformed origin rejection, and movement event creation.

## ARE notes

No mock items. No fake trade facade. No wall-clock source. Origin evidence must be supplied by the caller from real runtime delta paths such as loot/crafting/trade/storage deltas. This PR does not claim to complete full trading integration; it implements the item movement and duplicate-origin guard foundation for #2048.

Refs #2048
