### PR TITLE
ci: run autonomous CI layer gates on all pull requests

### DIFF
--- a/.github/workflows/dependabot-checker.yml
+++ b/.github/workflows/dependabot-checker.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   ai-autofix-ci:
-    if: ${{ github.actor == 'dependabot[bot]' || contains(github.head_ref, 'fix/') }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -102,6 +102,7 @@ jobs:
       # COMMIT FIXES
       # ----------------------------
       - name: Commit AI fixes
+        if: ${{ github.actor == 'dependabot[bot]' || contains(github.head_ref, 'fix/') }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Changes the Autonomous CI Layer so the gate job runs on normal pull request branches.

The automatic commit step remains restricted to Dependabot or branches containing fix/.

Diff is limited to .github/workflows/dependabot-checker.yml.