### PR TITLE
feat(governance): add social and legend contracts

### DIFF
--- a/game-data/governance/law-flags.json
+++ b/game-data/governance/law-flags.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "lawFlags": [
+    {
+      "id": "trade_tariff_enabled",
+      "description": "Allows a real governance service to enable trade tariffs after validation.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "guard_patrol_priority",
+      "description": "Allows a real governance service to prioritize guard patrol funding after validation.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "war_declaration_locked",
+      "description": "Keeps war declaration locked unless real governance state validates it.",
+      "defaultEnabled": true
+    }
+  ]
+}

--- a/game-data/legends/significance-rules.json
+++ b/game-data/legends/significance-rules.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "rules": [
+    {
+      "eventType": "combat_result",
+      "baseKappa": 120,
+      "magnitudeWeightKappa": 500,
+      "participantWeightKappa": 25,
+      "thresholdKappa": 650
+    },
+    {
+      "eventType": "governance_change",
+      "baseKappa": 260,
+      "magnitudeWeightKappa": 400,
+      "participantWeightKappa": 20,
+      "thresholdKappa": 620
+    },
+    {
+      "eventType": "major_resource_collapse",
+      "baseKappa": 420,
+      "magnitudeWeightKappa": 550,
+      "participantWeightKappa": 10,
+      "thresholdKappa": 700
+    },
+    {
+      "eventType": "market_crash",
+      "baseKappa": 360,
+      "magnitudeWeightKappa": 450,
+      "participantWeightKappa": 15,
+      "thresholdKappa": 680
+    },
+    {
+      "eventType": "npc_memory_milestone",
+      "baseKappa": 220,
+      "magnitudeWeightKappa": 350,
+      "participantWeightKappa": 20,
+      "thresholdKappa": 640
+    },
+    {
+      "eventType": "territory_capture",
+      "baseKappa": 500,
+      "magnitudeWeightKappa": 450,
+      "participantWeightKappa": 30,
+      "thresholdKappa": 650
+    }
+  ]
+}

--- a/server/src/governance/GovernanceActionContract.ts
+++ b/server/src/governance/GovernanceActionContract.ts
@@ -1,0 +1,54 @@
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
+import type { GovernanceAction, GovernanceActionDiagnostic, GovernanceActionEvaluation, GovernanceActionKind } from "./GovernanceTypes.js";
+
+export type GovernanceActionValidator = (action: GovernanceAction) => readonly GovernanceActionDiagnostic[];
+
+export interface GovernanceActionEvaluationContext {
+  readonly validators?: Partial<Record<GovernanceActionKind, GovernanceActionValidator>>;
+}
+
+function diag(code: string, message: string): GovernanceActionDiagnostic {
+  return Object.freeze({ code, message, sideChannel: true });
+}
+
+function hash(action: GovernanceAction, status: string, diagnostics: readonly GovernanceActionDiagnostic[]): string {
+  return stableHash32([
+    "GOV_ACTION_EVAL_V1",
+    action.actionId,
+    action.kind,
+    action.actorId,
+    action.territoryId,
+    action.tick,
+    status,
+    diagnostics.map((entry) => entry.code).sort().join(","),
+  ].join("|")).toString(16);
+}
+
+export function evaluateGovernanceAction(action: GovernanceAction, context: GovernanceActionEvaluationContext = {}): GovernanceActionEvaluation {
+  const validator = context.validators?.[action.kind];
+
+  if (!validator) {
+    const diagnostics = Object.freeze([diag("unsupported_action", `No registered validator for ${action.kind}`)]);
+    return Object.freeze({
+      actionId: action.actionId,
+      kind: action.kind,
+      status: "unsupported_action",
+      supported: false,
+      mutatesState: false,
+      diagnostics,
+      evaluationHash: hash(action, "unsupported_action", diagnostics),
+    });
+  }
+
+  const diagnostics = Object.freeze([...validator(action)]);
+  const status = diagnostics.length > 0 ? "rejected" : "validated_no_mutation";
+  return Object.freeze({
+    actionId: action.actionId,
+    kind: action.kind,
+    status,
+    supported: diagnostics.length === 0,
+    mutatesState: false,
+    diagnostics,
+    evaluationHash: hash(action, status, diagnostics),
+  });
+}

--- a/server/src/governance/GovernanceTypes.ts
+++ b/server/src/governance/GovernanceTypes.ts
@@ -1,0 +1,62 @@
+export type TerritoryLayer =
+  | "kingdom"
+  | "province_or_region"
+  | "settlement"
+  | "village_or_city"
+  | "guild_or_faction_overlay";
+
+export type GovernanceActionKind =
+  | "raise_tax"
+  | "change_law_flag"
+  | "assign_guard_budget"
+  | "declare_war"
+  | "appoint_officer"
+  | "change_trade_policy";
+
+export type GovernanceActionStatus =
+  | "unsupported_action"
+  | "rejected"
+  | "validated_no_mutation";
+
+export interface TerritoryKey {
+  readonly id: string;
+  readonly layer: TerritoryLayer;
+  readonly parentId?: string;
+  readonly chunkKey?: string;
+}
+
+export interface GovernanceAction {
+  readonly actionId: string;
+  readonly kind: GovernanceActionKind;
+  readonly actorId: string;
+  readonly territoryId: string;
+  readonly tick: number;
+  readonly payload: Readonly<Record<string, unknown>>;
+}
+
+export interface GovernanceActionDiagnostic {
+  readonly code: string;
+  readonly message: string;
+  readonly sideChannel: true;
+}
+
+export interface GovernanceActionEvaluation {
+  readonly actionId: string;
+  readonly kind: GovernanceActionKind;
+  readonly status: GovernanceActionStatus;
+  readonly supported: boolean;
+  readonly mutatesState: false;
+  readonly diagnostics: readonly GovernanceActionDiagnostic[];
+  readonly evaluationHash: string;
+}
+
+export interface LawFlagDefinition {
+  readonly id: string;
+  readonly description: string;
+  readonly defaultEnabled: boolean;
+}
+
+export interface GovernanceContentPack {
+  readonly schemaVersion: 1;
+  readonly lawFlags: readonly LawFlagDefinition[];
+}

--- a/server/src/governance/TerritoryModel.ts
+++ b/server/src/governance/TerritoryModel.ts
@@ -1,0 +1,43 @@
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
+import type { TerritoryKey, TerritoryLayer } from "./GovernanceTypes.js";
+
+const LAYER_ORDER: readonly TerritoryLayer[] = Object.freeze([
+  "kingdom",
+  "province_or_region",
+  "settlement",
+  "village_or_city",
+  "guild_or_faction_overlay",
+]);
+
+export function isTerritoryLayer(value: unknown): value is TerritoryLayer {
+  return typeof value === "string" && (LAYER_ORDER as readonly string[]).includes(value);
+}
+
+export function compareTerritoryKeys(a: TerritoryKey, b: TerritoryKey): number {
+  const layerDelta = LAYER_ORDER.indexOf(a.layer) - LAYER_ORDER.indexOf(b.layer);
+  if (layerDelta !== 0) return layerDelta;
+  return a.id.localeCompare(b.id) || String(a.parentId ?? "").localeCompare(String(b.parentId ?? ""));
+}
+
+export function sortTerritories<T extends TerritoryKey>(territories: readonly T[]): readonly T[] {
+  return Object.freeze([...territories].sort(compareTerritoryKeys));
+}
+
+export function territoryHash(territory: TerritoryKey): string {
+  return stableHash32([
+    "TERRITORY_MODEL_V1",
+    territory.layer,
+    territory.id,
+    territory.parentId ?? "",
+    territory.chunkKey ?? "",
+  ].join("|")).toString(16);
+}
+
+export function validateTerritoryKey(territory: TerritoryKey): readonly string[] {
+  const errors: string[] = [];
+  if (!territory.id.trim()) errors.push("territory_id_required");
+  if (!isTerritoryLayer(territory.layer)) errors.push("invalid_territory_layer");
+  if (territory.parentId !== undefined && !territory.parentId.trim()) errors.push("empty_parent_id");
+  if (territory.chunkKey !== undefined && !territory.chunkKey.trim()) errors.push("empty_chunk_key");
+  return Object.freeze(errors);
+}

--- a/server/src/legends/LegendRecordTypes.ts
+++ b/server/src/legends/LegendRecordTypes.ts
@@ -1,0 +1,70 @@
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
+import { scoreWorldEventSignificance, type LegendaryWorldEvent, type SignificanceRulesContent } from "./WorldEventSignificance.js";
+
+export interface LegendCandidate {
+  readonly candidateId: string;
+  readonly eventId: string;
+  readonly eventType: LegendaryWorldEvent["type"];
+  readonly tick: number;
+  readonly significanceKappa: number;
+  readonly sourceHash: string;
+  readonly origin: "world_event";
+  readonly textSideChannelOnly: true;
+}
+
+export interface LegendRecord extends LegendCandidate {
+  readonly recordHash: string;
+  readonly stableSortKey: string;
+}
+
+export function createLegendCandidateFromWorldEvent(
+  event: LegendaryWorldEvent,
+  rules?: SignificanceRulesContent,
+): LegendCandidate | null {
+  const significance = scoreWorldEventSignificance(event, rules);
+  if (!significance.qualifies) return null;
+  const candidateId = `legend_${stableHash32([
+    "LEGEND_CANDIDATE_V1",
+    event.eventId,
+    event.type,
+    event.tick,
+    event.sourceHash,
+    significance.scoreKappa,
+  ].join("|")).toString(16)}`;
+  return Object.freeze({
+    candidateId,
+    eventId: event.eventId,
+    eventType: event.type,
+    tick: event.tick,
+    significanceKappa: significance.scoreKappa,
+    sourceHash: event.sourceHash,
+    origin: "world_event",
+    textSideChannelOnly: true,
+  });
+}
+
+export function createLegendRecord(candidate: LegendCandidate): LegendRecord {
+  const stableSortKey = [
+    String(1000 - candidate.significanceKappa).padStart(4, "0"),
+    String(candidate.tick).padStart(12, "0"),
+    candidate.eventId,
+  ].join(":");
+  const recordHash = stableHash32([
+    "LEGEND_RECORD_V1",
+    candidate.candidateId,
+    candidate.eventId,
+    candidate.eventType,
+    candidate.tick,
+    candidate.significanceKappa,
+    candidate.sourceHash,
+  ].join("|")).toString(16);
+  return Object.freeze({ ...candidate, stableSortKey, recordHash });
+}
+
+export function sortLegendRecords(records: readonly LegendRecord[]): readonly LegendRecord[] {
+  return Object.freeze([...records].sort((a, b) =>
+    b.significanceKappa - a.significanceKappa ||
+    a.tick - b.tick ||
+    a.eventId.localeCompare(b.eventId)
+  ));
+}

--- a/server/src/legends/WorldEventSignificance.ts
+++ b/server/src/legends/WorldEventSignificance.ts
@@ -1,0 +1,109 @@
+import { existsSync, readFileSync } from "node:fs";
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
+import { resolveContentFile } from "../modules/content/contentDataRoot.js";
+
+export type LegendaryWorldEventType =
+  | "combat_result"
+  | "market_crash"
+  | "governance_change"
+  | "territory_capture"
+  | "major_resource_collapse"
+  | "npc_memory_milestone";
+
+export interface LegendaryWorldEvent {
+  readonly eventId: string;
+  readonly type: LegendaryWorldEventType;
+  readonly tick: number;
+  readonly chunkKey?: string;
+  readonly actorIds?: readonly string[];
+  readonly targetIds?: readonly string[];
+  readonly magnitudeKappa?: number;
+  readonly sourceHash: string;
+}
+
+export interface SignificanceRule {
+  readonly eventType: LegendaryWorldEventType;
+  readonly baseKappa: number;
+  readonly magnitudeWeightKappa: number;
+  readonly participantWeightKappa: number;
+  readonly thresholdKappa: number;
+}
+
+export interface SignificanceRulesContent {
+  readonly schemaVersion: 1;
+  readonly rules: readonly SignificanceRule[];
+}
+
+export interface WorldEventSignificanceResult {
+  readonly eventId: string;
+  readonly eventType: LegendaryWorldEventType;
+  readonly scoreKappa: number;
+  readonly thresholdKappa: number;
+  readonly qualifies: boolean;
+  readonly scoreHash: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function clampKappa(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1000, Math.trunc(value)));
+}
+
+function normalizeRule(value: unknown): SignificanceRule | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const eventType = record.eventType;
+  if (typeof eventType !== "string") return null;
+  if (!["combat_result", "market_crash", "governance_change", "territory_capture", "major_resource_collapse", "npc_memory_milestone"].includes(eventType)) return null;
+  return Object.freeze({
+    eventType: eventType as LegendaryWorldEventType,
+    baseKappa: clampKappa(Number(record.baseKappa)),
+    magnitudeWeightKappa: clampKappa(Number(record.magnitudeWeightKappa)),
+    participantWeightKappa: clampKappa(Number(record.participantWeightKappa)),
+    thresholdKappa: clampKappa(Number(record.thresholdKappa)),
+  });
+}
+
+export function loadSignificanceRules(): SignificanceRulesContent {
+  const filePath = resolveContentFile("legends/significance-rules.json");
+  if (!existsSync(filePath)) return Object.freeze({ schemaVersion: 1, rules: Object.freeze([]) });
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+  const root = asRecord(parsed);
+  const rawRules = Array.isArray(root?.rules) ? root.rules : [];
+  const rules = rawRules.map(normalizeRule).filter((rule): rule is SignificanceRule => Boolean(rule));
+  return Object.freeze({ schemaVersion: 1, rules: Object.freeze(rules.sort((a, b) => a.eventType.localeCompare(b.eventType))) });
+}
+
+export function scoreWorldEventSignificance(
+  event: LegendaryWorldEvent,
+  content: SignificanceRulesContent = loadSignificanceRules(),
+): WorldEventSignificanceResult {
+  const rule = content.rules.find((candidate) => candidate.eventType === event.type);
+  const participants = new Set([...(event.actorIds ?? []), ...(event.targetIds ?? [])]);
+  const magnitude = clampKappa(event.magnitudeKappa ?? 0);
+  const scoreKappa = rule
+    ? clampKappa(rule.baseKappa + Math.trunc((magnitude * rule.magnitudeWeightKappa) / 1000) + participants.size * rule.participantWeightKappa)
+    : 0;
+  const thresholdKappa = rule?.thresholdKappa ?? 1000;
+  const scoreHash = stableHash32([
+    "WORLD_EVENT_SIGNIFICANCE_V1",
+    event.eventId,
+    event.type,
+    event.tick,
+    event.chunkKey ?? "",
+    event.sourceHash,
+    scoreKappa,
+    thresholdKappa,
+  ].join("|")).toString(16);
+  return Object.freeze({
+    eventId: event.eventId,
+    eventType: event.type,
+    scoreKappa,
+    thresholdKappa,
+    qualifies: scoreKappa >= thresholdKappa,
+    scoreHash,
+  });
+}

--- a/server/src/social/FamilyGraphTypes.ts
+++ b/server/src/social/FamilyGraphTypes.ts
@@ -1,0 +1,37 @@
+export type FamilyRelationKind =
+  | "parent"
+  | "child"
+  | "sibling"
+  | "partner"
+  | "ancestor"
+  | "descendant"
+  | "house_member";
+
+export interface FamilyGraphPerson {
+  readonly id: string;
+  readonly kind: "player" | "npc";
+  readonly houseId?: string;
+}
+
+export interface FamilyGraphRelation {
+  readonly fromId: string;
+  readonly toId: string;
+  readonly relation: FamilyRelationKind;
+  readonly sourceEventId: string;
+  readonly observedTick: number;
+}
+
+export interface FamilyHouseContract {
+  readonly houseId: string;
+  readonly founderId?: string;
+  readonly settlementId?: string;
+  readonly memberIds: readonly string[];
+  readonly sourceEventIds: readonly string[];
+}
+
+export interface FamilyGraphContract {
+  readonly schemaVersion: 1;
+  readonly persons: readonly FamilyGraphPerson[];
+  readonly relations: readonly FamilyGraphRelation[];
+  readonly houses: readonly FamilyHouseContract[];
+}

--- a/server/src/social/SocialGraphTypes.ts
+++ b/server/src/social/SocialGraphTypes.ts
@@ -1,0 +1,37 @@
+export type SocialRelationKind =
+  | "ally"
+  | "rival"
+  | "mentor"
+  | "apprentice"
+  | "trade_partner"
+  | "guildmate"
+  | "reputation_source";
+
+export interface SocialGraphNode {
+  readonly id: string;
+  readonly kind: "player" | "npc" | "guild" | "faction" | "settlement";
+}
+
+export interface SocialGraphEdge {
+  readonly fromId: string;
+  readonly toId: string;
+  readonly relation: SocialRelationKind;
+  readonly weightKappa: number;
+  readonly lastObservedTick: number;
+  readonly sourceEventId: string;
+}
+
+export interface ReputationContract {
+  readonly subjectId: string;
+  readonly scopeId: string;
+  readonly scoreKappa: number;
+  readonly sourceEventIds: readonly string[];
+  readonly updatedTick: number;
+}
+
+export interface SocialGraphContract {
+  readonly schemaVersion: 1;
+  readonly nodes: readonly SocialGraphNode[];
+  readonly edges: readonly SocialGraphEdge[];
+  readonly reputation: readonly ReputationContract[];
+}

--- a/server/src/tests/governance-contract.test.ts
+++ b/server/src/tests/governance-contract.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { evaluateGovernanceAction } from "../governance/GovernanceActionContract.js";
+import { sortTerritories, territoryHash, validateTerritoryKey } from "../governance/TerritoryModel.js";
+import type { GovernanceAction, TerritoryKey } from "../governance/GovernanceTypes.js";
+
+function action(kind: GovernanceAction["kind"] = "raise_tax"): GovernanceAction {
+  return Object.freeze({
+    actionId: "gov_action_001",
+    kind,
+    actorId: "actor_council_1",
+    territoryId: "territory_village_1",
+    tick: 1234,
+    payload: Object.freeze({ rateKappa: 120 }),
+  });
+}
+
+describe("governance contracts", () => {
+  it("marks unsupported governance actions as no-mutation diagnostics", () => {
+    const result = evaluateGovernanceAction(action("declare_war"));
+
+    expect(result.supported).toBe(false);
+    expect(result.status).toBe("unsupported_action");
+    expect(result.mutatesState).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("unsupported_action");
+    expect(result.evaluationHash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("keeps deterministic evaluation hashes for identical actions", () => {
+    const a = evaluateGovernanceAction(action("change_trade_policy"));
+    const b = evaluateGovernanceAction(action("change_trade_policy"));
+
+    expect(a.evaluationHash).toBe(b.evaluationHash);
+  });
+
+  it("validates and sorts territory keys deterministically", () => {
+    const territories: TerritoryKey[] = [
+      { id: "guild_overlay_1", layer: "guild_or_faction_overlay", parentId: "village_1" },
+      { id: "kingdom_1", layer: "kingdom" },
+      { id: "settlement_1", layer: "settlement", parentId: "province_1" },
+    ];
+
+    expect(validateTerritoryKey(territories[0])).toEqual([]);
+    expect(sortTerritories(territories).map((territory) => territory.layer)).toEqual([
+      "kingdom",
+      "settlement",
+      "guild_or_faction_overlay",
+    ]);
+    expect(territoryHash(territories[0])).toBe(territoryHash(territories[0]));
+  });
+});

--- a/server/src/tests/legend-records.test.ts
+++ b/server/src/tests/legend-records.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  createLegendCandidateFromWorldEvent,
+  createLegendRecord,
+  sortLegendRecords,
+} from "../legends/LegendRecordTypes.js";
+import type { LegendaryWorldEvent, SignificanceRulesContent } from "../legends/WorldEventSignificance.js";
+
+const rules: SignificanceRulesContent = Object.freeze({
+  schemaVersion: 1,
+  rules: Object.freeze([
+    Object.freeze({
+      eventType: "territory_capture",
+      baseKappa: 500,
+      magnitudeWeightKappa: 500,
+      participantWeightKappa: 20,
+      thresholdKappa: 650,
+    }),
+    Object.freeze({
+      eventType: "combat_result",
+      baseKappa: 100,
+      magnitudeWeightKappa: 100,
+      participantWeightKappa: 10,
+      thresholdKappa: 700,
+    }),
+  ]),
+});
+
+function territoryEvent(overrides: Partial<LegendaryWorldEvent> = {}): LegendaryWorldEvent {
+  return Object.freeze({
+    eventId: "event_territory_capture_001",
+    type: "territory_capture",
+    tick: 700,
+    chunkKey: "chunk:4:9",
+    actorIds: Object.freeze(["guild_1"]),
+    targetIds: Object.freeze(["settlement_1"]),
+    magnitudeKappa: 800,
+    sourceHash: "world_event_hash_capture_001",
+    ...overrides,
+  });
+}
+
+describe("legend records", () => {
+  it("creates identical LegendCandidate values for identical WorldEvents", () => {
+    const first = createLegendCandidateFromWorldEvent(territoryEvent(), rules);
+    const second = createLegendCandidateFromWorldEvent(territoryEvent(), rules);
+
+    expect(first).not.toBeNull();
+    expect(first).toEqual(second);
+    expect(first?.origin).toBe("world_event");
+    expect(first?.textSideChannelOnly).toBe(true);
+  });
+
+  it("does not create a LegendCandidate for low significance events", () => {
+    const candidate = createLegendCandidateFromWorldEvent(
+      Object.freeze({
+        eventId: "event_minor_combat_001",
+        type: "combat_result",
+        tick: 701,
+        magnitudeKappa: 50,
+        actorIds: Object.freeze(["npc_1"]),
+        targetIds: Object.freeze(["rat_1"]),
+        sourceHash: "minor_combat_hash",
+      }),
+      rules,
+    );
+
+    expect(candidate).toBeNull();
+  });
+
+  it("sorts LegendRecords by significance, tick, and eventId", () => {
+    const high = createLegendRecord(createLegendCandidateFromWorldEvent(territoryEvent({ eventId: "event_b", tick: 900, magnitudeKappa: 900 }), rules)!);
+    const tieEarly = createLegendRecord(createLegendCandidateFromWorldEvent(territoryEvent({ eventId: "event_a", tick: 800, magnitudeKappa: 800 }), rules)!);
+    const tieLate = createLegendRecord(createLegendCandidateFromWorldEvent(territoryEvent({ eventId: "event_c", tick: 900, magnitudeKappa: 800 }), rules)!);
+
+    expect(sortLegendRecords([tieLate, high, tieEarly]).map((record) => record.eventId)).toEqual([
+      "event_b",
+      "event_a",
+      "event_c",
+    ]);
+  });
+});

--- a/server/src/tests/world-event-significance.test.ts
+++ b/server/src/tests/world-event-significance.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadSignificanceRules,
+  scoreWorldEventSignificance,
+  type LegendaryWorldEvent,
+} from "../legends/WorldEventSignificance.js";
+
+describe("world event significance", () => {
+  const event: LegendaryWorldEvent = Object.freeze({
+    eventId: "event_resource_collapse_001",
+    type: "major_resource_collapse",
+    tick: 500,
+    chunkKey: "chunk:0:0",
+    actorIds: Object.freeze(["settlement_1"]),
+    targetIds: Object.freeze(["iron_vein_7"]),
+    magnitudeKappa: 700,
+    sourceHash: "world_event_hash_001",
+  });
+
+  it("loads significance rules from game-data", () => {
+    const rules = loadSignificanceRules();
+
+    expect(rules.schemaVersion).toBe(1);
+    expect(rules.rules.length).toBeGreaterThan(0);
+    expect(rules.rules.some((rule) => rule.eventType === "major_resource_collapse")).toBe(true);
+  });
+
+  it("calculates deterministic significance scores", () => {
+    const rules = loadSignificanceRules();
+    const first = scoreWorldEventSignificance(event, rules);
+    const second = scoreWorldEventSignificance(event, rules);
+
+    expect(first).toEqual(second);
+    expect(first.scoreKappa).toBeGreaterThan(0);
+    expect(first.scoreHash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("returns zero score for event types without loaded rules", () => {
+    const result = scoreWorldEventSignificance(event, Object.freeze({ schemaVersion: 1, rules: Object.freeze([]) }));
+
+    expect(result.scoreKappa).toBe(0);
+    expect(result.qualifies).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #2075 as a contract/content slice without adding fake runtime state.

- Adds Governance contracts and deterministic territory helpers.
- Adds GovernanceAction evaluation where unsupported actions are side-channel diagnostics and never mutate state.
- Adds SocialGraph and FamilyGraph contracts only, with no runtime stub data.
- Adds WorldEvent significance scoring from `game-data/legends/significance-rules.json`.
- Adds LegendCandidate and LegendRecord helpers that only derive from explicit WorldEvent inputs.
- Adds `game-data/governance/law-flags.json` and `game-data/legends/significance-rules.json`.
- Adds tests for no-mutation governance actions, deterministic significance, legend candidate creation, low-significance rejection, stable legend sorting, and game-data rule loading.

## ARE notes

No fake kingdom. No fake legend runtime. No snapshot extension. No client truth. No random or wall-clock source.

Closes #2075
