### PR TITLE
fix(are): finish deterministic runtime audit cleanup

### DIFF
--- a/server/src/engine/TickManager.ts
+++ b/server/src/engine/TickManager.ts
@@ -4,8 +4,8 @@ export class TickManager {
     private readonly TICK_INTERVAL_MS: number = 100;
     private orchestrator: MasterExpansionOrchestrator;
     private isRunning: boolean = false;
-    private nextTickTime: number = 0;
     private timer: NodeJS.Timeout | null = null;
+    private tickSequence: number = 0;
 
     constructor(orchestrator: MasterExpansionOrchestrator) {
         this.orchestrator = orchestrator;
@@ -14,45 +14,31 @@ export class TickManager {
     public start(): void {
         if (this.isRunning) return;
         this.isRunning = true;
-        this.nextTickTime = Date.now() + this.TICK_INTERVAL_MS;
-        this.scheduleTick();
+        this.tickSequence = 0;
+        this.timer = setInterval(() => {
+            this.executeTick();
+        }, this.TICK_INTERVAL_MS);
     }
 
     public stop(): void {
         this.isRunning = false;
         if (this.timer) {
-            clearTimeout(this.timer);
+            clearInterval(this.timer);
             this.timer = null;
         }
     }
 
-    private scheduleTick(): void {
-        if (!this.isRunning) return;
-
-        const now = Date.now();
-        const delay = Math.max(0, this.nextTickTime - now);
-
-        this.timer = setTimeout(() => {
-            this.executeTick();
-        }, delay);
+    public getCurrentTick(): number {
+        return this.tickSequence;
     }
 
     private executeTick(): void {
         if (!this.isRunning) return;
 
-        // Execute primary logic via the MasterExpansionOrchestrator
-        // This ensures combat results and building logic are processed in the same atomic step
+        this.tickSequence += 1;
+
+        // Execute primary logic via the MasterExpansionOrchestrator.
+        // Runtime truth is carried by the logical tick sequence; the host timer is only cadence plumbing.
         this.orchestrator.processTick();
-
-        // Calculate next tick with zero-drift compensation
-        this.nextTickTime += this.TICK_INTERVAL_MS;
-
-        // If we are lagging behind more than one interval, catch up to current time
-        const now = Date.now();
-        if (this.nextTickTime < now) {
-            this.nextTickTime = now + this.TICK_INTERVAL_MS;
-        }
-
-        this.scheduleTick();
     }
 }

--- a/server/src/engine/core/AREPayload.ts
+++ b/server/src/engine/core/AREPayload.ts
@@ -1,3 +1,5 @@
+const ARE_PAYLOAD_TICK_MS = 100;
+
 export interface INPCState {
     id: string;
     v: [number, number, number];
@@ -14,13 +16,19 @@ export interface IAREPayload {
     en: Record<string, INPCState>;
 }
 
+function normalizeTick(tick: number): number {
+    if (!Number.isSafeInteger(tick) || tick < 0) return 0;
+    return tick;
+}
+
 export class AREPayload {
     private readonly _data: IAREPayload;
 
     constructor(tick: number, npcs: INPCState[]) {
+        const safeTick = normalizeTick(tick);
         this._data = {
-            tk: tick,
-            ts: Date.now(),
+            tk: safeTick,
+            ts: safeTick * ARE_PAYLOAD_TICK_MS,
             en: this._filterAndMap(npcs)
         };
     }
@@ -31,18 +39,14 @@ export class AREPayload {
      */
     private _filterAndMap(npcs: INPCState[]): Record<string, INPCState> {
         const lookup: Record<string, INPCState> = Object.create(null);
-        const len = npcs.length;
-        
-        for (let i = 0; i < len; i++) {
-            const npc = npcs[i];
-            
-            // Status validation: 0 is considered 'void' or 'invalid'
-            // Ensures stateless determinism by only including relevant actors
-            if (npc.s > 0 && npc.h > 0) {
-                lookup[npc.id] = npc;
-            }
+        const activeNpcs = npcs
+            .filter((npc) => npc.s > 0 && npc.h > 0)
+            .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+        for (const npc of activeNpcs) {
+            lookup[npc.id] = npc;
         }
-        
+
         return lookup;
     }
 

--- a/server/src/logic/AREStateCompiler.ts
+++ b/server/src/logic/AREStateCompiler.ts
@@ -31,14 +31,20 @@ export interface DeltaSnapshot {
     deleted: string[];
 }
 
+function compareStableString(a: string, b: string): number {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+}
+
 function stableNpcProjection(npc: NPC): Record<string, unknown> {
     return {
         id: npc.id,
         profile: npc.profile,
         genealogy: {
             generation: npc.genealogy.generation,
-            lineage: [...npc.genealogy.lineage].sort(),
-            mutations: [...npc.genealogy.mutations].sort(),
+            lineage: [...npc.genealogy.lineage].sort(compareStableString),
+            mutations: [...npc.genealogy.mutations].sort(compareStableString),
         },
         stats: {
             integrity: npc.stats.integrity,
@@ -71,7 +77,7 @@ export class AREStateCompiler extends EventEmitter {
         const deleted: string[] = [];
         const currentSerializedState: Map<string, string> = new Map();
 
-        for (const [id, npc] of [...state.npcs.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
+        for (const [id, npc] of [...state.npcs.entries()].sort(([a], [b]) => compareStableString(a, b))) {
             const serialized = JSON.stringify(stableNpcProjection(npc));
             currentSerializedState.set(id, serialized);
 
@@ -80,7 +86,7 @@ export class AREStateCompiler extends EventEmitter {
             }
         }
 
-        for (const id of [...this.lastKnownState.keys()].sort()) {
+        for (const id of [...this.lastKnownState.keys()].sort(compareStableString)) {
             if (!state.npcs.has(id)) {
                 deleted.push(id);
             }
@@ -117,8 +123,8 @@ export class AREStateCompiler extends EventEmitter {
             worldChecksum,
             upserted: upserted
                 .map(stableNpcProjection)
-                .sort((a, b) => String(a.id).localeCompare(String(b.id))),
-            deleted: [...deleted].sort(),
+                .sort((a, b) => compareStableString(String(a.id), String(b.id))),
+            deleted: [...deleted].sort(compareStableString),
         });
         return `fnv1a32-integrity-${fnv1a32(raw)}`;
     }
@@ -140,7 +146,7 @@ export class AREStateCompiler extends EventEmitter {
 
     private async processGenealogyShift(npcs: NPC[], threshold: number): Promise<void> {
         const BATCH_SIZE = 100;
-        const orderedNpcs = [...npcs].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+        const orderedNpcs = [...npcs].sort((a, b) => compareStableString(a.id, b.id));
 
         for (let i = 0; i < orderedNpcs.length; i += BATCH_SIZE) {
             const batch = orderedNpcs.slice(i, i + BATCH_SIZE);

--- a/server/src/logic/AREStateCompiler.ts
+++ b/server/src/logic/AREStateCompiler.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events';
 
+const ARE_STATE_COMPILER_TICK_MS = 100;
+
 export interface NPC {
     id: string;
     profile: string;
@@ -29,9 +31,35 @@ export interface DeltaSnapshot {
     deleted: string[];
 }
 
+function stableNpcProjection(npc: NPC): Record<string, unknown> {
+    return {
+        id: npc.id,
+        profile: npc.profile,
+        genealogy: {
+            generation: npc.genealogy.generation,
+            lineage: [...npc.genealogy.lineage].sort(),
+            mutations: [...npc.genealogy.mutations].sort(),
+        },
+        stats: {
+            integrity: npc.stats.integrity,
+            legendSpreadChance: npc.stats.legendSpreadChance,
+        },
+    };
+}
+
+function fnv1a32(input: string): string {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < input.length; i += 1) {
+        hash ^= input.charCodeAt(i);
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash.toString(16).padStart(8, '0');
+}
+
 export class AREStateCompiler extends EventEmitter {
     private lastKnownState: Map<string, string> = new Map();
     private currentVersion: number = 0;
+    private mutationSequence: number = 0;
     private isProcessingGenealogy: boolean = false;
 
     constructor() {
@@ -43,8 +71,8 @@ export class AREStateCompiler extends EventEmitter {
         const deleted: string[] = [];
         const currentSerializedState: Map<string, string> = new Map();
 
-        for (const [id, npc] of state.npcs) {
-            const serialized = JSON.stringify(npc);
+        for (const [id, npc] of [...state.npcs.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
+            const serialized = JSON.stringify(stableNpcProjection(npc));
             currentSerializedState.set(id, serialized);
 
             if (this.lastKnownState.get(id) !== serialized) {
@@ -52,7 +80,7 @@ export class AREStateCompiler extends EventEmitter {
             }
         }
 
-        for (const id of this.lastKnownState.keys()) {
+        for (const id of [...this.lastKnownState.keys()].sort()) {
             if (!state.npcs.has(id)) {
                 deleted.push(id);
             }
@@ -63,10 +91,10 @@ export class AREStateCompiler extends EventEmitter {
         this.currentVersion++;
 
         const snapshot: DeltaSnapshot = {
-            timestamp: Date.now(),
+            timestamp: this.currentVersion * ARE_STATE_COMPILER_TICK_MS,
             baseVersion: previousVersion,
             targetVersion: this.currentVersion,
-            integrityHash: this.computeIntegrityHash(upserted, deleted),
+            integrityHash: this.computeIntegrityHash(upserted, deleted, previousVersion, this.currentVersion, state.version, state.checksum),
             upserted,
             deleted
         };
@@ -74,15 +102,25 @@ export class AREStateCompiler extends EventEmitter {
         return snapshot;
     }
 
-    private computeIntegrityHash(upserted: NPC[], deleted: string[]): string {
-        const raw = JSON.stringify({ u: upserted.length, d: deleted.length, t: Date.now() });
-        let hash = 0;
-        for (let i = 0; i < raw.length; i++) {
-            const char = raw.charCodeAt(i);
-            hash = ((hash << 5) - hash) + char;
-            hash |= 0;
-        }
-        return `sha256-integrity-${hash.toString(16)}`;
+    private computeIntegrityHash(
+        upserted: NPC[],
+        deleted: string[],
+        baseVersion: number,
+        targetVersion: number,
+        worldVersion: number,
+        worldChecksum: string,
+    ): string {
+        const raw = JSON.stringify({
+            baseVersion,
+            targetVersion,
+            worldVersion,
+            worldChecksum,
+            upserted: upserted
+                .map(stableNpcProjection)
+                .sort((a, b) => String(a.id).localeCompare(String(b.id))),
+            deleted: [...deleted].sort(),
+        });
+        return `fnv1a32-integrity-${fnv1a32(raw)}`;
     }
 
     public triggerGenealogyUpdate(npcs: NPC[], threshold: number): void {
@@ -102,17 +140,18 @@ export class AREStateCompiler extends EventEmitter {
 
     private async processGenealogyShift(npcs: NPC[], threshold: number): Promise<void> {
         const BATCH_SIZE = 100;
-        
-        for (let i = 0; i < npcs.length; i += BATCH_SIZE) {
-            const batch = npcs.slice(i, i + BATCH_SIZE);
-            
+        const orderedNpcs = [...npcs].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+        for (let i = 0; i < orderedNpcs.length; i += BATCH_SIZE) {
+            const batch = orderedNpcs.slice(i, i + BATCH_SIZE);
+
             for (const npc of batch) {
                 if (npc.stats.legendSpreadChance >= threshold && npc.profile !== 'Builder') {
                     this.applyBuilderMutation(npc);
                 }
             }
 
-            if (i + BATCH_SIZE < npcs.length) {
+            if (i + BATCH_SIZE < orderedNpcs.length) {
                 await this.yieldControl();
             }
         }
@@ -120,14 +159,16 @@ export class AREStateCompiler extends EventEmitter {
 
     private applyBuilderMutation(npc: NPC): void {
         const oldProfile = npc.profile;
+        this.mutationSequence += 1;
+        const mutationTick = this.currentVersion + this.mutationSequence;
         npc.profile = 'Builder';
-        npc.genealogy.mutations.push(`LEGEND_SPREAD_THRESHOLD_REACHED_${Date.now()}`);
-        
+        npc.genealogy.mutations.push(`LEGEND_SPREAD_THRESHOLD_REACHED_${mutationTick}`);
+
         this.emit('npcEvolved', {
             id: npc.id,
             previousProfile: oldProfile,
             newProfile: 'Builder',
-            timestamp: Date.now()
+            timestamp: mutationTick * ARE_STATE_COMPILER_TICK_MS
         });
     }
 

--- a/server/src/tests/are-determinism-a4.test.ts
+++ b/server/src/tests/are-determinism-a4.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { AREPayload, type INPCState } from "../engine/core/AREPayload";
+import { AREStateCompiler, type NPC, type WorldState } from "../logic/AREStateCompiler";
+
+function createNpc(id: string, profile = "Villager", legendSpreadChance = 0): NPC {
+  return {
+    id,
+    profile,
+    genealogy: {
+      lineage: [`lineage-${id}`],
+      generation: 1,
+      mutations: [],
+    },
+    stats: {
+      legendSpreadChance,
+      integrity: 1000,
+    },
+  };
+}
+
+function createNpcState(id: string, status = 1): INPCState {
+  return {
+    id,
+    v: [0, 0, 0],
+    r: 0,
+    s: status,
+    h: 100,
+    a: 0,
+    p: {},
+  };
+}
+
+function createWorldState(entries: Array<[string, NPC]>): WorldState {
+  return {
+    version: 7,
+    checksum: "chunk:7:13:kappa1000",
+    npcs: new Map(entries),
+  };
+}
+
+describe("A4 determinism runtime fixes", () => {
+  it("derives ARE payload timestamps from the logical tick", () => {
+    const payloadA = new AREPayload(42, [
+      createNpcState("npc_b"),
+      createNpcState("npc_void", 0),
+      createNpcState("npc_a"),
+    ]);
+    const payloadB = new AREPayload(42, [
+      createNpcState("npc_a"),
+      createNpcState("npc_b"),
+      createNpcState("npc_void", 0),
+    ]);
+
+    expect(payloadA.timestamp).toBe(4200);
+    expect(payloadA.serialize()).toBe(payloadB.serialize());
+    expect(Object.keys(AREPayload.deserialize(payloadA.serialize()).en)).toEqual(["npc_a", "npc_b"]);
+  });
+
+  it("creates repeatable delta snapshots without wall-clock entropy", async () => {
+    const worldA = createWorldState([
+      ["npc_b", createNpc("npc_b")],
+      ["npc_a", createNpc("npc_a")],
+    ]);
+    const worldB = createWorldState([
+      ["npc_a", createNpc("npc_a")],
+      ["npc_b", createNpc("npc_b")],
+    ]);
+
+    const compilerA = new AREStateCompiler();
+    const compilerB = new AREStateCompiler();
+
+    const snapshotA = await compilerA.createDeltaSnapshot(worldA);
+    const snapshotB = await compilerB.createDeltaSnapshot(worldB);
+
+    expect(snapshotA.timestamp).toBe(100);
+    expect(snapshotA.integrityHash).toBe(snapshotB.integrityHash);
+    expect(snapshotA.upserted.map((npc) => npc.id)).toEqual(["npc_a", "npc_b"]);
+
+    const secondA = await compilerA.createDeltaSnapshot(worldA);
+    const secondB = await compilerB.createDeltaSnapshot(worldB);
+
+    expect(secondA.timestamp).toBe(200);
+    expect(secondA.upserted).toHaveLength(0);
+    expect(secondA.integrityHash).toBe(secondB.integrityHash);
+  });
+
+  it("orders genealogy mutations by NPC id with tick-derived event timestamps", async () => {
+    const compiler = new AREStateCompiler();
+    const npcA = createNpc("npc_a", "Scholar", 1000);
+    const npcB = createNpc("npc_b", "Farmer", 1000);
+    const events: Array<{ id: string; timestamp: number }> = [];
+
+    compiler.on("npcEvolved", (event: { id: string; timestamp: number }) => {
+      events.push(event);
+    });
+
+    compiler.triggerGenealogyUpdate([npcB, npcA], 500);
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(events.map((event) => event.id)).toEqual(["npc_a", "npc_b"]);
+    expect(events.map((event) => event.timestamp)).toEqual([100, 200]);
+    expect(npcA.genealogy.mutations).toEqual(["LEGEND_SPREAD_THRESHOLD_REACHED_1"]);
+    expect(npcB.genealogy.mutations).toEqual(["LEGEND_SPREAD_THRESHOLD_REACHED_2"]);
+  });
+});


### PR DESCRIPTION
Completes the remaining #2041 runtime cleanup slice with real ARE deterministic logic.

Changes:
- removes explicit wall-clock reads from `server/src/engine/TickManager.ts`
- derives `AREPayload.timestamp` from the logical 10Hz tick instead of `Date.now()`
- makes `AREStateCompiler` delta timestamps, integrity hashes and genealogy mutation events deterministic from version/tick/ordered inputs
- adds runtime tests for tick-derived payloads, repeatable delta snapshots and ordered genealogy mutations

No mocks, no fake snapshots, no workflow changes.

Closes #2041