### PR TITLE
fix(auth): cover session expiry and ws limits

### DIFF
--- a/server/src/gameplay/identity/sessionTokenService.ts
+++ b/server/src/gameplay/identity/sessionTokenService.ts
@@ -27,6 +27,10 @@ function createOpaqueToken(): string {
   return `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
 }
 
+function isExpired(record: SessionTokenRecord, nowMs: number): boolean {
+  return record.expiresAtMs <= nowMs;
+}
+
 export function createSessionTokenService(
   repository: IdentityRepository
 ): SessionTokenService {
@@ -48,7 +52,15 @@ export function createSessionTokenService(
     },
 
     async verifyToken(token) {
-      return repository.getSessionToken(token);
+      const record = await repository.getSessionToken(token);
+      if (!record) return null;
+
+      if (isExpired(record, Date.now())) {
+        await repository.deleteSessionToken(token);
+        return null;
+      }
+
+      return record;
     },
 
     async revokeToken(token) {

--- a/server/src/tests/session-token-service.test.ts
+++ b/server/src/tests/session-token-service.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { createSessionTokenService } from "../gameplay/identity/sessionTokenService.js";
+import type { IdentityRepository } from "../gameplay/identity/identityRepository.js";
+import type { CharacterRecord, SessionTokenRecord, StableIdentity } from "../gameplay/identity/types.js";
+
+function createRepositoryWithToken(record: SessionTokenRecord): IdentityRepository & { deleted: string[] } {
+  const deleted: string[] = [];
+  return {
+    deleted,
+    async getIdentityByStableGuestId(): Promise<StableIdentity | null> {
+      return null;
+    },
+    async getIdentityById(): Promise<StableIdentity | null> {
+      return null;
+    },
+    async upsertIdentity(): Promise<void> {},
+    async listCharacters(): Promise<CharacterRecord[]> {
+      return [];
+    },
+    async getCharacter(): Promise<CharacterRecord | null> {
+      return null;
+    },
+    async upsertCharacter(): Promise<void> {},
+    async getSessionToken(token: string): Promise<SessionTokenRecord | null> {
+      return token === record.token ? { ...record } : null;
+    },
+    async upsertSessionToken(): Promise<void> {},
+    async deleteSessionToken(token: string): Promise<void> {
+      deleted.push(token);
+    },
+  };
+}
+
+describe("SessionTokenService", () => {
+  it("returns active tokens from the repository", async () => {
+    const repository = createRepositoryWithToken({
+      token: "sess_active",
+      identityId: "identity_1",
+      playerId: "player_1",
+      characterId: "character_1",
+      createdAtMs: Date.now() - 1000,
+      expiresAtMs: Date.now() + 1000 * 60,
+    });
+    const service = createSessionTokenService(repository);
+
+    await expect(service.verifyToken("sess_active")).resolves.toMatchObject({
+      token: "sess_active",
+      identityId: "identity_1",
+      playerId: "player_1",
+    });
+    expect(repository.deleted).toEqual([]);
+  });
+
+  it("rejects and deletes expired tokens even when the repository returns them", async () => {
+    const repository = createRepositoryWithToken({
+      token: "sess_expired",
+      identityId: "identity_1",
+      playerId: "player_1",
+      characterId: "character_1",
+      createdAtMs: Date.now() - 1000 * 60,
+      expiresAtMs: Date.now() - 1,
+    });
+    const service = createSessionTokenService(repository);
+
+    await expect(service.verifyToken("sess_expired")).resolves.toBeNull();
+    expect(repository.deleted).toEqual(["sess_expired"]);
+  });
+});

--- a/server/src/tests/ws-player-uid-rate.test.ts
+++ b/server/src/tests/ws-player-uid-rate.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import WebSocket from "ws";
+import { GameConfig } from "../config/GameConfig.js";
 
 async function listenOnRandomPort(httpServer: ReturnType<typeof createServer>): Promise<number> {
   await new Promise<void>((resolve) => httpServer.listen(0, resolve));
@@ -17,13 +18,46 @@ async function openSocket(url: string, options?: ConstructorParameters<typeof We
   return ws;
 }
 
-describe("GameWebSocketServer per-uid rate limit", () => {
+async function closeServer(ws: WebSocket, gws: { stop(): void }, httpServer: ReturnType<typeof createServer>): Promise<void> {
+  ws.close();
+  gws.stop();
+  await new Promise<void>((resolve) => {
+    httpServer.close(() => resolve());
+  });
+}
+
+describe("GameWebSocketServer rate limit and identity proof", () => {
   afterEach(() => {
     delete process.env.WS_MAX_MESSAGES_PER_PLAYER_UID_PER_SECOND;
     delete process.env.ALLOW_GUEST_LOGIN;
     delete process.env.ALLOW_DEV_LOGIN;
     delete process.env.ALLOW_DEV_PLAYER_ID;
     delete process.env.NODE_ENV;
+  });
+
+  it("drops messages after socket budget in a rolling second", async () => {
+    const { GameWebSocketServer } = await import("../networking/WebSocketServer.js");
+
+    const httpServer = createServer();
+    const gws = new GameWebSocketServer(httpServer);
+    gws.start();
+    let received = 0;
+    gws.onPlayerMessage = () => {
+      received += 1;
+    };
+    const port = await listenOnRandomPort(httpServer);
+    const ws = await openSocket(`ws://127.0.0.1:${port}/ws`);
+
+    for (let i = 0; i < GameConfig.wsMaxMessagesPerSecond + 20; i++) {
+      ws.send(JSON.stringify({ type: "noop", i }));
+    }
+    await new Promise((r) => setTimeout(r, 80));
+
+    const stats = gws.getRuntimeStats();
+    expect(received).toBeLessThanOrEqual(GameConfig.wsMaxMessagesPerSecond);
+    expect(stats.droppedRateLimitedMessages).toBeGreaterThan(0);
+
+    await closeServer(ws, gws, httpServer);
   });
 
   it("drops messages after uid budget in a rolling second", async () => {
@@ -50,12 +84,9 @@ describe("GameWebSocketServer per-uid rate limit", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(received).toBeLessThanOrEqual(4);
+    expect(gws.getRuntimeStats().droppedRateLimitedMessages).toBeGreaterThan(0);
 
-    ws.close();
-    gws.stop();
-    await new Promise<void>((resolve) => {
-      httpServer.close(() => resolve());
-    });
+    await closeServer(ws, gws, httpServer);
   });
 
   it("maps upgrade player identity through the shared HTTP resolver", async () => {
@@ -79,11 +110,7 @@ describe("GameWebSocketServer per-uid rate limit", () => {
     expect(stats.trackedPlayerUids).toBe(1);
     expect(stats.playerUidMessagesInWindow).toBe(1);
 
-    ws.close();
-    gws.stop();
-    await new Promise<void>((resolve) => {
-      httpServer.close(() => resolve());
-    });
+    await closeServer(ws, gws, httpServer);
   });
 
   it("does not map request supplied player id in production without explicit allow flag", async () => {
@@ -106,10 +133,6 @@ describe("GameWebSocketServer per-uid rate limit", () => {
     expect(stats.trackedPlayerUids).toBe(0);
     expect(stats.playerUidMessagesInWindow).toBe(0);
 
-    ws.close();
-    gws.stop();
-    await new Promise<void>((resolve) => {
-      httpServer.close(() => resolve());
-    });
+    await closeServer(ws, gws, httpServer);
   });
 });


### PR DESCRIPTION
## Summary

- Enforces expired session-token rejection in `SessionTokenService.verifyToken()`.
- Deletes expired session tokens after rejection.
- Adds service tests for active and expired tokens.
- Extends WebSocket tests for socket-level and player-uid message budgets.

Refs #2040
