### PR TITLE
fix(auth): require explicit production player fallback

### DIFF
--- a/server/src/auth/PlayerIdentityResolver.ts
+++ b/server/src/auth/PlayerIdentityResolver.ts
@@ -32,17 +32,17 @@ export interface PlayerIdentityRequestLike {
   session?: { playerId?: string; userId?: string };
 }
 
-function envNotFalse(key: string): boolean {
-  return !["0", "false", "no"].includes(
-    process.env[key]?.trim().toLowerCase() || "",
-  );
+const TRUTHY_ENV = new Set(["1", "true", "yes", "on"]);
+
+function envTruthy(key: string): boolean {
+  const value = process.env[key]?.trim().toLowerCase();
+  return value ? TRUTHY_ENV.has(value) : false;
 }
 
-const DEV_FALLBACK_ENABLED =
-  process.env.NODE_ENV !== "production" ||
-  process.env.ALLOW_DEV_PLAYER_ID === "true" ||
-  envNotFalse("ALLOW_GUEST_LOGIN") ||
-  envNotFalse("ALLOW_DEV_LOGIN");
+export function isDevPlayerIdentityFallbackEnabled(): boolean {
+  if (process.env.NODE_ENV !== "production") return true;
+  return envTruthy("ALLOW_DEV_PLAYER_ID") || envTruthy("ALLOW_GUEST_LOGIN") || envTruthy("ALLOW_DEV_LOGIN");
+}
 
 function firstHeaderValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
@@ -64,9 +64,7 @@ function bodyPlayerId(body: unknown): unknown {
   return (body as Record<string, unknown>).playerId;
 }
 
-export function resolveHttpPlayerIdentity(
-  req: PlayerIdentityRequestLike,
-): PlayerIdentity {
+export function resolveHttpPlayerIdentity(req: PlayerIdentityRequestLike): PlayerIdentity {
   // 1. Prefer real auth middleware if it exists
   const authUser = req as Record<string, unknown>;
   const authId = normalizePlayerId(
@@ -101,7 +99,7 @@ export function resolveHttpPlayerIdentity(
   // 3. Dev/playtest fallback only. This preserves per-guest HTTP state
   // for the current 2D guest-login flow instead of collapsing everyone
   // into the shared "anonymous" profile.
-  if (DEV_FALLBACK_ENABLED) {
+  if (isDevPlayerIdentityFallbackEnabled()) {
     const headerId = normalizePlayerId(
       firstHeaderValue(req.headers?.["x-player-id"]) ??
       firstHeaderValue(req.headers?.["x-areloria-player-id"]),
@@ -127,7 +125,7 @@ export function resolveHttpPlayerIdentity(
 }
 
 export function assertPlayerIdentityAllowed(identity: PlayerIdentity): void {
-  if (process.env.NODE_ENV === "production" && !identity.authenticated && !DEV_FALLBACK_ENABLED) {
+  if (process.env.NODE_ENV === "production" && !identity.authenticated && !isDevPlayerIdentityFallbackEnabled()) {
     throw new Error("authenticated_player_required");
   }
 }

--- a/server/src/tests/identity-resolver.test.ts
+++ b/server/src/tests/identity-resolver.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isDevPlayerIdentityFallbackEnabled, resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
+
+const KEYS = ["NODE_ENV", "ALLOW_DEV_PLAYER_ID", "ALLOW_GUEST_LOGIN", "ALLOW_DEV_LOGIN"] as const;
+let saved: Partial<Record<(typeof KEYS)[number], string | undefined>> = {};
+
+function resetEnv(): void {
+  for (const key of KEYS) {
+    const value = saved[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+describe("resolveHttpPlayerIdentity", () => {
+  beforeEach(() => {
+    saved = Object.fromEntries(KEYS.map((key) => [key, process.env[key]]));
+    delete process.env.ALLOW_DEV_PLAYER_ID;
+    delete process.env.ALLOW_GUEST_LOGIN;
+    delete process.env.ALLOW_DEV_LOGIN;
+  });
+
+  afterEach(() => {
+    resetEnv();
+  });
+
+  it("uses auth identity before request supplied ids", () => {
+    process.env.NODE_ENV = "production";
+    const identity = resolveHttpPlayerIdentity({
+      user: { id: "auth_player" },
+      headers: { "x-player-id": "header_player" },
+      query: { playerId: "query_player" },
+      body: { playerId: "body_player" },
+    });
+
+    expect(identity.playerId).toBe("auth_player");
+    expect(identity.source).toBe("auth");
+    expect(identity.authenticated).toBe(true);
+  });
+
+  it("keeps request supplied ids disabled in production by default", () => {
+    process.env.NODE_ENV = "production";
+
+    expect(isDevPlayerIdentityFallbackEnabled()).toBe(false);
+    expect(resolveHttpPlayerIdentity({ headers: { "x-player-id": "guest_player" } })).toEqual({
+      playerId: "anonymous",
+      source: "anonymous",
+      authenticated: false,
+    });
+  });
+
+  it("accepts request supplied ids in production only with an explicit allow flag", () => {
+    process.env.NODE_ENV = "production";
+    process.env.ALLOW_GUEST_LOGIN = "true";
+
+    expect(isDevPlayerIdentityFallbackEnabled()).toBe(true);
+    expect(resolveHttpPlayerIdentity({ headers: { "x-player-id": "guest_player" } })).toEqual({
+      playerId: "guest_player",
+      source: "dev-fallback",
+      authenticated: false,
+    });
+  });
+
+  it("keeps local development fallback available", () => {
+    process.env.NODE_ENV = "development";
+
+    expect(isDevPlayerIdentityFallbackEnabled()).toBe(true);
+    expect(resolveHttpPlayerIdentity({ query: { playerId: "local_player" } }).playerId).toBe("local_player");
+  });
+});


### PR DESCRIPTION
## Summary

Implements a concrete slice of #2040.

- Makes production request-supplied player identity fallback default-deny.
- Allows production fallback only when `ALLOW_DEV_PLAYER_ID`, `ALLOW_GUEST_LOGIN`, or `ALLOW_DEV_LOGIN` is explicitly truthy.
- Keeps local development fallback behavior intact for playtests.
- Makes fallback enablement dynamic so tests and runtime env changes are evaluated consistently.
- Adds tests for auth identity precedence, production default lock, explicit allow flag, and local development fallback.

## ARE notes

No auth mock is added to the runtime path. Auth/session identity still wins. Request-supplied player IDs are only accepted in production when explicitly configured.

Refs #2040
