### PR TITLE
fix(auth): align websocket player identity with HTTP resolver

### DIFF
--- a/server/src/networking/WebSocketServer.ts
+++ b/server/src/networking/WebSocketServer.ts
@@ -1,8 +1,10 @@
-import type { Server as HttpServer } from "node:http";
+import type { IncomingMessage, Server as HttpServer } from "node:http";
+import { URL } from "node:url";
 import { WebSocketServer, WebSocket } from "ws";
 import { randomUUID } from "node:crypto";
 import { GameConfig } from "../config/GameConfig.js";
 import { collectiveIngressRuntime } from "../collective/CollectiveIngressRuntime.js";
+import { resolveHttpPlayerIdentity, type PlayerIdentityRequestLike } from "../auth/PlayerIdentityResolver.js";
 
 const WS_RL_WINDOW_MS = 1000;
 
@@ -35,6 +37,25 @@ function playerUidMessageCap(): number {
   if (!raw) return GameConfig.wsMaxMessagesPerPlayerUidPerSecond;
   const n = Number(raw);
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : GameConfig.wsMaxMessagesPerPlayerUidPerSecond;
+}
+
+function queryFromRequestUrl(req: IncomingMessage): Record<string, unknown> {
+  const parsed = new URL(String(req.url || "/ws"), "http://127.0.0.1");
+  const query: Record<string, unknown> = {};
+  for (const [key, value] of parsed.searchParams.entries()) {
+    query[key] = value;
+  }
+  return query;
+}
+
+function resolveUpgradePlayerUid(req: IncomingMessage): string | null {
+  const identity = resolveHttpPlayerIdentity({
+    headers: req.headers as PlayerIdentityRequestLike["headers"],
+    query: queryFromRequestUrl(req),
+    user: (req as IncomingMessage & { user?: PlayerIdentityRequestLike["user"] }).user,
+    session: (req as IncomingMessage & { session?: PlayerIdentityRequestLike["session"] }).session,
+  });
+  return identity.source === "anonymous" ? null : identity.playerId;
 }
 
 export class GameWebSocketServer {
@@ -72,10 +93,14 @@ export class GameWebSocketServer {
     };
     this.httpServer.on("upgrade", this.upgradeHandler);
 
-    this.wss.on("connection", (socket: WebSocket & { id?: string }) => {
+    this.wss.on("connection", (socket: WebSocket & { id?: string }, req: IncomingMessage) => {
       const id = randomUUID();
       socket.id = id;
       this.totalConnections += 1;
+      const upgradePlayerUid = resolveUpgradePlayerUid(req);
+      if (upgradePlayerUid) {
+        this.socketToPlayerUid.set(id, upgradePlayerUid);
+      }
       const tracked = socket as TrackedSocket;
       tracked._entitySyncIntervalMs = GameConfig.stateBroadcastIntervalMs;
       tracked._lastEntitySyncSentAt = 0;

--- a/server/src/tests/ws-player-uid-rate.test.ts
+++ b/server/src/tests/ws-player-uid-rate.test.ts
@@ -3,9 +3,27 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import WebSocket from "ws";
 
+async function listenOnRandomPort(httpServer: ReturnType<typeof createServer>): Promise<number> {
+  await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+  return (httpServer.address() as AddressInfo).port;
+}
+
+async function openSocket(url: string, options?: ConstructorParameters<typeof WebSocket>[1]): Promise<WebSocket> {
+  const ws = new WebSocket(url, options);
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+  return ws;
+}
+
 describe("GameWebSocketServer per-uid rate limit", () => {
   afterEach(() => {
     delete process.env.WS_MAX_MESSAGES_PER_PLAYER_UID_PER_SECOND;
+    delete process.env.ALLOW_GUEST_LOGIN;
+    delete process.env.ALLOW_DEV_LOGIN;
+    delete process.env.ALLOW_DEV_PLAYER_ID;
+    delete process.env.NODE_ENV;
   });
 
   it("drops messages after uid budget in a rolling second", async () => {
@@ -21,15 +39,9 @@ describe("GameWebSocketServer per-uid rate limit", () => {
       received += 1;
     };
     gws.resolveSocketToPlayerUid = () => "same_uid";
+    const port = await listenOnRandomPort(httpServer);
 
-    await new Promise<void>((resolve) => httpServer.listen(0, resolve));
-    const port = (httpServer.address() as AddressInfo).port;
-
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
-    await new Promise<void>((resolve, reject) => {
-      ws.once("open", () => resolve());
-      ws.once("error", reject);
-    });
+    const ws = await openSocket(`ws://127.0.0.1:${port}/ws`);
 
     for (let i = 0; i < 12; i++) {
       ws.send(JSON.stringify({ type: "noop", i }));
@@ -40,6 +52,62 @@ describe("GameWebSocketServer per-uid rate limit", () => {
     expect(received).toBeLessThanOrEqual(4);
 
     ws.close();
+    gws.stop();
+    await new Promise<void>((resolve) => {
+      httpServer.close(() => resolve());
+    });
+  });
+
+  it("maps upgrade player identity through the shared HTTP resolver", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ALLOW_GUEST_LOGIN = "true";
+
+    const { GameWebSocketServer } = await import("../networking/WebSocketServer.js");
+
+    const httpServer = createServer();
+    const gws = new GameWebSocketServer(httpServer);
+    gws.start();
+    const port = await listenOnRandomPort(httpServer);
+
+    const ws = await openSocket(`ws://127.0.0.1:${port}/ws`, {
+      headers: { "x-player-id": "ws_player" },
+    });
+    ws.send(JSON.stringify({ type: "noop", from: "identity-test" }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const stats = gws.getRuntimeStats();
+    expect(stats.trackedPlayerUids).toBe(1);
+    expect(stats.playerUidMessagesInWindow).toBe(1);
+
+    ws.close();
+    gws.stop();
+    await new Promise<void>((resolve) => {
+      httpServer.close(() => resolve());
+    });
+  });
+
+  it("does not map request supplied player id in production without explicit allow flag", async () => {
+    process.env.NODE_ENV = "production";
+
+    const { GameWebSocketServer } = await import("../networking/WebSocketServer.js");
+
+    const httpServer = createServer();
+    const gws = new GameWebSocketServer(httpServer);
+    gws.start();
+    const port = await listenOnRandomPort(httpServer);
+
+    const ws = await openSocket(`ws://127.0.0.1:${port}/ws`, {
+      headers: { "x-player-id": "ws_player" },
+    });
+    ws.send(JSON.stringify({ type: "noop", from: "identity-test" }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const stats = gws.getRuntimeStats();
+    expect(stats.trackedPlayerUids).toBe(0);
+    expect(stats.playerUidMessagesInWindow).toBe(0);
+
+    ws.close();
+    gws.stop();
     await new Promise<void>((resolve) => {
       httpServer.close(() => resolve());
     });


### PR DESCRIPTION
## Summary

Continues #2040 after #2068.

- Resolves WebSocket upgrade player identity through the shared `PlayerIdentityResolver`.
- Keeps socket id separate, but maps the socket to the resolved server-side player uid when auth/session/dev fallback is allowed.
- Production request-supplied WebSocket player ids remain blocked unless the same explicit allow flags used by HTTP are enabled.
- Adds WebSocket tests for allowed production fallback and blocked default production fallback.

## ARE notes

No fake login packet. No UI identity truth path. WebSocket identity now uses the same server-side resolver rules as HTTP.

Refs #2040
