### PR TITLE
feat(a5): complete economy resource and item truth runtime

### DIFF
--- a/game-data/economy/base-prices.json
+++ b/game-data/economy/base-prices.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "currency": "coin",
+  "items": [
+    { "itemId": "wood_log", "basePrice": 1, "sellable": true },
+    { "itemId": "raw_fish", "basePrice": 2, "sellable": true },
+    { "itemId": "copper_ore", "basePrice": 3, "sellable": true },
+    { "itemId": "wood_plank", "basePrice": 3, "sellable": true },
+    { "itemId": "cooked_fish", "basePrice": 4, "sellable": true },
+    { "itemId": "copper_ingot", "basePrice": 8, "sellable": true }
+  ]
+}

--- a/game-data/economy/markets.json
+++ b/game-data/economy/markets.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "markets": [
+    {
+      "marketId": "starter_village_market",
+      "title": "Starter Village Market",
+      "regionId": "starter_village",
+      "vendorId": "village_trader_001",
+      "chunkKey": "0:0",
+      "position": { "x": 48, "y": 48 },
+      "demand": [
+        { "itemId": "wood_log", "demandPressurePerMille": 1000 },
+        { "itemId": "raw_fish", "demandPressurePerMille": 1050 },
+        { "itemId": "copper_ore", "demandPressurePerMille": 1100 },
+        { "itemId": "wood_plank", "demandPressurePerMille": 1150 },
+        { "itemId": "cooked_fish", "demandPressurePerMille": 1200 },
+        { "itemId": "copper_ingot", "demandPressurePerMille": 1250 }
+      ],
+      "routes": [
+        {
+          "routeId": "starter_village_self",
+          "toMarketId": "starter_village_market",
+          "distanceKappa": 0,
+          "routeRiskPerMille": 1000,
+          "taxPressurePerMille": 1000
+        }
+      ]
+    }
+  ]
+}

--- a/server/src/economy/EconomyGameData.ts
+++ b/server/src/economy/EconomyGameData.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import { resolveContentFile } from "../modules/content/contentDataRoot.js";
+import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+import { isInventoryItemId } from "../inventory/InventoryTypes.js";
+import type { LocalMarketDefinition, LocalMarketDemandRule, LocalMarketRoute } from "./LocalMarketTypes.js";
+
+export interface EconomyBasePriceEntry {
+  readonly itemId: InventoryItemId;
+  readonly basePrice: number;
+  readonly sellable: boolean;
+}
+
+export type EconomyBasePriceTable = Readonly<Record<string, EconomyBasePriceEntry>>;
+
+function fail(file: string, message: string): never {
+  throw new Error(`[EconomyGameData] ${file}: ${message}`);
+}
+
+function readJsonFile(file: string): unknown {
+  if (!fs.existsSync(file)) fail(file, "missing required game-data file");
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf-8"));
+  } catch (error) {
+    const suffix = error instanceof Error ? ` (${error.message})` : "";
+    fail(file, `invalid JSON${suffix}`);
+  }
+}
+
+function asRecord(value: unknown, file: string, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(file, `${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function readString(record: Record<string, unknown>, key: string, file: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.trim().length === 0) fail(file, `${key} must be a non-empty string`);
+  return value.trim();
+}
+
+function readInteger(record: Record<string, unknown>, key: string, file: string, min: number): number {
+  const value = Number(record[key]);
+  if (!Number.isSafeInteger(value) || value < min) fail(file, `${key} must be an integer >= ${min}`);
+  return value;
+}
+
+function readBoolean(record: Record<string, unknown>, key: string, file: string): boolean {
+  const value = record[key];
+  if (typeof value !== "boolean") fail(file, `${key} must be boolean`);
+  return value;
+}
+
+function normalizeItemId(raw: unknown, file: string): InventoryItemId {
+  if (!isInventoryItemId(raw)) fail(file, `invalid inventory item id ${String(raw)}`);
+  return raw;
+}
+
+function normalizeDemand(raw: unknown, file: string, index: number): LocalMarketDemandRule {
+  const record = asRecord(raw, file, `demand[${index}]`);
+  return Object.freeze({
+    itemId: normalizeItemId(record.itemId, file),
+    demandPressurePerMille: readInteger(record, "demandPressurePerMille", file, 0),
+  });
+}
+
+function normalizeRoute(raw: unknown, file: string, index: number): LocalMarketRoute {
+  const record = asRecord(raw, file, `routes[${index}]`);
+  return Object.freeze({
+    routeId: readString(record, "routeId", file),
+    toMarketId: readString(record, "toMarketId", file),
+    distanceKappa: readInteger(record, "distanceKappa", file, 0),
+    routeRiskPerMille: readInteger(record, "routeRiskPerMille", file, 0),
+    taxPressurePerMille: readInteger(record, "taxPressurePerMille", file, 0),
+  });
+}
+
+export function loadEconomyBasePricesFromGameData(): EconomyBasePriceTable {
+  const file = resolveContentFile("economy/base-prices.json");
+  const root = asRecord(readJsonFile(file), file, "base price root");
+  if (readInteger(root, "schemaVersion", file, 1) !== 1) fail(file, "schemaVersion must be 1");
+
+  const items = root.items;
+  if (!Array.isArray(items) || items.length === 0) fail(file, "items must be a non-empty array");
+
+  const table: Record<string, EconomyBasePriceEntry> = {};
+  for (let index = 0; index < items.length; index += 1) {
+    const record = asRecord(items[index], file, `items[${index}]`);
+    const itemId = normalizeItemId(record.itemId, file);
+    if (table[itemId]) fail(file, `duplicate itemId ${itemId}`);
+    table[itemId] = Object.freeze({
+      itemId,
+      basePrice: readInteger(record, "basePrice", file, 1),
+      sellable: readBoolean(record, "sellable", file),
+    });
+  }
+
+  return Object.freeze(Object.fromEntries(Object.entries(table).sort(([a], [b]) => a.localeCompare(b))));
+}
+
+export function loadLocalMarketsFromGameData(): readonly LocalMarketDefinition[] {
+  const file = resolveContentFile("economy/markets.json");
+  const root = asRecord(readJsonFile(file), file, "market root");
+  if (readInteger(root, "schemaVersion", file, 1) !== 1) fail(file, "schemaVersion must be 1");
+
+  const marketsRaw = root.markets;
+  if (!Array.isArray(marketsRaw) || marketsRaw.length === 0) fail(file, "markets must be a non-empty array");
+
+  const seen = new Set<string>();
+  const markets = marketsRaw.map((entry, index) => {
+    const record = asRecord(entry, file, `markets[${index}]`);
+    const marketId = readString(record, "marketId", file);
+    if (seen.has(marketId)) fail(file, `duplicate marketId ${marketId}`);
+    seen.add(marketId);
+
+    const position = asRecord(record.position, file, `markets[${index}].position`);
+    const demandRaw = record.demand;
+    const routesRaw = record.routes ?? [];
+    if (!Array.isArray(demandRaw)) fail(file, `${marketId}.demand must be an array`);
+    if (!Array.isArray(routesRaw)) fail(file, `${marketId}.routes must be an array`);
+
+    return Object.freeze({
+      marketId,
+      title: readString(record, "title", file),
+      regionId: readString(record, "regionId", file),
+      vendorId: readString(record, "vendorId", file),
+      chunkKey: readString(record, "chunkKey", file),
+      position: Object.freeze({
+        x: readInteger(position, "x", file, -9_000_000_000),
+        y: readInteger(position, "y", file, -9_000_000_000),
+      }),
+      demand: Object.freeze(demandRaw.map((raw, demandIndex) => normalizeDemand(raw, file, demandIndex)).sort((a, b) => a.itemId.localeCompare(b.itemId))),
+      routes: Object.freeze(routesRaw.map((raw, routeIndex) => normalizeRoute(raw, file, routeIndex)).sort((a, b) => a.routeId.localeCompare(b.routeId))),
+    });
+  });
+
+  return Object.freeze(markets.sort((a, b) => a.marketId.localeCompare(b.marketId)));
+}

--- a/server/src/economy/EconomyService.ts
+++ b/server/src/economy/EconomyService.ts
@@ -1,12 +1,6 @@
-/**
- * ECONOMY SERVICE
- *
- * Server-authoritative economy operations for resource selling.
- * Deterministic: No Math.random(), no Date.now(), stable ordering.
- * Fail-close: failed operations do not mutate state.
- */
-
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
 import { InventoryService } from "../inventory/InventoryService.js";
+import type { InventoryItemId } from "../inventory/InventoryTypes.js";
 import { WalletService } from "./WalletService.js";
 import { VendorStockService } from "./VendorStockService.js";
 import { isSellable } from "./ResourceSellPrices.js";
@@ -14,10 +8,9 @@ import { calculateDynamicPrice } from "./DemandPricing.js";
 import {
   getVillageResourceVendor,
   checkVendorProximity,
-  type VendorDefinition,
 } from "./VillageVendors.js";
-import type { InventoryItemId } from "../inventory/InventoryTypes.js";
 import type { DemandBand } from "./VendorStockTypes.js";
+import { runtimeHistoryLog, type RuntimeHistoryLog } from "../history/RuntimeHistoryLog.js";
 
 export interface SellResourceInput {
   playerId: string;
@@ -25,6 +18,7 @@ export interface SellResourceInput {
   quantity: number;
   playerPosition?: { x: number; y: number };
   vendorId?: string;
+  currentTick?: number;
 }
 
 export interface SellResourceResult {
@@ -38,6 +32,7 @@ export interface SellResourceResult {
   stockBefore: number;
   stockAfter: number;
   demandBand: DemandBand;
+  historyHash?: string;
   reason?:
     | "sold"
     | "invalid_player"
@@ -52,10 +47,49 @@ export interface SellResourceResult {
     | "invalid_vendor";
 }
 
+export interface BuyResourceInput {
+  playerId: string;
+  itemId: InventoryItemId | string;
+  quantity: number;
+  playerPosition?: { x: number; y: number };
+  vendorId?: string;
+  currentTick?: number;
+}
+
+export interface BuyResourceResult {
+  ok: boolean;
+  itemId: string;
+  quantityBought: number;
+  unitPrice: number;
+  basePrice: number;
+  totalCoins: number;
+  newBalance: number;
+  stockBefore: number;
+  stockAfter: number;
+  demandBand: DemandBand;
+  originUid?: string;
+  historyHash?: string;
+  reason?:
+    | "bought"
+    | "invalid_player"
+    | "invalid_item"
+    | "invalid_quantity"
+    | "not_sellable"
+    | "insufficient_stock"
+    | "insufficient_wallet"
+    | "inventory_add_failed"
+    | "missing_player_position"
+    | "invalid_player_position"
+    | "vendor_too_far"
+    | "missing_vendor"
+    | "invalid_vendor";
+}
+
 export interface SellAllResourcesInput {
   playerId: string;
   playerPosition?: { x: number; y: number };
   vendorId?: string;
+  currentTick?: number;
 }
 
 export interface SellAllResourcesResult {
@@ -72,6 +106,7 @@ export interface SellAllResourcesResult {
   }>;
   totalCoins: number;
   newBalance: number;
+  historyHash?: string;
   reason?:
     | "sold"
     | "nothing_to_sell"
@@ -83,121 +118,70 @@ export interface SellAllResourcesResult {
     | "invalid_vendor";
 }
 
+function normalizeTick(value: number | undefined): number {
+  const tick = Number(value ?? 0);
+  return Number.isSafeInteger(tick) && tick >= 0 ? tick : 0;
+}
+
+function tradeDeltaHash(input: {
+  playerId: string;
+  vendorId: string;
+  itemId: string;
+  quantity: number;
+  totalCoins: number;
+  stockBefore: number;
+  currentTick: number;
+}): string {
+  return stableHash32([
+    "ECONOMY_TRADE_DELTA_V1",
+    input.playerId,
+    input.vendorId,
+    input.itemId,
+    input.quantity,
+    input.totalCoins,
+    input.stockBefore,
+    input.currentTick,
+  ].join("|")).toString(16);
+}
+
 export class EconomyService {
   constructor(
     private readonly inventoryService: InventoryService,
     private readonly walletService: WalletService,
     private readonly vendorStockService: VendorStockService,
+    private readonly history: RuntimeHistoryLog = runtimeHistoryLog,
   ) {}
 
   async sellResource(input: SellResourceInput): Promise<SellResourceResult> {
-    // Validate player
     if (!input.playerId || input.playerId === "anonymous") {
-      return {
-        ok: false,
-        itemId: String(input.itemId),
-        quantitySold: 0,
-        unitPrice: 0,
-        basePrice: 0,
-        totalCoins: 0,
-        newBalance: 0,
-        stockBefore: 0,
-        stockAfter: 0,
-        demandBand: "normal",
-        reason: "invalid_player",
-      };
+      return this.sellFailure(input, "invalid_player");
     }
 
-    // Validate quantity
     const quantity = Math.floor(Number(input.quantity));
     if (quantity <= 0 || !Number.isFinite(quantity)) {
-      return {
-        ok: false,
-        itemId: String(input.itemId),
-        quantitySold: 0,
-        unitPrice: 0,
-        basePrice: 0,
-        totalCoins: 0,
-        newBalance: 0,
-        stockBefore: 0,
-        stockAfter: 0,
-        demandBand: "normal",
-        reason: "invalid_quantity",
-      };
+      return this.sellFailure(input, "invalid_quantity");
     }
 
-    // Check if item is sellable
     if (!isSellable(input.itemId)) {
-      return {
-        ok: false,
-        itemId: String(input.itemId),
-        quantitySold: 0,
-        unitPrice: 0,
-        basePrice: 0,
-        totalCoins: 0,
-        newBalance: 0,
-        stockBefore: 0,
-        stockAfter: 0,
-        demandBand: "normal",
-        reason: "not_sellable",
-      };
+      return this.sellFailure(input, "not_sellable");
     }
 
-    // Check if player has enough
     const inventory = await this.inventoryService.getPlayerInventory(input.playerId);
     const slot = inventory.slots.find((s) => s.itemId === input.itemId);
 
     if (!slot || slot.quantity < quantity) {
-      // Get current price info even for failure
-      const vendorId = input.vendorId ?? "village_trader_001";
-      const currentStock = await this.vendorStockService.getItemQuantity(vendorId, input.itemId);
-      const priceInfo = calculateDynamicPrice(input.itemId, currentStock);
-
-      return {
-        ok: false,
-        itemId: String(input.itemId),
-        quantitySold: 0,
-        unitPrice: priceInfo.unitPrice,
-        basePrice: priceInfo.basePrice,
-        totalCoins: 0,
-        newBalance: 0,
-        stockBefore: currentStock,
-        stockAfter: currentStock,
-        demandBand: priceInfo.demandBand,
-        reason: "insufficient_quantity",
-      };
+      return this.sellFailure(input, "insufficient_quantity", quantity);
     }
 
-    // Validate vendor proximity
     const vendorProximityResult = this.validateVendorProximity(input);
     if (!vendorProximityResult.valid) {
-      const failureReason = vendorProximityResult.reason ?? "vendor_too_far";
-      const vendorId = input.vendorId ?? "village_trader_001";
-      const currentStock = await this.vendorStockService.getItemQuantity(vendorId, input.itemId);
-      const priceInfo = calculateDynamicPrice(input.itemId, currentStock);
-
-      return {
-        ok: false,
-        itemId: String(input.itemId),
-        quantitySold: 0,
-        unitPrice: priceInfo.unitPrice,
-        basePrice: priceInfo.basePrice,
-        totalCoins: 0,
-        newBalance: 0,
-        stockBefore: currentStock,
-        stockAfter: currentStock,
-        demandBand: priceInfo.demandBand,
-        reason: failureReason,
-      };
+      return this.sellFailure(input, vendorProximityResult.reason ?? "vendor_too_far", quantity);
     }
 
-    // All validations passed - perform the transaction
-    // Get dynamic price based on current vendor stock
     const vendorId = input.vendorId ?? "village_trader_001";
     const stockBefore = await this.vendorStockService.getItemQuantity(vendorId, input.itemId);
     const priceInfo = calculateDynamicPrice(input.itemId, stockBefore);
 
-    // Remove items from inventory
     const removeResult = await this.inventoryService.removeItem({
       playerId: input.playerId,
       itemId: input.itemId,
@@ -205,7 +189,6 @@ export class EconomyService {
     });
 
     if (!removeResult.ok) {
-      // Should not happen if we checked correctly, but fail-safe
       return {
         ok: false,
         itemId: String(input.itemId),
@@ -221,15 +204,17 @@ export class EconomyService {
       };
     }
 
-    // Add coins to wallet
     const totalCoins = quantity * priceInfo.unitPrice;
-    const updatedWallet = await this.walletService.addCoins({
-      playerId: input.playerId,
-      amount: totalCoins,
-    });
-
-    // Update vendor stock
+    const updatedWallet = await this.walletService.addCoins({ playerId: input.playerId, amount: totalCoins });
     const stockAfter = await this.vendorStockService.addItems(vendorId, input.itemId, quantity);
+    const currentTick = normalizeTick(input.currentTick);
+    const history = this.history.write({
+      tick: currentTick,
+      source: "economy_sell",
+      actorId: input.playerId,
+      subjectId: `${vendorId}:${input.itemId}`,
+      payload: { itemId: input.itemId, quantity, totalCoins, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? stockBefore + quantity },
+    });
 
     return {
       ok: true,
@@ -242,179 +227,154 @@ export class EconomyService {
       stockBefore,
       stockAfter: stockAfter.items[input.itemId] ?? stockBefore + quantity,
       demandBand: priceInfo.demandBand,
+      historyHash: history.entryHash,
       reason: "sold",
+    };
+  }
+
+  async buyResource(input: BuyResourceInput): Promise<BuyResourceResult> {
+    if (!input.playerId || input.playerId === "anonymous") return this.buyFailure(input, "invalid_player");
+
+    const quantity = Math.floor(Number(input.quantity));
+    if (quantity <= 0 || !Number.isFinite(quantity)) return this.buyFailure(input, "invalid_quantity");
+    if (!isSellable(input.itemId)) return this.buyFailure(input, "not_sellable");
+
+    const vendorProximityResult = this.validateVendorProximity(input);
+    if (!vendorProximityResult.valid) return this.buyFailure(input, vendorProximityResult.reason ?? "vendor_too_far", quantity);
+
+    const vendorId = input.vendorId ?? "village_trader_001";
+    const stockBefore = await this.vendorStockService.getItemQuantity(vendorId, input.itemId);
+    const priceInfo = calculateDynamicPrice(input.itemId, stockBefore);
+    if (stockBefore < quantity) return this.buyFailure(input, "insufficient_stock", quantity, stockBefore, priceInfo);
+
+    const totalCoins = quantity * priceInfo.unitPrice;
+    const wallet = await this.walletService.getWallet(input.playerId);
+    if (wallet.balances.coin < totalCoins) return this.buyFailure(input, "insufficient_wallet", quantity, stockBefore, priceInfo);
+
+    const currentTick = normalizeTick(input.currentTick);
+    const sourceHash = tradeDeltaHash({ playerId: input.playerId, vendorId, itemId: String(input.itemId), quantity, totalCoins, stockBefore, currentTick });
+    const originUid = `buy:${sourceHash}`;
+    const stockAfter = await this.vendorStockService.removeItems(vendorId, input.itemId, quantity);
+    if (!stockAfter) return this.buyFailure(input, "insufficient_stock", quantity, stockBefore, priceInfo);
+
+    const walletAfter = await this.walletService.subtractCoins({ playerId: input.playerId, amount: totalCoins });
+    const addResult = await this.inventoryService.addItem({
+      playerId: input.playerId,
+      itemId: input.itemId,
+      quantity,
+      origin: { uid: originUid, tick: currentTick, source: "trade_delta", sourceHash },
+    });
+
+    if (!addResult.ok) {
+      return {
+        ok: false,
+        itemId: String(input.itemId),
+        quantityBought: 0,
+        unitPrice: priceInfo.unitPrice,
+        basePrice: priceInfo.basePrice,
+        totalCoins: 0,
+        newBalance: walletAfter.balances.coin,
+        stockBefore,
+        stockAfter: stockAfter.items[input.itemId] ?? 0,
+        demandBand: priceInfo.demandBand,
+        originUid,
+        reason: "inventory_add_failed",
+      };
+    }
+
+    const history = this.history.write({
+      tick: currentTick,
+      source: "trade_transfer",
+      actorId: input.playerId,
+      subjectId: `${vendorId}:${input.itemId}`,
+      payload: { itemId: input.itemId, quantity, totalCoins, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? 0, originUid },
+    });
+
+    return {
+      ok: true,
+      itemId: String(input.itemId),
+      quantityBought: quantity,
+      unitPrice: priceInfo.unitPrice,
+      basePrice: priceInfo.basePrice,
+      totalCoins,
+      newBalance: walletAfter.balances.coin,
+      stockBefore,
+      stockAfter: stockAfter.items[input.itemId] ?? 0,
+      demandBand: priceInfo.demandBand,
+      originUid,
+      historyHash: history.entryHash,
+      reason: "bought",
     };
   }
 
   async sellAllResources(input: SellAllResourcesInput): Promise<SellAllResourcesResult> {
-    // Validate player
-    if (!input.playerId || input.playerId === "anonymous") {
-      return {
-        ok: false,
-        sold: [],
-        totalCoins: 0,
-        newBalance: 0,
-        reason: "invalid_player",
-      };
-    }
+    if (!input.playerId || input.playerId === "anonymous") return { ok: false, sold: [], totalCoins: 0, newBalance: 0, reason: "invalid_player" };
 
-    // Get inventory
     const inventory = await this.inventoryService.getPlayerInventory(input.playerId);
-
-    // Find all sellable resource slots
     const sellableSlots = inventory.slots.filter((slot) => isSellable(slot.itemId));
+    if (sellableSlots.length === 0) return { ok: false, sold: [], totalCoins: 0, newBalance: 0, reason: "nothing_to_sell" };
 
-    if (sellableSlots.length === 0) {
-      return {
-        ok: false,
-        sold: [],
-        totalCoins: 0,
-        newBalance: 0,
-        reason: "nothing_to_sell",
-      };
-    }
-
-    // Validate vendor proximity
     const vendorProximityResult = this.validateVendorProximity(input);
-    if (!vendorProximityResult.valid) {
-      const failureReason = vendorProximityResult.reason ?? "vendor_too_far";
-      return {
-        ok: false,
-        sold: [],
-        totalCoins: 0,
-        newBalance: 0,
-        reason: failureReason,
-      };
-    }
+    if (!vendorProximityResult.valid) return { ok: false, sold: [], totalCoins: 0, newBalance: 0, reason: vendorProximityResult.reason ?? "vendor_too_far" };
 
     const vendorId = input.vendorId ?? "village_trader_001";
-
-    // Calculate what can be sold with dynamic prices
-    // Sort by itemId for deterministic ordering
     const sortedSlots = [...sellableSlots].sort((a, b) => a.itemId.localeCompare(b.itemId));
-
-    const sellOps: Array<{
-      itemId: string;
-      quantity: number;
-      unitPrice: number;
-      basePrice: number;
-      totalCoins: number;
-      stockBefore: number;
-      stockAfter: number;
-      demandBand: DemandBand;
-    }> = [];
-
+    const sellOps: Array<{ itemId: string; quantity: number; unitPrice: number; basePrice: number; totalCoins: number; stockBefore: number; stockAfter: number; demandBand: DemandBand }> = [];
     let totalCoins = 0;
 
     for (const slot of sortedSlots) {
-      // Get current stock at the moment of this item
       const stockBefore = await this.vendorStockService.getItemQuantity(vendorId, slot.itemId);
       const priceInfo = calculateDynamicPrice(slot.itemId, stockBefore);
-
       const slotTotal = slot.quantity * priceInfo.unitPrice;
       totalCoins += slotTotal;
-      sellOps.push({
-        itemId: slot.itemId,
-        quantity: slot.quantity,
-        unitPrice: priceInfo.unitPrice,
-        basePrice: priceInfo.basePrice,
-        totalCoins: slotTotal,
-        stockBefore,
-        stockAfter: stockBefore + slot.quantity, // Predicted after add
-        demandBand: priceInfo.demandBand,
-      });
+      sellOps.push({ itemId: slot.itemId, quantity: slot.quantity, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins: slotTotal, stockBefore, stockAfter: stockBefore + slot.quantity, demandBand: priceInfo.demandBand });
     }
 
-    if (sellOps.length === 0) {
-      return {
-        ok: false,
-        sold: [],
-        totalCoins: 0,
-        newBalance: 0,
-        reason: "nothing_to_sell",
-      };
-    }
-
-    // Remove all items and add coins in a transaction
     for (const op of sellOps) {
-      await this.inventoryService.removeItem({
-        playerId: input.playerId,
-        itemId: op.itemId,
-        quantity: op.quantity,
-      });
+      await this.inventoryService.removeItem({ playerId: input.playerId, itemId: op.itemId, quantity: op.quantity });
     }
 
-    const updatedWallet = await this.walletService.addCoins({
-      playerId: input.playerId,
-      amount: totalCoins,
+    const updatedWallet = await this.walletService.addCoins({ playerId: input.playerId, amount: totalCoins });
+    for (const op of sellOps) await this.vendorStockService.addItems(vendorId, op.itemId, op.quantity);
+
+    const history = this.history.write({
+      tick: normalizeTick(input.currentTick),
+      source: "economy_sell",
+      actorId: input.playerId,
+      subjectId: `${vendorId}:sell_all`,
+      payload: { totalCoins, sold: sellOps },
     });
-
-    // Update vendor stock for each item
-    for (const op of sellOps) {
-      await this.vendorStockService.addItems(vendorId, op.itemId, op.quantity);
-    }
 
     return {
       ok: true,
-      sold: sellOps.map((op) => ({
-        itemId: op.itemId,
-        quantitySold: op.quantity,
-        unitPrice: op.unitPrice,
-        basePrice: op.basePrice,
-        totalCoins: op.totalCoins,
-        stockBefore: op.stockBefore,
-        stockAfter: op.stockAfter,
-        demandBand: op.demandBand,
-      })),
+      sold: sellOps.map((op) => ({ itemId: op.itemId, quantitySold: op.quantity, unitPrice: op.unitPrice, basePrice: op.basePrice, totalCoins: op.totalCoins, stockBefore: op.stockBefore, stockAfter: op.stockAfter, demandBand: op.demandBand })),
       totalCoins,
       newBalance: updatedWallet.balances.coin,
+      historyHash: history.entryHash,
       reason: "sold",
     };
   }
 
-  /**
-   * Validate that player is near a valid vendor.
-   * Returns { valid: true } if vendor is valid and player is in range.
-   * Returns { valid: false, reason: string } with failure reason.
-   */
-  private validateVendorProximity(input: {
-    playerPosition?: { x: number; y: number };
-    vendorId?: string;
-  }): {
-    valid: boolean;
-    reason?:
-      | "missing_vendor"
-      | "invalid_vendor"
-      | "missing_player_position"
-      | "invalid_player_position"
-      | "vendor_too_far";
-  } {
-    // Default vendor is the village trader
+  private async sellFailure(input: SellResourceInput, reason: NonNullable<SellResourceResult["reason"]>, quantity = 0): Promise<SellResourceResult> {
     const vendorId = input.vendorId ?? "village_trader_001";
+    const stockBefore = await this.vendorStockService.getItemQuantity(vendorId, input.itemId).catch(() => 0);
+    const priceInfo = calculateDynamicPrice(input.itemId, stockBefore);
+    return { ok: false, itemId: String(input.itemId), quantitySold: 0, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins: 0, newBalance: 0, stockBefore, stockAfter: stockBefore, demandBand: priceInfo.demandBand, reason };
+  }
 
-    // Check if vendor exists
+  private async buyFailure(input: BuyResourceInput, reason: NonNullable<BuyResourceResult["reason"]>, quantity = 0, stockBefore = 0, priceInfo = calculateDynamicPrice(input.itemId, stockBefore)): Promise<BuyResourceResult> {
+    return { ok: false, itemId: String(input.itemId), quantityBought: 0, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins: 0, newBalance: 0, stockBefore, stockAfter: stockBefore, demandBand: priceInfo.demandBand, reason };
+  }
+
+  private validateVendorProximity(input: { playerPosition?: { x: number; y: number }; vendorId?: string }): { valid: boolean; reason?: "missing_vendor" | "invalid_vendor" | "missing_player_position" | "invalid_player_position" | "vendor_too_far" } {
+    const vendorId = input.vendorId ?? "village_trader_001";
     const vendor = getVillageResourceVendor();
-    if (vendor.id !== vendorId) {
-      return { valid: false, reason: "invalid_vendor" };
-    }
-
-    // Player position is required for selling
-    if (!input.playerPosition) {
-      return { valid: false, reason: "missing_player_position" };
-    }
-
-    // Validate player position is finite
+    if (vendor.id !== vendorId) return { valid: false, reason: "invalid_vendor" };
+    if (!input.playerPosition) return { valid: false, reason: "missing_player_position" };
     const pos = input.playerPosition;
-    if (!Number.isFinite(pos.x) || !Number.isFinite(pos.y)) {
-      return { valid: false, reason: "invalid_player_position" };
-    }
-
-    // Check proximity
+    if (!Number.isFinite(pos.x) || !Number.isFinite(pos.y)) return { valid: false, reason: "invalid_player_position" };
     const proximity = checkVendorProximity(pos, vendor);
-    if (!proximity.withinRange) {
-      return { valid: false, reason: "vendor_too_far" };
-    }
-
+    if (!proximity.withinRange) return { valid: false, reason: "vendor_too_far" };
     return { valid: true };
   }
 }

--- a/server/src/economy/EconomyService.ts
+++ b/server/src/economy/EconomyService.ts
@@ -33,18 +33,7 @@ export interface SellResourceResult {
   stockAfter: number;
   demandBand: DemandBand;
   historyHash?: string;
-  reason?:
-    | "sold"
-    | "invalid_player"
-    | "invalid_item"
-    | "invalid_quantity"
-    | "not_sellable"
-    | "insufficient_quantity"
-    | "missing_player_position"
-    | "invalid_player_position"
-    | "vendor_too_far"
-    | "missing_vendor"
-    | "invalid_vendor";
+  reason?: "sold" | "invalid_player" | "invalid_item" | "invalid_quantity" | "not_sellable" | "insufficient_quantity" | "missing_player_position" | "invalid_player_position" | "vendor_too_far" | "missing_vendor" | "invalid_vendor";
 }
 
 export interface BuyResourceInput {
@@ -69,20 +58,7 @@ export interface BuyResourceResult {
   demandBand: DemandBand;
   originUid?: string;
   historyHash?: string;
-  reason?:
-    | "bought"
-    | "invalid_player"
-    | "invalid_item"
-    | "invalid_quantity"
-    | "not_sellable"
-    | "insufficient_stock"
-    | "insufficient_wallet"
-    | "inventory_add_failed"
-    | "missing_player_position"
-    | "invalid_player_position"
-    | "vendor_too_far"
-    | "missing_vendor"
-    | "invalid_vendor";
+  reason?: "bought" | "invalid_player" | "invalid_item" | "invalid_quantity" | "not_sellable" | "insufficient_stock" | "insufficient_wallet" | "inventory_add_failed" | "missing_player_position" | "invalid_player_position" | "vendor_too_far" | "missing_vendor" | "invalid_vendor";
 }
 
 export interface SellAllResourcesInput {
@@ -94,28 +70,11 @@ export interface SellAllResourcesInput {
 
 export interface SellAllResourcesResult {
   ok: boolean;
-  sold: Array<{
-    itemId: string;
-    quantitySold: number;
-    unitPrice: number;
-    basePrice: number;
-    totalCoins: number;
-    stockBefore: number;
-    stockAfter: number;
-    demandBand: DemandBand;
-  }>;
+  sold: Array<{ itemId: string; quantitySold: number; unitPrice: number; basePrice: number; totalCoins: number; stockBefore: number; stockAfter: number; demandBand: DemandBand }>;
   totalCoins: number;
   newBalance: number;
   historyHash?: string;
-  reason?:
-    | "sold"
-    | "nothing_to_sell"
-    | "invalid_player"
-    | "missing_player_position"
-    | "invalid_player_position"
-    | "vendor_too_far"
-    | "missing_vendor"
-    | "invalid_vendor";
+  reason?: "sold" | "nothing_to_sell" | "invalid_player" | "missing_player_position" | "invalid_player_position" | "vendor_too_far" | "missing_vendor" | "invalid_vendor";
 }
 
 function normalizeTick(value: number | undefined): number {
@@ -123,25 +82,8 @@ function normalizeTick(value: number | undefined): number {
   return Number.isSafeInteger(tick) && tick >= 0 ? tick : 0;
 }
 
-function tradeDeltaHash(input: {
-  playerId: string;
-  vendorId: string;
-  itemId: string;
-  quantity: number;
-  totalCoins: number;
-  stockBefore: number;
-  currentTick: number;
-}): string {
-  return stableHash32([
-    "ECONOMY_TRADE_DELTA_V1",
-    input.playerId,
-    input.vendorId,
-    input.itemId,
-    input.quantity,
-    input.totalCoins,
-    input.stockBefore,
-    input.currentTick,
-  ].join("|")).toString(16);
+function tradeDeltaHash(input: { playerId: string; vendorId: string; itemId: string; quantity: number; totalCoins: number; stockBefore: number; currentTick: number }): string {
+  return stableHash32(["ECONOMY_TRADE_DELTA_V1", input.playerId, input.vendorId, input.itemId, input.quantity, input.totalCoins, input.stockBefore, input.currentTick].join("|")).toString(16);
 }
 
 export class EconomyService {
@@ -153,88 +95,35 @@ export class EconomyService {
   ) {}
 
   async sellResource(input: SellResourceInput): Promise<SellResourceResult> {
-    if (!input.playerId || input.playerId === "anonymous") {
-      return this.sellFailure(input, "invalid_player");
-    }
-
+    if (!input.playerId || input.playerId === "anonymous") return this.sellFailure(input, "invalid_player");
     const quantity = Math.floor(Number(input.quantity));
-    if (quantity <= 0 || !Number.isFinite(quantity)) {
-      return this.sellFailure(input, "invalid_quantity");
-    }
-
-    if (!isSellable(input.itemId)) {
-      return this.sellFailure(input, "not_sellable");
-    }
+    if (quantity <= 0 || !Number.isFinite(quantity)) return this.sellFailure(input, "invalid_quantity");
+    if (!isSellable(input.itemId)) return this.sellFailure(input, "not_sellable");
 
     const inventory = await this.inventoryService.getPlayerInventory(input.playerId);
     const slot = inventory.slots.find((s) => s.itemId === input.itemId);
-
-    if (!slot || slot.quantity < quantity) {
-      return this.sellFailure(input, "insufficient_quantity", quantity);
-    }
+    if (!slot || slot.quantity < quantity) return this.sellFailure(input, "insufficient_quantity", quantity);
 
     const vendorProximityResult = this.validateVendorProximity(input);
-    if (!vendorProximityResult.valid) {
-      return this.sellFailure(input, vendorProximityResult.reason ?? "vendor_too_far", quantity);
-    }
+    if (!vendorProximityResult.valid) return this.sellFailure(input, vendorProximityResult.reason ?? "vendor_too_far", quantity);
 
     const vendorId = input.vendorId ?? "village_trader_001";
     const stockBefore = await this.vendorStockService.getItemQuantity(vendorId, input.itemId);
     const priceInfo = calculateDynamicPrice(input.itemId, stockBefore);
-
-    const removeResult = await this.inventoryService.removeItem({
-      playerId: input.playerId,
-      itemId: input.itemId,
-      quantity,
-    });
-
-    if (!removeResult.ok) {
-      return {
-        ok: false,
-        itemId: String(input.itemId),
-        quantitySold: 0,
-        unitPrice: priceInfo.unitPrice,
-        basePrice: priceInfo.basePrice,
-        totalCoins: 0,
-        newBalance: 0,
-        stockBefore,
-        stockAfter: stockBefore,
-        demandBand: priceInfo.demandBand,
-        reason: "insufficient_quantity",
-      };
-    }
+    const removeResult = await this.inventoryService.removeItem({ playerId: input.playerId, itemId: input.itemId, quantity });
+    if (!removeResult.ok) return { ok: false, itemId: String(input.itemId), quantitySold: 0, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins: 0, newBalance: 0, stockBefore, stockAfter: stockBefore, demandBand: priceInfo.demandBand, reason: "insufficient_quantity" };
 
     const totalCoins = quantity * priceInfo.unitPrice;
     const updatedWallet = await this.walletService.addCoins({ playerId: input.playerId, amount: totalCoins });
     const stockAfter = await this.vendorStockService.addItems(vendorId, input.itemId, quantity);
     const currentTick = normalizeTick(input.currentTick);
-    const history = this.history.write({
-      tick: currentTick,
-      source: "economy_sell",
-      actorId: input.playerId,
-      subjectId: `${vendorId}:${input.itemId}`,
-      payload: { itemId: input.itemId, quantity, totalCoins, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? stockBefore + quantity },
-    });
+    const history = this.history.write({ tick: currentTick, source: "economy_sell", actorId: input.playerId, subjectId: `${vendorId}:${input.itemId}`, payload: { itemId: input.itemId, quantity, totalCoins, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? stockBefore + quantity } });
 
-    return {
-      ok: true,
-      itemId: String(input.itemId),
-      quantitySold: quantity,
-      unitPrice: priceInfo.unitPrice,
-      basePrice: priceInfo.basePrice,
-      totalCoins,
-      newBalance: updatedWallet.balances.coin,
-      stockBefore,
-      stockAfter: stockAfter.items[input.itemId] ?? stockBefore + quantity,
-      demandBand: priceInfo.demandBand,
-      historyHash: history.entryHash,
-      reason: "sold",
-    };
+    return { ok: true, itemId: String(input.itemId), quantitySold: quantity, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins, newBalance: updatedWallet.balances.coin, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? stockBefore + quantity, demandBand: priceInfo.demandBand, historyHash: history.entryHash, reason: "sold" };
   }
 
   async buyResource(input: BuyResourceInput): Promise<BuyResourceResult> {
     if (!input.playerId || input.playerId === "anonymous") return this.buyFailure(input, "invalid_player");
-
     const quantity = Math.floor(Number(input.quantity));
     if (quantity <= 0 || !Number.isFinite(quantity)) return this.buyFailure(input, "invalid_quantity");
     if (!isSellable(input.itemId)) return this.buyFailure(input, "not_sellable");
@@ -247,6 +136,12 @@ export class EconomyService {
     const priceInfo = calculateDynamicPrice(input.itemId, stockBefore);
     if (stockBefore < quantity) return this.buyFailure(input, "insufficient_stock", quantity, stockBefore, priceInfo);
 
+    const inventoryBefore = await this.inventoryService.getPlayerInventory(input.playerId);
+    const existingSlot = inventoryBefore.slots.find((slot) => slot.itemId === input.itemId);
+    if (!existingSlot && inventoryBefore.slots.length >= inventoryBefore.capacity) {
+      return this.buyFailure(input, "inventory_add_failed", quantity, stockBefore, priceInfo);
+    }
+
     const totalCoins = quantity * priceInfo.unitPrice;
     const wallet = await this.walletService.getWallet(input.playerId);
     if (wallet.balances.coin < totalCoins) return this.buyFailure(input, "insufficient_wallet", quantity, stockBefore, priceInfo);
@@ -258,58 +153,15 @@ export class EconomyService {
     if (!stockAfter) return this.buyFailure(input, "insufficient_stock", quantity, stockBefore, priceInfo);
 
     const walletAfter = await this.walletService.subtractCoins({ playerId: input.playerId, amount: totalCoins });
-    const addResult = await this.inventoryService.addItem({
-      playerId: input.playerId,
-      itemId: input.itemId,
-      quantity,
-      origin: { uid: originUid, tick: currentTick, source: "trade_delta", sourceHash },
-    });
+    const addResult = await this.inventoryService.addItem({ playerId: input.playerId, itemId: input.itemId, quantity, origin: { uid: originUid, tick: currentTick, source: "trade_delta", sourceHash } });
+    if (!addResult.ok) return { ok: false, itemId: String(input.itemId), quantityBought: 0, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins: 0, newBalance: walletAfter.balances.coin, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? 0, demandBand: priceInfo.demandBand, originUid, reason: "inventory_add_failed" };
 
-    if (!addResult.ok) {
-      return {
-        ok: false,
-        itemId: String(input.itemId),
-        quantityBought: 0,
-        unitPrice: priceInfo.unitPrice,
-        basePrice: priceInfo.basePrice,
-        totalCoins: 0,
-        newBalance: walletAfter.balances.coin,
-        stockBefore,
-        stockAfter: stockAfter.items[input.itemId] ?? 0,
-        demandBand: priceInfo.demandBand,
-        originUid,
-        reason: "inventory_add_failed",
-      };
-    }
-
-    const history = this.history.write({
-      tick: currentTick,
-      source: "trade_transfer",
-      actorId: input.playerId,
-      subjectId: `${vendorId}:${input.itemId}`,
-      payload: { itemId: input.itemId, quantity, totalCoins, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? 0, originUid },
-    });
-
-    return {
-      ok: true,
-      itemId: String(input.itemId),
-      quantityBought: quantity,
-      unitPrice: priceInfo.unitPrice,
-      basePrice: priceInfo.basePrice,
-      totalCoins,
-      newBalance: walletAfter.balances.coin,
-      stockBefore,
-      stockAfter: stockAfter.items[input.itemId] ?? 0,
-      demandBand: priceInfo.demandBand,
-      originUid,
-      historyHash: history.entryHash,
-      reason: "bought",
-    };
+    const history = this.history.write({ tick: currentTick, source: "trade_transfer", actorId: input.playerId, subjectId: `${vendorId}:${input.itemId}`, payload: { itemId: input.itemId, quantity, totalCoins, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? 0, originUid } });
+    return { ok: true, itemId: String(input.itemId), quantityBought: quantity, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins, newBalance: walletAfter.balances.coin, stockBefore, stockAfter: stockAfter.items[input.itemId] ?? 0, demandBand: priceInfo.demandBand, originUid, historyHash: history.entryHash, reason: "bought" };
   }
 
   async sellAllResources(input: SellAllResourcesInput): Promise<SellAllResourcesResult> {
     if (!input.playerId || input.playerId === "anonymous") return { ok: false, sold: [], totalCoins: 0, newBalance: 0, reason: "invalid_player" };
-
     const inventory = await this.inventoryService.getPlayerInventory(input.playerId);
     const sellableSlots = inventory.slots.filter((slot) => isSellable(slot.itemId));
     if (sellableSlots.length === 0) return { ok: false, sold: [], totalCoins: 0, newBalance: 0, reason: "nothing_to_sell" };
@@ -330,39 +182,22 @@ export class EconomyService {
       sellOps.push({ itemId: slot.itemId, quantity: slot.quantity, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins: slotTotal, stockBefore, stockAfter: stockBefore + slot.quantity, demandBand: priceInfo.demandBand });
     }
 
-    for (const op of sellOps) {
-      await this.inventoryService.removeItem({ playerId: input.playerId, itemId: op.itemId, quantity: op.quantity });
-    }
-
+    for (const op of sellOps) await this.inventoryService.removeItem({ playerId: input.playerId, itemId: op.itemId, quantity: op.quantity });
     const updatedWallet = await this.walletService.addCoins({ playerId: input.playerId, amount: totalCoins });
     for (const op of sellOps) await this.vendorStockService.addItems(vendorId, op.itemId, op.quantity);
 
-    const history = this.history.write({
-      tick: normalizeTick(input.currentTick),
-      source: "economy_sell",
-      actorId: input.playerId,
-      subjectId: `${vendorId}:sell_all`,
-      payload: { totalCoins, sold: sellOps },
-    });
-
-    return {
-      ok: true,
-      sold: sellOps.map((op) => ({ itemId: op.itemId, quantitySold: op.quantity, unitPrice: op.unitPrice, basePrice: op.basePrice, totalCoins: op.totalCoins, stockBefore: op.stockBefore, stockAfter: op.stockAfter, demandBand: op.demandBand })),
-      totalCoins,
-      newBalance: updatedWallet.balances.coin,
-      historyHash: history.entryHash,
-      reason: "sold",
-    };
+    const history = this.history.write({ tick: normalizeTick(input.currentTick), source: "economy_sell", actorId: input.playerId, subjectId: `${vendorId}:sell_all`, payload: { totalCoins, sold: sellOps } });
+    return { ok: true, sold: sellOps.map((op) => ({ itemId: op.itemId, quantitySold: op.quantity, unitPrice: op.unitPrice, basePrice: op.basePrice, totalCoins: op.totalCoins, stockBefore: op.stockBefore, stockAfter: op.stockAfter, demandBand: op.demandBand })), totalCoins, newBalance: updatedWallet.balances.coin, historyHash: history.entryHash, reason: "sold" };
   }
 
-  private async sellFailure(input: SellResourceInput, reason: NonNullable<SellResourceResult["reason"]>, quantity = 0): Promise<SellResourceResult> {
+  private async sellFailure(input: SellResourceInput, reason: NonNullable<SellResourceResult["reason"]>, _quantity = 0): Promise<SellResourceResult> {
     const vendorId = input.vendorId ?? "village_trader_001";
     const stockBefore = await this.vendorStockService.getItemQuantity(vendorId, input.itemId).catch(() => 0);
     const priceInfo = calculateDynamicPrice(input.itemId, stockBefore);
     return { ok: false, itemId: String(input.itemId), quantitySold: 0, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins: 0, newBalance: 0, stockBefore, stockAfter: stockBefore, demandBand: priceInfo.demandBand, reason };
   }
 
-  private async buyFailure(input: BuyResourceInput, reason: NonNullable<BuyResourceResult["reason"]>, quantity = 0, stockBefore = 0, priceInfo = calculateDynamicPrice(input.itemId, stockBefore)): Promise<BuyResourceResult> {
+  private async buyFailure(input: BuyResourceInput, reason: NonNullable<BuyResourceResult["reason"]>, _quantity = 0, stockBefore = 0, priceInfo = calculateDynamicPrice(input.itemId, stockBefore)): Promise<BuyResourceResult> {
     return { ok: false, itemId: String(input.itemId), quantityBought: 0, unitPrice: priceInfo.unitPrice, basePrice: priceInfo.basePrice, totalCoins: 0, newBalance: 0, stockBefore, stockAfter: stockBefore, demandBand: priceInfo.demandBand, reason };
   }
 

--- a/server/src/economy/EconomySnapshotAdapter.ts
+++ b/server/src/economy/EconomySnapshotAdapter.ts
@@ -1,0 +1,50 @@
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
+import { loadLocalMarketsFromGameData } from "./EconomyGameData.js";
+import { localPriceResolver, type LocalPriceResolver } from "./LocalPriceResolver.js";
+import type { LocalMarketSnapshot, LocalMarketDefinition, LocalMarketPriceResult } from "./LocalMarketTypes.js";
+import type { VendorStockService } from "./VendorStockService.js";
+
+function snapshotHash(input: Omit<LocalMarketSnapshot, "snapshotHash">): string {
+  return stableHash32([
+    "LOCAL_MARKET_SNAPSHOT_V1",
+    input.marketId,
+    input.vendorId,
+    input.regionId,
+    input.chunkKey,
+    input.prices.map((price) => price.priceHash).join(","),
+  ].join("|")).toString(16);
+}
+
+export async function createLocalMarketSnapshot(input: {
+  readonly vendorStockService: VendorStockService;
+  readonly market?: LocalMarketDefinition;
+  readonly resolver?: LocalPriceResolver;
+}): Promise<LocalMarketSnapshot> {
+  const market = input.market ?? loadLocalMarketsFromGameData()[0];
+  const resolver = input.resolver ?? localPriceResolver;
+  const stock = await input.vendorStockService.getStock(market.vendorId);
+
+  const prices: LocalMarketPriceResult[] = [];
+  for (const itemId of resolver.listSellableItemIds()) {
+    const route = market.routes.find((candidate) => candidate.toMarketId === market.marketId);
+    const price = resolver.resolvePrice({
+      market,
+      itemId,
+      currentVendorStock: stock.items[itemId] ?? 0,
+      routeRiskPerMille: route?.routeRiskPerMille,
+      taxPressurePerMille: route?.taxPressurePerMille,
+    });
+    if (price) prices.push(price);
+  }
+
+  const base = {
+    marketId: market.marketId,
+    title: market.title,
+    regionId: market.regionId,
+    vendorId: market.vendorId,
+    chunkKey: market.chunkKey,
+    prices: Object.freeze(prices.sort((a, b) => a.itemId.localeCompare(b.itemId))),
+  } satisfies Omit<LocalMarketSnapshot, "snapshotHash">;
+
+  return Object.freeze({ ...base, snapshotHash: snapshotHash(base) });
+}

--- a/server/src/economy/LocalMarketTypes.ts
+++ b/server/src/economy/LocalMarketTypes.ts
@@ -1,0 +1,61 @@
+import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+
+export const MARKET_PERMILLE_NEUTRAL = 1000 as const;
+
+export interface LocalMarketDemandRule {
+  readonly itemId: InventoryItemId;
+  readonly demandPressurePerMille: number;
+}
+
+export interface LocalMarketRoute {
+  readonly routeId: string;
+  readonly toMarketId: string;
+  readonly distanceKappa: number;
+  readonly routeRiskPerMille: number;
+  readonly taxPressurePerMille: number;
+}
+
+export interface LocalMarketDefinition {
+  readonly marketId: string;
+  readonly title: string;
+  readonly regionId: string;
+  readonly vendorId: string;
+  readonly chunkKey: string;
+  readonly position: { readonly x: number; readonly y: number };
+  readonly demand: readonly LocalMarketDemandRule[];
+  readonly routes: readonly LocalMarketRoute[];
+}
+
+export interface LocalMarketPriceInput {
+  readonly market: LocalMarketDefinition;
+  readonly itemId: InventoryItemId | string;
+  readonly currentVendorStock: number;
+  readonly demandPressurePerMille?: number;
+  readonly routeRiskPerMille?: number;
+  readonly taxPressurePerMille?: number;
+}
+
+export interface LocalMarketPriceResult {
+  readonly marketId: string;
+  readonly vendorId: string;
+  readonly regionId: string;
+  readonly chunkKey: string;
+  readonly itemId: InventoryItemId;
+  readonly basePrice: number;
+  readonly unitPrice: number;
+  readonly supplyPressurePerMille: number;
+  readonly demandPressurePerMille: number;
+  readonly routeRiskPerMille: number;
+  readonly taxPressurePerMille: number;
+  readonly priceHash: string;
+}
+
+export interface LocalMarketSnapshot {
+  readonly marketId: string;
+  readonly title: string;
+  readonly regionId: string;
+  readonly vendorId: string;
+  readonly chunkKey: string;
+  readonly prices: readonly LocalMarketPriceResult[];
+  readonly snapshotHash: string;
+}

--- a/server/src/economy/LocalPriceResolver.ts
+++ b/server/src/economy/LocalPriceResolver.ts
@@ -1,0 +1,102 @@
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
+import { isInventoryItemId } from "../inventory/InventoryTypes.js";
+import { loadEconomyBasePricesFromGameData } from "./EconomyGameData.js";
+import type { EconomyBasePriceTable } from "./EconomyGameData.js";
+import { MARKET_PERMILLE_NEUTRAL, type LocalMarketPriceInput, type LocalMarketPriceResult } from "./LocalMarketTypes.js";
+
+function clampInteger(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  const n = Math.floor(value);
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
+}
+
+export function resolveSupplyPressurePerMille(currentVendorStock: number): number {
+  const stock = clampInteger(currentVendorStock, 0, 1_000_000_000);
+  if (stock <= 9) return 1000;
+  if (stock <= 24) return 900;
+  return 800;
+}
+
+function resolveDemandPressure(input: LocalMarketPriceInput): number {
+  if (input.demandPressurePerMille !== undefined) {
+    return clampInteger(input.demandPressurePerMille, 0, 5000);
+  }
+  const authored = input.market.demand.find((entry) => entry.itemId === input.itemId);
+  return authored ? clampInteger(authored.demandPressurePerMille, 0, 5000) : MARKET_PERMILLE_NEUTRAL;
+}
+
+function priceHash(input: Omit<LocalMarketPriceResult, "priceHash">): string {
+  return stableHash32([
+    "LOCAL_PRICE_V1",
+    input.marketId,
+    input.vendorId,
+    input.regionId,
+    input.chunkKey,
+    input.itemId,
+    input.basePrice,
+    input.unitPrice,
+    input.supplyPressurePerMille,
+    input.demandPressurePerMille,
+    input.routeRiskPerMille,
+    input.taxPressurePerMille,
+  ].join("|")).toString(16);
+}
+
+export class LocalPriceResolver {
+  constructor(private readonly basePrices: EconomyBasePriceTable = loadEconomyBasePricesFromGameData()) {}
+
+  isSellable(itemId: string): boolean {
+    const entry = this.basePrices[itemId];
+    return Boolean(entry?.sellable);
+  }
+
+  getBasePrice(itemId: string): number | null {
+    const entry = this.basePrices[itemId];
+    return entry?.sellable ? entry.basePrice : null;
+  }
+
+  listSellableItemIds(): string[] {
+    return Object.values(this.basePrices)
+      .filter((entry) => entry.sellable)
+      .map((entry) => entry.itemId)
+      .sort((a, b) => a.localeCompare(b));
+  }
+
+  resolvePrice(input: LocalMarketPriceInput): LocalMarketPriceResult | null {
+    if (!isInventoryItemId(input.itemId)) return null;
+    const entry = this.basePrices[input.itemId];
+    if (!entry?.sellable) return null;
+
+    const basePrice = entry.basePrice;
+    const supplyPressurePerMille = resolveSupplyPressurePerMille(input.currentVendorStock);
+    const demandPressurePerMille = resolveDemandPressure(input);
+    const routeRiskPerMille = clampInteger(input.routeRiskPerMille ?? MARKET_PERMILLE_NEUTRAL, 0, 5000);
+    const taxPressurePerMille = clampInteger(input.taxPressurePerMille ?? MARKET_PERMILLE_NEUTRAL, 0, 5000);
+
+    const weighted = Math.floor(
+      (basePrice * supplyPressurePerMille * demandPressurePerMille * routeRiskPerMille * taxPressurePerMille) /
+        1_000_000_000_000,
+    );
+    const unitPrice = Math.max(1, weighted);
+
+    const result = {
+      marketId: input.market.marketId,
+      vendorId: input.market.vendorId,
+      regionId: input.market.regionId,
+      chunkKey: input.market.chunkKey,
+      itemId: input.itemId,
+      basePrice,
+      unitPrice,
+      supplyPressurePerMille,
+      demandPressurePerMille,
+      routeRiskPerMille,
+      taxPressurePerMille,
+    } satisfies Omit<LocalMarketPriceResult, "priceHash">;
+
+    return Object.freeze({ ...result, priceHash: priceHash(result) });
+  }
+}
+
+export const localPriceResolver = new LocalPriceResolver();

--- a/server/src/economy/MarketOrderBookService.ts
+++ b/server/src/economy/MarketOrderBookService.ts
@@ -1,0 +1,40 @@
+import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+import type { LocalMarketDefinition, LocalMarketPriceResult } from "./LocalMarketTypes.js";
+import { LocalPriceResolver, localPriceResolver } from "./LocalPriceResolver.js";
+
+export interface MarketSupplyEntry {
+  readonly itemId: InventoryItemId;
+  readonly quantity: number;
+}
+
+export interface MarketOrderBookSnapshot {
+  readonly marketId: string;
+  readonly vendorId: string;
+  readonly prices: readonly LocalMarketPriceResult[];
+}
+
+export class MarketOrderBookService {
+  constructor(private readonly resolver: LocalPriceResolver = localPriceResolver) {}
+
+  createSnapshot(input: {
+    readonly market: LocalMarketDefinition;
+    readonly supply: readonly MarketSupplyEntry[];
+  }): MarketOrderBookSnapshot {
+    const supplyByItem = new Map(input.supply.map((entry) => [entry.itemId, Math.max(0, Math.floor(entry.quantity))] as const));
+    const prices = this.resolver
+      .listSellableItemIds()
+      .map((itemId) => this.resolver.resolvePrice({
+        market: input.market,
+        itemId,
+        currentVendorStock: supplyByItem.get(itemId as InventoryItemId) ?? 0,
+      }))
+      .filter((price): price is LocalMarketPriceResult => Boolean(price))
+      .sort((a, b) => a.itemId.localeCompare(b.itemId));
+
+    return Object.freeze({
+      marketId: input.market.marketId,
+      vendorId: input.market.vendorId,
+      prices: Object.freeze(prices),
+    });
+  }
+}

--- a/server/src/economy/ResourceSellPrices.ts
+++ b/server/src/economy/ResourceSellPrices.ts
@@ -1,36 +1,15 @@
-/**
- * RESOURCE SELL PRICES
- *
- * Deterministic sell prices for gathered and processed resources.
- * No Math.random(), no Date.now(), no dynamic market prices.
- * Prices are stable integers in coins.
- * 
- * Premium pricing: Processed items are worth more than raw inputs.
- * This creates the resource processing economy loop:
- * - wood_log x2 (2 coins) → wood_plank (3 coins) = +1 profit
- * - copper_ore x2 (6 coins) → copper_ingot (8 coins) = +2 profit
- * - raw_fish (2 coins) → cooked_fish (4 coins) = +2 profit
- */
+import { loadEconomyBasePricesFromGameData } from "./EconomyGameData.js";
 
-import type { InventoryItemId } from "../inventory/InventoryTypes.js";
+const economyBasePrices = loadEconomyBasePricesFromGameData();
 
-/**
- * Sell price in coins per unit.
- * Only resource items are sellable; equipment and quest items are not.
- * 
- * Raw materials: wood_log, copper_ore, raw_fish
- * Processed materials (premium): wood_plank, copper_ingot, cooked_fish
- */
-export const RESOURCE_SELL_PRICES: Record<string, number> = {
-  // Raw gathered resources
-  wood_log: 1,
-  copper_ore: 3,
-  raw_fish: 2,
-  // Processed resources (premium values)
-  wood_plank: 3,
-  copper_ingot: 8,
-  cooked_fish: 4,
-} as const;
+export const RESOURCE_SELL_PRICES: Readonly<Record<string, number>> = Object.freeze(
+  Object.fromEntries(
+    Object.values(economyBasePrices)
+      .filter((entry) => entry.sellable)
+      .map((entry) => [entry.itemId, entry.basePrice] as const)
+      .sort(([a], [b]) => a.localeCompare(b)),
+  ),
+);
 
 export interface SellPriceResult {
   sellable: true;
@@ -44,11 +23,6 @@ export interface NotSellableResult {
 
 export type GetSellPriceResult = SellPriceResult | NotSellableResult;
 
-/**
- * Get the sell price for an item ID.
- * Returns sellable=true and price if the item can be sold.
- * Returns sellable=false if the item is equipment, quest item, or unknown.
- */
 export function getSellPrice(itemId: string): GetSellPriceResult {
   const price = RESOURCE_SELL_PRICES[itemId];
   if (price === undefined) {
@@ -57,16 +31,10 @@ export function getSellPrice(itemId: string): GetSellPriceResult {
   return { sellable: true, price: Number(price) };
 }
 
-/**
- * Check if an item ID is sellable (has a price in the table).
- */
 export function isSellable(itemId: string): boolean {
   return itemId in RESOURCE_SELL_PRICES;
 }
 
-/**
- * Get all sellable resource item IDs.
- */
 export function getSellableItemIds(): string[] {
-  return Object.keys(RESOURCE_SELL_PRICES);
+  return Object.keys(RESOURCE_SELL_PRICES).sort((a, b) => a.localeCompare(b));
 }

--- a/server/src/economy/TradeRouteGraph.ts
+++ b/server/src/economy/TradeRouteGraph.ts
@@ -1,0 +1,61 @@
+import type { LocalMarketDefinition, LocalMarketRoute } from "./LocalMarketTypes.js";
+
+export interface ResolvedTradeRoute {
+  readonly fromMarketId: string;
+  readonly toMarketId: string;
+  readonly routeId: string;
+  readonly distanceKappa: number;
+  readonly routeRiskPerMille: number;
+  readonly taxPressurePerMille: number;
+}
+
+export class TradeRouteGraph {
+  private readonly marketsById = new Map<string, LocalMarketDefinition>();
+
+  constructor(markets: readonly LocalMarketDefinition[]) {
+    for (const market of [...markets].sort((a, b) => a.marketId.localeCompare(b.marketId))) {
+      this.marketsById.set(market.marketId, market);
+    }
+  }
+
+  listMarkets(): readonly LocalMarketDefinition[] {
+    return Object.freeze([...this.marketsById.values()].sort((a, b) => a.marketId.localeCompare(b.marketId)));
+  }
+
+  getMarket(marketId: string): LocalMarketDefinition | null {
+    return this.marketsById.get(marketId) ?? null;
+  }
+
+  resolveRoute(fromMarketId: string, toMarketId: string): ResolvedTradeRoute | null {
+    const from = this.marketsById.get(fromMarketId);
+    if (!from) return null;
+
+    const direct = from.routes.find((route) => route.toMarketId === toMarketId) ?? null;
+    if (!direct) {
+      if (fromMarketId === toMarketId) {
+        return Object.freeze({
+          fromMarketId,
+          toMarketId,
+          routeId: `${fromMarketId}:self`,
+          distanceKappa: 0,
+          routeRiskPerMille: 1000,
+          taxPressurePerMille: 1000,
+        });
+      }
+      return null;
+    }
+
+    return this.toResolved(fromMarketId, direct);
+  }
+
+  private toResolved(fromMarketId: string, route: LocalMarketRoute): ResolvedTradeRoute {
+    return Object.freeze({
+      fromMarketId,
+      toMarketId: route.toMarketId,
+      routeId: route.routeId,
+      distanceKappa: route.distanceKappa,
+      routeRiskPerMille: route.routeRiskPerMille,
+      taxPressurePerMille: route.taxPressurePerMille,
+    });
+  }
+}

--- a/server/src/economy/VendorStockService.ts
+++ b/server/src/economy/VendorStockService.ts
@@ -2,7 +2,7 @@
  * VENDOR STOCK SERVICE
  *
  * Server-authoritative vendor stock service with persistence hydration.
- * Deterministic: No Math.random(), no Date.now(), stable ordering.
+ * Deterministic: seeded/tick-safe runtime and stable ordering.
  */
 
 import { VendorStockStore } from "./VendorStockStore.js";

--- a/server/src/economy/VendorStockService.ts
+++ b/server/src/economy/VendorStockService.ts
@@ -20,50 +20,40 @@ export class VendorStockService {
     private readonly persistence: VendorStockPersistenceAdapter,
   ) {}
 
-  /**
-   * Get the stock state for a vendor.
-   */
   async getStock(vendorId: string): Promise<VendorStockState> {
     await this.hydrateVendor(vendorId);
     return this.store.getStock(vendorId);
   }
 
-  /**
-   * Get the quantity of a specific item in vendor stock.
-   */
   async getItemQuantity(vendorId: string, itemId: string): Promise<number> {
     await this.hydrateVendor(vendorId);
     return this.store.getItemQuantity(vendorId, itemId);
   }
 
-  /**
-   * Add items to vendor stock after a player sells them.
-   * Persists the updated state.
-   */
   async addItems(vendorId: string, itemId: string, quantity: number): Promise<VendorStockState> {
     await this.hydrateVendor(vendorId);
     const result = this.store.addItems(vendorId, itemId, quantity);
 
     if (result.items[itemId] !== undefined) {
-      await this.persistence.saveStock(
-        createPersistedVendorStockState(vendorId, result),
-      );
+      await this.persistence.saveStock(createPersistedVendorStockState(vendorId, result));
     }
 
     return result;
   }
 
-  /**
-   * Get all stock entries as an array for a vendor.
-   */
+  async removeItems(vendorId: string, itemId: string, quantity: number): Promise<VendorStockState | null> {
+    await this.hydrateVendor(vendorId);
+    const result = this.store.removeItems(vendorId, itemId, quantity);
+    if (!result) return null;
+    await this.persistence.saveStock(createPersistedVendorStockState(vendorId, result));
+    return result;
+  }
+
   async getStockEntries(vendorId: string): Promise<Array<{ itemId: string; quantity: number }>> {
     await this.hydrateVendor(vendorId);
     return this.store.getStockEntries(vendorId);
   }
 
-  /**
-   * Hydrate a vendor's stock from persistence.
-   */
   private async hydrateVendor(vendorId: string): Promise<void> {
     if (this.hydratedVendors.has(vendorId)) return;
 
@@ -75,17 +65,11 @@ export class VendorStockService {
     this.hydratedVendors.add(vendorId);
   }
 
-  /**
-   * Clear hydration state for testing.
-   */
   clearForTests(): void {
     this.hydratedVendors.clear();
   }
 }
 
-/**
- * Create a persisted vendor stock state from a runtime state.
- */
 function createPersistedVendorStockState(
   vendorId: string,
   state: VendorStockState,

--- a/server/src/economy/VendorStockStore.ts
+++ b/server/src/economy/VendorStockStore.ts
@@ -2,7 +2,7 @@
  * VENDOR STOCK STORE
  *
  * Server-authoritative in-memory vendor stock store.
- * Deterministic: No Math.random(), stable ordering, no Date.now().
+ * Deterministic: seeded/tick-safe runtime, stable ordering, no host-clock truth.
  */
 
 import {

--- a/server/src/economy/VendorStockStore.ts
+++ b/server/src/economy/VendorStockStore.ts
@@ -14,10 +14,6 @@ import {
 export class VendorStockStore {
   private readonly stocks = new Map<string, VendorStockState>();
 
-  /**
-   * Get the stock state for a vendor.
-   * Creates a default empty state if not yet tracked.
-   */
   getStock(vendorId: string): VendorStockState {
     const existing = this.stocks.get(vendorId);
     if (existing) return existing;
@@ -27,20 +23,12 @@ export class VendorStockStore {
     return created;
   }
 
-  /**
-   * Get the quantity of a specific item in vendor stock.
-   * Returns 0 if vendor or item not found.
-   */
   getItemQuantity(vendorId: string, itemId: string): number {
     const state = this.getStock(vendorId);
     const qty = state.items[itemId];
     return typeof qty === "number" ? qty : 0;
   }
 
-  /**
-   * Add items to vendor stock.
-   * Returns the new stock state.
-   */
   addItems(vendorId: string, itemId: string, quantity: number): VendorStockState {
     const state = this.getStock(vendorId);
     const currentQty = this.getItemQuantity(vendorId, itemId);
@@ -60,22 +48,38 @@ export class VendorStockStore {
     return nextState;
   }
 
-  /**
-   * Replace a vendor's stock state entirely.
-   * Used for hydration from persistence.
-   */
+  removeItems(vendorId: string, itemId: string, quantity: number): VendorStockState | null {
+    const state = this.getStock(vendorId);
+    const currentQty = this.getItemQuantity(vendorId, itemId);
+    const removedQty = normalizeStockQuantity(quantity);
+
+    if (removedQty === 0 || currentQty < removedQty) return null;
+
+    const nextItems: Record<string, number> = { ...state.items };
+    const nextQty = currentQty - removedQty;
+    if (nextQty > 0) {
+      nextItems[itemId] = nextQty;
+    } else {
+      delete nextItems[itemId];
+    }
+
+    const nextState: VendorStockState = {
+      ...state,
+      items: Object.freeze(Object.fromEntries(Object.entries(nextItems).sort(([a], [b]) => a.localeCompare(b)))),
+    };
+
+    this.stocks.set(vendorId, nextState);
+    return nextState;
+  }
+
   replaceStock(vendorId: string, state: VendorStockState): void {
     this.stocks.set(vendorId, Object.freeze({
       vendorId: state.vendorId,
       schemaVersion: state.schemaVersion,
-      items: Object.freeze({ ...state.items }),
+      items: Object.freeze(Object.fromEntries(Object.entries(state.items).sort(([a], [b]) => a.localeCompare(b)))),
     }));
   }
 
-  /**
-   * Get all stock entries as an array for a vendor.
-   * Filters out zero-quantity items.
-   */
   getStockEntries(vendorId: string): Array<{ itemId: string; quantity: number }> {
     const state = this.getStock(vendorId);
     return Object.entries(state.items)
@@ -84,9 +88,6 @@ export class VendorStockStore {
       .sort((a, b) => a.itemId.localeCompare(b.itemId));
   }
 
-  /**
-   * Clear all stock for testing.
-   */
   clearForTests(): void {
     this.stocks.clear();
   }

--- a/server/src/economy/WalletService.ts
+++ b/server/src/economy/WalletService.ts
@@ -32,12 +32,18 @@ export class WalletService {
     await this.hydratePlayer(input.playerId);
     const result = this.store.addCoins(input.playerId, input.amount);
 
-    if (result) {
-      await this.persistence.saveWallet(
-        createPersistedWalletState(input.playerId, result),
-      );
-    }
+    await this.persistence.saveWallet(createPersistedWalletState(input.playerId, result));
+    return result;
+  }
 
+  async subtractCoins(input: {
+    playerId: string;
+    amount: number;
+  }): Promise<WalletState> {
+    await this.hydratePlayer(input.playerId);
+    const result = this.store.subtractCoins(input.playerId, input.amount);
+
+    await this.persistence.saveWallet(createPersistedWalletState(input.playerId, result));
     return result;
   }
 

--- a/server/src/economy/WalletService.ts
+++ b/server/src/economy/WalletService.ts
@@ -2,7 +2,7 @@
  * WALLET SERVICE
  *
  * Server-authoritative wallet service with persistence hydration.
- * Deterministic: No Math.random(), no Date.now(), stable ordering.
+ * Deterministic: seeded/tick-safe runtime and stable ordering.
  */
 
 import { WalletStore } from "./WalletStore.js";

--- a/server/src/economy/economyRoute.ts
+++ b/server/src/economy/economyRoute.ts
@@ -1,7 +1,5 @@
 import express, { Router, type Response } from "express";
 import rateLimit from "express-rate-limit";
-import rateLimit from "express-rate-limit";
-import rateLimit from "express-rate-limit";
 import { stableHash32 } from "../core/determinism/AREDeterminism.js";
 import { tickContextProvider } from "../core/are/TickSystemContextProvider.js";
 import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
@@ -12,6 +10,23 @@ import { npcQuestService } from "../quests/NpcQuestService.js";
 import { runtimeHistoryLog } from "../history/RuntimeHistoryLog.js";
 
 const router = Router();
+
+const economyLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { ok: false, error: "rate_limited" },
+});
+
+const buyResourceRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { ok: false, error: "rate_limited" },
+});
+
 const tradeTransferRateLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 30,
@@ -21,21 +36,6 @@ const tradeTransferRateLimiter = rateLimit({
 });
 
 router.use(express.json());
-const buyResourceRateLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 30,
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-
-const economyLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 60,
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
 router.use(economyLimiter);
 
 const MAX_POSITION = 100_000;
@@ -108,7 +108,7 @@ router.post("/sell-all-resources", async (req, res) => {
   const playerPosition = parsePosition(req.body?.playerPosition);
   const vendorId = parseSafeId(req.body?.vendorId) ?? undefined;
   if (req.body?.playerPosition !== undefined && !playerPosition) return void res.status(400).json({ ok: false, error: "invalid_player_position" });
-router.post("/buy-resource", buyResourceRateLimiter, async (req, res) => {
+
   try {
     const result = await economyService.sellAllResources({ playerId: identity.playerId, playerPosition: playerPosition ?? undefined, vendorId, currentTick: currentServerTick() });
     res.status(result.ok ? 200 : 400).json({ ok: result.ok, result });
@@ -118,11 +118,11 @@ router.post("/buy-resource", buyResourceRateLimiter, async (req, res) => {
   }
 });
 
-router.post("/buy-resource", async (req, res) => {
+router.post("/buy-resource", buyResourceRateLimiter, async (req, res) => {
   const identity = resolveHttpPlayerIdentity(req);
   if (!requireProductionAuth(identity, res)) return;
 
-router.post("/trade-transfer", tradeTransferRateLimiter, async (req, res) => {
+  const itemId = parseSafeId(req.body?.itemId);
   const quantity = parseQuantity(req.body?.quantity);
   const playerPosition = parsePosition(req.body?.playerPosition);
   const vendorId = parseSafeId(req.body?.vendorId) ?? undefined;
@@ -140,7 +140,7 @@ router.post("/trade-transfer", tradeTransferRateLimiter, async (req, res) => {
   }
 });
 
-router.post("/trade-transfer", async (req, res) => {
+router.post("/trade-transfer", tradeTransferRateLimiter, async (req, res) => {
   const identity = resolveHttpPlayerIdentity(req);
   if (!requireProductionAuth(identity, res)) return;
 

--- a/server/src/economy/economyRoute.ts
+++ b/server/src/economy/economyRoute.ts
@@ -1,4 +1,4 @@
-import express, { Router } from "express";
+import express, { Router, type Response } from "express";
 import { stableHash32 } from "../core/determinism/AREDeterminism.js";
 import { tickContextProvider } from "../core/are/TickSystemContextProvider.js";
 import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
@@ -38,7 +38,7 @@ function parsePosition(value: unknown): { x: number; y: number } | null {
   return { x, y };
 }
 
-function requireProductionAuth(identity: { authenticated: boolean }, res: express.Response): boolean {
+function requireProductionAuth(identity: { authenticated: boolean }, res: Response): boolean {
   if (process.env.NODE_ENV === "production" && !identity.authenticated) {
     res.status(401).json({ ok: false, error: "authenticated_player_required" });
     return false;

--- a/server/src/economy/economyRoute.ts
+++ b/server/src/economy/economyRoute.ts
@@ -1,4 +1,5 @@
 import express, { Router, type Response } from "express";
+import rateLimit from "express-rate-limit";
 import { stableHash32 } from "../core/determinism/AREDeterminism.js";
 import { tickContextProvider } from "../core/are/TickSystemContextProvider.js";
 import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
@@ -10,6 +11,15 @@ import { runtimeHistoryLog } from "../history/RuntimeHistoryLog.js";
 
 const router = Router();
 router.use(express.json());
+
+const economyLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+router.use(economyLimiter);
 
 const MAX_POSITION = 100_000;
 const MIN_POSITION = -100_000;

--- a/server/src/economy/economyRoute.ts
+++ b/server/src/economy/economyRoute.ts
@@ -1,5 +1,6 @@
 import express, { Router, type Response } from "express";
 import rateLimit from "express-rate-limit";
+import rateLimit from "express-rate-limit";
 import { stableHash32 } from "../core/determinism/AREDeterminism.js";
 import { tickContextProvider } from "../core/are/TickSystemContextProvider.js";
 import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
@@ -11,6 +12,13 @@ import { runtimeHistoryLog } from "../history/RuntimeHistoryLog.js";
 
 const router = Router();
 router.use(express.json());
+const buyResourceRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 
 const economyLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -91,7 +99,7 @@ router.post("/sell-all-resources", async (req, res) => {
   const playerPosition = parsePosition(req.body?.playerPosition);
   const vendorId = parseSafeId(req.body?.vendorId) ?? undefined;
   if (req.body?.playerPosition !== undefined && !playerPosition) return void res.status(400).json({ ok: false, error: "invalid_player_position" });
-
+router.post("/buy-resource", buyResourceRateLimiter, async (req, res) => {
   try {
     const result = await economyService.sellAllResources({ playerId: identity.playerId, playerPosition: playerPosition ?? undefined, vendorId, currentTick: currentServerTick() });
     res.status(result.ok ? 200 : 400).json({ ok: result.ok, result });

--- a/server/src/economy/economyRoute.ts
+++ b/server/src/economy/economyRoute.ts
@@ -1,36 +1,31 @@
-/**
- * ECONOMY API ROUTE
- *
- * Server-authoritative economy API for resource selling.
- * No Date.now(), no Math.random(), stable ordering.
- * Requires vendor proximity for selling.
- */
-
 import express, { Router } from "express";
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
+import { tickContextProvider } from "../core/are/TickSystemContextProvider.js";
 import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
+import { getInventoryStore } from "../inventory/inventoryRuntime.js";
+import { transferInventoryItem } from "../inventory/InventoryTransferService.js";
 import { economyService } from "./economyRuntime.js";
 import { npcQuestService } from "../quests/NpcQuestService.js";
+import { runtimeHistoryLog } from "../history/RuntimeHistoryLog.js";
 
 const router = Router();
-
 router.use(express.json());
 
-function parseItemId(value: unknown): string | null {
+const MAX_POSITION = 100_000;
+const MIN_POSITION = -100_000;
+
+function parseSafeId(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
-  if (!/^[a-zA-Z0-9_]{1,64}$/.test(trimmed)) return null;
+  if (!/^[a-zA-Z0-9_-]{1,96}$/.test(trimmed)) return null;
   return trimmed;
 }
 
 function parseQuantity(value: unknown): number {
   const n = Math.floor(Number(value));
-  if (!Number.isFinite(n) || n < 0) return -1;
+  if (!Number.isFinite(n) || n <= 0) return -1;
   return n;
 }
-
-// Maximum allowed player position values (prevent overflow/exploit)
-const MAX_POSITION = 100_000;
-const MIN_POSITION = -100_000;
 
 function parsePosition(value: unknown): { x: number; y: number } | null {
   if (!value || typeof value !== "object") return null;
@@ -38,148 +33,116 @@ function parsePosition(value: unknown): { x: number; y: number } | null {
   const x = Number(pos.x);
   const y = Number(pos.y);
   if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
-  // Validate bounds to prevent overflow/exploit
   if (x < MIN_POSITION || x > MAX_POSITION) return null;
   if (y < MIN_POSITION || y > MAX_POSITION) return null;
   return { x, y };
 }
 
-function parseVendorId(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  if (!/^[a-zA-Z0-9_]{1,64}$/.test(trimmed)) return null;
-  return trimmed;
+function requireProductionAuth(identity: { authenticated: boolean }, res: express.Response): boolean {
+  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
+    res.status(401).json({ ok: false, error: "authenticated_player_required" });
+    return false;
+  }
+  return true;
 }
 
-/**
- * POST /api/economy/sell-resource
- *
- * Sell a specific quantity of a resource item.
- * Requires player to be near the village trader.
- * Consumes items from inventory, adds coins to wallet.
- */
+function currentServerTick(): number {
+  const tick = Number(tickContextProvider.getContext().tickIndex);
+  return Number.isSafeInteger(tick) && tick >= 0 ? tick : 0;
+}
+
 router.post("/sell-resource", async (req, res) => {
   const identity = resolveHttpPlayerIdentity(req);
+  if (!requireProductionAuth(identity, res)) return;
 
-  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
-    res.status(401).json({
-      ok: false,
-      error: "authenticated_player_required",
-    });
-    return;
-  }
-
-  const itemId = parseItemId(req.body?.itemId);
+  const itemId = parseSafeId(req.body?.itemId);
   const quantity = parseQuantity(req.body?.quantity);
   const playerPosition = parsePosition(req.body?.playerPosition);
-  const vendorId = parseVendorId(req.body?.vendorId);
+  const vendorId = parseSafeId(req.body?.vendorId) ?? undefined;
 
-  if (!itemId) {
-    res.status(400).json({
-      ok: false,
-      error: "invalid_item_id",
-    });
-    return;
-  }
-
-  if (quantity <= 0) {
-    res.status(400).json({
-      ok: false,
-      error: "invalid_quantity",
-    });
-    return;
-  }
-
-  // Validate player position if provided
-  if (req.body?.playerPosition !== undefined && !playerPosition) {
-    res.status(400).json({
-      ok: false,
-      error: "invalid_player_position",
-    });
-    return;
-  }
+  if (!itemId) return void res.status(400).json({ ok: false, error: "invalid_item_id" });
+  if (quantity <= 0) return void res.status(400).json({ ok: false, error: "invalid_quantity" });
+  if (req.body?.playerPosition !== undefined && !playerPosition) return void res.status(400).json({ ok: false, error: "invalid_player_position" });
 
   try {
-    const result = await economyService.sellResource({
-      playerId: identity.playerId,
-      itemId,
-      quantity,
-      playerPosition: playerPosition ?? undefined,
-      vendorId: vendorId ?? undefined,
-    });
-
-    // Update NPC quest progress if sell succeeded
-    if (result.ok) {
-      npcQuestService.updateQuestProgress(
-        identity.playerId,
-        "sell",
-        itemId,
-        quantity,
-      );
-    }
-
-    const statusCode = result.ok ? 200 : 400;
-    res.status(statusCode).json({
-      ok: result.ok,
-      result,
-    });
+    const result = await economyService.sellResource({ playerId: identity.playerId, itemId, quantity, playerPosition: playerPosition ?? undefined, vendorId, currentTick: currentServerTick() });
+    if (result.ok) npcQuestService.updateQuestProgress(identity.playerId, "sell", itemId, quantity);
+    res.status(result.ok ? 200 : 400).json({ ok: result.ok, result });
   } catch (error) {
     console.error("[economy-sell-resource] Failed to sell resource:", error);
-    res.status(500).json({
-      ok: false,
-      error: "internal_error",
-    });
+    res.status(500).json({ ok: false, error: "internal_error" });
   }
 });
 
-/**
- * POST /api/economy/sell-all-resources
- *
- * Sell all sellable resource items in the player's inventory.
- * Requires player to be near the village trader.
- * Consumes all resource items, adds coins to wallet.
- */
 router.post("/sell-all-resources", async (req, res) => {
   const identity = resolveHttpPlayerIdentity(req);
-
-  if (process.env.NODE_ENV === "production" && !identity.authenticated) {
-    res.status(401).json({
-      ok: false,
-      error: "authenticated_player_required",
-    });
-    return;
-  }
+  if (!requireProductionAuth(identity, res)) return;
 
   const playerPosition = parsePosition(req.body?.playerPosition);
-  const vendorId = parseVendorId(req.body?.vendorId);
-
-  // Validate player position if provided
-  if (req.body?.playerPosition !== undefined && !playerPosition) {
-    res.status(400).json({
-      ok: false,
-      error: "invalid_player_position",
-    });
-    return;
-  }
+  const vendorId = parseSafeId(req.body?.vendorId) ?? undefined;
+  if (req.body?.playerPosition !== undefined && !playerPosition) return void res.status(400).json({ ok: false, error: "invalid_player_position" });
 
   try {
-    const result = await economyService.sellAllResources({
-      playerId: identity.playerId,
-      playerPosition: playerPosition ?? undefined,
-      vendorId: vendorId ?? undefined,
-    });
-
-    const statusCode = result.ok ? 200 : 400;
-    res.status(statusCode).json({
-      ok: result.ok,
-      result,
-    });
+    const result = await economyService.sellAllResources({ playerId: identity.playerId, playerPosition: playerPosition ?? undefined, vendorId, currentTick: currentServerTick() });
+    res.status(result.ok ? 200 : 400).json({ ok: result.ok, result });
   } catch (error) {
     console.error("[economy-sell-all-resources] Failed to sell resources:", error);
-    res.status(500).json({
-      ok: false,
-      error: "internal_error",
-    });
+    res.status(500).json({ ok: false, error: "internal_error" });
+  }
+});
+
+router.post("/buy-resource", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  if (!requireProductionAuth(identity, res)) return;
+
+  const itemId = parseSafeId(req.body?.itemId);
+  const quantity = parseQuantity(req.body?.quantity);
+  const playerPosition = parsePosition(req.body?.playerPosition);
+  const vendorId = parseSafeId(req.body?.vendorId) ?? undefined;
+
+  if (!itemId) return void res.status(400).json({ ok: false, error: "invalid_item_id" });
+  if (quantity <= 0) return void res.status(400).json({ ok: false, error: "invalid_quantity" });
+  if (req.body?.playerPosition !== undefined && !playerPosition) return void res.status(400).json({ ok: false, error: "invalid_player_position" });
+
+  try {
+    const result = await economyService.buyResource({ playerId: identity.playerId, itemId, quantity, playerPosition: playerPosition ?? undefined, vendorId, currentTick: currentServerTick() });
+    res.status(result.ok ? 200 : 400).json({ ok: result.ok, result });
+  } catch (error) {
+    console.error("[economy-buy-resource] Failed to buy resource:", error);
+    res.status(500).json({ ok: false, error: "internal_error" });
+  }
+});
+
+router.post("/trade-transfer", async (req, res) => {
+  const identity = resolveHttpPlayerIdentity(req);
+  if (!requireProductionAuth(identity, res)) return;
+
+  const toPlayerId = parseSafeId(req.body?.toPlayerId);
+  const itemId = parseSafeId(req.body?.itemId);
+  const quantity = parseQuantity(req.body?.quantity);
+  const tick = currentServerTick();
+
+  if (!toPlayerId) return void res.status(400).json({ ok: false, error: "invalid_receiver" });
+  if (!itemId) return void res.status(400).json({ ok: false, error: "invalid_item_id" });
+  if (quantity <= 0) return void res.status(400).json({ ok: false, error: "invalid_quantity" });
+
+  const sourceHash = stableHash32(["HTTP_TRADE_TRANSFER_V1", identity.playerId, toPlayerId, itemId, quantity, tick].join("|")).toString(16);
+  const result = transferInventoryItem(getInventoryStore(), { fromPlayerId: identity.playerId, toPlayerId, itemId, quantity, tick, uid: `trade:${sourceHash}`, sourceHash });
+
+  if (result.ok) {
+    runtimeHistoryLog.write({ tick, source: "trade_transfer", actorId: identity.playerId, subjectId: `${toPlayerId}:${itemId}`, payload: result });
+  }
+
+  res.status(result.ok ? 200 : 400).json({ ok: result.ok, result });
+});
+
+router.get("/market-snapshot", async (_req, res) => {
+  try {
+    const snapshot = await economyService.marketSnapshot();
+    res.json({ ok: true, snapshot });
+  } catch (error) {
+    console.error("[economy-market-snapshot] Failed to create snapshot:", error);
+    res.status(500).json({ ok: false, error: "internal_error" });
   }
 });
 

--- a/server/src/economy/economyRoute.ts
+++ b/server/src/economy/economyRoute.ts
@@ -1,6 +1,7 @@
 import express, { Router, type Response } from "express";
 import rateLimit from "express-rate-limit";
 import rateLimit from "express-rate-limit";
+import rateLimit from "express-rate-limit";
 import { stableHash32 } from "../core/determinism/AREDeterminism.js";
 import { tickContextProvider } from "../core/are/TickSystemContextProvider.js";
 import { resolveHttpPlayerIdentity } from "../auth/PlayerIdentityResolver.js";
@@ -11,6 +12,14 @@ import { npcQuestService } from "../quests/NpcQuestService.js";
 import { runtimeHistoryLog } from "../history/RuntimeHistoryLog.js";
 
 const router = Router();
+const tradeTransferRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { ok: false, error: "rate_limited" },
+});
+
 router.use(express.json());
 const buyResourceRateLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -113,7 +122,7 @@ router.post("/buy-resource", async (req, res) => {
   const identity = resolveHttpPlayerIdentity(req);
   if (!requireProductionAuth(identity, res)) return;
 
-  const itemId = parseSafeId(req.body?.itemId);
+router.post("/trade-transfer", tradeTransferRateLimiter, async (req, res) => {
   const quantity = parseQuantity(req.body?.quantity);
   const playerPosition = parsePosition(req.body?.playerPosition);
   const vendorId = parseSafeId(req.body?.vendorId) ?? undefined;

--- a/server/src/economy/economyRuntime.ts
+++ b/server/src/economy/economyRuntime.ts
@@ -2,7 +2,6 @@
  * ECONOMY RUNTIME
  *
  * Singleton economy service instances for the server.
- * Provides lazy initialization and access to EconomyService, WalletService, and VendorStockService.
  */
 
 import { EconomyService } from "./EconomyService.js";
@@ -13,6 +12,8 @@ import { VendorStockService } from "./VendorStockService.js";
 import { VendorStockStore } from "./VendorStockStore.js";
 import { JsonVendorStockPersistenceAdapter } from "./JsonVendorStockPersistenceAdapter.js";
 import { getInventoryService } from "../inventory/inventoryRuntime.js";
+import { runtimeHistoryLog } from "../history/RuntimeHistoryLog.js";
+import { createLocalMarketSnapshot } from "./EconomySnapshotAdapter.js";
 
 const walletStore = new WalletStore();
 const walletAdapter = new JsonWalletPersistenceAdapter();
@@ -28,7 +29,7 @@ async function getOrCreateService(): Promise<EconomyService> {
   if (servicePromise) return servicePromise;
 
   const inventoryService = await getInventoryService();
-  servicePromise = Promise.resolve(new EconomyService(inventoryService, walletService, vendorStockService));
+  servicePromise = Promise.resolve(new EconomyService(inventoryService, walletService, vendorStockService, runtimeHistoryLog));
   return servicePromise;
 }
 
@@ -49,8 +50,6 @@ export { walletStore as walletStore };
 export { vendorStockService };
 export { vendorStockStore as vendorStockStore };
 
-// Singleton economyService interface for route handlers
-// Uses lazy initialization to avoid circular dependency issues
 export const economyService = {
   sellResource: async (input: {
     playerId: string;
@@ -58,6 +57,7 @@ export const economyService = {
     quantity: number;
     playerPosition?: { x: number; y: number };
     vendorId?: string;
+    currentTick?: number;
   }) => {
     const service = await getEconomyService();
     return service.sellResource(input);
@@ -66,8 +66,21 @@ export const economyService = {
     playerId: string;
     playerPosition?: { x: number; y: number };
     vendorId?: string;
+    currentTick?: number;
   }) => {
     const service = await getEconomyService();
     return service.sellAllResources(input);
   },
+  buyResource: async (input: {
+    playerId: string;
+    itemId: string;
+    quantity: number;
+    playerPosition?: { x: number; y: number };
+    vendorId?: string;
+    currentTick?: number;
+  }) => {
+    const service = await getEconomyService();
+    return service.buyResource(input);
+  },
+  marketSnapshot: async () => createLocalMarketSnapshot({ vendorStockService }),
 };

--- a/server/src/economy/index.ts
+++ b/server/src/economy/index.ts
@@ -1,9 +1,3 @@
-/**
- * ECONOMY MODULE
- *
- * Server-authoritative economy for resource selling and currency management.
- */
-
 export { EconomyService } from "./EconomyService.js";
 export { WalletService } from "./WalletService.js";
 export { WalletStore } from "./WalletStore.js";
@@ -14,3 +8,9 @@ export { VendorStockService } from "./VendorStockService.js";
 export { VendorStockStore } from "./VendorStockStore.js";
 export { type VendorStockState, type VendorStockSnapshot, type VendorPriceInfo, type DemandBand } from "./VendorStockTypes.js";
 export { calculateDynamicPrice, getDemandBand, getDemandHint, isPriceAffected, DEMAND_THRESHOLDS, DEMAND_PRICE_ADJUSTMENT } from "./DemandPricing.js";
+export { LocalPriceResolver, localPriceResolver, resolveSupplyPressurePerMille } from "./LocalPriceResolver.js";
+export { MarketOrderBookService } from "./MarketOrderBookService.js";
+export { TradeRouteGraph } from "./TradeRouteGraph.js";
+export { createLocalMarketSnapshot } from "./EconomySnapshotAdapter.js";
+export { loadEconomyBasePricesFromGameData, loadLocalMarketsFromGameData } from "./EconomyGameData.js";
+export type { LocalMarketDefinition, LocalMarketSnapshot, LocalMarketPriceResult } from "./LocalMarketTypes.js";

--- a/server/src/history/RuntimeHistoryLog.ts
+++ b/server/src/history/RuntimeHistoryLog.ts
@@ -1,0 +1,67 @@
+import { stableHash32 } from "../core/determinism/AREDeterminism.js";
+import type { RuntimeHistoryEntry, RuntimeHistoryWriteInput } from "./RuntimeHistoryTypes.js";
+
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return String(value);
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort((a, b) => a.localeCompare(b))
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(",")}}`;
+}
+
+function normalizeTick(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) return 0;
+  return value;
+}
+
+function normalizeText(value: string, fallback: string): string {
+  const trimmed = String(value ?? "").trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+export class RuntimeHistoryLog {
+  private readonly entries: RuntimeHistoryEntry[] = [];
+
+  write(input: RuntimeHistoryWriteInput): RuntimeHistoryEntry {
+    const sequence = this.entries.length;
+    const tick = normalizeTick(input.tick);
+    const actorId = normalizeText(input.actorId, "system");
+    const subjectId = normalizeText(input.subjectId, "unknown");
+    const chunkKey = normalizeText(input.chunkKey ?? "0:0", "0:0");
+    const payloadHash = stableHash32(stableStringify(input.payload)).toString(16);
+    const entrySeed = ["RUNTIME_HISTORY_V1", sequence, tick, input.source, actorId, subjectId, chunkKey, payloadHash].join("|");
+
+    const entry = Object.freeze({
+      schemaVersion: 1 as const,
+      sequence,
+      tick,
+      source: input.source,
+      actorId,
+      subjectId,
+      chunkKey,
+      payloadHash,
+      entryHash: stableHash32(entrySeed).toString(16),
+    });
+
+    this.entries.push(entry);
+    return entry;
+  }
+
+  list(): readonly RuntimeHistoryEntry[] {
+    return Object.freeze(this.entries.map((entry) => Object.freeze({ ...entry })));
+  }
+
+  listByActor(actorId: string): readonly RuntimeHistoryEntry[] {
+    return Object.freeze(this.entries.filter((entry) => entry.actorId === actorId).map((entry) => Object.freeze({ ...entry })));
+  }
+
+  clearForTests(): void {
+    this.entries.length = 0;
+  }
+}
+
+export const runtimeHistoryLog = new RuntimeHistoryLog();

--- a/server/src/history/RuntimeHistoryTypes.ts
+++ b/server/src/history/RuntimeHistoryTypes.ts
@@ -1,0 +1,22 @@
+export type RuntimeHistorySource = "economy_sell" | "trade_transfer" | "market_snapshot";
+
+export interface RuntimeHistoryEntry {
+  readonly schemaVersion: 1;
+  readonly sequence: number;
+  readonly tick: number;
+  readonly source: RuntimeHistorySource;
+  readonly actorId: string;
+  readonly subjectId: string;
+  readonly chunkKey: string;
+  readonly payloadHash: string;
+  readonly entryHash: string;
+}
+
+export interface RuntimeHistoryWriteInput {
+  readonly tick: number;
+  readonly source: RuntimeHistorySource;
+  readonly actorId: string;
+  readonly subjectId: string;
+  readonly chunkKey?: string;
+  readonly payload: unknown;
+}

--- a/server/src/inventory/InventoryService.ts
+++ b/server/src/inventory/InventoryService.ts
@@ -2,7 +2,7 @@
  * INVENTORY SERVICE
  *
  * Server-authoritative inventory service with persistence hydration.
- * Deterministic: No Math.random(), no Date.now(), stable ordering.
+ * Deterministic: seeded/tick-safe runtime and stable ordering.
  */
 
 import { InventoryStore } from "./InventoryStore.js";

--- a/server/src/inventory/InventoryService.ts
+++ b/server/src/inventory/InventoryService.ts
@@ -12,8 +12,9 @@ import {
 } from "./InventoryPersistence.js";
 import type {
   InventoryAddResult,
-  InventoryRemoveResult,
   InventoryItemId,
+  InventoryItemOrigin,
+  InventoryRemoveResult,
   PlayerInventoryState,
 } from "./InventoryTypes.js";
 
@@ -34,6 +35,7 @@ export class InventoryService {
     playerId: string;
     itemId: InventoryItemId | string;
     quantity: number;
+    origin?: InventoryItemOrigin;
   }): Promise<InventoryAddResult> {
     await this.hydratePlayer(input.playerId);
 

--- a/server/src/tests/economy-market-runtime-a5.test.ts
+++ b/server/src/tests/economy-market-runtime-a5.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { EconomyService } from "../economy/EconomyService.js";
+import { VendorStockService } from "../economy/VendorStockService.js";
+import { VendorStockStore } from "../economy/VendorStockStore.js";
+import { WalletService } from "../economy/WalletService.js";
+import { WalletStore } from "../economy/WalletStore.js";
+import { createLocalMarketSnapshot } from "../economy/EconomySnapshotAdapter.js";
+import { VILLAGE_TRADER } from "../economy/VillageVendors.js";
+import { InventoryService } from "../inventory/InventoryService.js";
+import { InventoryStore } from "../inventory/InventoryStore.js";
+import { RuntimeHistoryLog } from "../history/RuntimeHistoryLog.js";
+
+const memoryPersistence = {
+  async loadWallet() { return null; },
+  async saveWallet() {},
+  async loadPlayerInventory() { return null; },
+  async savePlayerInventory() {},
+  async loadStock() { return null; },
+  async saveStock() {},
+  async health() { return { ok: true, driver: "memory" }; },
+};
+
+function nearVendorPosition() {
+  return { x: VILLAGE_TRADER.position.x, y: VILLAGE_TRADER.position.y };
+}
+
+describe("A5 economy market runtime", () => {
+  let inventoryStore: InventoryStore;
+  let inventoryService: InventoryService;
+  let walletStore: WalletStore;
+  let walletService: WalletService;
+  let vendorStockStore: VendorStockStore;
+  let vendorStockService: VendorStockService;
+  let history: RuntimeHistoryLog;
+  let economy: EconomyService;
+
+  beforeEach(() => {
+    inventoryStore = new InventoryStore();
+    inventoryService = new InventoryService(inventoryStore, memoryPersistence);
+    walletStore = new WalletStore();
+    walletService = new WalletService(walletStore, memoryPersistence);
+    vendorStockStore = new VendorStockStore();
+    vendorStockService = new VendorStockService(vendorStockStore, memoryPersistence);
+    history = new RuntimeHistoryLog();
+    economy = new EconomyService(inventoryService, walletService, vendorStockService, history);
+  });
+
+  it("buys from server-authoritative vendor stock and writes trade origin evidence", async () => {
+    walletStore.addCoins("player_a", 10);
+    vendorStockStore.addItems("village_trader_001", "wood_log", 5);
+
+    const result = await economy.buyResource({
+      playerId: "player_a",
+      itemId: "wood_log",
+      quantity: 2,
+      playerPosition: nearVendorPosition(),
+      currentTick: 44,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("bought");
+    expect(result.newBalance).toBe(8);
+    expect(result.stockBefore).toBe(5);
+    expect(result.stockAfter).toBe(3);
+    expect(result.originUid).toMatch(/^buy:/);
+    expect(result.historyHash).toBeTruthy();
+
+    const inventory = await inventoryService.getPlayerInventory("player_a");
+    expect(inventory.slots.find((slot) => slot.itemId === "wood_log")?.quantity).toBe(2);
+    expect(inventoryStore.getMovementEvents("player_a").at(-1)?.origin?.source).toBe("trade_delta");
+    expect(history.list()).toHaveLength(1);
+  });
+
+  it("rejects buy intent without mutating wallet, stock or inventory", async () => {
+    walletStore.addCoins("player_a", 1);
+    vendorStockStore.addItems("village_trader_001", "copper_ingot", 2);
+
+    const result = await economy.buyResource({
+      playerId: "player_a",
+      itemId: "copper_ingot",
+      quantity: 1,
+      playerPosition: nearVendorPosition(),
+      currentTick: 50,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("insufficient_wallet");
+    expect(walletStore.getWallet("player_a").balances.coin).toBe(1);
+    expect(vendorStockStore.getItemQuantity("village_trader_001", "copper_ingot")).toBe(2);
+    expect((await inventoryService.getPlayerInventory("player_a")).slots).toHaveLength(0);
+    expect(history.list()).toHaveLength(0);
+  });
+
+  it("sell path writes a real runtime history entry", async () => {
+    await inventoryService.addItem({ playerId: "player_a", itemId: "raw_fish", quantity: 3 });
+
+    const result = await economy.sellResource({
+      playerId: "player_a",
+      itemId: "raw_fish",
+      quantity: 2,
+      playerPosition: nearVendorPosition(),
+      currentTick: 60,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.historyHash).toBe(history.list()[0]?.entryHash);
+    expect(history.list()[0]?.source).toBe("economy_sell");
+  });
+
+  it("creates a server-derived market snapshot from vendor stock", async () => {
+    vendorStockStore.addItems("village_trader_001", "wood_log", 25);
+
+    const snapshot = await createLocalMarketSnapshot({ vendorStockService });
+
+    expect(snapshot.marketId).toBe("starter_village_market");
+    expect(snapshot.prices.length).toBeGreaterThanOrEqual(2);
+    expect(snapshot.prices.map((price) => price.itemId)).toEqual([...snapshot.prices.map((price) => price.itemId)].sort());
+    expect(snapshot.snapshotHash).toBeTruthy();
+  });
+});

--- a/server/src/tests/economy-market-runtime-a5.test.ts
+++ b/server/src/tests/economy-market-runtime-a5.test.ts
@@ -66,8 +66,9 @@ describe("A5 economy market runtime", () => {
     expect(result.historyHash).toBeTruthy();
 
     const inventory = await inventoryService.getPlayerInventory("player_a");
+    const movements = inventoryStore.getMovementEvents("player_a");
     expect(inventory.slots.find((slot) => slot.itemId === "wood_log")?.quantity).toBe(2);
-    expect(inventoryStore.getMovementEvents("player_a").at(-1)?.origin?.source).toBe("trade_delta");
+    expect(movements[movements.length - 1]?.origin?.source).toBe("trade_delta");
     expect(history.list()).toHaveLength(1);
   });
 

--- a/server/src/tests/local-market-price-resolver.test.ts
+++ b/server/src/tests/local-market-price-resolver.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { loadEconomyBasePricesFromGameData, loadLocalMarketsFromGameData } from "../economy/EconomyGameData.js";
+import { LocalPriceResolver, resolveSupplyPressurePerMille } from "../economy/LocalPriceResolver.js";
+import { MarketOrderBookService } from "../economy/MarketOrderBookService.js";
+import { TradeRouteGraph } from "../economy/TradeRouteGraph.js";
+
+describe("A5 local market price resolver", () => {
+  it("loads base prices from game-data and keeps sellable ordering stable", () => {
+    const prices = loadEconomyBasePricesFromGameData();
+    const resolver = new LocalPriceResolver(prices);
+
+    expect(resolver.getBasePrice("wood_log")).toBe(1);
+    expect(resolver.getBasePrice("copper_ingot")).toBe(8);
+    expect(resolver.listSellableItemIds()).toEqual([
+      "cooked_fish",
+      "copper_ingot",
+      "copper_ore",
+      "raw_fish",
+      "wood_log",
+      "wood_plank",
+    ]);
+  });
+
+  it("derives deterministic prices from supply, demand and neutral route/tax pressure", () => {
+    const market = loadLocalMarketsFromGameData()[0];
+    const resolver = new LocalPriceResolver(loadEconomyBasePricesFromGameData());
+
+    const first = resolver.resolvePrice({ market, itemId: "copper_ingot", currentVendorStock: 0 });
+    const second = resolver.resolvePrice({ market, itemId: "copper_ingot", currentVendorStock: 0 });
+    const stocked = resolver.resolvePrice({ market, itemId: "copper_ingot", currentVendorStock: 25 });
+
+    expect(first).toEqual(second);
+    expect(first?.basePrice).toBe(8);
+    expect(first?.demandPressurePerMille).toBe(1250);
+    expect(first?.routeRiskPerMille).toBe(1000);
+    expect(first?.taxPressurePerMille).toBe(1000);
+    expect(stocked?.supplyPressurePerMille).toBe(800);
+    expect(stocked?.unitPrice).toBeLessThan(first?.unitPrice ?? 0);
+  });
+
+  it("sorts market pressure model output and resolves trade routes deterministically", () => {
+    const [market] = loadLocalMarketsFromGameData();
+    const orderBook = new MarketOrderBookService(new LocalPriceResolver(loadEconomyBasePricesFromGameData()));
+    const graph = new TradeRouteGraph([market]);
+
+    const snapshot = orderBook.createSnapshot({
+      market,
+      supply: [
+        { itemId: "wood_log", quantity: 25 },
+        { itemId: "copper_ore", quantity: 0 },
+      ],
+    });
+
+    expect(snapshot.prices.map((price) => price.itemId)).toEqual([
+      "cooked_fish",
+      "copper_ingot",
+      "copper_ore",
+      "raw_fish",
+      "wood_log",
+      "wood_plank",
+    ]);
+    expect(graph.resolveRoute(market.marketId, market.marketId)?.routeRiskPerMille).toBe(1000);
+    expect(resolveSupplyPressurePerMille(25)).toBe(800);
+  });
+});

--- a/server/src/tests/runtime-history-log.test.ts
+++ b/server/src/tests/runtime-history-log.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { RuntimeHistoryLog } from "../history/RuntimeHistoryLog.js";
+
+describe("RuntimeHistoryLog", () => {
+  it("writes stable tick and hash ordered entries", () => {
+    const a = new RuntimeHistoryLog();
+    const b = new RuntimeHistoryLog();
+
+    const firstA = a.write({
+      tick: 12,
+      source: "economy_sell",
+      actorId: "player_a",
+      subjectId: "village_trader_001:wood_log",
+      chunkKey: "0:0",
+      payload: { quantity: 2, itemId: "wood_log" },
+    });
+    const firstB = b.write({
+      tick: 12,
+      source: "economy_sell",
+      actorId: "player_a",
+      subjectId: "village_trader_001:wood_log",
+      chunkKey: "0:0",
+      payload: { itemId: "wood_log", quantity: 2 },
+    });
+
+    expect(firstA).toEqual(firstB);
+    expect(firstA.sequence).toBe(0);
+    expect(firstA.tick).toBe(12);
+    expect(firstA.entryHash).toBeTruthy();
+  });
+
+  it("lists entries by actor without mutating stored history", () => {
+    const log = new RuntimeHistoryLog();
+    log.write({ tick: 1, source: "economy_sell", actorId: "player_a", subjectId: "s1", payload: { a: 1 } });
+    log.write({ tick: 2, source: "trade_transfer", actorId: "player_b", subjectId: "s2", payload: { b: 2 } });
+
+    expect(log.listByActor("player_a")).toHaveLength(1);
+    expect(log.list()).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Completes the A5 release train slice.

Runtime changes:
- adds game-data economy base prices and starter market content
- loads sell prices from game-data instead of code truth
- adds LocalPriceResolver, MarketOrderBookService, TradeRouteGraph and market snapshot adapter
- adds RuntimeHistoryLog and connects EconomyService sell/buy success paths to real history entries
- adds buy-resource runtime mutation through wallet, vendor stock and inventory origin evidence
- adds trade-transfer HTTP path backed by InventoryTransferService and server tick
- adds runtime tests for market prices, buy/sell/history and snapshots

Closes #2048
Closes #2072
Closes #2076
Closes #2080